### PR TITLE
Github actions to push images

### DIFF
--- a/.github/workflows/push-image-backend.yml
+++ b/.github/workflows/push-image-backend.yml
@@ -3,9 +3,8 @@ name: Build Api Server Docker Image
 on:
   push:
     branches:
-      - 'main'
       - 'develop'
-      - 'feature/**'
+      - 'master'
     tags:
       - '*'
 

--- a/.github/workflows/push-image-backend.yml
+++ b/.github/workflows/push-image-backend.yml
@@ -1,0 +1,55 @@
+name: Build Api Server Docker Image
+
+on:
+  push:
+    branches:
+      - 'main'
+      - 'develop'
+      - 'feature/**'
+    tags:
+      - '*'
+
+jobs:
+  build_push_backend:
+    name: Build Api Server Docker Image
+    runs-on: ubuntu-20.04
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3.3.0
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2.1.0
+        with:
+          platforms: linux/arm64,linux/amd64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2.5.0
+
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v2.1.0
+        with:
+          registry: "ghcr.io"
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4.3.0
+        with:
+          images: ghcr.io/${{ github.repository }}-backend
+
+      - name: Build Api Server
+        uses: docker/build-push-action@v4.0.0
+        with:
+          context: ./apiserver
+          file: ./apiserver/Dockerfile.api
+          platforms: linux/arm64,linux/amd64
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/push-image-frontend.yml
+++ b/.github/workflows/push-image-frontend.yml
@@ -3,9 +3,8 @@ name: Build Frontend Docker Image
 on:
   push:
     branches:
-      - 'main'
       - 'develop'
-      - 'feature/**'
+      - 'master'
 
 jobs:
   build_push_frontend:

--- a/.github/workflows/push-image-frontend.yml
+++ b/.github/workflows/push-image-frontend.yml
@@ -1,0 +1,53 @@
+name: Build Frontend Docker Image
+
+on:
+  push:
+    branches:
+      - 'main'
+      - 'develop'
+      - 'feature/**'
+
+jobs:
+  build_push_frontend:
+    name: Build Frontend Docker Image
+    runs-on: ubuntu-20.04
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3.3.0
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2.1.0
+        with:
+          platforms: linux/arm64,linux/amd64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2.5.0
+
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v2.1.0
+        with:
+          registry: "ghcr.io"
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4.3.0
+        with:
+          images: ghcr.io/${{ github.repository }}-frontend
+
+      - name: Build Frontend Server
+        uses: docker/build-push-action@v4.0.0
+        with:
+          context: .
+          file: ./apps/app/Dockerfile.web
+          platforms: linux/arm64,linux/amd64
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Add Github Actions that will build and publish Frontend and Backend images of plane to Github's registry.

Things to note:
1. This is my first time with Github Actions, and wanted to give it a shot, so any feedback/commit is welcomed.
2. ARM jobs take longer, specially Backend, specially because the [Gevent](https://github.com/gevent/gevent) dependency does not have any wheels for arm64, and as it builds it from source on the spot, increases build time notoriusly.
3. The auto generated labes/tags from the `docker/metadata-action` job might not be accurate or adequate.