### PR TITLE
fix: old labels must have black color in project settings

### DIFF
--- a/apps/app/components/labels/labels-list-modal.tsx
+++ b/apps/app/components/labels/labels-list-modal.tsx
@@ -146,7 +146,7 @@ export const LabelsListModal: React.FC<Props> = ({ isOpen, handleClose, parent }
                                   <span
                                     className="block h-1.5 w-1.5 flex-shrink-0 rounded-full"
                                     style={{
-                                      backgroundColor: label.color,
+                                      backgroundColor: label.color !== "" ? label.color : "#000000",
                                     }}
                                   />
                                   {label.name}


### PR DESCRIPTION
fix: 
- old labels must have black color in project settings