### PR TITLE
fix: progress chart to show the ideal line only when data is present

### DIFF
--- a/apps/app/components/core/sidebar/progress-chart.tsx
+++ b/apps/app/components/core/sidebar/progress-chart.tsx
@@ -93,16 +93,19 @@ const ProgressChart: React.FC<Props> = ({ distribution, startDate, endDate, tota
             id: "ideal",
             color: "#a9bbd0",
             fill: "transparent",
-            data: [
-              {
-                x: chartData[0].currentDate,
-                y: totalIssues,
-              },
-              {
-                x: chartData[chartData.length - 1].currentDate,
-                y: 0,
-              },
-            ],
+            data:
+              chartData.length > 0
+                ? [
+                    {
+                      x: chartData[0].currentDate,
+                      y: totalIssues,
+                    },
+                    {
+                      x: chartData[chartData.length - 1].currentDate,
+                      y: 0,
+                    },
+                  ]
+                : [],
           },
         ]}
         layers={["grid", "markers", "areas", DashedLine, "slices", "points", "axes", "legends"]}


### PR DESCRIPTION
fix:

- progress chart to show the ideal line only when data is present.