### PR TITLE
fix: return sequence id on issue flat serializer

### DIFF
--- a/apiserver/plane/api/serializers/issue.py
+++ b/apiserver/plane/api/serializers/issue.py
@@ -37,6 +37,7 @@ class IssueFlatSerializer(BaseSerializer):
             "priority",
             "start_date",
             "target_date",
+            "sequence_id",
         ]
 
 


### PR DESCRIPTION
fix: return sequence id on issue flat serializer