### PR TITLE
fix: redis url for docker in production settings

### DIFF
--- a/apiserver/plane/settings/production.py
+++ b/apiserver/plane/settings/production.py
@@ -242,5 +242,9 @@ LOGGER_BASE_URL = os.environ.get("LOGGER_BASE_URL", False)
 redis_url = os.environ.get("REDIS_URL")
 broker_url = f"{redis_url}?ssl_cert_reqs={ssl.CERT_NONE.name}&ssl_ca_certs={certifi.where()}"
 
-CELERY_RESULT_BACKEND = broker_url
-CELERY_BROKER_URL = broker_url
+if DOCKERIZED:
+    CELERY_BROKER_URL = REDIS_URL
+    CELERY_RESULT_BACKEND = REDIS_URL
+else:
+    CELERY_RESULT_BACKEND = broker_url
+    CELERY_BROKER_URL = broker_url


### PR DESCRIPTION
fix: redis url for docker in production settings