### PR TITLE
fix: show the assignee name in the custom analytics tooltip

### DIFF
--- a/apps/app/components/analytics/custom-analytics/graph/custom-tooltip.tsx
+++ b/apps/app/components/analytics/custom-analytics/graph/custom-tooltip.tsx
@@ -3,19 +3,28 @@ import { BarTooltipProps } from "@nivo/bar";
 import { DATE_KEYS } from "constants/analytics";
 import { renderMonthAndYear } from "helpers/analytics.helper";
 // types
-import { IAnalyticsParams } from "types";
+import { IAnalyticsParams, IAnalyticsResponse } from "types";
 
 type Props = {
   datum: BarTooltipProps<any>;
+  analytics: IAnalyticsResponse;
   params: IAnalyticsParams;
 };
 
-export const CustomTooltip: React.FC<Props> = ({ datum, params }) => {
+export const CustomTooltip: React.FC<Props> = ({ datum, analytics, params }) => {
   let tooltipValue: string | number = "";
 
   if (params.segment) {
     if (DATE_KEYS.includes(params.segment)) tooltipValue = renderMonthAndYear(datum.id);
-    else tooltipValue = datum.id;
+    else if (params.segment === "assignees__email") {
+      const assignee = analytics.extras.assignee_details.find(
+        (a) => a.assignees__email === datum.id
+      );
+
+      if (assignee)
+        tooltipValue = assignee.assignees__first_name + " " + assignee.assignees__last_name;
+      else tooltipValue = "No assignees";
+    } else tooltipValue = datum.id;
   } else {
     if (DATE_KEYS.includes(params.x_axis)) tooltipValue = datum.indexValue;
     else tooltipValue = datum.id === "count" ? "Issue count" : "Estimate";

--- a/apps/app/components/analytics/custom-analytics/graph/index.tsx
+++ b/apps/app/components/analytics/custom-analytics/graph/index.tsx
@@ -66,7 +66,7 @@ export const AnalyticsGraph: React.FC<Props> = ({
         )
       }
       customYAxisTickValues={generateYAxisTickValues()}
-      tooltip={(datum) => <CustomTooltip datum={datum} params={params} />}
+      tooltip={(datum) => <CustomTooltip datum={datum} analytics={analytics} params={params} />}
       height={fullScreen ? "400px" : "300px"}
       margin={{
         right: 20,


### PR DESCRIPTION
fix:

- show the assignee name in the custom analytics tooltip.