### PR TITLE
dev: home page redirection logic, context refractor

### DIFF
--- a/apps/app/components/command-palette/index.tsx
+++ b/apps/app/components/command-palette/index.tsx
@@ -172,17 +172,17 @@ const CommandPalette: React.FC = () => {
           <CreateUpdateCycleModal
             isOpen={isCreateCycleModalOpen}
             setIsOpen={setIsCreateCycleModalOpen}
-            projectId={activeProject.slug}
+            projectId={activeProject.id}
           />
           <CreateUpdateModuleModal
             isOpen={isCreateModuleModalOpen}
             setIsOpen={setIsCreateModuleModalOpen}
-            projectId={activeProject.slug}
+            projectId={activeProject.id}
           />
           <CreateUpdateIssuesModal
             isOpen={isIssueModalOpen}
             setIsOpen={setIsIssueModalOpen}
-            projectId={activeProject.slug}
+            projectId={activeProject.id}
           />
         </>
       )}

--- a/apps/app/components/command-palette/index.tsx
+++ b/apps/app/components/command-palette/index.tsx
@@ -8,11 +8,10 @@ import useSWR from "swr";
 // hooks
 import useTheme from "lib/hooks/useTheme";
 import useToast from "lib/hooks/useToast";
-// constants
-import { PROJECT_DETAILS, PROJECT_ISSUES_LIST } from "constants/fetch-keys";
 // services
 import issuesServices from "lib/services/issues.service";
-import projectService from "lib/services/project.service";
+import projectServices from "lib/services/project.service";
+import userService from "lib/services/user.service";
 // components
 import ShortcutsModal from "components/command-palette/shortcuts";
 import { CreateProjectModal } from "components/project";
@@ -22,6 +21,8 @@ import CreateUpdateModuleModal from "components/project/modules/create-update-mo
 import BulkDeleteIssuesModal from "components/common/bulk-delete-issues-modal";
 // headless ui
 import { Combobox, Dialog, Transition } from "@headlessui/react";
+// constants
+import { PROJECTS_LIST, PROJECT_ISSUES_LIST, USER_ISSUE } from "constants/fetch-keys";
 // ui
 import { Button } from "ui";
 // icons
