### PR TITLE
fix: don't allow decimal in the y axis of completed issues graph

### DIFF
--- a/apps/app/components/workspace/completed-issues-graph.tsx
+++ b/apps/app/components/workspace/completed-issues-graph.tsx
@@ -60,7 +60,7 @@ export const CompletedIssuesGraph: React.FC<Props> = ({ month, issues, setMonth 
           <LineChart data={data}>
             <CartesianGrid stroke="#e2e2e2" />
             <XAxis dataKey="week_in_month" />
-            <YAxis dataKey="completed_count" />
+            <YAxis dataKey="completed_count" allowDecimals={false} />
             <Tooltip content={<CustomTooltip />} />
             <Line
               type="monotone"


### PR DESCRIPTION
fix: 
- prevent decimal value in the y axis of completed issues graph
