### PR TITLE
fix: typo while updating members in a module

### DIFF
--- a/apiserver/plane/api/serializers/module.py
+++ b/apiserver/plane/api/serializers/module.py
@@ -93,7 +93,7 @@ class ModuleWriteSerializer(BaseSerializer):
         links = validated_data.pop("links_list", None)
 
         if members is not None:
-            ModuleIssue.objects.filter(module=instance).delete()
+            ModuleMember.objects.filter(module=instance).delete()
             ModuleMember.objects.bulk_create(
                 [
                     ModuleMember(


### PR DESCRIPTION
fix: typo while updating members in a module