@@ -48,7 +49,11 @@ const CommandPalette: React.FC = () => {
   const [isBulkDeleteIssuesModalOpen, setIsBulkDeleteIssuesModalOpen] = useState(false);
 
   const router = useRouter();
+
   const { workspaceSlug, projectId } = router.query;
+
+  const { setToastAlert } = useToast();
+  const { toggleCollapsed } = useTheme();
 
   const { data: issues } = useSWR(
     workspaceSlug && projectId
@@ -59,20 +64,23 @@ const CommandPalette: React.FC = () => {
       : null
   );
 
-  const { data: projectDetails } = useSWR(
-    workspaceSlug && projectId ? PROJECT_DETAILS(projectId as string) : null,
-    workspaceSlug && projectId
-      ? () => projectService.getProject(workspaceSlug as string, projectId as string)
-      : null
+  const { data: myIssues } = useSWR<IIssue[]>(
+    workspaceSlug ? USER_ISSUE(workspaceSlug as string) : null,
+    workspaceSlug ? () => userService.userIssues(workspaceSlug as string) : null
   );
 
-  const { toggleCollapsed } = useTheme();
+  const { data: projects } = useSWR(
+    workspaceSlug ? PROJECTS_LIST(workspaceSlug as string) : null,
+    workspaceSlug ? () => projectServices.getProjects(workspaceSlug as string) : null
+  );
 
-  const { setToastAlert } = useToast();
+  const activeProject = !projectId
+    ? projects?.[0]
+    : projects?.find((project) => project.id === projectId);
 
   const filteredIssues: IIssue[] =
     query === ""
-      ? issues?.results ?? []
+      ? issues?.results ?? myIssues ?? []
       : issues?.results.filter((issue) => issue.name.toLowerCase().includes(query.toLowerCase())) ??
         [];
 
@@ -159,25 +167,25 @@ const CommandPalette: React.FC = () => {
     <>
       <ShortcutsModal isOpen={isShortcutsModalOpen} setIsOpen={setIsShortcutsModalOpen} />
       <CreateProjectModal isOpen={isProjectModalOpen} setIsOpen={setIsProjectModalOpen} />
-      {projectId && (
+      {activeProject && (
         <>
           <CreateUpdateCycleModal
             isOpen={isCreateCycleModalOpen}
             setIsOpen={setIsCreateCycleModalOpen}
-            projectId={projectId as string}
+            projectId={activeProject.slug}
           />
           <CreateUpdateModuleModal
             isOpen={isCreateModuleModalOpen}
             setIsOpen={setIsCreateModuleModalOpen}
-            projectId={projectId as string}
+            projectId={activeProject.slug}
+          />
+          <CreateUpdateIssuesModal
+            isOpen={isIssueModalOpen}
+            setIsOpen={setIsIssueModalOpen}
+            projectId={activeProject.slug}
           />
         </>
       )}
-      <CreateUpdateIssuesModal
-        isOpen={isIssueModalOpen}
-        setIsOpen={setIsIssueModalOpen}
-        projectId={projectId as string}
-      />
       <BulkDeleteIssuesModal
         isOpen={isBulkDeleteIssuesModalOpen}
         setIsOpen={setIsBulkDeleteIssuesModalOpen}
@@ -270,7 +278,7 @@ const CommandPalette: React.FC = () => {
                                         }}
                                       />
                                       <span className="flex-shrink-0 text-xs text-gray-500">
-                                        {projectDetails?.identifier}-{issue.sequence_id}
+                                        {activeProject?.identifier}-{issue.sequence_id}
                                       </span>
                                       <span>{issue.name}</span>
                                     </div>

--- a/apps/app/components/common/bulk-delete-issues-modal.tsx
+++ b/apps/app/components/common/bulk-delete-issues-modal.tsx
@@ -8,8 +8,8 @@ import useSWR, { mutate } from "swr";
 import { SubmitHandler, useForm } from "react-hook-form";
 // services
 import issuesServices from "lib/services/issues.service";
+import projectService from "lib/services/project.service";
 // hooks
-import useUser from "lib/hooks/useUser";
 import useToast from "lib/hooks/useToast";
 // headless ui
 import { Combobox, Dialog, Transition } from "@headlessui/react";
@@ -20,7 +20,7 @@ import { FolderIcon, MagnifyingGlassIcon } from "@heroicons/react/24/outline";
 // types
 import { IIssue, IssueResponse } from "types";
 // fetch keys
-import { PROJECT_ISSUES_LIST } from "constants/fetch-keys";
+import { PROJECT_ISSUES_LIST, PROJECT_DETAILS } from "constants/fetch-keys";
 // common
 import { classNames } from "constants/common";
 
@@ -40,29 +40,34 @@ const BulkDeleteIssuesModal: React.FC<Props> = ({ isOpen, setIsOpen }) => {
   const router = useRouter();
 
   const {
-    query: { workspaceSlug },
+    query: { workspaceSlug, projectId },
   } = router;
 
-  const { activeWorkspace, activeProject } = useUser();
-
   const { data: issues } = useSWR(
-    activeWorkspace && activeProject
-      ? PROJECT_ISSUES_LIST(activeWorkspace.slug, activeProject.id)
+    workspaceSlug && projectId
+      ? PROJECT_ISSUES_LIST(workspaceSlug as string, projectId as string)
       : null,
-    activeWorkspace && activeProject
-      ? () => issuesServices.getIssues(activeWorkspace.slug, activeProject.id)
+    workspaceSlug && projectId
+      ? () => issuesServices.getIssues(workspaceSlug as string, projectId as string)
+      : null
+  );
+
+  const { data: projectDetails } = useSWR(
+    workspaceSlug && projectId ? PROJECT_DETAILS(projectId as string) : null,
+    workspaceSlug && projectId
+      ? () => projectService.getProject(workspaceSlug as string, projectId as string)
       : null
   );
 
   const { setToastAlert } = useToast();
+
+  const { register, handleSubmit, reset } = useForm<FormInput>();
 
   const filteredIssues: IIssue[] =
     query === ""
       ? issues?.results ?? []
       : issues?.results.filter((issue) => issue.name.toLowerCase().includes(query.toLowerCase())) ??
         [];
-
-  const { register, handleSubmit, reset } = useForm<FormInput>();
 
   const handleClose = () => {
     setIsOpen(false);
@@ -80,9 +85,9 @@ const BulkDeleteIssuesModal: React.FC<Props> = ({ isOpen, setIsOpen }) => {
       return;
     }
 
-    if (activeWorkspace && activeProject) {
+    if (workspaceSlug && projectId) {
       issuesServices
-        .bulkDeleteIssues(activeWorkspace.slug, activeProject.id, data)
+        .bulkDeleteIssues(workspaceSlug as string, projectId as string, data)
         .then((res) => {
           setToastAlert({
             title: "Success",
@@ -90,7 +95,7 @@ const BulkDeleteIssuesModal: React.FC<Props> = ({ isOpen, setIsOpen }) => {
             message: res.message,
           });
           mutate<IssueResponse>(
-            PROJECT_ISSUES_LIST(activeWorkspace.slug, activeProject.id),
+            PROJECT_ISSUES_LIST(workspaceSlug as string, projectId as string),
             (prevData) => {
               return {
                 ...(prevData as IssueResponse),
@@ -197,7 +202,7 @@ const BulkDeleteIssuesModal: React.FC<Props> = ({ isOpen, setIsOpen }) => {
                                           }}
                                         />
                                         <span className="flex-shrink-0 text-xs text-gray-500">
-                                          {activeProject?.identifier}-{issue.sequence_id}
+                                          {projectDetails?.identifier}-{issue.sequence_id}
                                         </span>
                                         <span>{issue.name}</span>
                                       </div>

--- a/apps/app/components/common/list-view/single-issue.tsx
+++ b/apps/app/components/common/list-view/single-issue.tsx
@@ -79,10 +79,6 @@ const SingleListIssue: React.FC<Props> = ({
               </span>
             )}
             <span>{issue.name}</span>
-            {/* <div className="absolute bottom-full left-0 mb-2 z-10 hidden group-hover:block p-2 bg-white shadow-md rounded-md max-w-sm whitespace-nowrap">
-    <h5 className="font-medium mb-1">Name</h5>
-    <div>{issue.name}</div>
-  </div> */}
           </a>
         </Link>
       </div>

--- a/apps/app/components/project/confirm-project-deletion.tsx
+++ b/apps/app/components/project/confirm-project-deletion.tsx
@@ -1,4 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
+// next
+import { useRouter } from "next/router";
 // headless ui
 import { Dialog, Transition } from "@headlessui/react";
 // services
@@ -21,15 +23,17 @@ type Props = {
 
 const ConfirmProjectDeletion: React.FC<Props> = ({ isOpen, data, onClose }) => {
   const [isDeleteLoading, setIsDeleteLoading] = useState(false);
-
-  const [selectedProject, setSelectedProject] = useState<IProject | null>(null);
-
   const [confirmProjectName, setConfirmProjectName] = useState("");
   const [confirmDeleteMyProject, setConfirmDeleteMyProject] = useState(false);
+  const [selectedProject, setSelectedProject] = useState<IProject | null>(null);
 
   const canDelete = confirmProjectName === data?.name && confirmDeleteMyProject;
 
-  const { activeWorkspace, mutateProjects } = useUser();
+  const router = useRouter();
+
+  const {
+    query: { workspaceSlug },
+  } = router;
 
   const { setToastAlert } = useToast();
 
@@ -47,12 +51,12 @@ const ConfirmProjectDeletion: React.FC<Props> = ({ isOpen, data, onClose }) => {
 
   const handleDeletion = async () => {
     setIsDeleteLoading(true);
-    if (!data || !activeWorkspace || !canDelete) return;
+    if (!data || !workspaceSlug || !canDelete) return;
     await projectService
-      .deleteProject(activeWorkspace.slug, data.id)
+      .deleteProject(workspaceSlug as string, data.id)
       .then(() => {
         handleClose();
-        mutateProjects((prevData) => (prevData ?? []).filter((item) => item.id !== data.id), false);
+        // TODO: add project mutation here
         setToastAlert({
           title: "Success",
           type: "success",
@@ -127,7 +131,7 @@ const ConfirmProjectDeletion: React.FC<Props> = ({ isOpen, data, onClose }) => {
                           removed. This action cannot be undone.
                         </p>
                       </div>
-                      <div className="h-0.5 bg-gray-200 my-3" />
+                      <div className="my-3 h-0.5 bg-gray-200" />
                       <div className="mt-3">
                         <p className="text-sm">
                           Enter the project name{" "}

--- a/apps/app/components/project/create-project-modal.tsx
+++ b/apps/app/components/project/create-project-modal.tsx
@@ -15,14 +15,8 @@ import { createSimilarString, getRandomEmoji } from "constants/common";
 // constants
 import { NETWORK_CHOICES } from "constants/";
 // fetch keys
-import {
-  PROJECTS_LIST,
-  WORKSPACE_DETAILS,
-  WORKSPACE_MEMBERS,
-  WORKSPACE_MEMBERS_ME,
-} from "constants/fetch-keys";
+import { PROJECTS_LIST, WORKSPACE_DETAILS, WORKSPACE_MEMBERS_ME } from "constants/fetch-keys";
 // hooks
-import useUser from "lib/hooks/useUser";
 import useToast from "lib/hooks/useToast";
 // ui
 import { Button, Input, TextArea, Select, EmojiIconPicker } from "ui";
@@ -169,19 +163,9 @@ export const CreateProjectModal: React.FC<Props> = (props) => {
   };
 
   // FIXME: remove this and authorize using getServerSideProps
-
-  if (myWorkspaceMembership) {
+  if (myWorkspaceMembership && isOpen) {
     if (myWorkspaceMembership.role <= 10) return <IsGuestCondition setIsOpen={setIsOpen} />;
   }
-
-  // if (workspaceMembers) {
-  //   const isMember = workspaceMembers.find((member) => member.member.id === user?.id);
-  //   const isGuest = workspaceMembers.find(
-  //     (member) => member.member.id === user?.id && member.role === 5
-  //   );
-
-  //   if ((!isMember || isGuest) && isOpen) return <IsGuestCondition setIsOpen={setIsOpen} />;
-  // }
 
   return (
     <Transition.Root show={isOpen} as={React.Fragment}>

--- a/apps/app/components/project/cycles/confirm-cycle-deletion.tsx
+++ b/apps/app/components/project/cycles/confirm-cycle-deletion.tsx
@@ -1,4 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
+// next
+import { useRouter } from "next/router";
 // swr
 import { mutate } from "swr";
 // headless ui
@@ -23,11 +25,14 @@ type Props = {
 };
 
 const ConfirmCycleDeletion: React.FC<Props> = ({ isOpen, setIsOpen, data }) => {
+  const cancelButtonRef = useRef(null);
   const [isDeleteLoading, setIsDeleteLoading] = useState(false);
 
-  const { activeWorkspace } = useUser();
+  const router = useRouter();
 
-  const cancelButtonRef = useRef(null);
+  const {
+    query: { workspaceSlug },
+  } = router;
 
   const handleClose = () => {
     setIsOpen(false);
@@ -36,9 +41,9 @@ const ConfirmCycleDeletion: React.FC<Props> = ({ isOpen, setIsOpen, data }) => {
 
   const handleDeletion = async () => {
     setIsDeleteLoading(true);
-    if (!data || !activeWorkspace) return;
+    if (!data || !workspaceSlug) return;
     await cycleService
-      .deleteCycle(activeWorkspace.slug, data.project, data.id)
+      .deleteCycle(workspaceSlug as string, data.project, data.id)
       .then(() => {
         mutate<ICycle[]>(
           CYCLE_LIST(data.project),

--- a/apps/app/components/project/cycles/create-update-cycle-modal.tsx
+++ b/apps/app/components/project/cycles/create-update-cycle-modal.tsx
@@ -1,4 +1,6 @@
 import React, { useEffect } from "react";
+// next
+import { useRouter } from "next/router";
 // swr
 import { mutate } from "swr";
 // react hook form
@@ -39,7 +41,11 @@ const CreateUpdateCycleModal: React.FC<Props> = ({ isOpen, setIsOpen, data, proj
     }, 500);
   };
 
-  const { activeWorkspace } = useUser();
+  const router = useRouter();
+
+  const {
+    query: { workspaceSlug },
+  } = router;
 
   const {
     register,
@@ -52,7 +58,7 @@ const CreateUpdateCycleModal: React.FC<Props> = ({ isOpen, setIsOpen, data, proj
   });
 
   const onSubmit = async (formData: ICycle) => {
-    if (!activeWorkspace) return;
+    if (!workspaceSlug) return;
     const payload = {
       ...formData,
       start_date: formData.start_date ? renderDateFormat(formData.start_date) : null,
@@ -60,7 +66,7 @@ const CreateUpdateCycleModal: React.FC<Props> = ({ isOpen, setIsOpen, data, proj
     };
     if (!data) {
       await cycleService
-        .createCycle(activeWorkspace.slug, projectId, payload)
+        .createCycle(workspaceSlug as string, projectId, payload)
         .then((res) => {
           mutate<ICycle[]>(CYCLE_LIST(projectId), (prevData) => [res, ...(prevData ?? [])], false);
           handleClose();
@@ -74,7 +80,7 @@ const CreateUpdateCycleModal: React.FC<Props> = ({ isOpen, setIsOpen, data, proj
         });
     } else {
       await cycleService
-        .updateCycle(activeWorkspace.slug, projectId, data.id, payload)
+        .updateCycle(workspaceSlug as string, projectId, data.id, payload)
         .then((res) => {
           mutate<ICycle[]>(
             CYCLE_LIST(projectId),

--- a/apps/app/components/project/cycles/cycle-detail-sidebar/index.tsx
+++ b/apps/app/components/project/cycles/cycle-detail-sidebar/index.tsx
@@ -37,16 +37,14 @@ const defaultValues: Partial<ICycle> = {
 };
 
 const CycleDetailSidebar: React.FC<Props> = ({ cycle, cycleIssues }) => {
-  const { activeWorkspace, activeProject } = useUser();
-
   const router = useRouter();
   const {
-    query: { workspaceSlug },
+    query: { workspaceSlug, projectId },
   } = router;
 
   const { setToastAlert } = useToast();
 
-  const { reset, watch, control } = useForm({
+  const { reset, control } = useForm({
     defaultValues,
   });
 
@@ -60,10 +58,10 @@ const CycleDetailSidebar: React.FC<Props> = ({ cycle, cycleIssues }) => {
   };
 
   const submitChanges = (data: Partial<ICycle>) => {
-    if (!activeWorkspace || !activeProject || !module) return;
+    if (!workspaceSlug || !projectId || !module) return;
 
     cyclesService
-      .patchCycle(activeWorkspace.slug, activeProject.id, cycle?.id ?? "", data)
+      .patchCycle(workspaceSlug as string, projectId as string, cycle?.id ?? "", data)
       .then((res) => {
         console.log(res);
         mutate(CYCLE_DETAIL);
@@ -72,8 +70,6 @@ const CycleDetailSidebar: React.FC<Props> = ({ cycle, cycleIssues }) => {
         console.log(e);
       });
   };
-
-  const handleDeleteCycle = () => {};
 
   useEffect(() => {
     if (cycle)
@@ -94,7 +90,7 @@ const CycleDetailSidebar: React.FC<Props> = ({ cycle, cycleIssues }) => {
                 className="rounded-md border p-2 shadow-sm duration-300 hover:bg-gray-100 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
                 onClick={() =>
                   copyTextToClipboard(
-                    `https://app.plane.so/${workspaceSlug}/projects/${activeProject?.id}/cycles/${cycle.id}`
+                    `https://app.plane.so/${workspaceSlug}/projects/${projectId}/cycles/${cycle.id}`
                   )
                     .then(() => {
                       setToastAlert({
@@ -112,13 +108,6 @@ const CycleDetailSidebar: React.FC<Props> = ({ cycle, cycleIssues }) => {
               >
                 <LinkIcon className="h-3.5 w-3.5" />
               </button>
-              {/* <button
-                type="button"
-                className="rounded-md border border-red-500 p-2 text-red-500 shadow-sm duration-300 hover:bg-red-50 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
-                onClick={() => handleDeleteCycle()}
-              >
-                <TrashIcon className="h-3.5 w-3.5" />
-              </button> */}
             </div>
           </div>
           <div className="divide-y-2 divide-gray-100 text-xs">

--- a/apps/app/components/project/cycles/list-view/index.tsx
+++ b/apps/app/components/project/cycles/list-view/index.tsx
@@ -1,8 +1,9 @@
-// react
 import React from "react";
-// swr
+
+import { useRouter } from "next/router";
+
 import useSWR from "swr";
-// headless ui
+
 import { Disclosure, Transition } from "@headlessui/react";
 // services
 import workspaceService from "lib/services/workspace.service";
@@ -52,17 +53,18 @@ const CyclesListView: React.FC<Props> = ({
   handleDeleteIssue,
   setPreloadedData,
 }) => {
-  const { activeWorkspace, activeProject } = useUser();
+  const router = useRouter();
+  const { workspaceSlug, projectId } = router.query;
 
   const { data: people } = useSWR<IWorkspaceMember[]>(
-    activeWorkspace ? WORKSPACE_MEMBERS : null,
-    activeWorkspace ? () => workspaceService.workspaceMembers(activeWorkspace.slug) : null
+    workspaceSlug ? WORKSPACE_MEMBERS : null,
+    workspaceSlug ? () => workspaceService.workspaceMembers(workspaceSlug as string) : null
   );
 
   const { data: states } = useSWR(
-    activeWorkspace && activeProject ? STATE_LIST(activeProject.id) : null,
-    activeWorkspace && activeProject
-      ? () => stateService.getStates(activeWorkspace.slug, activeProject.id)
+    workspaceSlug && projectId ? STATE_LIST(projectId as string) : null,
+    workspaceSlug && projectId
+      ? () => stateService.getStates(workspaceSlug as string, projectId as string)
       : null
   );
 

--- a/apps/app/components/project/issues/BoardView/single-board.tsx
+++ b/apps/app/components/project/issues/BoardView/single-board.tsx
@@ -1,8 +1,9 @@
-// react
 import React, { useState } from "react";
-// swr
+
+import { useRouter } from "next/router";
+
 import useSWR from "swr";
-// react-beautiful-dnd
+
 import { Draggable } from "react-beautiful-dnd";
 import StrictModeDroppable from "components/dnd/StrictModeDroppable";
 // services
@@ -63,7 +64,8 @@ const SingleBoard: React.FC<Props> = ({
   // Collapse/Expand
   const [show, setShow] = useState(true);
 
-  const { activeWorkspace } = useUser();
+  const router = useRouter();
+  const { workspaceSlug } = router.query;
 
   if (selectedGroup === "priority")
     groupTitle === "high"
@@ -75,8 +77,8 @@ const SingleBoard: React.FC<Props> = ({
       : (bgColor = "#ff0000");
 
   const { data: people } = useSWR<IWorkspaceMember[]>(
-    activeWorkspace ? WORKSPACE_MEMBERS : null,
-    activeWorkspace ? () => workspaceService.workspaceMembers(activeWorkspace.slug) : null
+    workspaceSlug ? WORKSPACE_MEMBERS : null,
+    workspaceSlug ? () => workspaceService.workspaceMembers(workspaceSlug as string) : null
   );
 
   return (

--- a/apps/app/components/project/issues/BoardView/state/confirm-state-delete.tsx
+++ b/apps/app/components/project/issues/BoardView/state/confirm-state-delete.tsx
@@ -1,15 +1,15 @@
 import React, { useEffect, useRef, useState } from "react";
-// swr
+
+import { useRouter } from "next/router";
+
 import useSWR, { mutate } from "swr";
-// headless ui
+
 import { Dialog, Transition } from "@headlessui/react";
 // services
 import stateServices from "lib/services/state.service";
 import issuesServices from "lib/services/issues.service";
 // fetch api
 import { STATE_LIST, PROJECT_ISSUES_LIST } from "constants/fetch-keys";
-// hooks
-import useUser from "lib/hooks/useUser";
 // common
 import { groupBy } from "constants/common";
 // icons
@@ -27,17 +27,17 @@ type Props = {
 
 const ConfirmStateDeletion: React.FC<Props> = ({ isOpen, onClose, data }) => {
   const [isDeleteLoading, setIsDeleteLoading] = useState(false);
-
   const [issuesWithThisStateExist, setIssuesWithThisStateExist] = useState(true);
 
-  const { activeWorkspace, activeProject } = useUser();
+  const router = useRouter();
+  const { workspaceSlug, projectId } = router.query;
 
   const { data: issues } = useSWR(
-    activeWorkspace && activeProject
-      ? PROJECT_ISSUES_LIST(activeWorkspace.slug, activeProject.id)
+    workspaceSlug && projectId
+      ? PROJECT_ISSUES_LIST(workspaceSlug as string, projectId as string)
       : null,
-    activeWorkspace && activeProject
-      ? () => issuesServices.getIssues(activeWorkspace.slug, activeProject.id)
+    workspaceSlug && projectId
+      ? () => issuesServices.getIssues(workspaceSlug as string, projectId as string)
       : null
   );
 
@@ -50,9 +50,9 @@ const ConfirmStateDeletion: React.FC<Props> = ({ isOpen, onClose, data }) => {
 
   const handleDeletion = async () => {
     setIsDeleteLoading(true);
-    if (!data || !activeWorkspace || issuesWithThisStateExist) return;
+    if (!data || !workspaceSlug || issuesWithThisStateExist) return;
     await stateServices
-      .deleteState(activeWorkspace.slug, data.project, data.id)
+      .deleteState(workspaceSlug as string, data.project, data.id)
       .then(() => {
         mutate<IState[]>(
           STATE_LIST(data.project),

--- a/apps/app/components/project/issues/BoardView/state/create-update-state-modal.tsx
+++ b/apps/app/components/project/issues/BoardView/state/create-update-state-modal.tsx
@@ -1,11 +1,13 @@
 import React, { useEffect } from "react";
-// swr
+
+import { useRouter } from "next/router";
+
 import { mutate } from "swr";
-// react hook form
+
 import { Controller, useForm } from "react-hook-form";
-// react color
+
 import { TwitterPicker } from "react-color";
-// headless
+
 import { Dialog, Popover, Transition } from "@headlessui/react";
 // services
 import stateService from "lib/services/state.service";
@@ -45,7 +47,8 @@ const CreateUpdateStateModal: React.FC<Props> = ({ isOpen, data, projectId, hand
     }, 500);
   };
 
-  const { activeWorkspace } = useUser();
+  const router = useRouter();
+  const { workspaceSlug } = router.query;
 
   const {
     register,
@@ -60,13 +63,13 @@ const CreateUpdateStateModal: React.FC<Props> = ({ isOpen, data, projectId, hand
   });
 
   const onSubmit = async (formData: IState) => {
-    if (!activeWorkspace) return;
+    if (!workspaceSlug) return;
     const payload: IState = {
       ...formData,
     };
     if (!data) {
       await stateService
-        .createState(activeWorkspace.slug, projectId, payload)
+        .createState(workspaceSlug as string, projectId, payload)
         .then((res) => {
           mutate<IState[]>(STATE_LIST(projectId), (prevData) => [...(prevData ?? []), res], false);
           onClose();
@@ -80,7 +83,7 @@ const CreateUpdateStateModal: React.FC<Props> = ({ isOpen, data, projectId, hand
         });
     } else {
       await stateService
-        .updateState(activeWorkspace.slug, projectId, data.id, payload)
+        .updateState(workspaceSlug as string, projectId, data.id, payload)
         .then((res) => {
           mutate<IState[]>(
             STATE_LIST(projectId),
@@ -185,14 +188,14 @@ const CreateUpdateStateModal: React.FC<Props> = ({ isOpen, data, projectId, hand
                             {({ open }) => (
                               <>
                                 <Popover.Button
-                                  className={`group bg-white rounded-md inline-flex items-center text-base font-medium hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 ${
+                                  className={`group inline-flex items-center rounded-md bg-white text-base font-medium hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 ${
                                     open ? "text-gray-900" : "text-gray-500"
                                   }`}
                                 >
                                   <span>Color</span>
                                   {watch("color") && watch("color") !== "" && (
                                     <span
-                                      className="w-4 h-4 ml-2 rounded"
+                                      className="ml-2 h-4 w-4 rounded"
                                       style={{
                                         backgroundColor: watch("color") ?? "green",
                                       }}
@@ -215,7 +218,7 @@ const CreateUpdateStateModal: React.FC<Props> = ({ isOpen, data, projectId, hand
                                   leaveFrom="opacity-100 translate-y-0"
                                   leaveTo="opacity-0 translate-y-1"
                                 >
-                                  <Popover.Panel className="fixed z-50 transform left-5 mt-3 px-2 w-screen max-w-xs sm:px-0">
+                                  <Popover.Panel className="fixed left-5 z-50 mt-3 w-screen max-w-xs transform px-2 sm:px-0">
                                     <Controller
                                       name="color"
                                       control={control}

--- a/apps/app/components/project/issues/confirm-issue-deletion.tsx
+++ b/apps/app/components/project/issues/confirm-issue-deletion.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useRef, useState } from "react";
-// swr
+
+import { useRouter } from "next/router";
+
 import { mutate } from "swr";
 // headless ui
 import { Dialog, Transition } from "@headlessui/react";
@@ -26,7 +28,8 @@ type Props = {
 const ConfirmIssueDeletion: React.FC<Props> = ({ isOpen, handleClose, data }) => {
   const [isDeleteLoading, setIsDeleteLoading] = useState(false);
 
-  const { activeWorkspace, activeProject } = useUser();
+  const router = useRouter();
+  const { workspaceSlug } = router.query;
 
   const { setToastAlert } = useToast();
 
@@ -39,13 +42,13 @@ const ConfirmIssueDeletion: React.FC<Props> = ({ isOpen, handleClose, data }) =>
 
   const handleDeletion = async () => {
     setIsDeleteLoading(true);
-    if (!data || !activeWorkspace) return;
+    if (!data || !workspaceSlug) return;
     const projectId = data.project;
     await issueServices
-      .deleteIssue(activeWorkspace.slug, projectId, data.id)
+      .deleteIssue(workspaceSlug as string, projectId, data.id)
       .then(() => {
         mutate<IssueResponse>(
-          PROJECT_ISSUES_LIST(activeWorkspace.slug, projectId),
+          PROJECT_ISSUES_LIST(workspaceSlug as string, projectId),
           (prevData) => {
             return {
               ...(prevData as IssueResponse),
@@ -103,7 +106,7 @@ const ConfirmIssueDeletion: React.FC<Props> = ({ isOpen, handleClose, data }) =>
                 <div className="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
                   <div className="sm:flex sm:items-start">
                     <div>
-                      <div className="mx-auto h-16 w-16 grid place-items-center rounded-full bg-red-100">
+                      <div className="mx-auto grid h-16 w-16 place-items-center rounded-full bg-red-100">
                         <ExclamationTriangleIcon
                           className="h-8 w-8 text-red-600"
                           aria-hidden="true"
@@ -111,10 +114,10 @@ const ConfirmIssueDeletion: React.FC<Props> = ({ isOpen, handleClose, data }) =>
                       </div>
                       <Dialog.Title
                         as="h3"
-                        className="text-lg font-medium leading-6 text-gray-900 mt-3"
+                        className="mt-3 text-lg font-medium leading-6 text-gray-900"
                       >
                         Are you sure you want to delete {`"`}
-                        {activeProject?.identifier}-{data?.sequence_id} - {data?.name}?{`"`}
+                        {data?.project_detail.identifier}-{data?.sequence_id} - {data?.name}?{`"`}
                       </Dialog.Title>
                       <div className="mt-2">
                         <p className="text-sm text-gray-500">

--- a/apps/app/components/project/issues/create-update-issue-modal/select-assignee.tsx
+++ b/apps/app/components/project/issues/create-update-issue-modal/select-assignee.tsx
@@ -1,12 +1,12 @@
 import React from "react";
-// swr
+
+import { useRouter } from "next/router";
+
 import useSWR from "swr";
-// react hook form
+
 import { Controller } from "react-hook-form";
 // service
 import projectServices from "lib/services/project.service";
-// hooks
-import useUser from "lib/hooks/useUser";
 // fetch keys
 import { PROJECT_MEMBERS } from "constants/fetch-keys";
 // types
@@ -21,12 +21,13 @@ type Props = {
 };
 
 const SelectAssignee: React.FC<Props> = ({ control }) => {
-  const { activeWorkspace, activeProject } = useUser();
+  const router = useRouter();
+  const { workspaceSlug, projectId } = router.query;
 
   const { data: people } = useSWR(
-    activeWorkspace && activeProject ? PROJECT_MEMBERS(activeProject.id) : null,
-    activeWorkspace && activeProject
-      ? () => projectServices.projectMembers(activeWorkspace.slug, activeProject.id)
+    workspaceSlug && projectId ? PROJECT_MEMBERS(projectId as string) : null,
+    workspaceSlug && projectId
+      ? () => projectServices.projectMembers(workspaceSlug as string, projectId as string)
       : null
   );
 

--- a/apps/app/components/project/issues/create-update-issue-modal/select-cycle.tsx
+++ b/apps/app/components/project/issues/create-update-issue-modal/select-cycle.tsx
@@ -3,8 +3,6 @@ import React from "react";
 import useSWR from "swr";
 // react hook form
 import { Controller } from "react-hook-form";
-// hooks
-import useUser from "lib/hooks/useUser";
 // services
 import cycleServices from "lib/services/cycles.service";
 // constants

--- a/apps/app/components/project/issues/create-update-issue-modal/select-labels.tsx
+++ b/apps/app/components/project/issues/create-update-issue-modal/select-labels.tsx
@@ -1,13 +1,13 @@
 import React, { useEffect, useState } from "react";
-// swr
+
+import { useRouter } from "next/router";
+
 import useSWR from "swr";
-// react hook form
+
 import { useForm, Controller } from "react-hook-form";
 import type { Control } from "react-hook-form";
 // services
 import issuesServices from "lib/services/issues.service";
-// hooks
-import useUser from "lib/hooks/useUser";
 // fetching keys
 import { PROJECT_ISSUE_LABELS } from "constants/fetch-keys";
 // icons
@@ -28,21 +28,22 @@ const defaultValues: Partial<IIssueLabels> = {
 };
 
 const SelectLabels: React.FC<Props> = ({ control }) => {
-  const { activeWorkspace, activeProject } = useUser();
+  const router = useRouter();
+  const { workspaceSlug, projectId } = router.query;
 
   const [isOpen, setIsOpen] = useState(false);
 
   const { data: issueLabels, mutate: issueLabelsMutate } = useSWR<IIssueLabels[]>(
-    activeProject && activeWorkspace ? PROJECT_ISSUE_LABELS(activeProject.id) : null,
-    activeProject && activeWorkspace
-      ? () => issuesServices.getIssueLabels(activeWorkspace.slug, activeProject.id)
+    workspaceSlug && projectId ? PROJECT_ISSUE_LABELS(workspaceSlug as string) : null,
+    workspaceSlug && projectId
+      ? () => issuesServices.getIssueLabels(workspaceSlug as string, projectId as string)
       : null
   );
 
   const onSubmit = async (data: IIssueLabels) => {
-    if (!activeProject || !activeWorkspace || isSubmitting) return;
+    if (!projectId || !workspaceSlug || isSubmitting) return;
     await issuesServices
-      .createIssueLabel(activeWorkspace.slug, activeProject.id, data)
+      .createIssueLabel(workspaceSlug as string, projectId as string, data)
       .then((response) => {
         issueLabelsMutate((prevData) => [...(prevData ?? []), response], false);
         setIsOpen(false);

--- a/apps/app/components/project/issues/issue-detail/activity/index.tsx
+++ b/apps/app/components/project/issues/issue-detail/activity/index.tsx
@@ -1,13 +1,14 @@
 import React from "react";
-// next
-import { useRouter } from "next/router";
+
 import Image from "next/image";
+import { useRouter } from "next/router";
+
+import useSWR from "swr";
+
 // fetch-keys
 import { PROJECT_ISSUES_ACTIVITY, STATE_LIST, PROJECT_ISSUES_LIST } from "constants/fetch-keys";
 // common
 import { addSpaceIfCamelCase, timeAgo } from "constants/common";
-// swr
-import useSWR from "swr";
 // services
 import stateService from "lib/services/state.service";
 import issuesServices from "lib/services/issues.service";
@@ -38,25 +39,23 @@ const activityIcons: {
 const IssueActivitySection: React.FC = () => {
   const router = useRouter();
 
-  const { issueId, projectId } = router.query;
-
-  const { activeWorkspace, activeProject } = useUser();
+  const { workspaceSlug, projectId, issueId } = router.query;
 
   const { data: issues } = useSWR(
-    activeWorkspace && activeProject
-      ? PROJECT_ISSUES_LIST(activeWorkspace.slug, activeProject.id)
+    workspaceSlug && projectId
+      ? PROJECT_ISSUES_LIST(workspaceSlug as string, projectId as string)
       : null,
-    activeWorkspace && activeProject
-      ? () => issuesServices.getIssues(activeWorkspace.slug, activeProject.id)
+    workspaceSlug && projectId
+      ? () => issuesServices.getIssues(workspaceSlug as string, projectId as string)
       : null
   );
 
   const { data: issueActivities } = useSWR<any[]>(
-    activeWorkspace && projectId && issueId ? PROJECT_ISSUES_ACTIVITY : null,
-    activeWorkspace && projectId && issueId
+    workspaceSlug && projectId && issueId ? PROJECT_ISSUES_ACTIVITY : null,
+    workspaceSlug && projectId && issueId
       ? () =>
           issuesServices.getIssueActivities(
-            activeWorkspace.slug,
+            workspaceSlug as string,
             projectId as string,
             issueId as string
           )
@@ -64,9 +63,9 @@ const IssueActivitySection: React.FC = () => {
   );
 
   const { data: states } = useSWR(
-    activeWorkspace && activeProject ? STATE_LIST(activeProject.id) : null,
-    activeWorkspace && activeProject
-      ? () => stateService.getStates(activeWorkspace.slug, activeProject.id)
+    workspaceSlug && projectId ? STATE_LIST(projectId as string) : null,
+    workspaceSlug && projectId
+      ? () => stateService.getStates(workspaceSlug as string, projectId as string)
       : null
   );
 

--- a/apps/app/components/project/issues/issue-detail/add-as-sub-issue.tsx
+++ b/apps/app/components/project/issues/issue-detail/add-as-sub-issue.tsx
@@ -1,8 +1,9 @@
-// react
 import React, { useState } from "react";
-// swr
+
+import { useRouter } from "next/router";
+
 import useSWR, { mutate } from "swr";
-// headless ui
+
 import { Combobox, Dialog, Transition } from "@headlessui/react";
 // services
 import issuesServices from "lib/services/issues.service";
@@ -26,14 +27,15 @@ type Props = {
 const AddAsSubIssue: React.FC<Props> = ({ isOpen, setIsOpen, parent }) => {
   const [query, setQuery] = useState("");
 
-  const { activeWorkspace, activeProject } = useUser();
+  const router = useRouter();
+  const { workspaceSlug, projectId } = router.query;
 
   const { data: issues } = useSWR(
-    activeWorkspace && activeProject
-      ? PROJECT_ISSUES_LIST(activeWorkspace.slug, activeProject.id)
+    workspaceSlug && projectId
+      ? PROJECT_ISSUES_LIST(workspaceSlug as string, projectId as string)
       : null,
-    activeWorkspace && activeProject
-      ? () => issuesServices.getIssues(activeWorkspace.slug, activeProject.id)
+    workspaceSlug && projectId
+      ? () => issuesServices.getIssues(workspaceSlug as string, projectId as string)
       : null
   );
 
@@ -49,12 +51,12 @@ const AddAsSubIssue: React.FC<Props> = ({ isOpen, setIsOpen, parent }) => {
   };
 
   const addAsSubIssue = (issueId: string) => {
-    if (activeWorkspace && activeProject) {
+    if (workspaceSlug && projectId) {
       issuesServices
-        .patchIssue(activeWorkspace.slug, activeProject.id, issueId, { parent: parent?.id })
+        .patchIssue(workspaceSlug as string, projectId as string, issueId, { parent: parent?.id })
         .then((res) => {
           mutate<IssueResponse>(
-            PROJECT_ISSUES_LIST(activeWorkspace.slug, activeProject.id),
+            PROJECT_ISSUES_LIST(workspaceSlug as string, projectId as string),
             (prevData) => ({
               ...(prevData as IssueResponse),
               results: (prevData?.results ?? []).map((p) =>

--- a/apps/app/components/project/issues/issue-detail/comment/issue-comment-section.tsx
+++ b/apps/app/components/project/issues/issue-detail/comment/issue-comment-section.tsx
@@ -34,16 +34,14 @@ const IssueCommentSection: React.FC = () => {
 
   const router = useRouter();
 
-  let { issueId, projectId } = router.query;
-
-  const { activeWorkspace } = useUser();
+  let { workspaceSlug, projectId, issueId } = router.query;
 
   const { data: comments, mutate } = useSWR<IIssueComment[]>(
-    activeWorkspace && projectId && issueId ? PROJECT_ISSUES_COMMENTS(issueId as string) : null,
-    activeWorkspace && projectId && issueId
+    workspaceSlug && projectId && issueId ? PROJECT_ISSUES_COMMENTS(issueId as string) : null,
+    workspaceSlug && projectId && issueId
       ? () =>
           issuesServices.getIssueComments(
-            activeWorkspace.slug,
+            workspaceSlug as string,
             projectId as string,
             issueId as string
           )
@@ -51,9 +49,9 @@ const IssueCommentSection: React.FC = () => {
   );
 
   const onSubmit = async (formData: IIssueComment) => {
-    if (!activeWorkspace || !projectId || !issueId || isSubmitting) return;
+    if (!workspaceSlug || !projectId || !issueId || isSubmitting) return;
     await issuesServices
-      .createIssueComment(activeWorkspace.slug, projectId as string, issueId as string, formData)
+      .createIssueComment(workspaceSlug as string, projectId as string, issueId as string, formData)
       .then((response) => {
         console.log(response);
         mutate((prevData) => [response, ...(prevData ?? [])]);
@@ -65,10 +63,10 @@ const IssueCommentSection: React.FC = () => {
   };
 
   const onCommentUpdate = async (comment: IIssueComment) => {
-    if (!activeWorkspace || !projectId || !issueId || isSubmitting) return;
+    if (!workspaceSlug || !projectId || !issueId || isSubmitting) return;
     await issuesServices
       .patchIssueComment(
-        activeWorkspace.slug,
+        workspaceSlug as string,
         projectId as string,
         issueId as string,
         comment.id,
@@ -88,9 +86,14 @@ const IssueCommentSection: React.FC = () => {
   };
 
   const onCommentDelete = async (commentId: string) => {
-    if (!activeWorkspace || !projectId || !issueId || isSubmitting) return;
+    if (!workspaceSlug || !projectId || !issueId || isSubmitting) return;
     await issuesServices
-      .deleteIssueComment(activeWorkspace.slug, projectId as string, issueId as string, commentId)
+      .deleteIssueComment(
+        workspaceSlug as string,
+        projectId as string,
+        issueId as string,
+        commentId
+      )
       .then((response) => {
         mutate((prevData) => (prevData ?? []).filter((c) => c.id !== commentId));
         console.log(response);

--- a/apps/app/components/project/issues/issue-detail/issue-detail-sidebar/index.tsx
+++ b/apps/app/components/project/issues/issue-detail/issue-detail-sidebar/index.tsx
@@ -10,7 +10,6 @@ import { TwitterPicker } from "react-color";
 // services
 import issuesServices from "lib/services/issues.service";
 // hooks
-import useUser from "lib/hooks/useUser";
 import useToast from "lib/hooks/useToast";
 // components
 import ConfirmIssueDeletion from "components/project/issues/confirm-issue-deletion";
@@ -39,7 +38,7 @@ import {
 import type { Control } from "react-hook-form";
 import type { ICycle, IIssue, IIssueLabels } from "types";
 // fetch-keys
-import { PROJECT_ISSUE_LABELS, PROJECT_ISSUES_LIST } from "constants/fetch-keys";
+import { PROJECT_ISSUE_LABELS, PROJECT_ISSUES_LIST, PROJECT_DETAILS } from "constants/fetch-keys";
 // common
 import { copyTextToClipboard } from "constants/common";
 
@@ -62,34 +61,28 @@ const IssueDetailSidebar: React.FC<Props> = ({
   watch: watchIssue,
 }) => {
   const [createLabelForm, setCreateLabelForm] = useState(false);
-
-  const { activeWorkspace, activeProject } = useUser();
+  const [deleteIssueModal, setDeleteIssueModal] = useState(false);
 
   const router = useRouter();
-
-  const {
-    query: { workspaceSlug },
-  } = router;
+  const { workspaceSlug, projectId } = router.query;
 
   const { setToastAlert } = useToast();
 
   const { data: issues } = useSWR(
-    activeWorkspace && activeProject
-      ? PROJECT_ISSUES_LIST(activeWorkspace.slug, activeProject.id)
+    workspaceSlug && projectId
+      ? PROJECT_ISSUES_LIST(workspaceSlug as string, projectId as string)
       : null,
-    activeWorkspace && activeProject
-      ? () => issuesServices.getIssues(activeWorkspace.slug, activeProject.id)
+    workspaceSlug && projectId
+      ? () => issuesServices.getIssues(workspaceSlug as string, projectId as string)
       : null
   );
 
   const { data: issueLabels, mutate: issueLabelMutate } = useSWR<IIssueLabels[]>(
-    activeProject && activeWorkspace ? PROJECT_ISSUE_LABELS(activeProject.id) : null,
-    activeProject && activeWorkspace
-      ? () => issuesServices.getIssueLabels(activeWorkspace.slug, activeProject.id)
+    workspaceSlug && projectId ? PROJECT_ISSUE_LABELS(projectId as string) : null,
+    workspaceSlug && projectId
+      ? () => issuesServices.getIssueLabels(workspaceSlug as string, projectId as string)
       : null
   );
-
-  const [deleteIssueModal, setDeleteIssueModal] = useState(false);
 
   const {
     register,
@@ -103,9 +96,9 @@ const IssueDetailSidebar: React.FC<Props> = ({
   });
 
   const handleNewLabel = (formData: any) => {
-    if (!activeWorkspace || !activeProject || isSubmitting) return;
+    if (!workspaceSlug || !projectId || isSubmitting) return;
     issuesServices
-      .createIssueLabel(activeWorkspace.slug, activeProject.id, formData)
+      .createIssueLabel(workspaceSlug as string, projectId as string, formData)
       .then((res) => {
         console.log(res);
         reset(defaultValues);
@@ -116,11 +109,11 @@ const IssueDetailSidebar: React.FC<Props> = ({
   };
 
   const handleCycleChange = (cycleDetail: ICycle) => {
-    if (!activeWorkspace || !activeProject || !issueDetail) return;
+    if (!workspaceSlug || !projectId || !issueDetail) return;
 
     submitChanges({ cycle: cycleDetail.id, cycle_detail: cycleDetail });
     issuesServices
-      .addIssueToCycle(activeWorkspace.slug, activeProject.id, cycleDetail.id, {
+      .addIssueToCycle(workspaceSlug as string, projectId as string, cycleDetail.id, {
         issues: [issueDetail.id],
       })
       .then(() => {
@@ -138,7 +131,7 @@ const IssueDetailSidebar: React.FC<Props> = ({
       <div className="h-full w-full divide-y-2 divide-gray-100">
         <div className="flex items-center justify-between pb-3">
           <h4 className="text-sm font-medium">
-            {activeProject?.identifier}-{issueDetail?.sequence_id}
+            {issueDetail?.project_detail?.identifier}-{issueDetail?.sequence_id}
           </h4>
           <div className="flex flex-wrap items-center gap-2">
             <button
@@ -146,7 +139,7 @@ const IssueDetailSidebar: React.FC<Props> = ({
               className="rounded-md border p-2 shadow-sm duration-300 hover:bg-gray-100 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
               onClick={() =>
                 copyTextToClipboard(
-                  `https://app.plane.so/${workspaceSlug}/projects/${activeProject?.id}/issues/${issueDetail?.id}`
+                  `https://app.plane.so/${workspaceSlug}/projects/${issueDetail?.project_detail?.id}/issues/${issueDetail?.id}`
                 )
                   .then(() => {
                     setToastAlert({

--- a/apps/app/components/project/issues/issue-detail/issue-detail-sidebar/select-assignee.tsx
+++ b/apps/app/components/project/issues/issue-detail/issue-detail-sidebar/select-assignee.tsx
@@ -1,10 +1,10 @@
-// react
 import React from "react";
-// next
+
 import Image from "next/image";
-// swr
+import { useRouter } from "next/router";
+
 import useSWR from "swr";
-// react-hook-form
+
 import { Control, Controller } from "react-hook-form";
 // services
 import workspaceService from "lib/services/workspace.service";
@@ -29,17 +29,18 @@ type Props = {
 };
 
 const SelectAssignee: React.FC<Props> = ({ control, submitChanges }) => {
-  const { activeWorkspace } = useUser();
+  const router = useRouter();
+  const { workspaceSlug } = router.query;
 
   const { data: people } = useSWR(
-    activeWorkspace ? WORKSPACE_MEMBERS(activeWorkspace.slug) : null,
-    activeWorkspace ? () => workspaceService.workspaceMembers(activeWorkspace.slug) : null
+    workspaceSlug ? WORKSPACE_MEMBERS(workspaceSlug as string) : null,
+    workspaceSlug ? () => workspaceService.workspaceMembers(workspaceSlug as string) : null
   );
 
   return (
-    <div className="flex items-center py-2 flex-wrap">
+    <div className="flex flex-wrap items-center py-2">
       <div className="flex items-center gap-x-2 text-sm sm:basis-1/2">
-        <UserGroupIcon className="flex-shrink-0 h-4 w-4" />
+        <UserGroupIcon className="h-4 w-4 flex-shrink-0" />
         <p>Assignees</p>
       </div>
       <div className="sm:basis-1/2">
@@ -58,14 +59,14 @@ const SelectAssignee: React.FC<Props> = ({ control, submitChanges }) => {
             >
               {({ open }) => (
                 <div className="relative">
-                  <Listbox.Button className="w-full flex items-center gap-1 text-xs cursor-pointer">
+                  <Listbox.Button className="flex w-full cursor-pointer items-center gap-1 text-xs">
                     <span
                       className={classNames(
                         value ? "" : "text-gray-900",
-                        "hidden truncate sm:block text-left"
+                        "hidden truncate text-left sm:block"
                       )}
                     >
-                      <div className="flex items-center gap-1 text-xs cursor-pointer">
+                      <div className="flex cursor-pointer items-center gap-1 text-xs">
                         {value && Array.isArray(value) ? (
                           <>
                             {value.length > 0 ? (
@@ -82,7 +83,7 @@ const SelectAssignee: React.FC<Props> = ({ control, submitChanges }) => {
                                     }`}
                                   >
                                     {person && person.avatar && person.avatar !== "" ? (
-                                      <div className="h-5 w-5 border-2 bg-white border-white rounded-full">
+                                      <div className="h-5 w-5 rounded-full border-2 border-white bg-white">
                                         <Image
                                           src={person.avatar}
                                           height="100%"
@@ -93,7 +94,7 @@ const SelectAssignee: React.FC<Props> = ({ control, submitChanges }) => {
                                       </div>
                                     ) : (
                                       <div
-                                        className={`h-5 w-5 bg-gray-700 text-white border-2 border-white grid place-items-center rounded-full`}
+                                        className={`grid h-5 w-5 place-items-center rounded-full border-2 border-white bg-gray-700 text-white`}
                                       >
                                         {person?.first_name.charAt(0)}
                                       </div>
@@ -102,7 +103,7 @@ const SelectAssignee: React.FC<Props> = ({ control, submitChanges }) => {
                                 );
                               })
                             ) : (
-                              <div className="h-5 w-5 border-2 bg-white border-white rounded-full">
+                              <div className="h-5 w-5 rounded-full border-2 border-white bg-white">
                                 <Image
                                   src={User}
                                   height="100%"
@@ -128,7 +129,7 @@ const SelectAssignee: React.FC<Props> = ({ control, submitChanges }) => {
                     leaveFrom="transform opacity-100 scale-100"
                     leaveTo="transform opacity-0 scale-95"
                   >
-                    <Listbox.Options className="absolute z-10 left-0 mt-1 w-auto bg-white shadow-lg max-h-48 rounded-md py-1 text-xs ring-1 ring-black ring-opacity-5 overflow-auto focus:outline-none">
+                    <Listbox.Options className="absolute left-0 z-10 mt-1 max-h-48 w-auto overflow-auto rounded-md bg-white py-1 text-xs shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none">
                       <div className="py-1">
                         {people ? (
                           people.length > 0 ? (
@@ -138,7 +139,7 @@ const SelectAssignee: React.FC<Props> = ({ control, submitChanges }) => {
                                 className={({ active, selected }) =>
                                   `${
                                     active || selected ? "bg-indigo-50" : ""
-                                  } flex items-center gap-2 text-gray-900 cursor-pointer select-none p-2 truncate`
+                                  } flex cursor-pointer select-none items-center gap-2 truncate p-2 text-gray-900`
                                 }
                                 value={option.member.id}
                               >
@@ -153,7 +154,7 @@ const SelectAssignee: React.FC<Props> = ({ control, submitChanges }) => {
                                     />
                                   </div>
                                 ) : (
-                                  <div className="flex-shrink-0 h-4 w-4 bg-gray-700 text-white grid place-items-center capitalize rounded-full">
+                                  <div className="grid h-4 w-4 flex-shrink-0 place-items-center rounded-full bg-gray-700 capitalize text-white">
                                     {option.member.first_name && option.member.first_name !== ""
                                       ? option.member.first_name.charAt(0)
                                       : option.member.email.charAt(0)}

--- a/apps/app/components/project/issues/issue-detail/issue-detail-sidebar/select-blocked.tsx
+++ b/apps/app/components/project/issues/issue-detail/issue-detail-sidebar/select-blocked.tsx
@@ -1,18 +1,16 @@
-// react
 import React, { useState } from "react";
-// next
+
 import Link from "next/link";
 import { useRouter } from "next/router";
-// swr
+
 import useSWR from "swr";
-// react-hook-form
+
 import { SubmitHandler, useForm, UseFormWatch } from "react-hook-form";
 // services
 import issuesService from "lib/services/issues.service";
 // constants
 import { PROJECT_ISSUES_LIST } from "constants/fetch-keys";
 // hooks
-import useUser from "lib/hooks/useUser";
 import useToast from "lib/hooks/useToast";
 // headless ui
 import { Combobox, Dialog, Transition } from "@headlessui/react";
@@ -37,28 +35,27 @@ type Props = {
   watch: UseFormWatch<IIssue>;
 };
 
-const SelectBlocked: React.FC<Props> = ({ submitChanges, issueDetail, issuesList, watch }) => {
+const SelectBlocked: React.FC<Props> = ({ submitChanges, issuesList, watch }) => {
   const [query, setQuery] = useState("");
   const [isBlockedModalOpen, setIsBlockedModalOpen] = useState(false);
 
   const router = useRouter();
   const {
-    query: { workspaceSlug },
+    query: { workspaceSlug, projectId },
   } = router;
 
-  const { activeWorkspace, activeProject } = useUser();
   const { setToastAlert } = useToast();
 
-  const { data: issues, mutate: mutateIssues } = useSWR(
-    activeWorkspace && activeProject
-      ? PROJECT_ISSUES_LIST(activeWorkspace.slug, activeProject.id)
+  const { data: issues } = useSWR(
+    workspaceSlug && projectId
+      ? PROJECT_ISSUES_LIST(workspaceSlug as string, projectId as string)
       : null,
-    activeWorkspace && activeProject
-      ? () => issuesService.getIssues(activeWorkspace.slug, activeProject.id)
+    workspaceSlug && projectId
+      ? () => issuesService.getIssues(workspaceSlug as string, projectId as string)
       : null
   );
 
-  const { register, handleSubmit, reset, watch: watchIssues } = useForm<FormInput>();
+  const { register, handleSubmit, reset } = useForm<FormInput>();
 
   const handleClose = () => {
     setIsBlockedModalOpen(false);
@@ -105,15 +102,15 @@ const SelectBlocked: React.FC<Props> = ({ submitChanges, issueDetail, issuesList
                   }}
                 >
                   <Link
-                    href={`/${workspaceSlug}/projects/${activeProject?.id}/issues/${
+                    href={`/${workspaceSlug}/projects/${projectId}/issues/${
                       issues?.results.find((i) => i.id === issue)?.id
                     }`}
                   >
                     <a className="flex items-center gap-1">
                       <BlockedIcon height={10} width={10} />
-                      {`${activeProject?.identifier}-${
-                        issues?.results.find((i) => i.id === issue)?.sequence_id
-                      }`}
+                      {`${
+                        issues?.results.find((i) => i.id === issue)?.project_detail?.identifier
+                      }-${issues?.results.find((i) => i.id === issue)?.sequence_id}`}
                     </a>
                   </Link>
                   <span className="opacity-0 duration-300 group-hover:opacity-100">
@@ -201,28 +198,28 @@ const SelectBlocked: React.FC<Props> = ({ submitChanges, issueDetail, issuesList
                                           )
                                         }
                                       >
-                                        {({ active }) => (
-                                          <>
-                                            <div className="flex items-center gap-2">
-                                              <input
-                                                type="checkbox"
-                                                {...register("issue_ids")}
-                                                id={`issue-${issue.id}`}
-                                                value={issue.id}
-                                              />
-                                              <span
-                                                className="block h-1.5 w-1.5 flex-shrink-0 rounded-full"
-                                                style={{
-                                                  backgroundColor: issue.state_detail.color,
-                                                }}
-                                              />
-                                              <span className="flex-shrink-0 text-xs text-gray-500">
-                                                {activeProject?.identifier}-{issue.sequence_id}
-                                              </span>
-                                              <span>{issue.name}</span>
-                                            </div>
-                                          </>
-                                        )}
+                                        <div className="flex items-center gap-2">
+                                          <input
+                                            type="checkbox"
+                                            {...register("issue_ids")}
+                                            id={`issue-${issue.id}`}
+                                            value={issue.id}
+                                          />
+                                          <span
+                                            className="block h-1.5 w-1.5 flex-shrink-0 rounded-full"
+                                            style={{
+                                              backgroundColor: issue.state_detail.color,
+                                            }}
+                                          />
+                                          <span className="flex-shrink-0 text-xs text-gray-500">
+                                            {
+                                              issues?.results.find((i) => i.id === issue.id)
+                                                ?.project_detail?.identifier
+                                            }
+                                            -{issue.sequence_id}
+                                          </span>
+                                          <span>{issue.name}</span>
+                                        </div>
                                       </Combobox.Option>
                                     );
                                   }

--- a/apps/app/components/project/issues/issue-detail/issue-detail-sidebar/select-blocker.tsx
+++ b/apps/app/components/project/issues/issue-detail/issue-detail-sidebar/select-blocker.tsx
@@ -1,18 +1,17 @@
-// react
 import React, { useState } from "react";
-// next
+
 import Link from "next/link";
 import { useRouter } from "next/router";
-// swr
+
 import useSWR from "swr";
-// react-hook-form
+
 import { SubmitHandler, useForm, UseFormWatch } from "react-hook-form";
 // constants
-import { PROJECT_ISSUES_LIST } from "constants/fetch-keys";
+import { PROJECT_ISSUES_LIST, PROJECT_DETAILS } from "constants/fetch-keys";
 // services
 import issuesServices from "lib/services/issues.service";
+import projectService from "lib/services/project.service";
 // hooks
-import useUser from "lib/hooks/useUser";
 import useToast from "lib/hooks/useToast";
 // headless ui
 import { Combobox, Dialog, Transition } from "@headlessui/react";
@@ -40,20 +39,26 @@ const SelectBlocker: React.FC<Props> = ({ submitChanges, issuesList, watch }) =>
   const [query, setQuery] = useState("");
   const [isBlockerModalOpen, setIsBlockerModalOpen] = useState(false);
 
-  const { activeProject, activeWorkspace } = useUser();
   const { setToastAlert } = useToast();
 
   const router = useRouter();
   const {
-    query: { workspaceSlug },
+    query: { projectId, workspaceSlug },
   } = router;
 
   const { data: issues } = useSWR(
-    activeWorkspace && activeProject
-      ? PROJECT_ISSUES_LIST(activeWorkspace.slug, activeProject.id)
+    workspaceSlug && projectId
+      ? PROJECT_ISSUES_LIST(workspaceSlug as string, projectId as string)
       : null,
-    activeWorkspace && activeProject
-      ? () => issuesServices.getIssues(activeWorkspace.slug, activeProject.id)
+    workspaceSlug && projectId
+      ? () => issuesServices.getIssues(workspaceSlug as string, projectId as string)
+      : null
+  );
+
+  const { data: projectDetails } = useSWR(
+    workspaceSlug && projectId ? PROJECT_DETAILS(projectId as string) : null,
+    workspaceSlug && projectId
+      ? () => projectService.getProject(workspaceSlug as string, projectId as string)
       : null
   );
 
@@ -96,13 +101,13 @@ const SelectBlocker: React.FC<Props> = ({ submitChanges, issuesList, watch }) =>
                   className="group flex cursor-pointer items-center gap-1 rounded-2xl border border-white px-1.5 py-0.5 text-xs text-yellow-500 duration-300 hover:border-yellow-500 hover:bg-yellow-50"
                 >
                   <Link
-                    href={`/${workspaceSlug}/projects/${activeProject?.id}/issues/${
+                    href={`/${workspaceSlug}/projects/${projectDetails?.id}/issues/${
                       issues?.results.find((i) => i.id === issue)?.id
                     }`}
                   >
                     <a className="flex items-center gap-1">
                       <BlockerIcon height={10} width={10} />
-                      {`${activeProject?.identifier}-${
+                      {`${projectDetails?.identifier}-${
                         issues?.results.find((i) => i.id === issue)?.sequence_id
                       }`}
                     </a>
@@ -218,7 +223,7 @@ const SelectBlocker: React.FC<Props> = ({ submitChanges, issuesList, watch }) =>
                                                 }}
                                               />
                                               <span className="flex-shrink-0 text-xs text-gray-500">
-                                                {activeProject?.identifier}-{issue.sequence_id}
+                                                {projectDetails?.identifier}-{issue.sequence_id}
                                               </span>
                                               <span>{issue.name}</span>
                                             </div>

--- a/apps/app/components/project/issues/issue-detail/issue-detail-sidebar/select-cycle.tsx
+++ b/apps/app/components/project/issues/issue-detail/issue-detail-sidebar/select-cycle.tsx
@@ -1,7 +1,9 @@
 import React from "react";
-// swr
+
+import { useRouter } from "next/router";
+
 import useSWR, { mutate } from "swr";
-// react-hook-form
+
 import { Control, Controller, UseFormWatch } from "react-hook-form";
 // hooks
 import useUser from "lib/hooks/useUser";
@@ -26,21 +28,22 @@ type Props = {
   watch: UseFormWatch<IIssue>;
 };
 
-const SelectCycle: React.FC<Props> = ({ issueDetail, control, handleCycleChange, watch }) => {
-  const { activeWorkspace, activeProject } = useUser();
+const SelectCycle: React.FC<Props> = ({ issueDetail, control, handleCycleChange }) => {
+  const router = useRouter();
+  const { workspaceSlug, projectId } = router.query;
 
   const { data: cycles } = useSWR(
-    activeWorkspace && activeProject ? CYCLE_LIST(activeProject.id) : null,
-    activeWorkspace && activeProject
-      ? () => cyclesService.getCycles(activeWorkspace.slug, activeProject.id)
+    workspaceSlug && projectId ? CYCLE_LIST(projectId as string) : null,
+    workspaceSlug && projectId
+      ? () => cyclesService.getCycles(workspaceSlug as string, projectId as string)
       : null
   );
 
   const removeIssueFromCycle = (bridgeId: string, cycleId: string) => {
-    if (!activeWorkspace || !activeProject) return;
+    if (!workspaceSlug || !projectId) return;
 
     issuesService
-      .removeIssueFromCycle(activeWorkspace.slug, activeProject.id, cycleId, bridgeId)
+      .removeIssueFromCycle(workspaceSlug as string, projectId as string, cycleId, bridgeId)
       .then((res) => {
         console.log(res);
         mutate<CycleIssueResponse[]>(
@@ -50,8 +53,8 @@ const SelectCycle: React.FC<Props> = ({ issueDetail, control, handleCycleChange,
         );
 
         mutate(
-          activeWorkspace && activeProject
-            ? PROJECT_ISSUES_LIST(activeWorkspace.slug, activeProject.id)
+          workspaceSlug && projectId
+            ? PROJECT_ISSUES_LIST(workspaceSlug as string, projectId as string)
             : null
         );
       })

--- a/apps/app/components/project/issues/issue-detail/issue-detail-sidebar/select-module.tsx
+++ b/apps/app/components/project/issues/issue-detail/issue-detail-sidebar/select-module.tsx
@@ -1,10 +1,10 @@
 import React from "react";
-// swr
+
+import { useRouter } from "next/router";
+
 import useSWR from "swr";
-// react-hook-form
+
 import { Control, Controller } from "react-hook-form";
-// hooks
-import useUser from "lib/hooks/useUser";
 // constants
 import { MODULE_LIST } from "constants/fetch-keys";
 // services
@@ -24,12 +24,13 @@ type Props = {
 };
 
 const SelectModule: React.FC<Props> = ({ control, handleModuleChange }) => {
-  const { activeWorkspace, activeProject } = useUser();
+  const router = useRouter();
+  const { workspaceSlug, projectId } = router.query;
 
   const { data: modules } = useSWR(
-    activeWorkspace && activeProject ? MODULE_LIST(activeProject.id) : null,
-    activeWorkspace && activeProject
-      ? () => modulesService.getModules(activeWorkspace.slug, activeProject.id)
+    workspaceSlug && projectId ? MODULE_LIST(projectId as string) : null,
+    workspaceSlug && projectId
+      ? () => modulesService.getModules(workspaceSlug as string, projectId as string)
       : null
   );
 

--- a/apps/app/components/project/issues/issue-detail/issue-detail-sidebar/select-parent.tsx
+++ b/apps/app/components/project/issues/issue-detail/issue-detail-sidebar/select-parent.tsx
@@ -1,15 +1,14 @@
-// react
 import React, { useState } from "react";
-// swr
+
+import { useRouter } from "next/router";
+
 import useSWR from "swr";
-// react-hook-form
+
 import { Control, Controller, UseFormWatch } from "react-hook-form";
 // fetch keys
 import { PROJECT_ISSUES_LIST } from "constants/fetch-keys";
 // services
 import issuesServices from "lib/services/issues.service";
-// hooks
-import useUser from "lib/hooks/useUser";
 // components
 import IssuesListModal from "components/project/issues/issues-list-modal";
 // icons
@@ -34,14 +33,15 @@ const SelectParent: React.FC<Props> = ({
 }) => {
   const [isParentModalOpen, setIsParentModalOpen] = useState(false);
 
-  const { activeProject, activeWorkspace } = useUser();
+  const router = useRouter();
+  const { workspaceSlug, projectId } = router.query;
 
   const { data: issues } = useSWR(
-    activeWorkspace && activeProject
-      ? PROJECT_ISSUES_LIST(activeWorkspace.slug, activeProject.id)
+    workspaceSlug && projectId
+      ? PROJECT_ISSUES_LIST(workspaceSlug as string, projectId as string)
       : null,
-    activeWorkspace && activeProject
-      ? () => issuesServices.getIssues(activeWorkspace.slug, activeProject.id)
+    workspaceSlug && projectId
+      ? () => issuesServices.getIssues(workspaceSlug as string, projectId as string)
       : null
   );
 
@@ -76,9 +76,9 @@ const SelectParent: React.FC<Props> = ({
           onClick={() => setIsParentModalOpen(true)}
         >
           {watch("parent") && watch("parent") !== ""
-            ? `${activeProject?.identifier}-${
-                issues?.results.find((i) => i.id === watch("parent"))?.sequence_id
-              }`
+            ? `${
+                issues?.results.find((i) => i.id === watch("parent"))?.project_detail?.identifier
+              }-${issues?.results.find((i) => i.id === watch("parent"))?.sequence_id}`
             : "Select issue"}
         </button>
       </div>

--- a/apps/app/components/project/issues/issue-detail/issue-detail-sidebar/select-state.tsx
+++ b/apps/app/components/project/issues/issue-detail/issue-detail-sidebar/select-state.tsx
@@ -1,14 +1,14 @@
 import React from "react";
-// swr
+
+import { useRouter } from "next/router";
+
 import useSWR from "swr";
-// react-hook-form
+
 import { Control, Controller } from "react-hook-form";
 // services
 import stateService from "lib/services/state.service";
 // icons
 import { Squares2X2Icon } from "@heroicons/react/24/outline";
-// hooks
-import useUser from "lib/hooks/useUser";
 // constants
 import { classNames } from "constants/common";
 import { STATE_LIST } from "constants/fetch-keys";
@@ -23,12 +23,13 @@ type Props = {
 };
 
 const SelectState: React.FC<Props> = ({ control, submitChanges }) => {
-  const { activeWorkspace, activeProject } = useUser();
+  const router = useRouter();
+  const { workspaceSlug, projectId } = router.query;
 
   const { data: states } = useSWR(
-    activeWorkspace && activeProject ? STATE_LIST(activeProject.id) : null,
-    activeWorkspace && activeProject
-      ? () => stateService.getStates(activeWorkspace.slug, activeProject.id)
+    workspaceSlug && projectId ? STATE_LIST(projectId as string) : null,
+    workspaceSlug && projectId
+      ? () => stateService.getStates(workspaceSlug as string, projectId as string)
       : null
   );
 

--- a/apps/app/components/project/issues/issues-list-modal.tsx
+++ b/apps/app/components/project/issues/issues-list-modal.tsx
@@ -1,15 +1,14 @@
-// react
 import React, { useState } from "react";
-// headless ui
+
 import { Combobox, Dialog, Transition } from "@headlessui/react";
 // ui
 import { Button } from "ui";
 // icons
 import { MagnifyingGlassIcon, RectangleStackIcon } from "@heroicons/react/24/outline";
+// constants
+import { classNames } from "constants/common";
 // types
 import { IIssue } from "types";
-import { classNames } from "constants/common";
-import useUser from "lib/hooks/useUser";
 
 type Props = {
   isOpen: boolean;
@@ -34,8 +33,6 @@ const IssuesListModal: React.FC<Props> = ({
 }) => {
   const [query, setQuery] = useState("");
   const [values, setValues] = useState<string[]>([]);
-
-  const { activeProject } = useUser();
 
   const handleClose = () => {
     onClose();
@@ -77,21 +74,14 @@ const IssuesListModal: React.FC<Props> = ({
               <Dialog.Panel className="relative mx-auto max-w-2xl transform divide-y divide-gray-500 divide-opacity-10 rounded-xl bg-white bg-opacity-80 shadow-2xl ring-1 ring-black ring-opacity-5 backdrop-blur backdrop-filter transition-all">
                 {multiple ? (
                   <>
-                    <Combobox
-                      value={value}
-                      onChange={(val) => {
-                        // setValues(val);
-                        console.log(val);
-                      }}
-                      multiple
-                    >
+                    <Combobox value={value} onChange={(val) => {}} multiple>
                       <div className="relative m-1">
                         <MagnifyingGlassIcon
                           className="pointer-events-none absolute top-3.5 left-4 h-5 w-5 text-gray-900 text-opacity-40"
                           aria-hidden="true"
                         />
                         <Combobox.Input
-                          className="h-12 w-full border-0 bg-transparent pl-11 pr-4 text-gray-900 placeholder-gray-500 focus:ring-0 sm:text-sm outline-none"
+                          className="h-12 w-full border-0 bg-transparent pl-11 pr-4 text-gray-900 placeholder-gray-500 outline-none focus:ring-0 sm:text-sm"
                           placeholder="Search..."
                           onChange={(e) => setQuery(e.target.value)}
                           displayValue={() => ""}
@@ -116,7 +106,7 @@ const IssuesListModal: React.FC<Props> = ({
                                   value={issue.id}
                                   className={({ active }) =>
                                     classNames(
-                                      "flex items-center gap-2 cursor-pointer select-none rounded-md px-3 py-2",
+                                      "flex cursor-pointer select-none items-center gap-2 rounded-md px-3 py-2",
                                       active ? "bg-gray-900 bg-opacity-5 text-gray-900" : ""
                                     )
                                   }
@@ -125,13 +115,13 @@ const IssuesListModal: React.FC<Props> = ({
                                     <>
                                       <input type="checkbox" checked={selected} readOnly />
                                       <span
-                                        className="flex-shrink-0 h-1.5 w-1.5 block rounded-full"
+                                        className="block h-1.5 w-1.5 flex-shrink-0 rounded-full"
                                         style={{
                                           backgroundColor: issue.state_detail.color,
                                         }}
                                       />
                                       <span className="flex-shrink-0 text-xs text-gray-500">
-                                        {activeProject?.identifier}-{issue.sequence_id}
+                                        {issue.project_detail?.identifier}-{issue.sequence_id}
                                       </span>{" "}
                                       {issue.id}
                                     </>
@@ -155,7 +145,7 @@ const IssuesListModal: React.FC<Props> = ({
                         </div>
                       )}
                     </Combobox>
-                    <div className="flex justify-end items-center gap-2 p-3">
+                    <div className="flex items-center justify-end gap-2 p-3">
                       <Button type="button" theme="danger" size="sm" onClick={handleClose}>
                         Cancel
                       </Button>
@@ -172,7 +162,7 @@ const IssuesListModal: React.FC<Props> = ({
                         aria-hidden="true"
                       />
                       <Combobox.Input
-                        className="h-12 w-full border-0 bg-transparent pl-11 pr-4 text-gray-900 placeholder-gray-500 focus:ring-0 sm:text-sm outline-none"
+                        className="h-12 w-full border-0 bg-transparent pl-11 pr-4 text-gray-900 placeholder-gray-500 outline-none focus:ring-0 sm:text-sm"
                         placeholder="Search..."
                         onChange={(e) => setQuery(e.target.value)}
                         displayValue={() => ""}
@@ -197,26 +187,24 @@ const IssuesListModal: React.FC<Props> = ({
                                 value={issue.id}
                                 className={({ active }) =>
                                   classNames(
-                                    "flex items-center gap-2 cursor-pointer select-none rounded-md px-3 py-2",
+                                    "flex cursor-pointer select-none items-center gap-2 rounded-md px-3 py-2",
                                     active ? "bg-gray-900 bg-opacity-5 text-gray-900" : ""
                                   )
                                 }
                                 onClick={() => handleClose()}
                               >
-                                {({ selected }) => (
-                                  <>
-                                    <span
-                                      className="flex-shrink-0 h-1.5 w-1.5 block rounded-full"
-                                      style={{
-                                        backgroundColor: issue.state_detail.color,
-                                      }}
-                                    />
-                                    <span className="flex-shrink-0 text-xs text-gray-500">
-                                      {activeProject?.identifier}-{issue.sequence_id}
-                                    </span>{" "}
-                                    {issue.name}
-                                  </>
-                                )}
+                                <>
+                                  <span
+                                    className="block h-1.5 w-1.5 flex-shrink-0 rounded-full"
+                                    style={{
+                                      backgroundColor: issue.state_detail.color,
+                                    }}
+                                  />
+                                  <span className="flex-shrink-0 text-xs text-gray-500">
+                                    {issue.project_detail?.identifier}-{issue.sequence_id}
+                                  </span>{" "}
+                                  {issue.name}
+                                </>
                               </Combobox.Option>
                             ))}
                           </ul>

--- a/apps/app/components/project/issues/my-issues/ChangeStateDropdown.tsx
+++ b/apps/app/components/project/issues/my-issues/ChangeStateDropdown.tsx
@@ -1,6 +1,7 @@
-// react
 import React from "react";
-// swr
+
+import { useRouter } from "next/router";
+
 import useSWR from "swr";
 // hooks
 import useUser from "lib/hooks/useUser";
@@ -25,11 +26,12 @@ type Props = {
 };
 
 const ChangeStateDropdown: React.FC<Props> = ({ issue, updateIssues }) => {
-  const { activeWorkspace } = useUser();
+  const router = useRouter();
+  const { workspaceSlug } = router.query;
 
   const { data: states } = useSWR<IState[]>(
-    activeWorkspace ? STATE_LIST(issue.project) : null,
-    activeWorkspace ? () => stateServices.getStates(activeWorkspace.slug, issue.project) : null
+    workspaceSlug ? STATE_LIST(issue.project) : null,
+    workspaceSlug ? () => stateServices.getStates(workspaceSlug as string, issue.project) : null
   );
 
   return (
@@ -38,8 +40,8 @@ const ChangeStateDropdown: React.FC<Props> = ({ issue, updateIssues }) => {
         as="div"
         value={issue.state}
         onChange={(data: string) => {
-          if (!activeWorkspace) return;
-          updateIssues(activeWorkspace.slug, issue.project, issue.id, {
+          if (!workspaceSlug) return;
+          updateIssues(workspaceSlug as string, issue.project, issue.id, {
             state: data,
             state_detail: states?.find((state) => state.id === data),
           });
@@ -50,7 +52,7 @@ const ChangeStateDropdown: React.FC<Props> = ({ issue, updateIssues }) => {
           <>
             <div>
               <Listbox.Button
-                className="inline-flex items-center whitespace-nowrap rounded-full bg-gray-50 px-2 py-1 text-xs font-medium text-gray-500 hover:bg-gray-100 border"
+                className="inline-flex items-center whitespace-nowrap rounded-full border bg-gray-50 px-2 py-1 text-xs font-medium text-gray-500 hover:bg-gray-100"
                 style={{
                   border: `2px solid ${issue.state_detail.color}`,
                   backgroundColor: `${issue.state_detail.color}20`,
@@ -59,7 +61,7 @@ const ChangeStateDropdown: React.FC<Props> = ({ issue, updateIssues }) => {
                 <span
                   className={classNames(
                     issue.state ? "" : "text-gray-900",
-                    "hidden capitalize sm:block w-16"
+                    "hidden w-16 capitalize sm:block"
                   )}
                 >
                   {addSpaceIfCamelCase(issue.state_detail.name)}
@@ -73,7 +75,7 @@ const ChangeStateDropdown: React.FC<Props> = ({ issue, updateIssues }) => {
                 leaveFrom="opacity-100"
                 leaveTo="opacity-0"
               >
-                <Listbox.Options className="fixed z-10 mt-1 bg-white shadow-lg max-h-28 rounded-md py-1 text-xs ring-1 ring-black ring-opacity-5 overflow-auto focus:outline-none">
+                <Listbox.Options className="fixed z-10 mt-1 max-h-28 overflow-auto rounded-md bg-white py-1 text-xs shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none">
                   {states?.map((state) => (
                     <Listbox.Option
                       key={state.id}

--- a/apps/app/components/project/modules/confirm-module-deleteion.tsx
+++ b/apps/app/components/project/modules/confirm-module-deleteion.tsx
@@ -6,8 +6,6 @@ import { useRouter } from "next/router";
 import { mutate } from "swr";
 // services
 import modulesService from "lib/services/modules.service";
-// hooks
-import useUser from "lib/hooks/useUser";
 // headless ui
 import { Dialog, Transition } from "@headlessui/react";
 // ui
@@ -28,8 +26,6 @@ type Props = {
 const ConfirmModuleDeletion: React.FC<Props> = ({ isOpen, setIsOpen, data }) => {
   const [isDeleteLoading, setIsDeleteLoading] = useState(false);
 
-  const { activeWorkspace } = useUser();
-
   const router = useRouter();
   const {
     query: { workspaceSlug },
@@ -45,9 +41,9 @@ const ConfirmModuleDeletion: React.FC<Props> = ({ isOpen, setIsOpen, data }) => 
   const handleDeletion = async () => {
     setIsDeleteLoading(true);
 
-    if (!activeWorkspace || !data) return;
+    if (!workspaceSlug || !data) return;
     await modulesService
-      .deleteModule(activeWorkspace.slug, data.project, data.id)
+      .deleteModule(workspaceSlug as string, data.project, data.id)
       .then(() => {
         mutate(MODULE_LIST(data.project));
         router.push(`/${workspaceSlug}/projects/${data.project}/modules`);

--- a/apps/app/components/project/modules/create-update-module-modal/select-lead.tsx
+++ b/apps/app/components/project/modules/create-update-module-modal/select-lead.tsx
@@ -1,14 +1,13 @@
-// react
 import React from "react";
-// swr
+
+import { useRouter } from "next/router";
+
 import useSWR from "swr";
-// react hook form
+
 import { Controller } from "react-hook-form";
 import type { Control } from "react-hook-form";
 // service
 import projectServices from "lib/services/project.service";
-// hooks
-import useUser from "lib/hooks/useUser";
 // ui
 import { SearchListbox } from "ui";
 // icons
@@ -23,12 +22,13 @@ type Props = {
 };
 
 const SelectLead: React.FC<Props> = ({ control }) => {
-  const { activeWorkspace, activeProject } = useUser();
+  const router = useRouter();
+  const { workspaceSlug, projectId } = router.query;
 
   const { data: people } = useSWR(
-    activeWorkspace && activeProject ? PROJECT_MEMBERS(activeProject.id) : null,
-    activeWorkspace && activeProject
-      ? () => projectServices.projectMembers(activeWorkspace.slug, activeProject.id)
+    workspaceSlug && projectId ? PROJECT_MEMBERS(projectId as string) : null,
+    workspaceSlug && projectId
+      ? () => projectServices.projectMembers(workspaceSlug as string, projectId as string)
       : null
   );
 

--- a/apps/app/components/project/modules/create-update-module-modal/select-members.tsx
+++ b/apps/app/components/project/modules/create-update-module-modal/select-members.tsx
@@ -1,14 +1,14 @@
-// react
 import React from "react";
-// swr
+
+import { useRouter } from "next/router";
+
 import useSWR from "swr";
-// react hook form
+
 import { Controller } from "react-hook-form";
 import type { Control } from "react-hook-form";
 // service
 import projectServices from "lib/services/project.service";
-// hooks
-import useUser from "lib/hooks/useUser";
+
 // ui
 import { SearchListbox } from "ui";
 // icons
@@ -23,12 +23,13 @@ type Props = {
 };
 
 const SelectMembers: React.FC<Props> = ({ control }) => {
-  const { activeWorkspace, activeProject } = useUser();
+  const router = useRouter();
+  const { workspaceSlug, projectId } = router.query;
 
   const { data: people } = useSWR(
-    activeWorkspace && activeProject ? PROJECT_MEMBERS(activeProject.id) : null,
-    activeWorkspace && activeProject
-      ? () => projectServices.projectMembers(activeWorkspace.slug, activeProject.id)
+    workspaceSlug && projectId ? PROJECT_MEMBERS(projectId as string) : null,
+    workspaceSlug && projectId
+      ? () => projectServices.projectMembers(workspaceSlug as string, projectId as string)
       : null
   );
 

--- a/apps/app/components/project/modules/list-view/index.tsx
+++ b/apps/app/components/project/modules/list-view/index.tsx
@@ -1,14 +1,14 @@
-// react
 import React from "react";
-// swr
+
+import { useRouter } from "next/router";
+
 import useSWR from "swr";
 // services
 import workspaceService from "lib/services/workspace.service";
 import stateService from "lib/services/state.service";
 // common
 import { addSpaceIfCamelCase } from "constants/common";
-// hooks
-import useUser from "lib/hooks/useUser";
+
 // components
 import SingleListIssue from "components/common/list-view/single-issue";
 // headless ui
@@ -52,17 +52,18 @@ const ModulesListView: React.FC<Props> = ({
   handleDeleteIssue,
   setPreloadedData,
 }) => {
-  const { activeWorkspace, activeProject } = useUser();
+  const router = useRouter();
+  const { workspaceSlug, projectId } = router.query;
 
   const { data: people } = useSWR<IWorkspaceMember[]>(
-    activeWorkspace ? WORKSPACE_MEMBERS : null,
-    activeWorkspace ? () => workspaceService.workspaceMembers(activeWorkspace.slug) : null
+    workspaceSlug ? WORKSPACE_MEMBERS : null,
+    workspaceSlug ? () => workspaceService.workspaceMembers(workspaceSlug as string) : null
   );
 
   const { data: states } = useSWR(
-    activeWorkspace && activeProject ? STATE_LIST(activeProject.id) : null,
-    activeWorkspace && activeProject
-      ? () => stateService.getStates(activeWorkspace.slug, activeProject.id)
+    workspaceSlug && projectId ? STATE_LIST(projectId as string) : null,
+    workspaceSlug && projectId
+      ? () => stateService.getStates(workspaceSlug as string, projectId as string)
       : null
   );
 

--- a/apps/app/components/project/modules/module-detail-sidebar/select-members.tsx
+++ b/apps/app/components/project/modules/module-detail-sidebar/select-members.tsx
@@ -1,15 +1,13 @@
-// react
 import React from "react";
-// next
+
 import Image from "next/image";
-// swr
+import { useRouter } from "next/router";
+
 import useSWR from "swr";
-// react-hook-form
+
 import { Control, Controller } from "react-hook-form";
 // services
 import workspaceService from "lib/services/workspace.service";
-// hooks
-import useUser from "lib/hooks/useUser";
 // headless ui
 import { Listbox, Transition } from "@headlessui/react";
 // ui
@@ -29,17 +27,18 @@ type Props = {
 };
 
 const SelectMembers: React.FC<Props> = ({ control, submitChanges }) => {
-  const { activeWorkspace } = useUser();
+  const router = useRouter();
+  const { workspaceSlug } = router.query;
 
   const { data: people } = useSWR(
-    activeWorkspace ? WORKSPACE_MEMBERS(activeWorkspace.slug) : null,
-    activeWorkspace ? () => workspaceService.workspaceMembers(activeWorkspace.slug) : null
+    workspaceSlug ? WORKSPACE_MEMBERS(workspaceSlug as string) : null,
+    workspaceSlug ? () => workspaceService.workspaceMembers(workspaceSlug as string) : null
   );
 
   return (
-    <div className="flex items-center py-2 flex-wrap">
+    <div className="flex flex-wrap items-center py-2">
       <div className="flex items-center gap-x-2 text-sm sm:basis-1/2">
-        <UserGroupIcon className="flex-shrink-0 h-4 w-4" />
+        <UserGroupIcon className="h-4 w-4 flex-shrink-0" />
         <p>Members</p>
       </div>
       <div className="sm:basis-1/2">
@@ -58,14 +57,14 @@ const SelectMembers: React.FC<Props> = ({ control, submitChanges }) => {
             >
               {({ open }) => (
                 <div className="relative">
-                  <Listbox.Button className="w-full flex items-center gap-1 text-xs cursor-pointer">
+                  <Listbox.Button className="flex w-full cursor-pointer items-center gap-1 text-xs">
                     <span
                       className={classNames(
                         value ? "" : "text-gray-900",
-                        "hidden truncate sm:block text-left"
+                        "hidden truncate text-left sm:block"
                       )}
                     >
-                      <div className="flex items-center gap-1 text-xs cursor-pointer">
+                      <div className="flex cursor-pointer items-center gap-1 text-xs">
                         {value && Array.isArray(value) ? (
                           <>
                             {value.length > 0 ? (
@@ -80,7 +79,7 @@ const SelectMembers: React.FC<Props> = ({ control, submitChanges }) => {
                                     }`}
                                   >
                                     {person && person.avatar && person.avatar !== "" ? (
-                                      <div className="h-5 w-5 border-2 bg-white border-white rounded-full">
+                                      <div className="h-5 w-5 rounded-full border-2 border-white bg-white">
                                         <Image
                                           src={person.avatar}
                                           height="100%"
@@ -91,7 +90,7 @@ const SelectMembers: React.FC<Props> = ({ control, submitChanges }) => {
                                       </div>
                                     ) : (
                                       <div
-                                        className={`h-5 w-5 bg-gray-700 text-white border-2 border-white grid place-items-center rounded-full capitalize`}
+                                        className={`grid h-5 w-5 place-items-center rounded-full border-2 border-white bg-gray-700 capitalize text-white`}
                                       >
                                         {person?.first_name && person.first_name !== ""
                                           ? person.first_name.charAt(0)
@@ -102,7 +101,7 @@ const SelectMembers: React.FC<Props> = ({ control, submitChanges }) => {
                                 );
                               })
                             ) : (
-                              <div className="h-5 w-5 border-2 bg-white border-white rounded-full">
+                              <div className="h-5 w-5 rounded-full border-2 border-white bg-white">
                                 <Image
                                   src={User}
                                   height="100%"
@@ -128,7 +127,7 @@ const SelectMembers: React.FC<Props> = ({ control, submitChanges }) => {
                     leaveFrom="transform opacity-100 scale-100"
                     leaveTo="transform opacity-0 scale-95"
                   >
-                    <Listbox.Options className="absolute z-10 left-0 mt-1 w-auto bg-white shadow-lg max-h-48 rounded-md py-1 text-xs ring-1 ring-black ring-opacity-5 overflow-auto focus:outline-none">
+                    <Listbox.Options className="absolute left-0 z-10 mt-1 max-h-48 w-auto overflow-auto rounded-md bg-white py-1 text-xs shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none">
                       <div className="py-1">
                         {people ? (
                           people.length > 0 ? (
@@ -138,7 +137,7 @@ const SelectMembers: React.FC<Props> = ({ control, submitChanges }) => {
                                 className={({ active, selected }) =>
                                   `${
                                     active || selected ? "bg-indigo-50" : ""
-                                  } flex items-center gap-2 text-gray-900 cursor-pointer select-none p-2 truncate`
+                                  } flex cursor-pointer select-none items-center gap-2 truncate p-2 text-gray-900`
                                 }
                                 value={option.member.id}
                               >
@@ -153,7 +152,7 @@ const SelectMembers: React.FC<Props> = ({ control, submitChanges }) => {
                                     />
                                   </div>
                                 ) : (
-                                  <div className="flex-shrink-0 h-4 w-4 bg-gray-700 text-white grid place-items-center capitalize rounded-full">
+                                  <div className="grid h-4 w-4 flex-shrink-0 place-items-center rounded-full bg-gray-700 capitalize text-white">
                                     {option.member.first_name && option.member.first_name !== ""
                                       ? option.member.first_name.charAt(0)
                                       : option.member.email.charAt(0)}

--- a/apps/app/components/project/modules/module-link-modal.tsx
+++ b/apps/app/components/project/modules/module-link-modal.tsx
@@ -1,10 +1,11 @@
-// react
-import React, { useEffect } from "react";
-// swr
+import React from "react";
+
+import { useRouter } from "next/router";
+
 import { mutate } from "swr";
-// react hook form
+
 import { useForm } from "react-hook-form";
-// headless
+
 import { Dialog, Transition } from "@headlessui/react";
 // services
 import modulesService from "lib/services/modules.service";
@@ -29,15 +30,8 @@ const defaultValues: ModuleLink = {
 };
 
 const ModuleLinkModal: React.FC<Props> = ({ isOpen, module, handleClose }) => {
-  const { activeWorkspace, activeProject } = useUser();
-
-  const onClose = () => {
-    handleClose();
-    const timeout = setTimeout(() => {
-      reset(defaultValues);
-      clearTimeout(timeout);
-    }, 500);
-  };
+  const router = useRouter();
+  const { workspaceSlug, projectId } = router.query;
 
   const {
     register,
@@ -50,7 +44,7 @@ const ModuleLinkModal: React.FC<Props> = ({ isOpen, module, handleClose }) => {
   });
 
   const onSubmit = async (formData: ModuleLink) => {
-    if (!activeWorkspace || !activeProject || !module) return;
+    if (!workspaceSlug || !projectId || !module) return;
 
     const previousLinks = module.link_module.map((l) => {
       return { title: l.title, url: l.url };
@@ -61,7 +55,7 @@ const ModuleLinkModal: React.FC<Props> = ({ isOpen, module, handleClose }) => {
     };
 
     await modulesService
-      .patchModule(activeWorkspace.slug, activeProject.id, module.id, payload)
+      .patchModule(workspaceSlug as string, projectId as string, module.id, payload)
       .then((res) => {
         mutate(MODULE_DETAIL);
         onClose();
@@ -73,6 +67,14 @@ const ModuleLinkModal: React.FC<Props> = ({ isOpen, module, handleClose }) => {
           });
         });
       });
+  };
+
+  const onClose = () => {
+    handleClose();
+    const timeout = setTimeout(() => {
+      reset(defaultValues);
+      clearTimeout(timeout);
+    }, 500);
   };
 
   return (

--- a/apps/app/components/project/send-project-invitation-modal.tsx
+++ b/apps/app/components/project/send-project-invitation-modal.tsx
@@ -1,9 +1,11 @@
 import React from "react";
-// swr
+
+import { useRouter } from "next/router";
+
 import useSWR, { mutate } from "swr";
-// react hook form
+
 import { useForm, Controller } from "react-hook-form";
-// headless
+
 import { Dialog, Transition, Listbox } from "@headlessui/react";
 // hooks
 import useUser from "lib/hooks/useUser";
@@ -42,24 +44,17 @@ const defaultValues: Partial<ProjectMember> = {
 };
 
 const SendProjectInvitationModal: React.FC<Props> = ({ isOpen, setIsOpen, members }) => {
-  const handleClose = () => {
-    setIsOpen(false);
-    const timeout = setTimeout(() => {
-      reset(defaultValues);
-      clearTimeout(timeout);
-    }, 500);
-  };
-
-  const { activeWorkspace, activeProject } = useUser();
+  const router = useRouter();
+  const { workspaceSlug, projectId } = router.query;
 
   const { setToastAlert } = useToast();
 
   const { data: people } = useSWR(
-    activeWorkspace ? WORKSPACE_MEMBERS(activeWorkspace.slug) : null,
-    activeWorkspace ? () => workspaceService.workspaceMembers(activeWorkspace.slug) : null,
+    workspaceSlug ? WORKSPACE_MEMBERS(workspaceSlug as string) : null,
+    workspaceSlug ? () => workspaceService.workspaceMembers(workspaceSlug as string) : null,
     {
       onErrorRetry(err, _, __, revalidate, revalidateOpts) {
-        if (err?.status === 403) return;
+        if (err?.status === 403 || err?.status === 401) return;
         setTimeout(() => revalidate(revalidateOpts), 5000);
       },
     }
@@ -70,7 +65,6 @@ const SendProjectInvitationModal: React.FC<Props> = ({ isOpen, setIsOpen, member
     formState: { errors, isSubmitting },
     handleSubmit,
     reset,
-    setError,
     setValue,
     control,
   } = useForm<ProjectMember>({
@@ -78,11 +72,10 @@ const SendProjectInvitationModal: React.FC<Props> = ({ isOpen, setIsOpen, member
   });
 
   const onSubmit = async (formData: ProjectMember) => {
-    if (!activeWorkspace || !activeProject || isSubmitting) return;
+    if (!workspaceSlug || !projectId || isSubmitting) return;
     await projectService
-      .inviteProject(activeWorkspace.slug, activeProject.id, formData)
+      .inviteProject(workspaceSlug as string, projectId as string, formData)
       .then((response) => {
-        console.log(response);
         setIsOpen(false);
         mutate(
           PROJECT_INVITATIONS,
@@ -100,6 +93,14 @@ const SendProjectInvitationModal: React.FC<Props> = ({ isOpen, setIsOpen, member
       .catch((error) => {
         console.log(error);
       });
+  };
+
+  const handleClose = () => {
+    setIsOpen(false);
+    const timeout = setTimeout(() => {
+      reset(defaultValues);
+      clearTimeout(timeout);
+    }, 500);
   };
 
   return (
@@ -156,12 +157,12 @@ const SendProjectInvitationModal: React.FC<Props> = ({ isOpen, setIsOpen, member
                             >
                               {({ open }) => (
                                 <>
-                                  <Listbox.Label className="text-gray-500 mb-2">
+                                  <Listbox.Label className="mb-2 text-gray-500">
                                     Email
                                   </Listbox.Label>
                                   <div className="relative">
                                     <Listbox.Button
-                                      className={`bg-white relative w-full border rounded-md shadow-sm pl-3 pr-10 py-2 text-left cursor-default focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm ${
+                                      className={`relative w-full cursor-default rounded-md border bg-white py-2 pl-3 pr-10 text-left shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 sm:text-sm ${
                                         errors.user_id ? "border-red-500 bg-red-50" : ""
                                       }`}
                                     >
@@ -170,7 +171,7 @@ const SendProjectInvitationModal: React.FC<Props> = ({ isOpen, setIsOpen, member
                                           ? people?.find((p) => p.member.id === value)?.member.email
                                           : "Select email"}
                                       </span>
-                                      <span className="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
+                                      <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
                                         <ChevronDownIcon
                                           className="h-5 w-5 text-gray-400"
                                           aria-hidden="true"
@@ -185,7 +186,7 @@ const SendProjectInvitationModal: React.FC<Props> = ({ isOpen, setIsOpen, member
                                       leaveFrom="opacity-100"
                                       leaveTo="opacity-0"
                                     >
-                                      <Listbox.Options className="absolute z-10 mt-1 w-full bg-white shadow-lg max-h-60 rounded-md py-1 text-base ring-1 ring-black ring-opacity-5 overflow-auto focus:outline-none sm:text-sm">
+                                      <Listbox.Options className="absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm">
                                         {people?.map(
                                           (person) =>
                                             !members.some(
@@ -195,8 +196,8 @@ const SendProjectInvitationModal: React.FC<Props> = ({ isOpen, setIsOpen, member
                                                 key={person.member.id}
                                                 className={({ active }) =>
                                                   `${
-                                                    active ? "text-white bg-theme" : "text-gray-900"
-                                                  } cursor-default select-none relative py-2 pl-3 pr-9 text-left`
+                                                    active ? "bg-theme text-white" : "text-gray-900"
+                                                  } relative cursor-default select-none py-2 pl-3 pr-9 text-left`
                                                 }
                                                 value={{
                                                   id: person.member.id,

--- a/apps/app/components/workspace/confirm-workspace-deletion.tsx
+++ b/apps/app/components/workspace/confirm-workspace-deletion.tsx
@@ -1,12 +1,11 @@
 import React, { useEffect, useRef, useState } from "react";
-// next
+
 import { useRouter } from "next/router";
-// headless ui
+
 import { Dialog, Transition } from "@headlessui/react";
 // services
 import workspaceService from "lib/services/workspace.service";
 // hooks
-import useUser from "lib/hooks/useUser";
 import useToast from "lib/hooks/useToast";
 // icons
 import { ExclamationTriangleIcon } from "@heroicons/react/24/outline";
@@ -22,22 +21,26 @@ type Props = {
 };
 
 const ConfirmWorkspaceDeletion: React.FC<Props> = ({ isOpen, data, onClose }) => {
-  const router = useRouter();
-
+  const cancelButtonRef = useRef(null);
   const [isDeleteLoading, setIsDeleteLoading] = useState(false);
-
-  const [selectedWorkspace, setSelectedWorkspace] = useState<IWorkspace | null>(null);
-
   const [confirmProjectName, setConfirmProjectName] = useState("");
   const [confirmDeleteMyProject, setConfirmDeleteMyProject] = useState(false);
+  const [selectedWorkspace, setSelectedWorkspace] = useState<IWorkspace | null>(null);
 
-  const canDelete = confirmProjectName === data?.name && confirmDeleteMyProject;
-
-  const { mutateWorkspaces } = useUser();
-
+  const router = useRouter();
   const { setToastAlert } = useToast();
 
-  const cancelButtonRef = useRef(null);
+  useEffect(() => {
+    if (data) setSelectedWorkspace(data);
+    else {
+      const timer = setTimeout(() => {
+        setSelectedWorkspace(null);
+        clearTimeout(timer);
+      }, 350);
+    }
+  }, [data]);
+
+  const canDelete = confirmProjectName === data?.name && confirmDeleteMyProject;
 
   const handleClose = () => {
     onClose();
@@ -51,9 +54,7 @@ const ConfirmWorkspaceDeletion: React.FC<Props> = ({ isOpen, data, onClose }) =>
       .deleteWorkspace(data.slug)
       .then(() => {
         handleClose();
-        mutateWorkspaces((prevData) => {
-          return (prevData ?? []).filter((workspace: IWorkspace) => workspace.slug !== data.slug);
-        }, false);
+        // TODO: add workspace mutation
         setToastAlert({
           type: "success",
           message: "Workspace deleted successfully",
@@ -66,16 +67,6 @@ const ConfirmWorkspaceDeletion: React.FC<Props> = ({ isOpen, data, onClose }) =>
         setIsDeleteLoading(false);
       });
   };
-
-  useEffect(() => {
-    if (data) setSelectedWorkspace(data);
-    else {
-      const timer = setTimeout(() => {
-        setSelectedWorkspace(null);
-        clearTimeout(timer);
-      }, 350);
-    }
-  }, [data]);
 
   return (
     <Transition.Root show={isOpen} as={React.Fragment}>

--- a/apps/app/contexts/user.context.tsx
+++ b/apps/app/contexts/user.context.tsx
@@ -1,44 +1,24 @@
-import React, { createContext, ReactElement, useEffect, useState } from "react";
-// next
-import Router from "next/router";
-import { useRouter } from "next/router";
+import React, { createContext, ReactElement } from "react";
 // swr
 import useSWR from "swr";
 // services
 import userService from "lib/services/user.service";
-import projectServices from "lib/services/project.service";
-import workspaceService from "lib/services/workspace.service";
 // constants
-import { CURRENT_USER, PROJECTS_LIST, USER_WORKSPACES } from "constants/fetch-keys";
+import { CURRENT_USER } from "constants/fetch-keys";
 
 // types
 import type { KeyedMutator } from "swr";
-import type { IUser, IWorkspace, IProject } from "types";
+import type { IUser } from "types";
 
 interface IUserContextProps {
   user?: IUser;
   isUserLoading: boolean;
   mutateUser: KeyedMutator<IUser>;
-  activeWorkspace?: IWorkspace;
-  mutateWorkspaces: KeyedMutator<IWorkspace[]>;
-  workspaces?: IWorkspace[];
-  projects?: IProject[];
-  setActiveProject: React.Dispatch<React.SetStateAction<IProject | undefined>>;
-  mutateProjects: KeyedMutator<IProject[]>;
-  activeProject?: IProject;
-  slug?: string;
 }
 
 export const UserContext = createContext<IUserContextProps>({} as IUserContextProps);
 
 export const UserProvider = ({ children }: { children: ReactElement }) => {
-  const [activeWorkspace, setActiveWorkspace] = useState<IWorkspace | undefined>();
-  const [activeProject, setActiveProject] = useState<IProject | undefined>();
-
-  const router = useRouter();
-
-  const { projectId } = router.query;
-
   // API to fetch user information
   const {
     data: user,
@@ -48,65 +28,12 @@ export const UserProvider = ({ children }: { children: ReactElement }) => {
     shouldRetryOnError: false,
   });
 
-  const {
-    data: workspaces,
-    error: workspaceError,
-    mutate: mutateWorkspaces,
-  } = useSWR<IWorkspace[]>(
-    user ? USER_WORKSPACES : null,
-    user ? () => workspaceService.userWorkspaces() : null,
-    {
-      shouldRetryOnError: false,
-    }
-  );
-
-  const { data: projects, mutate: mutateProjects } = useSWR<IProject[]>(
-    activeWorkspace ? PROJECTS_LIST(activeWorkspace.slug) : null,
-    activeWorkspace ? () => projectServices.getProjects(activeWorkspace.slug) : null
-  );
-
-  useEffect(() => {
-    if (!projects) return;
-    const activeProject = projects.find((project) => project.id === projectId);
-    setActiveProject(activeProject ?? projects[0]);
-  }, [projectId, projects]);
-
-  useEffect(() => {
-    if (user?.last_workspace_id) {
-      const workspace = workspaces?.find((item) => item.id === user?.last_workspace_id);
-      if (workspace) {
-        setActiveWorkspace(workspace);
-      } else {
-        const workspace = workspaces?.[0];
-        setActiveWorkspace(workspace);
-        userService.updateUser({ last_workspace_id: workspace?.id });
-      }
-    } else if (user) {
-      const workspace = workspaces?.[0];
-      setActiveWorkspace(workspace);
-      userService.updateUser({ last_workspace_id: workspace?.id });
-    }
-  }, [user, workspaces]);
-
-  useEffect(() => {
-    if (!workspaces) return;
-    if (workspaces.length === 0) Router.push("/invitations");
-  }, [workspaces]);
-
   return (
     <UserContext.Provider
       value={{
         user: error ? undefined : user,
         isUserLoading: Boolean(user === undefined && error === undefined),
         mutateUser: mutate,
-        activeWorkspace: workspaceError ? undefined : activeWorkspace,
-        mutateWorkspaces: mutateWorkspaces,
-        workspaces: workspaceError ? undefined : workspaces,
-        projects,
-        mutateProjects: mutateProjects,
-        activeProject,
-        setActiveProject,
-        slug: error ? undefined : user?.slug,
       }}
     >
       {children}

--- a/apps/app/lib/auth.ts
+++ b/apps/app/lib/auth.ts
@@ -1,9 +1,15 @@
 import { convertCookieStringToObject } from "./cookie";
 
 // types
-import type { IProjectMember, IUser } from "types";
+import type { IProjectMember, IUser, IWorkspace } from "types";
 // constants
-import { BASE_STAGING, PROJECT_MEMBER_ME, USER_ENDPOINT } from "constants/api-routes";
+import {
+  BASE_STAGING,
+  PROJECT_MEMBER_ME,
+  USER_ENDPOINT,
+  USER_WORKSPACES,
+  USER_WORKSPACE_INVITATIONS,
+} from "constants/api-routes";
 
 export const requiredAuth = async (cookie?: string) => {
   const cookies = convertCookieStringToObject(cookie);
@@ -49,6 +55,7 @@ export const requiredAdmin = async (workspaceSlug: string, projectId: string, co
 
   try {
     const data = await fetch(`${baseUrl}${PROJECT_MEMBER_ME(workspaceSlug, projectId)}`, {
+      method: "GET",
       headers: {
         Authorization: `Bearer ${token}`,
       },
@@ -63,4 +70,96 @@ export const requiredAdmin = async (workspaceSlug: string, projectId: string, co
   }
 
   return memberDetail || null;
+};
+
+export const homePageRedirect = async (cookie?: string) => {
+  const user = await requiredAuth(cookie);
+
+  if (!user)
+    return {
+      redirect: {
+        destination: "/signin",
+        permanent: false,
+      },
+    };
+
+  // FIXME: backend is returning object of user and workspace.
+  // Get KT if it's required to send user and workspace and if
+  // yes change below accordingly
+  if (!user.is_onboarded)
+    return {
+      redirect: {
+        destination: "/invitations",
+        permanent: false,
+      },
+    };
+
+  let workspaces: IWorkspace[] = [];
+
+  const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL || BASE_STAGING;
+
+  const cookies = convertCookieStringToObject(cookie);
+  const token = cookies?.accessToken;
+
+  try {
+    const data = await fetch(`${baseUrl}${USER_WORKSPACES}`, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+    })
+      .then((res) => res.json())
+      .then((data) => data);
+
+    workspaces = data;
+  } catch (e) {
+    console.error(e);
+  }
+
+  const lastActiveWorkspace = workspaces.find(
+    (workspace) => workspace.id === user.last_workspace_id
+  );
+
+  if (lastActiveWorkspace) {
+    return {
+      redirect: {
+        destination: `/${lastActiveWorkspace.slug}`,
+        permanent: false,
+      },
+    };
+  } else if (workspaces.length > 0) {
+    return {
+      redirect: {
+        destination: `/${workspaces[0].slug}`,
+        permanent: false,
+      },
+    };
+  }
+
+  const invitations = await fetch(`${baseUrl}${USER_WORKSPACE_INVITATIONS}`, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+  })
+    .then((res) => res.json())
+    .then((data) => data);
+
+  if (invitations.length > 0)
+    return {
+      redirect: {
+        destination: "/invitations",
+        permanent: false,
+      },
+    };
+  else {
+    return {
+      redirect: {
+        destination: "/create-workspace",
+        permanent: false,
+      },
+    };
+  }
 };

--- a/apps/app/lib/hooks/useMyIssueFilter.tsx
+++ b/apps/app/lib/hooks/useMyIssueFilter.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from "react";
-// swr
+
+import { useRouter } from "next/router";
+
 import useSWR from "swr";
 // constants
 import { STATE_LIST } from "constants/fetch-keys";
@@ -30,12 +32,16 @@ const useMyIssuesProperties = (issues?: IIssue[]) => {
   const [properties, setProperties] = useState<Properties>(initialValues);
   const [groupByProperty, setGroupByProperty] = useState<NestedKeyOf<IIssue> | null>(null);
 
-  const { activeWorkspace, activeProject, user } = useUser();
+  // FIXME: where this hook is used we may not have project id in the url
+  const router = useRouter();
+  const { workspaceSlug, projectId } = router.query;
+
+  const { user } = useUser();
 
   const { data: states } = useSWR(
-    activeWorkspace && activeProject ? STATE_LIST(activeProject.id) : null,
-    activeWorkspace && activeProject
-      ? () => stateService.getStates(activeWorkspace.slug, activeProject.id)
+    workspaceSlug && projectId ? STATE_LIST(projectId as string) : null,
+    workspaceSlug && projectId
+      ? () => stateService.getStates(workspaceSlug as string, projectId as string)
       : null
   );
 

--- a/apps/app/pages/[workspaceSlug]/projects/[projectId]/issues/[issueId].tsx
+++ b/apps/app/pages/[workspaceSlug]/projects/[projectId]/issues/[issueId].tsx
@@ -84,29 +84,22 @@ const IssueDetail: NextPage = () => {
   );
 
   const { data: activeProject } = useSWR(
-    activeWorkspace && projectId ? PROJECT_DETAILS(projectId as string) : null,
-    activeWorkspace && projectId
-      ? () => projectService.getProject(activeWorkspace.slug, projectId as string)
+    workspaceSlug && projectId ? PROJECT_DETAILS(projectId as string) : null,
+    workspaceSlug && projectId
+      ? () => projectService.getProject(workspaceSlug as string, projectId as string)
       : null
   );
 
   const { data: issues, mutate: mutateIssues } = useSWR(
-    activeWorkspace && activeProject
-      ? PROJECT_ISSUES_LIST(activeWorkspace.slug, activeProject.id)
+    workspaceSlug && projectId
+      ? PROJECT_ISSUES_LIST(workspaceSlug as string, projectId as string)
       : null,
-    activeWorkspace && activeProject
-      ? () => issuesServices.getIssues(activeWorkspace.slug, activeProject.id)
+    workspaceSlug && projectId
+      ? () => issuesServices.getIssues(workspaceSlug as string, projectId as string)
       : null
   );
 
-  const {
-    register,
-    formState: { errors },
-    handleSubmit,
-    reset,
-    control,
-    watch,
-  } = useForm<IIssue>({
+  const { register, handleSubmit, reset, control, watch } = useForm<IIssue>({
     defaultValues,
   });
 

--- a/apps/app/pages/[workspaceSlug]/projects/[projectId]/issues/index.tsx
+++ b/apps/app/pages/[workspaceSlug]/projects/[projectId]/issues/index.tsx
@@ -64,18 +64,18 @@ const ProjectIssues: NextPage = () => {
   );
 
   const { data: activeProject } = useSWR(
-    activeWorkspace && projectId ? PROJECT_DETAILS(projectId as string) : null,
-    activeWorkspace && projectId
-      ? () => projectService.getProject(activeWorkspace.slug, projectId as string)
+    workspaceSlug && projectId ? PROJECT_DETAILS(projectId as string) : null,
+    workspaceSlug && projectId
+      ? () => projectService.getProject(workspaceSlug as string, projectId as string)
       : null
   );
 
   const { data: projectIssues } = useSWR(
     activeWorkspace && activeProject
-      ? PROJECT_ISSUES_LIST(activeWorkspace.slug, activeProject.id)
+      ? PROJECT_ISSUES_LIST(workspaceSlug as string, projectId as string)
       : null,
     activeWorkspace && activeProject
-      ? () => issuesServices.getIssues(activeWorkspace.slug, activeProject.id)
+      ? () => issuesServices.getIssues(workspaceSlug as string, projectId as string)
       : null
   );
 

--- a/apps/app/pages/create-workspace.tsx
+++ b/apps/app/pages/create-workspace.tsx
@@ -31,14 +31,14 @@ const CreateWorkspace: NextPage = () => {
 
   const router = useRouter();
 
-  const { mutateWorkspaces, user } = useUser();
+  const { user } = useUser();
 
   const onSubmit = async (formData: IWorkspace) => {
     await workspaceService
       .createWorkspace(formData)
       .then((res) => {
         console.log(res);
-        mutateWorkspaces((prevData) => [...(prevData ?? []), res], false);
+        // TODO: add workspace mutations
         router.push("/");
       })
       .catch((err) => {

--- a/apps/app/pages/index.tsx
+++ b/apps/app/pages/index.tsx
@@ -8,16 +8,12 @@ import useUser from "lib/hooks/useUser";
 const Home: NextPage = () => {
   const router = useRouter();
 
-  const { user, isUserLoading, activeWorkspace, workspaces, slug } = useUser();
+  const { user, isUserLoading } = useUser();
 
   useEffect(() => {
     if (!isUserLoading && (!user || user === null)) router.push("/signin");
+    else router.push("/home");
   }, [isUserLoading, user, router]);
-
-  useEffect(() => {
-    if (slug) router.push(`/${slug}`);
-    else if (!activeWorkspace && workspaces?.length === 0) router.push("/invitations");
-  }, [activeWorkspace, router, workspaces, slug]);
 
   return <></>;
 };

--- a/apps/app/pages/index.tsx
+++ b/apps/app/pages/index.tsx
@@ -1,21 +1,17 @@
 import React, { useEffect } from "react";
-// next
-import type { NextPage } from "next";
-import { useRouter } from "next/router";
-// hooks
-import useUser from "lib/hooks/useUser";
+
+import type { NextPage, NextPageContext } from "next";
+
+// lib
+import { homePageRedirect } from "lib/auth";
 
 const Home: NextPage = () => {
-  const router = useRouter();
+  return null;
+};
 
-  const { user, isUserLoading } = useUser();
-
-  useEffect(() => {
-    if (!isUserLoading && (!user || user === null)) router.push("/signin");
-    else router.push("/home");
-  }, [isUserLoading, user, router]);
-
-  return <></>;
+export const getServerSideProps = (ctx: NextPageContext) => {
+  const cookies = ctx.req?.headers.cookie;
+  return homePageRedirect(cookies);
 };
 
 export default Home;

--- a/apps/app/pages/invitations.tsx
+++ b/apps/app/pages/invitations.tsx
@@ -31,16 +31,12 @@ const OnBoard: NextPage = () => {
   const { user } = useUser();
 
   const router = useRouter();
-  const { workspaceSlug } = router.query;
 
   const { data: invitations, mutate } = useSWR(USER_WORKSPACE_INVITATIONS, () =>
     workspaceService.userWorkspaceInvitations()
   );
 
-  const { data: workspaces } = useSWR(
-    workspaceSlug ? USER_WORKSPACES : null,
-    workspaceSlug ? () => workspaceService.userWorkspaces() : null
-  );
+  const { data: workspaces } = useSWR(USER_WORKSPACES, () => workspaceService.userWorkspaces());
 
   const handleInvitation = (
     workspace_invitation: IWorkspaceMemberInvitation,
@@ -57,8 +53,8 @@ const OnBoard: NextPage = () => {
     }
   };
 
-  const submitInvitations = () => {
-    userService.updateUserOnBoard().then((response) => {});
+  const submitInvitations = async () => {
+    await userService.updateUserOnBoard().then((response) => {});
     workspaceService
       .joinWorkspaces({ invitations: invitationsRespond })
       .then(async (res: any) => {
@@ -108,7 +104,7 @@ const OnBoard: NextPage = () => {
                   ))}
                 </ul>
                 <div className="mt-6 flex items-center gap-2">
-                  <Button className="w-full" theme="secondary" onClick={() => router.push("/home")}>
+                  <Button className="w-full" theme="secondary" onClick={() => router.push("/")}>
                     Skip
                   </Button>
                   <Button className="w-full" onClick={submitInvitations}>
@@ -135,7 +131,7 @@ const OnBoard: NextPage = () => {
                     </div>
                   </div>
                 ))}
-                <Link href="/home">
+                <Link href="/">
                   <Button type="button">Go to workspaces</Button>
                 </Link>
               </div>

--- a/apps/app/pages/invitations.tsx
+++ b/apps/app/pages/invitations.tsx
@@ -1,17 +1,18 @@
 import React, { useState } from "react";
-// next
+
 import Link from "next/link";
 import { useRouter } from "next/router";
 import type { NextPage, NextPageContext } from "next";
-// swr
+
 import useSWR from "swr";
 // services
-import workspaceService from "lib/services/workspace.service";
 import userService from "lib/services/user.service";
+import workspaceService from "lib/services/workspace.service";
 // hooks
 import useUser from "lib/hooks/useUser";
 // constants
 import { requiredAuth } from "lib/auth";
+import { USER_WORKSPACES } from "constants/fetch-keys";
 import { USER_WORKSPACE_INVITATIONS } from "constants/api-routes";
 // layouts
 import DefaultLayout from "layouts/DefaultLayout";
@@ -27,12 +28,18 @@ import type { IWorkspaceMemberInvitation } from "types";
 const OnBoard: NextPage = () => {
   const [invitationsRespond, setInvitationsRespond] = useState<string[]>([]);
 
-  const { workspaces, mutateWorkspaces, user, slug } = useUser();
+  const { user } = useUser();
 
   const router = useRouter();
+  const { workspaceSlug } = router.query;
 
   const { data: invitations, mutate } = useSWR(USER_WORKSPACE_INVITATIONS, () =>
     workspaceService.userWorkspaceInvitations()
+  );
+
+  const { data: workspaces } = useSWR(
+    workspaceSlug ? USER_WORKSPACES : null,
+    workspaceSlug ? () => workspaceService.userWorkspaces() : null
   );
 
   const handleInvitation = (
@@ -51,16 +58,13 @@ const OnBoard: NextPage = () => {
   };
 
   const submitInvitations = () => {
-    userService.updateUserOnBoard().then((response) => {
-      console.log(response);
-    });
+    userService.updateUserOnBoard().then((response) => {});
     workspaceService
       .joinWorkspaces({ invitations: invitationsRespond })
       .then(async (res: any) => {
         console.log(res);
         await mutate();
-        await mutateWorkspaces();
-        router.push(slug || "");
+        // TODO: add workspace mutations
       })
       .catch((err) => {
         console.log(err);
@@ -104,11 +108,7 @@ const OnBoard: NextPage = () => {
                   ))}
                 </ul>
                 <div className="mt-6 flex items-center gap-2">
-                  <Button
-                    className="w-full"
-                    theme="secondary"
-                    onClick={() => router.push(`/${slug}` || "/create-workspace")}
-                  >
+                  <Button className="w-full" theme="secondary" onClick={() => router.push("/home")}>
                     Skip
                   </Button>
                   <Button className="w-full" onClick={submitInvitations}>
@@ -135,7 +135,7 @@ const OnBoard: NextPage = () => {
                     </div>
                   </div>
                 ))}
-                <Link href={`/${slug || ""}`}>
+                <Link href="/home">
                   <Button type="button">Go to workspaces</Button>
                 </Link>
               </div>

--- a/apps/app/pages/magic-sign-in.tsx
+++ b/apps/app/pages/magic-sign-in.tsx
@@ -20,7 +20,7 @@ const MagicSignIn: NextPage = () => {
 
   const { setToastAlert } = useToast();
 
-  const { mutateUser, mutateWorkspaces } = useUser();
+  const { mutateUser } = useUser();
 
   useEffect(() => {
     setIsSigningIn(true);
@@ -31,7 +31,7 @@ const MagicSignIn: NextPage = () => {
       .then(async (res) => {
         setIsSigningIn(false);
         await mutateUser();
-        await mutateWorkspaces();
+        // TODO: add workspace mutations
         if (res.user.is_onboarded) router.push("/");
         else router.push("/invitations");
       })
@@ -39,7 +39,7 @@ const MagicSignIn: NextPage = () => {
         setErrorSignIn(err.response.data.error);
         setIsSigningIn(false);
       });
-  }, [password, key, mutateUser, mutateWorkspaces, router]);
+  }, [password, key, mutateUser, router]);
 
   return (
     <DefaultLayout
@@ -47,21 +47,21 @@ const MagicSignIn: NextPage = () => {
         title: "Magic Sign In",
       }}
     >
-      <div className="w-full h-screen flex justify-center items-center bg-gray-50 overflow-auto">
+      <div className="flex h-screen w-full items-center justify-center overflow-auto bg-gray-50">
         {isSigningIn ? (
-          <div className="w-full h-full flex flex-col gap-y-2 justify-center items-center">
+          <div className="flex h-full w-full flex-col items-center justify-center gap-y-2">
             <h2 className="text-4xl">Signing you in...</h2>
             <p className="text-sm text-gray-600">
               Please wait while we are preparing your take off.
             </p>
           </div>
         ) : errorSigningIn ? (
-          <div className="w-full h-full flex flex-col gap-y-2 justify-center items-center">
+          <div className="flex h-full w-full flex-col items-center justify-center gap-y-2">
             <h2 className="text-4xl">Error</h2>
             <p className="text-sm text-gray-600">
               {errorSigningIn}.
               <span
-                className="underline cursor-pointer"
+                className="cursor-pointer underline"
                 onClick={() => {
                   authenticationService
                     .emailCode({ email: (key as string).split("_")[1] })
@@ -86,7 +86,7 @@ const MagicSignIn: NextPage = () => {
             </p>
           </div>
         ) : (
-          <div className="w-full h-full flex flex-col gap-y-2 justify-center items-center">
+          <div className="flex h-full w-full flex-col items-center justify-center gap-y-2">
             <h2 className="text-4xl">Success</h2>
             <p className="text-sm text-gray-600">Redirecting you to the app...</p>
           </div>

--- a/apps/app/pages/signin.tsx
+++ b/apps/app/pages/signin.tsx
@@ -34,7 +34,7 @@ const SignIn: NextPage = () => {
   const [useCode, setUseCode] = useState(true);
   const router = useRouter();
 
-  const { mutateUser, mutateWorkspaces, slug } = useUser();
+  const { mutateUser } = useUser();
 
   const [githubToken, setGithubToken] = useState(undefined);
   const [loginCallBackURL, setLoginCallBackURL] = useState(undefined);
@@ -44,16 +44,17 @@ const SignIn: NextPage = () => {
   const onSignInSuccess = useCallback(
     async (res: IUser) => {
       await mutateUser();
-      await mutateWorkspaces();
+      // TODO: add mutate workspaces
       const nextLocation = router.asPath.split("?next=")[1];
 
       if (nextLocation) {
         router.push(nextLocation as string);
       } else {
         if (!res.user.is_onboarded) router.push("/invitations");
+        else router.push("/home");
       }
     },
-    [mutateUser, mutateWorkspaces, router]
+    [mutateUser, router]
   );
 
   const githubTokenMemo = React.useMemo(() => {
@@ -84,7 +85,7 @@ const SignIn: NextPage = () => {
           console.log(err);
         });
     }
-  }, [githubToken, mutateUser, mutateWorkspaces, router, onSignInSuccess]);
+  }, [githubToken, mutateUser, router, onSignInSuccess]);
 
   useEffect(() => {
     const origin =
@@ -93,10 +94,6 @@ const SignIn: NextPage = () => {
 
     return () => setIsGoogleAuthenticationLoading(false);
   }, []);
-
-  if (slug) {
-    router.push(`/${slug}`);
-  }
 
   return (
     <DefaultLayout

--- a/apps/app/pages/signin.tsx
+++ b/apps/app/pages/signin.tsx
@@ -51,7 +51,7 @@ const SignIn: NextPage = () => {
         router.push(nextLocation as string);
       } else {
         if (!res.user.is_onboarded) router.push("/invitations");
-        else router.push("/home");
+        else router.push("/");
       }
     },
     [mutateUser, router]

--- a/apps/app/types/users.d.ts
+++ b/apps/app/types/users.d.ts
@@ -17,9 +17,6 @@ export interface IUser {
   is_email_verified: boolean;
   token: string;
 
-  workspace: IWorkspace;
-  last_workspace_slug: string;
-
   my_issues_prop?: {
     properties: Properties;
     groupBy: NestedKeyOf<IIssue> | null;

--- a/apps/app/ui/search-listbox/index.tsx
+++ b/apps/app/ui/search-listbox/index.tsx
@@ -1,13 +1,11 @@
-// react
 import React, { useState } from "react";
-// next
+
 import Image from "next/image";
-// swr
+import { useRouter } from "next/router";
+
 import useSWR from "swr";
 // services
 import workspaceService from "lib/services/workspace.service";
-// hooks
-import useUser from "lib/hooks/useUser";
 // headless ui
 import { Transition, Combobox } from "@headlessui/react";
 // types
@@ -32,7 +30,8 @@ const SearchListbox: React.FC<Props> = ({
 }) => {
   const [query, setQuery] = useState("");
 
-  const { activeWorkspace } = useUser();
+  const router = useRouter();
+  const { workspaceSlug } = router.query;
 
   const filteredOptions =
     query === ""
@@ -53,8 +52,8 @@ const SearchListbox: React.FC<Props> = ({
   }
 
   const { data: people } = useSWR(
-    activeWorkspace ? WORKSPACE_MEMBERS(activeWorkspace.slug) : null,
-    activeWorkspace ? () => workspaceService.workspaceMembers(activeWorkspace.slug) : null
+    workspaceSlug ? WORKSPACE_MEMBERS(workspaceSlug as string) : null,
+    workspaceSlug ? () => workspaceService.workspaceMembers(workspaceSlug as string) : null
   );
 
   const userAvatar = (userId: string) => {
@@ -76,7 +75,7 @@ const SearchListbox: React.FC<Props> = ({
       );
     } else
       return (
-        <div className="flex-shrink-0 h-4 w-4 bg-gray-700 text-white grid place-items-center capitalize rounded-full">
+        <div className="grid h-4 w-4 flex-shrink-0 place-items-center rounded-full bg-gray-700 capitalize text-white">
           {user.member.first_name && user.member.first_name !== ""
             ? user.member.first_name.charAt(0)
             : user.member.email.charAt(0)}
@@ -90,7 +89,7 @@ const SearchListbox: React.FC<Props> = ({
         <>
           <Combobox.Label className="sr-only">{title}</Combobox.Label>
           <Combobox.Button
-            className={`flex items-center gap-1 hover:bg-gray-100 border rounded-md shadow-sm px-2 py-1 cursor-pointer focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 text-xs duration-300 ${
+            className={`flex cursor-pointer items-center gap-1 rounded-md border px-2 py-1 text-xs shadow-sm duration-300 hover:bg-gray-100 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 ${
               buttonClassName || ""
             }`}
           >
@@ -117,7 +116,7 @@ const SearchListbox: React.FC<Props> = ({
             leaveTo="opacity-0"
           >
             <Combobox.Options
-              className={`absolute z-10 mt-1 bg-white shadow-lg rounded-md py-1 ring-1 ring-black ring-opacity-5 focus:outline-none max-h-32 overflow-auto ${
+              className={`absolute z-10 mt-1 max-h-32 overflow-auto rounded-md bg-white py-1 shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none ${
                 width === "xs"
                   ? "w-20"
                   : width === "sm"
@@ -146,7 +145,7 @@ const SearchListbox: React.FC<Props> = ({
               } ${optionsClassName || ""}`}
             >
               <Combobox.Input
-                className="w-full bg-transparent border-b p-2 focus:outline-none text-xs"
+                className="w-full border-b bg-transparent p-2 text-xs focus:outline-none"
                 onChange={(event) => setQuery(event.target.value)}
                 placeholder="Search"
                 displayValue={(assigned: any) => assigned?.name}
@@ -160,7 +159,7 @@ const SearchListbox: React.FC<Props> = ({
                         className={({ active }) =>
                           `${
                             active ? "bg-indigo-50" : ""
-                          } flex items-center gap-2 cursor-pointer select-none truncate text-gray-900 p-2`
+                          } flex cursor-pointer select-none items-center gap-2 truncate p-2 text-gray-900`
                         }
                         value={option.value}
                       >


### PR DESCRIPTION
refractor: 

- removed the active project from the user context
- removed active workspace from user context
- removed projects from the user context
- removed workspaces from the user context
- changed from '/home' to '/' in sign-in and invitation pages
- added explicit GET request in fetch in auth.ts

fix:

- invitation page not fetching invitations 
- passing project id instead of slug in the command palette 