### PR TITLE
Add network timeout option to yarn install

### DIFF
--- a/apps/app/Dockerfile.web
+++ b/apps/app/Dockerfile.web
@@ -20,7 +20,7 @@ ARG NEXT_PUBLIC_API_BASE_URL=http://localhost:8000
 COPY .gitignore .gitignore
 COPY --from=builder /app/out/json/ .
 COPY --from=builder /app/out/yarn.lock ./yarn.lock
-RUN yarn install
+RUN yarn install --network-timeout 500000
 
 # Build the project
 COPY --from=builder /app/out/full/ .


### PR DESCRIPTION
Inside of the Dockerfile.web, the yarn install command is susceptible to encountering a ECONNECT timeout error on aarch64 and ARM devices (such as a raspberry pi). This explicit overwrite of the default network timeout extends the window for low power CPU devices.

Fixes #1213 