### PR TITLE
fix: cannot change the state if it's the only state in group 

### DIFF
--- a/apps/app/components/states/create-update-state-inline.tsx
+++ b/apps/app/components/states/create-update-state-inline.tsx
@@ -15,7 +15,7 @@ import stateService from "services/state.service";
 // hooks
 import useToast from "hooks/use-toast";
 // ui
-import { CustomSelect, Input, PrimaryButton, SecondaryButton } from "components/ui";
+import { CustomSelect, Input, PrimaryButton, SecondaryButton, Tooltip } from "components/ui";
 // types
 import type { ICurrentUserResponse, IState, IStateResponse } from "types";
 // fetch-keys
@@ -28,6 +28,7 @@ type Props = {
   onClose: () => void;
   selectedGroup: StateGroup | null;
   user: ICurrentUserResponse | undefined;
+  groupLength: number;
 };
 
 export type StateGroup = "backlog" | "unstarted" | "started" | "completed" | "cancelled" | null;
@@ -43,6 +44,7 @@ export const CreateUpdateStateInline: React.FC<Props> = ({
   onClose,
   selectedGroup,
   user,
+  groupLength,
 }) => {
   const router = useRouter();
   const { workspaceSlug, projectId } = router.query;
@@ -174,9 +176,8 @@ export const CreateUpdateStateInline: React.FC<Props> = ({
           {({ open }) => (
             <>
               <Popover.Button
-                className={`group inline-flex items-center text-base font-medium focus:outline-none ${
-                  open ? "text-brand-base" : "text-brand-secondary"
-                }`}
+                className={`group inline-flex items-center text-base font-medium focus:outline-none ${open ? "text-brand-base" : "text-brand-secondary"
+                  }`}
               >
                 {watch("color") && watch("color") !== "" && (
                   <span
@@ -228,22 +229,27 @@ export const CreateUpdateStateInline: React.FC<Props> = ({
           name="group"
           control={control}
           render={({ field: { value, onChange } }) => (
-            <CustomSelect
-              value={value}
-              onChange={onChange}
-              label={
-                Object.keys(GROUP_CHOICES).find((k) => k === value.toString())
-                  ? GROUP_CHOICES[value.toString() as keyof typeof GROUP_CHOICES]
-                  : "Select group"
-              }
-              input
-            >
-              {Object.keys(GROUP_CHOICES).map((key) => (
-                <CustomSelect.Option key={key} value={key}>
-                  {GROUP_CHOICES[key as keyof typeof GROUP_CHOICES]}
-                </CustomSelect.Option>
-              ))}
-            </CustomSelect>
+            <Tooltip tooltipContent={groupLength === 1 ? "Cannot have an empty group." : "Choose State"}  >
+              <div>
+                <CustomSelect
+                  disabled={groupLength === 1}
+                  value={value}
+                  onChange={onChange}
+                  label={
+                    Object.keys(GROUP_CHOICES).find((k) => k === value.toString())
+                      ? GROUP_CHOICES[value.toString() as keyof typeof GROUP_CHOICES]
+                      : "Select group"
+                  }
+                  input
+                >
+                  {Object.keys(GROUP_CHOICES).map((key) => (
+                    <CustomSelect.Option key={key} value={key}>
+                      {GROUP_CHOICES[key as keyof typeof GROUP_CHOICES]}
+                    </CustomSelect.Option>
+                  ))}
+                </CustomSelect>
+              </div>
+            </Tooltip>
           )}
         />
       )}

--- a/apps/app/pages/[workspaceSlug]/projects/[projectId]/settings/states.tsx
+++ b/apps/app/pages/[workspaceSlug]/projects/[projectId]/settings/states.tsx
@@ -98,6 +98,7 @@ const StatesSettings: NextPage = () => {
                         <div className="divide-y divide-brand-base rounded-[10px] border border-brand-base">
                           {key === activeGroup && (
                             <CreateUpdateStateInline
+                              groupLength={orderedStateGroups[key].length}
                               onClose={() => {
                                 setActiveGroup(null);
                                 setSelectedState(null);
@@ -128,6 +129,7 @@ const StatesSettings: NextPage = () => {
                                     setActiveGroup(null);
                                     setSelectedState(null);
                                   }}
+                                  groupLength={orderedStateGroups[key].length}
                                   data={
                                     statesList?.find((state) => state.id === selectedState) ?? null
                                   }


### PR DESCRIPTION
* Closes #1329 

## Issue in brief
Though an user cannot delete the only state of a group, one could change the group of that state by using the dropdown menu.

## Suggested Fixes/Changes 

- Check if `groupLength` is 1 (to see it's the only state in the group
- Disable the Dropdown if groupLength is 1
- Add a tooltip to suggest why the DropDown is disabled and the action to perform when it's enabled

## Updated screenshots of the above Suggested Changes

- If only one state in the group
<img width="600" alt="Screenshot 2023-06-22 at 1 10 29 PM" src="https://github.com/makeplane/plane/assets/73993394/ad8704a2-fb40-498b-ae45-1212c0f27593">

- If multiple states present in the group
<img width="600" alt="Screenshot 2023-06-22 at 1 44 11 PM" src="https://github.com/makeplane/plane/assets/73993394/0c7ffcf0-96de-4e79-86fd-421c32a67e00">

## Demo Time

### Before
https://github.com/makeplane/plane/assets/73993394/0a86f0f0-a5cf-415f-8180-eb0971e5cf55

### After
https://github.com/makeplane/plane/assets/73993394/8a939b45-d18c-4ce2-bdf1-98558cb35565

## Potential Further Steps
- Enforce this login on the backend as well



