### PR TITLE
fix: minor ui fixes

### DIFF
--- a/apps/app/components/workspace/help-section.tsx
+++ b/apps/app/components/workspace/help-section.tsx
@@ -57,7 +57,7 @@ export const WorkspaceHelpSection: FC<WorkspaceHelpSectionProps> = (props) => {
   return (
     <div
       className={`flex w-full items-center justify-between self-baseline border-t bg-white px-6 py-2 ${
-        sidebarCollapse ? "flex-col-reverse" : ""
+        sidebarCollapse ? "flex-col" : ""
       }`}
     >
       <button
@@ -73,7 +73,7 @@ export const WorkspaceHelpSection: FC<WorkspaceHelpSectionProps> = (props) => {
         }}
         title="Shortcuts"
       >
-        <BoltIcon className={`text-gray-500 ${sidebarCollapse ? "h-4 w-4" : "h-6 w-6"}`} />
+        <BoltIcon className="h-4 w-4 text-gray-500" />
         {!sidebarCollapse && <span>Shortcuts</span>}
       </button>
       <button
@@ -84,9 +84,7 @@ export const WorkspaceHelpSection: FC<WorkspaceHelpSectionProps> = (props) => {
         onClick={() => setIsNeedHelpOpen((prev) => !prev)}
         title="Help"
       >
-        <QuestionMarkCircleIcon
-          className={`text-gray-500 ${sidebarCollapse ? "h-4 w-4" : "h-6 w-6"}`}
-        />
+        <QuestionMarkCircleIcon className="h-4 w-4 text-gray-500" />
         {!sidebarCollapse && <span>Help</span>}
       </button>
       <button
@@ -94,11 +92,7 @@ export const WorkspaceHelpSection: FC<WorkspaceHelpSectionProps> = (props) => {
         className="flex items-center gap-3 rounded-md px-2 py-2 text-xs font-medium text-gray-500 outline-none hover:bg-gray-100 hover:text-gray-900 md:hidden"
         onClick={() => setSidebarActive(false)}
       >
-        <ArrowLongLeftIcon
-          className={`flex-shrink-0 text-gray-500 group-hover:text-gray-900 ${
-            sidebarCollapse ? "h-4 w-4" : "h-6 w-6"
-          }`}
-        />
+        <ArrowLongLeftIcon className="h-4 w-4 flex-shrink-0 text-gray-500 group-hover:text-gray-900" />
       </button>
       <button
         type="button"
@@ -108,8 +102,8 @@ export const WorkspaceHelpSection: FC<WorkspaceHelpSectionProps> = (props) => {
         onClick={() => toggleCollapsed()}
       >
         <ArrowLongLeftIcon
-          className={`flex-shrink-0 text-gray-500 duration-300 group-hover:text-gray-900 ${
-            sidebarCollapse ? "h-4 w-4 rotate-180" : "h-6 w-6"
+          className={`h-4 w-4 flex-shrink-0 text-gray-500 duration-300 group-hover:text-gray-900 ${
+            sidebarCollapse ? "rotate-180" : ""
           }`}
         />
       </button>

--- a/apps/app/contexts/issue-view.context.tsx
+++ b/apps/app/contexts/issue-view.context.tsx
@@ -60,7 +60,7 @@ export const initialState: StateType = {
   issueView: "list",
   groupByProperty: null,
   orderBy: "created_at",
-  showEmptyGroups: false,
+  showEmptyGroups: true,
   filters: {
     type: null,
     priority: null,
@@ -122,7 +122,7 @@ export const reducer: ReducerFunctionType = (state, action) => {
     case "SET_SHOW_EMPTY_STATES": {
       const newState = {
         ...state,
-        showEmptyGroups: payload?.showEmptyGroups || false,
+        showEmptyGroups: payload?.showEmptyGroups || true,
       };
 
       return {


### PR DESCRIPTION
fix:

- sidebar arrow positioning in the collapsed state.
- show empty groups option set to `true` by default.