### PR TITLE
fix: issue modal title text field reset

### DIFF
--- a/apps/app/components/issues/form.tsx
+++ b/apps/app/components/issues/form.tsx
@@ -94,6 +94,7 @@ export const IssueForm: FC<IssueFormProps> = ({
     reset,
     watch,
     control,
+    getValues,
     setValue,
     setFocus,
   } = useForm<IIssue>({
@@ -272,7 +273,11 @@ export const IssueForm: FC<IssueFormProps> = ({
                 />
                 <GptAssistantModal
                   isOpen={gptAssistantModal}
-                  handleClose={() => setGptAssistantModal(false)}
+                  handleClose={() => {
+                    setGptAssistantModal(false);
+                    // this is done so that the title do not reset after gpt popover closed
+                    reset(getValues());
+                  }}
                   inset="top-2 left-0"
                   content=""
                   htmlContent={watch("description_html")}


### PR DESCRIPTION
fix:

- title of issue modal is resetting itself also when switching tabs and on AI popover closes.