### PR TITLE
fix: workspace invitation page not showing workspaces

### DIFF
--- a/lib/hoc/withAuthWrapper.tsx
+++ b/lib/hoc/withAuthWrapper.tsx
@@ -1,30 +1,32 @@
-import React, { useEffect } from "react";
+import React from "react";
 // next
 import type { NextPage } from "next";
-// axios configurations
-import { setAxiosHeader } from "configuration/axios-configuration";
 // redirect
 import redirect from "lib/redirect";
 
-const withAuthWrapper = (WrappedComponent: NextPage) => {
+const withAuth = (WrappedComponent: NextPage) => {
   const Wrapper: NextPage<any> = (props) => {
-    useEffect(() => {
-      if (props?.tokenDetails && props?.tokenDetails?.access_token) {
-        setAxiosHeader(props.tokenDetails.access_token);
-      }
-    }, [props]);
-
     return <WrappedComponent {...props} />;
   };
 
   Wrapper.getInitialProps = async (ctx) => {
-    const componentProps =
-      WrappedComponent.getInitialProps &&
-      (await WrappedComponent.getInitialProps(ctx));
-    return { ...componentProps };
+    const isServer = typeof window === "undefined";
+
+    const cookies = isServer ? ctx?.req?.headers.cookie : document.cookie;
+
+    const token = cookies?.split("accessToken=")?.[1]?.split(";")?.[0];
+
+    if (!token) {
+      redirect(ctx, "/signin");
+    }
+
+    const pageProps =
+      WrappedComponent.getInitialProps && (await WrappedComponent.getInitialProps(ctx));
+
+    return { ...pageProps };
   };
 
   return Wrapper;
 };
 
-export default withAuthWrapper;
+export default withAuth;

--- a/lib/redirect.ts
+++ b/lib/redirect.ts
@@ -1,7 +1,8 @@
 // next imports
+import type { NextPageContext } from "next";
 import Router from "next/router";
 
-const redirect = (context: any, target: any) => {
+const redirect = (context: NextPageContext, target: any) => {
   if (context.res) {
     // server
     // 303: "See other"

--- a/pages/signin.tsx
+++ b/pages/signin.tsx
@@ -8,8 +8,6 @@ import Image from "next/image";
 import useUser from "lib/hooks/useUser";
 // services
 import authenticationService from "lib/services/authentication.service";
-// hoc
-import withAuthWrapper from "lib/hoc/withAuthWrapper";
 // layouts
 import DefaultLayout from "layouts/DefaultLayout";
 // social button
@@ -180,4 +178,4 @@ const SignIn: NextPage = () => {
   );
 };
 
-export default withAuthWrapper(SignIn);
+export default SignIn;

--- a/pages/workspace-member-invitation/[invitationId].tsx
+++ b/pages/workspace-member-invitation/[invitationId].tsx
@@ -11,8 +11,6 @@ import workspaceService from "lib/services/workspace.service";
 import { WORKSPACE_INVITATION } from "constants/fetch-keys";
 // hooks
 import useUser from "lib/hooks/useUser";
-// hoc
-import withAuthWrapper from "lib/hoc/withAuthWrapper";
 // layouts
 import DefaultLayout from "layouts/DefaultLayout";
 // ui
@@ -149,4 +147,4 @@ const WorkspaceInvitation: NextPage = () => {
   );
 };
 
-export default withAuthWrapper(WorkspaceInvitation);
+export default WorkspaceInvitation;

--- a/pages/workspace/index.tsx
+++ b/pages/workspace/index.tsx
@@ -9,6 +9,8 @@ import AdminLayout from "layouts/AdminLayout";
 import useSWR from "swr";
 // hooks
 import useUser from "lib/hooks/useUser";
+// hoc
+import withAuthWrapper from "lib/hoc/withAuthWrapper";
 // fetch keys
 import { USER_ISSUE } from "constants/fetch-keys";
 // services
@@ -167,4 +169,4 @@ const Workspace: NextPage = () => {
   );
 };
 
-export default Workspace;
+export default withAuthWrapper(Workspace);


### PR DESCRIPTION
fix:

- workspace invitation page, showing all the workspaces if there's no invitation to the user
- user has the option to choose from existing workspaces instead of the "create workspace" button
- made auth wrapper working
- added wrapper in protected routes and removed from public pages