### PR TITLE
fix: remove migrate command from worker script

### DIFF
--- a/apiserver/bin/worker
+++ b/apiserver/bin/worker
@@ -2,5 +2,4 @@
 set -e
 
 python manage.py wait_for_db
-python manage.py migrate
 celery -A plane.settings.celery worker -l info


### PR DESCRIPTION
fix: remove migrate command from worker script