### PR TITLE
adapt Page tabs layout to mobile screens

### DIFF
--- a/apps/app/pages/[workspaceSlug]/projects/[projectId]/pages/index.tsx
+++ b/apps/app/pages/[workspaceSlug]/projects/[projectId]/pages/index.tsx
@@ -123,7 +123,7 @@ const ProjectPages: NextPage = () => {
           </PrimaryButton>
         }
       >
-        <div className="space-y-5 p-8 h-full overflow-hidden flex flex-col">
+        <div className="relative space-y-5 p-8 h-full overflow-hidden flex flex-col">
           <h3 className="text-2xl font-semibold text-brand-base">Pages</h3>
           <Tab.Group
             as={Fragment}
@@ -146,8 +146,11 @@ const ProjectPages: NextPage = () => {
               }
             }}
           >
-            <Tab.List as="div" className="mb-6 flex items-center justify-between">
-              <div className="flex gap-4">
+            <Tab.List
+              as="div"
+              className="page-viewer-wrapper relative mb-6 flex items-center justify-between"
+            >
+              <div className="tabs-container flex gap-4">
                 {tabsList.map((tab, index) => (
                   <Tab
                     key={`${tab}-${index}`}
@@ -163,7 +166,7 @@ const ProjectPages: NextPage = () => {
                   </Tab>
                 ))}
               </div>
-              <div className="flex gap-x-1">
+              <div className="page-viewer flex gap-x-1">
                 <button
                   type="button"
                   className={`grid h-7 w-7 place-items-center rounded p-1 outline-none duration-300 hover:bg-brand-surface-2 ${

--- a/apps/app/styles/globals.css
+++ b/apps/app/styles/globals.css
@@ -9,6 +9,22 @@
     font-size: 1.375rem;
     line-height: 1.875rem;
   }
+
+  @media screen and (max-width: 500px) {
+    .page-viewer-wrapper {
+      position: relative;
+    }
+
+    .tabs-container {
+      flex-wrap: wrap;
+    }
+
+    .page-viewer {
+      position: absolute;
+      top: -50px;
+      right: 0;
+    }
+  }
 }
 
 @layer base {


### PR DESCRIPTION
This is a fix to #1380 

Fixed the broken layout of page tabs on mobile devices, now it will look like this:
<img width="363" alt="Screenshot 2023-06-23 at 23 25 32" src="https://github.com/makeplane/plane/assets/56432889/b51742c0-8f0f-4548-bac7-f687a9cb7d1e">
