### PR TITLE
chore: Dry up docker compose environment variables

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,36 @@
 version: "3.8"
 
+x-api-and-worker-env: &api-and-worker-env
+        DEBUG: ${DEBUG}
+        SENTRY_DSN: ${SENTRY_DSN}
+        DJANGO_SETTINGS_MODULE: plane.settings.production
+        DATABASE_URL: postgres://${PGUSER}:${PGPASSWORD}@${PGHOST}:5432/${PGDATABASE}
+        REDIS_URL: redis://plane-redis:6379/
+        EMAIL_HOST: ${EMAIL_HOST}
+        EMAIL_HOST_USER: ${EMAIL_HOST_USER}
+        EMAIL_HOST_PASSWORD: ${EMAIL_HOST_PASSWORD}
+        EMAIL_PORT: ${EMAIL_PORT}
+        EMAIL_FROM: ${EMAIL_FROM}
+        EMAIL_USE_TLS: ${EMAIL_USE_TLS}
+        EMAIL_USE_SSL: ${EMAIL_USE_SSL}
+        AWS_REGION: ${AWS_REGION}
+        AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+        AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+        AWS_S3_BUCKET_NAME: ${AWS_S3_BUCKET_NAME}
+        AWS_S3_ENDPOINT_URL: ${AWS_S3_ENDPOINT_URL}
+        FILE_SIZE_LIMIT: ${FILE_SIZE_LIMIT}
+        WEB_URL: ${WEB_URL}
+        GITHUB_CLIENT_SECRET: ${GITHUB_CLIENT_SECRET}
+        DISABLE_COLLECTSTATIC: 1
+        DOCKERIZED: 1
+        OPENAI_API_KEY: ${OPENAI_API_KEY}
+        GPT_ENGINE: ${GPT_ENGINE}
+        SECRET_KEY: ${SECRET_KEY}
+        DEFAULT_EMAIL: ${DEFAULT_EMAIL}
+        DEFAULT_PASSWORD: ${DEFAULT_PASSWORD}
+        USE_MINIO: ${USE_MINIO}
+        ENABLE_SIGNUP: ${ENABLE_SIGNUP}
+
 services:
         plane-web:
                 container_name: planefrontend
@@ -37,35 +68,7 @@ services:
                 env_file:
                         - .env
                 environment:
-                        DEBUG: ${DEBUG}
-                        SENTRY_DSN: ${SENTRY_DSN}
-                        DJANGO_SETTINGS_MODULE: plane.settings.production
-                        DATABASE_URL: postgres://${PGUSER}:${PGPASSWORD}@${PGHOST}:5432/${PGDATABASE}
-                        REDIS_URL: redis://plane-redis:6379/
-                        EMAIL_HOST: ${EMAIL_HOST}
-                        EMAIL_HOST_USER: ${EMAIL_HOST_USER}
-                        EMAIL_HOST_PASSWORD: ${EMAIL_HOST_PASSWORD}
-                        EMAIL_PORT: ${EMAIL_PORT}
-                        EMAIL_FROM: ${EMAIL_FROM}
-                        EMAIL_USE_TLS: ${EMAIL_USE_TLS}
-                        EMAIL_USE_SSL: ${EMAIL_USE_SSL}
-                        AWS_REGION: ${AWS_REGION}
-                        AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
-                        AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
-                        AWS_S3_BUCKET_NAME: ${AWS_S3_BUCKET_NAME}
-                        AWS_S3_ENDPOINT_URL: ${AWS_S3_ENDPOINT_URL}
-                        FILE_SIZE_LIMIT: ${FILE_SIZE_LIMIT}
-                        WEB_URL: ${WEB_URL}
-                        GITHUB_CLIENT_SECRET: ${GITHUB_CLIENT_SECRET}
-                        DISABLE_COLLECTSTATIC: 1
-                        DOCKERIZED: 1
-                        OPENAI_API_KEY: ${OPENAI_API_KEY}
-                        GPT_ENGINE: ${GPT_ENGINE}
-                        SECRET_KEY: ${SECRET_KEY}
-                        DEFAULT_EMAIL: ${DEFAULT_EMAIL}
-                        DEFAULT_PASSWORD: ${DEFAULT_PASSWORD}
-                        USE_MINIO: ${USE_MINIO}
-                        ENABLE_SIGNUP: ${ENABLE_SIGNUP}
+                        <<: *api-and-worker-env
                 depends_on:
                         - plane-db
                         - plane-redis
@@ -80,35 +83,7 @@ services:
                 env_file:
                         - .env
                 environment:
-                        DEBUG: ${DEBUG}
-                        SENTRY_DSN: ${SENTRY_DSN}
-                        DJANGO_SETTINGS_MODULE: plane.settings.production
-                        DATABASE_URL: postgres://${PGUSER}:${PGPASSWORD}@${PGHOST}:5432/${PGDATABASE}
-                        REDIS_URL: redis://plane-redis:6379/
-                        EMAIL_HOST: ${EMAIL_HOST}
-                        EMAIL_HOST_USER: ${EMAIL_HOST_USER}
-                        EMAIL_HOST_PASSWORD: ${EMAIL_HOST_PASSWORD}
-                        EMAIL_PORT: ${EMAIL_PORT}
-                        EMAIL_FROM: ${EMAIL_FROM}
-                        EMAIL_USE_TLS: ${EMAIL_USE_TLS}
-                        EMAIL_USE_SSL: ${EMAIL_USE_SSL}
-                        AWS_REGION: ${AWS_REGION}
-                        AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
-                        AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
-                        AWS_S3_BUCKET_NAME: ${AWS_S3_BUCKET_NAME}
-                        AWS_S3_ENDPOINT_URL: ${AWS_S3_ENDPOINT_URL}
-                        FILE_SIZE_LIMIT: ${FILE_SIZE_LIMIT}
-                        WEB_URL: ${WEB_URL}
-                        GITHUB_CLIENT_SECRET: ${GITHUB_CLIENT_SECRET}
-                        DISABLE_COLLECTSTATIC: 1
-                        DOCKERIZED: 1
-                        OPENAI_API_KEY: ${OPENAI_API_KEY}
-                        GPT_ENGINE: ${GPT_ENGINE}
-                        SECRET_KEY: ${SECRET_KEY}
-                        DEFAULT_EMAIL: ${DEFAULT_EMAIL:-captain@plane.so}
-                        DEFAULT_PASSWORD: ${DEFAULT_PASSWORD:-password123}
-                        USE_MINIO: ${USE_MINIO}
-                        ENABLE_SIGNUP: ${ENABLE_SIGNUP}
+                        <<: *api-and-worker-env
                 depends_on:
                         - plane-api
                         - plane-db


### PR DESCRIPTION
* chore: Use docker compose extensions to dry up duplicate environment variables between worker and api services.
See: https://docs.docker.com/compose/compose-file/11-extension/