### PR TITLE
chore: speedup replace-env-vars.sh

### DIFF
--- a/replace-env-vars.sh
+++ b/replace-env-vars.sh
@@ -11,7 +11,4 @@ fi
 # Only peform action if $FROM and $TO are different.
 echo "Replacing all statically built instances of $FROM with this string $TO ."
 
-find apps/app/.next -type f |
-while read file; do
-    sed -i "s|$FROM|$TO|g" "$file"
-done
+grep -R -la "${FROM}" apps/app/.next | xargs -I{} sed -i "s|$FROM|$TO|g" "{}"


### PR DESCRIPTION
The previous implementation of this script uses `find` to enumerate *all files* under the app directory, then reads all of those files in a single while loop to apply `sed`. This is extremely slow with ~80k files during build time. We don't need to read all these files like that; we can use grep to search for files that we actually need to update and then parallelize the sed command to do it.

I ran `shellcheck` against the script to make sure I didn't introduce any obvious new footguns and made sure `docker-compose -f docker-compose.yml up --build` still built the image and ran without issues.