### PR TITLE
chore: remove github importer tab

### DIFF
--- a/apps/app/layouts/settings-navbar.tsx
+++ b/apps/app/layouts/settings-navbar.tsx
@@ -29,10 +29,10 @@ const SettingsNavbar: React.FC<Props> = ({ profilePage = false }) => {
       label: "Integrations",
       href: `/${workspaceSlug}/settings/integrations`,
     },
-    {
-      label: "Import/Export",
-      href: `/${workspaceSlug}/settings/import-export`,
-    },
+    // {
+    //   label: "Import/Export",
+    //   href: `/${workspaceSlug}/settings/import-export`,
+    // },
   ];
 
   const projectLinks: Array<{


### PR DESCRIPTION
chore:

- remove GitHub importer tab from workspace settings.