### PR TITLE
feat: confirm workspace deletion 

### DIFF
--- a/apps/app/components/project/confirm-project-deletion.tsx
+++ b/apps/app/components/project/confirm-project-deletion.tsx
@@ -161,7 +161,7 @@ const ConfirmProjectDeletion: React.FC<Props> = ({ isOpen, data, onClose }) => {
                               setConfirmDeleteMyProject(false);
                             }
                           }}
-                          name="projectName"
+                          name="typeDelete"
                         />
                       </div>
                     </div>

--- a/apps/app/constants/api-routes.ts
+++ b/apps/app/constants/api-routes.ts
@@ -24,7 +24,7 @@ export const S3_URL = `/api/file-assets/`;
 // LIST USER INVITATIONS ---- RESPOND INVITATIONS IN BULK
 export const USER_WORKSPACE_INVITATIONS = "/api/users/me/invitations/workspaces/";
 export const USER_PROJECT_INVITATIONS = "/api/users/me/invitations/projects/";
-
+export const LAST_ACTIVE_WORKSPACE_AND_PROJECTS = "/api/users/last-visited-workspace/";
 export const USER_WORKSPACE_INVITATION = (invitationId: string) =>
   `/api/users/me/invitations/${invitationId}/`;
 

--- a/apps/app/constants/api-routes.ts
+++ b/apps/app/constants/api-routes.ts
@@ -15,7 +15,8 @@ export const MAGIC_LINK_SIGNIN = "/api/magic-sign-in/";
 export const USER_ENDPOINT = "/api/users/me/";
 export const CHANGE_PASSWORD = "/api/users/me/change-password/";
 export const USER_ONBOARD_ENDPOINT = "/api/users/me/onboard/";
-export const USER_ISSUES_ENDPOINT = "/api/users/me/issues/";
+export const USER_ISSUES_ENDPOINT = (workspaceSlug: string) =>
+  `/api/workspaces/${workspaceSlug}/my-issues/`;
 export const USER_WORKSPACES = "/api/users/me/workspaces";
 
 // s3 file url
@@ -32,8 +33,6 @@ export const JOIN_WORKSPACE = (workspaceSlug: string, invitationId: string) =>
   `/api/users/me/invitations/workspaces/${workspaceSlug}/${invitationId}/join/`;
 export const JOIN_PROJECT = (workspaceSlug: string) =>
   `/api/workspaces/${workspaceSlug}/projects/join/`;
-
-export const USER_ISSUES = "/api/users/me/issues/";
 
 // workspaces
 export const WORKSPACES_ENDPOINT = "/api/workspaces/";

--- a/apps/app/constants/fetch-keys.ts
+++ b/apps/app/constants/fetch-keys.ts
@@ -29,4 +29,4 @@ export const CYCLE_DETAIL = "CYCLE_DETAIL";
 export const STATE_LIST = (projectId: string) => `STATE_LIST_${projectId}`;
 export const STATE_DETAIL = "STATE_DETAIL";
 
-export const USER_ISSUE = "USER_ISSUE";
+export const USER_ISSUE = (workspaceSlug: string) => `USER_ISSUE_${workspaceSlug}`;

--- a/apps/app/lib/services/user.service.ts
+++ b/apps/app/lib/services/user.service.ts
@@ -16,8 +16,8 @@ class UserService extends APIService {
     };
   }
 
