### PR TITLE
fix: add dockerized variable to staging as magic links are failing in staging

### DIFF
--- a/apiserver/plane/settings/staging.py
+++ b/apiserver/plane/settings/staging.py
@@ -167,6 +167,7 @@ CSRF_COOKIE_SECURE = True
 
 
 REDIS_URL = os.environ.get("REDIS_URL")
+DOCKERIZED = os.environ.get("DOCKERIZED", False)
 
 CACHES = {
     "default": {


### PR DESCRIPTION
fix: add dockerized variable to staging as magic links are failing in staging