### PR TITLE
remove noHeader prop & show navigation as burger menu on [workspaceSlug] page, mobile screens

### DIFF
--- a/apps/app/pages/[workspaceSlug]/index.tsx
+++ b/apps/app/pages/[workspaceSlug]/index.tsx
@@ -40,7 +40,7 @@ const WorkspacePage: NextPage = () => {
   }, [month, workspaceSlug]);
 
   return (
-    <WorkspaceAuthorizationLayout noHeader>
+    <WorkspaceAuthorizationLayout>
       {isProductUpdatesModalOpen && (
         <ProductUpdatesModal
           isOpen={isProductUpdatesModalOpen}


### PR DESCRIPTION
This is a fix to bug #1332 [bug]: Unable to navigate via mobile on [workspaceSlug] page 