### PR TITLE
fix: auto generated secret key to only generate hexadecimal characters

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -4,4 +4,4 @@ cp ./.env.example ./.env
 echo -e "\nNEXT_PUBLIC_API_BASE_URL=http://$1"  >> ./.env
 export LC_ALL=C
 export LC_CTYPE=C
-echo -e "\nSECRET_KEY=\"$(tr -dc 'a-z0-9!@#$%^&*(-_=+)' < /dev/urandom | head -c50)\""  >> ./.env
+echo -e "SECRET_KEY=\"$(tr -dc 'a-f0-9' < /dev/urandom | head -c50)\"" >> ./.env


### PR DESCRIPTION
fix: auto generated secret key to only generate hexadecimal characters

This PR should fix #1127