### PR TITLE
docs: update readme to include default email and password for self hosting setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ cd plane
 docker-compose up
 ```
 
+<strong>You can use the default email and password for your first login `captain@plane.so` and `password123`.</strong> 
 
 ## 🚀 Features
 


### PR DESCRIPTION
docs: update readme to include default email and password for self hosting setup