### PR TITLE
fix: rename db host name for docker setup

### DIFF
--- a/apiserver/.env.example
+++ b/apiserver/.env.example
@@ -1,7 +1,7 @@
 SECRET_KEY="<-- django secret -->"
 DJANGO_SETTINGS_MODULE="plane.settings.production"
 # Database
-DATABASE_URL=postgres://plane:plane@plane-db-1:5432/plane
+DATABASE_URL=postgres://plane:plane@db:5432/plane
 # Cache
 REDIS_URL=redis://redis:6379/
 # SMPT


### PR DESCRIPTION
fix: rename db host name for docker setup