### PR TITLE
fix: typo on workspace url check

### DIFF
--- a/apiserver/plane/api/urls.py
+++ b/apiserver/plane/api/urls.py
@@ -151,7 +151,7 @@ urlpatterns = [
     ),
     ## Workspaces ##
     path(
-        "workspace-name-check/",
+        "workspace-slug-check/",
         WorkSpaceAvailabilityCheckEndpoint.as_view(),
         name="workspace-availability",
     ),


### PR DESCRIPTION
fix: typo on workspace url check