-  async userIssues(): Promise<any> {
-    return this.get(USER_ISSUES_ENDPOINT)
+  async userIssues(workspaceSlug: string): Promise<any> {
+    return this.get(USER_ISSUES_ENDPOINT(workspaceSlug))
       .then((response) => {
         return response?.data;
       })

--- a/apps/app/lib/services/workspace.service.ts
+++ b/apps/app/lib/services/workspace.service.ts
@@ -11,6 +11,7 @@ import {
   WORKSPACE_INVITATION_DETAIL,
   USER_WORKSPACE_INVITATION,
   USER_WORKSPACE_INVITATIONS,
+  LAST_ACTIVE_WORKSPACE_AND_PROJECTS,
 } from "constants/api-routes";
 // services
 import APIService from "lib/services/api.service";
@@ -18,7 +19,12 @@ import APIService from "lib/services/api.service";
 const { NEXT_PUBLIC_API_BASE_URL } = process.env;
 
 // types
-import { IWorkspace, IWorkspaceMember, IWorkspaceMemberInvitation } from "types";
+import {
+  ILastActiveWorkspaceDetails,
+  IWorkspace,
+  IWorkspaceMember,
+  IWorkspaceMemberInvitation,
+} from "types";
 
 class WorkspaceService extends APIService {
   constructor() {
@@ -89,6 +95,16 @@ class WorkspaceService extends APIService {
 
   async joinWorkspaces(data: any): Promise<any> {
     return this.post(USER_WORKSPACE_INVITATIONS, data)
+      .then((response) => {
+        return response?.data;
+      })
+      .catch((error) => {
+        throw error?.response?.data;
+      });
+  }
+
+  async getLastActiveWorkspaceAndProjects(): Promise<ILastActiveWorkspaceDetails> {
+    return this.get(LAST_ACTIVE_WORKSPACE_AND_PROJECTS)
       .then((response) => {
         return response?.data;
       })

--- a/apps/app/pages/me/my-issues.tsx
+++ b/apps/app/pages/me/my-issues.tsx
@@ -33,11 +33,11 @@ import { Menu, Transition } from "@headlessui/react";
 const MyIssues: NextPage = () => {
   const [selectedWorkspace, setSelectedWorkspace] = useState<string | null>(null);
 
-  const { user, workspaces } = useUser();
+  const { user, workspaces, activeWorkspace } = useUser();
 
   const { data: myIssues, mutate: mutateMyIssues } = useSWR<IIssue[]>(
-    user ? USER_ISSUE : null,
-    user ? () => userService.userIssues() : null
+    user && activeWorkspace ? USER_ISSUE(activeWorkspace.slug) : null,
+    user && activeWorkspace ? () => userService.userIssues(activeWorkspace.slug) : null
   );
 
   const updateMyIssues = (

--- a/apps/app/pages/me/profile.tsx
+++ b/apps/app/pages/me/profile.tsx
@@ -49,7 +49,7 @@ const Profile: NextPage = () => {
   const [isImageUploading, setIsImageUploading] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
 
-  const { user: myProfile, mutateUser, projects } = useUser();
+  const { user: myProfile, mutateUser, projects, activeWorkspace } = useUser();
 
   const { setToastAlert } = useToast();
 
@@ -86,8 +86,8 @@ const Profile: NextPage = () => {
   } = useForm<IUser>({ defaultValues });
 
   const { data: myIssues } = useSWR<IIssue[]>(
-    myProfile ? USER_ISSUE : null,
-    myProfile ? () => userService.userIssues() : null
+    myProfile && activeWorkspace ? USER_ISSUE(activeWorkspace.slug) : null,
+    myProfile && activeWorkspace ? () => userService.userIssues(activeWorkspace.slug) : null
   );
 
   const { data: invitations } = useSWR(USER_WORKSPACE_INVITATIONS, () =>
@@ -103,7 +103,7 @@ const Profile: NextPage = () => {
       icon: RectangleStackIcon,
       title: "My Issues",
       number: myIssues?.length ?? 0,
-      description: "View the list of issues assigned to you across the workspace.",
+      description: "View the list of issues assigned to you for this workspace.",
       href: "/me/my-issues",
     },
     {

--- a/apps/app/pages/me/profile.tsx
+++ b/apps/app/pages/me/profile.tsx
@@ -1,24 +1,30 @@
 import React, { useEffect, useState } from "react";
 // next
+import Link from "next/link";
 import Image from "next/image";
 import type { NextPage } from "next";
+// swr
+import useSWR from "swr";
 // react hook form
 import { useForm } from "react-hook-form";
 // react dropzone
-import Dropzone, { useDropzone } from "react-dropzone";
+import Dropzone from "react-dropzone";
 // hooks
 import useUser from "lib/hooks/useUser";
+import useToast from "lib/hooks/useToast";
 // hoc
 import withAuth from "lib/hoc/withAuthWrapper";
 // layouts
 import AppLayout from "layouts/AppLayout";
+// constants
+import { USER_ISSUE, USER_WORKSPACE_INVITATIONS } from "constants/fetch-keys";
 // services
 import userService from "lib/services/user.service";
 import fileServices from "lib/services/file.service";
+import workspaceService from "lib/services/workspace.service";
 // ui
 import { BreadcrumbItem, Breadcrumbs, Button, Input, Spinner } from "ui";
-// types
-import type { IIssue, IUser, IWorkspaceMemberInvitation } from "types";
+// icons
 import {
   ChevronRightIcon,
   ClipboardDocumentListIcon,
@@ -28,11 +34,8 @@ import {
   UserPlusIcon,
   XMarkIcon,
 } from "@heroicons/react/24/outline";
-import useSWR from "swr";
-import { USER_ISSUE, USER_WORKSPACE_INVITATIONS } from "constants/fetch-keys";
-import useToast from "lib/hooks/useToast";
-import Link from "next/link";
-import workspaceService from "lib/services/workspace.service";
+// types
+import type { IIssue, IUser } from "types";
 
 const defaultValues: Partial<IUser> = {
   avatar: "",
@@ -51,8 +54,14 @@ const Profile: NextPage = () => {
   const { setToastAlert } = useToast();
 
   const onSubmit = (formData: IUser) => {
+    const payload: Partial<IUser> = {
+      id: formData.id,
+      first_name: formData.first_name,
+      last_name: formData.last_name,
+      avatar: formData.avatar,
+    };
     userService
-      .updateUser(formData)
+      .updateUser(payload)
       .then((response) => {
         mutateUser(response, false);
         setIsEditing(false);
@@ -81,9 +90,8 @@ const Profile: NextPage = () => {
     myProfile ? () => userService.userIssues() : null
   );
 
-  const { data: invitations } = useSWR<IWorkspaceMemberInvitation[]>(
-    USER_WORKSPACE_INVITATIONS,
-    () => workspaceService.userWorkspaceInvitations()
+  const { data: invitations } = useSWR(USER_WORKSPACE_INVITATIONS, () =>
+    workspaceService.userWorkspaceInvitations()
   );
 
   useEffect(() => {
@@ -128,7 +136,8 @@ const Profile: NextPage = () => {
           <>
             <div className="space-y-5">
               <section className="relative p-5 rounded-xl flex gap-10 bg-secondary">
-                <div
+                <button
+                  type="button"
                   className="absolute top-4 right-4 bg-indigo-100 hover:bg-theme hover:text-white rounded p-1 cursor-pointer duration-300"
                   onClick={() => setIsEditing((prevData) => !prevData)}
                 >
@@ -137,7 +146,7 @@ const Profile: NextPage = () => {
                   ) : (
                     <PencilIcon className="h-4 w-4" />
                   )}
-                </div>
+                </button>
                 <div className="flex-shrink-0">
                   <Dropzone
                     multiple={false}
@@ -244,21 +253,7 @@ const Profile: NextPage = () => {
                     </div>
                     <div>
                       <h4 className="text-sm text-gray-500">Email ID</h4>
-                      {isEditing ? (
-                        <Input
-                          id="email"
-                          type="email"
-                          register={register}
-                          error={errors.email}
-                          name="email"
-                          validations={{
-                            required: "Email is required",
-                          }}
-                          placeholder="Enter email"
-                        />
-                      ) : (
-                        <h2>{myProfile.email}</h2>
-                      )}
+                      <h2>{myProfile.email}</h2>
                     </div>
                   </div>
                   {isEditing && (

--- a/apps/app/pages/workspace/index.tsx
+++ b/apps/app/pages/workspace/index.tsx
@@ -26,8 +26,8 @@ const Workspace: NextPage = () => {
   const { user, activeWorkspace, projects } = useUser();
 
   const { data: myIssues } = useSWR<IIssue[]>(
-    user ? USER_ISSUE : null,
-    user ? () => userService.userIssues() : null
+    user && activeWorkspace ? USER_ISSUE(activeWorkspace.slug) : null,
+    user && activeWorkspace ? () => userService.userIssues(activeWorkspace.slug) : null
   );
 
   const cards = [

--- a/apps/app/pages/workspace/settings.tsx
+++ b/apps/app/pages/workspace/settings.tsx
@@ -3,6 +3,8 @@ import React, { useEffect, useState } from "react";
 import Image from "next/image";
 // react hook form
 import { useForm } from "react-hook-form";
+// headless ui
+import { Tab } from "@headlessui/react";
 // react dropzone
 import Dropzone from "react-dropzone";
 // services
@@ -17,13 +19,12 @@ import AppLayout from "layouts/AppLayout";
 import useUser from "lib/hooks/useUser";
 import useToast from "lib/hooks/useToast";
 // components
-import ConfirmWorkspaceDeletion from "components/workspace/ConfirmWorkspaceDeletion";
+import ConfirmWorkspaceDeletion from "components/workspace/confirm-workspace-deletion";
 // ui
 import { Spinner, Button, Input, Select } from "ui";
 import { BreadcrumbItem, Breadcrumbs } from "ui/Breadcrumbs";
 // types
 import type { IWorkspace } from "types";
-import { Tab } from "@headlessui/react";
 
 const defaultValues: Partial<IWorkspace> = {
   name: "",
@@ -90,7 +91,13 @@ const WorkspaceSettings = () => {
         title: "Plane - Workspace Settings",
       }}
     >
-      <ConfirmWorkspaceDeletion isOpen={isOpen} setIsOpen={setIsOpen} />
+      <ConfirmWorkspaceDeletion
+        isOpen={isOpen}
+        onClose={() => {
+          setIsOpen(false);
+        }}
+        data={activeWorkspace ?? null}
+      />
       <div className="space-y-5">
         <Breadcrumbs>
           <BreadcrumbItem title={`${activeWorkspace?.name ?? "Workspace"} Settings`} />

--- a/apps/app/types/workspace.d.ts
+++ b/apps/app/types/workspace.d.ts
@@ -36,3 +36,8 @@ export interface IWorkspaceMember {
   created_by: string;
   updated_by: string;
 }
+
+export interface ILastActiveWorkspaceDetails {
+  workspace_details: IWorkspace;
+  project_details: IProject[];
+}


### PR DESCRIPTION
feat: 

- confirm workspace deletion by typing workspace name and 'delete my workspace'
- showing toast alert on workspace & project deletion
- email can't be edited on the profile page

fix:

- 404 error for my issues, since the API endpoint was changed to be isolated to the workspace

refractor:

- fixed inconsistent imports 
- made services for fetching details related to the last active workspace
- made the confirm-workspace-delete model better by handling functions and props in a more reusable manner