### PR TITLE
Add dos2unix for building docker image on win

### DIFF
--- a/apps/app/Dockerfile.web
+++ b/apps/app/Dockerfile.web
@@ -13,6 +13,7 @@ RUN turbo prune --scope=app --docker
 FROM node:18-alpine AS installer
 
 RUN apk add --no-cache libc6-compat
+RUN apk add --no-cache dos2unix
 WORKDIR /app
 ARG NEXT_PUBLIC_API_BASE_URL=http://localhost:8000
 
@@ -25,7 +26,10 @@ RUN yarn install
 # Build the project
 COPY --from=builder /app/out/full/ .
 COPY turbo.json turbo.json
+
 COPY replace-env-vars.sh /usr/local/bin/
+RUN dos2unix /usr/local/bin/replace-env-vars.sh && apk del dos2unix && rm -rf /var/lib/apt/lists/*
+
 USER root
 RUN chmod +x /usr/local/bin/replace-env-vars.sh
 


### PR DESCRIPTION
When I tried to build a project on windows, I got an error (RUN replace-env-vars.sh - process caused "no such file or directory")

Cause in replace-env-vars.sh, shebang #!/bin/sh returns not found for wsl
This is not critical, but it will add the ability to build the project under different systems (I think this is more for development)