### PR TITLE
feat: Added Tag based classification between images based on master & develop

### DIFF
--- a/.github/workflows/push-image-backend.yml
+++ b/.github/workflows/push-image-backend.yml
@@ -50,6 +50,16 @@ jobs:
         uses: docker/metadata-action@v4.3.0
         with:
           images: ghcr.io/${{ github.repository }}-backend
+      
+      - name: Get latest release tag
+        id: get-latest-tag
+        run: |
+          if [[ ${{ github.ref }} == 'refs/heads/master' ]]; then
+            export "RELEASE_TAG=$(curl --silent --header 'Accept: application/vnd.github.v3+json' "https://api.github.com/repos/${{ github.repository }}/releases/latest" | jq -r .tag_name)"
+          else
+            export "RELEASE_TAG=development"
+          fi
+          echo "RELEASE_TAG=${RELEASE_TAG#v}" >> $GITHUB_ENV
 
       - name: Build and Push to GitHub Container Registry
         uses: docker/build-push-action@v4.0.0
@@ -60,10 +70,11 @@ jobs:
           push: true
           cache-from: type=gha
           cache-to: type=gha
-          tags: ${{ steps.ghmeta.outputs.tags }}
+          tags: ${{ github.repository }}:${{ env.RELEASE_TAG }}
           labels: ${{ steps.ghmeta.outputs.labels }}
 
       - name: Build and Push to Docker Hub
+        id: build-and-push-image
         uses: docker/build-push-action@v4.0.0
         with:
           context: ./apiserver
@@ -72,6 +83,7 @@ jobs:
           push: true
           cache-from: type=gha
           cache-to: type=gha
-          tags: ${{ steps.dkrmeta.outputs.tags }}
+          tags: ${{ github.repository }}:${{ env.RELEASE_TAG }}
           labels: ${{ steps.dkrmeta.outputs.labels }}
+
 

--- a/.github/workflows/push-image-backend.yml
+++ b/.github/workflows/push-image-backend.yml
@@ -4,9 +4,8 @@ on:
   push:
     branches:
       - 'develop'
-      - 'master'
     tags:
-      - '*'
+      - '*.*.*'
 
 jobs:
   build_push_backend:
@@ -39,29 +38,28 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
-      - name: Extract metadata (tags, labels) for Docker (Docker Hub)
+      - name: Extract metadata (tags, labels) for Docker (Docker Hub) Develop
         id: ghmeta
         uses: docker/metadata-action@v4.3.0
         with:
           images: makeplane/plane-backend
+          flavor: |
+            latest=false
+          tags: |
+            type=semver,pattern={{version}}
 
       - name: Extract metadata (tags, labels) for Docker (Github)
         id: dkrmeta
         uses: docker/metadata-action@v4.3.0
         with:
           images: ghcr.io/${{ github.repository }}-backend
-      
-      - name: Get latest release tag
-        id: get-latest-tag
-        run: |
-          if [[ ${{ github.ref }} == 'refs/heads/master' ]]; then
-            export "RELEASE_TAG=$(curl --silent --header 'Accept: application/vnd.github.v3+json' "https://api.github.com/repos/${{ github.repository }}/releases/latest" | jq -r .tag_name)"
-          else
-            export "RELEASE_TAG=development"
-          fi
-          echo "RELEASE_TAG=${RELEASE_TAG#v}" >> $GITHUB_ENV
+          flavor: |
+            latest=false
+          tags: |
+            type=ref,event=tag
 
-      - name: Build and Push to GitHub Container Registry
+      - name: Build and Push to GitHub Container Registry Develop
+        if: startsWith(github.ref, 'refs/heads/develop')
         uses: docker/build-push-action@v4.0.0
         with:
           context: ./apiserver
@@ -70,11 +68,12 @@ jobs:
           push: true
           cache-from: type=gha
           cache-to: type=gha
-          tags: ${{ github.repository }}:${{ env.RELEASE_TAG }}
+          tags: makeplane/plane-backend:develop
           labels: ${{ steps.ghmeta.outputs.labels }}
 
       - name: Build and Push to Docker Hub
-        id: build-and-push-image
+        id: build-and-push-image-develop
+        if: startsWith(github.ref, 'refs/heads/develop')
         uses: docker/build-push-action@v4.0.0
         with:
           context: ./apiserver
@@ -83,7 +82,32 @@ jobs:
           push: true
           cache-from: type=gha
           cache-to: type=gha
-          tags: ${{ github.repository }}:${{ env.RELEASE_TAG }}
+          tags: makeplane/plane-backend:develop
           labels: ${{ steps.dkrmeta.outputs.labels }}
 
+      - name: Build and Push to GitHub Container Registry Tag 
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: docker/build-push-action@v4.0.0
+        with:
+          context: ./apiserver
+          file: ./apiserver/Dockerfile.api
+          platforms: linux/arm64,linux/amd64
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha
+          tags: ${{ steps.ghmeta.outputs.tags }}
+          labels: ${{ steps.ghmeta.outputs.labels }}
 
+      - name: Build and Push to Docker Hub
+        id: build-and-push-image-tag
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: docker/build-push-action@v4.0.0
+        with:
+          context: ./apiserver
+          file: ./apiserver/Dockerfile.api
+          platforms: linux/arm64,linux/amd64
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha
+          tags: ${{ steps.dkrmeta.outputs.tags }}
+          labels: ${{ steps.dkrmeta.outputs.labels }}

--- a/.github/workflows/push-image-frontend.yml
+++ b/.github/workflows/push-image-frontend.yml
@@ -51,6 +51,16 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}-frontend
 
+      - name: Get latest release tag
+        id: get-latest-tag
+        run: |
+          if [[ ${{ github.ref }} == 'refs/heads/master' ]]; then
+            export "RELEASE_TAG=$(curl --silent --header 'Accept: application/vnd.github.v3+json' "https://api.github.com/repos/${{ github.repository }}/releases/latest" | jq -r .tag_name)"
+          else
+            export "RELEASE_TAG=development"
+          fi
+          echo "RELEASE_TAG=${RELEASE_TAG#v}" >> $GITHUB_ENV
+
       - name: Build and Push to GitHub Container Registry
         uses: docker/build-push-action@v4.0.0
         with:
@@ -60,7 +70,7 @@ jobs:
           push: true
           cache-from: type=gha
           cache-to: type=gha
-          tags: ${{ steps.ghmeta.outputs.tags }}
+          tags: ${{ github.repository }}:${{ env.RELEASE_TAG }}
           labels: ${{ steps.ghmeta.outputs.labels }}
       
       - name: Build and Push to Docker Container Registry
@@ -72,6 +82,6 @@ jobs:
           push: true
           cache-from: type=gha
           cache-to: type=gha
-          tags: ${{ steps.dkrmeta.outputs.tags }}
+          tags: ${{ github.repository }}:${{ env.RELEASE_TAG }}
           labels: ${{ steps.dkrmeta.outputs.labels }}
 

--- a/.github/workflows/push-image-frontend.yml
+++ b/.github/workflows/push-image-frontend.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - 'develop'
-      - 'master'
     tags:
       - '*'
 
@@ -39,29 +38,29 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
       
-      - name: Extract metadata (tags, labels) for Docker (Docker Hub)
+      - name: Extract metadata (tags, labels) for Docker (Docker Hub) Develop
         id: ghmeta
         uses: docker/metadata-action@v4.3.0
         with:
           images: makeplane/plane-frontend
+          flavor: |
+            latest=false
+          tags: |
+            type=semver,pattern={{version}}
+
 
       - name: Extract metadata (tags, labels) for Docker (Github)
         id: meta
         uses: docker/metadata-action@v4.3.0
         with:
           images: ghcr.io/${{ github.repository }}-frontend
+          flavor: |
+            latest=false
+          tags: |
+            type=ref,event=tag
 
-      - name: Get latest release tag
-        id: get-latest-tag
-        run: |
-          if [[ ${{ github.ref }} == 'refs/heads/master' ]]; then
-            export "RELEASE_TAG=$(curl --silent --header 'Accept: application/vnd.github.v3+json' "https://api.github.com/repos/${{ github.repository }}/releases/latest" | jq -r .tag_name)"
-          else
-            export "RELEASE_TAG=development"
-          fi
-          echo "RELEASE_TAG=${RELEASE_TAG#v}" >> $GITHUB_ENV
-
-      - name: Build and Push to GitHub Container Registry
+      - name: Build and Push to GitHub Container Registry Develop
+        if: startsWith(github.ref, 'refs/heads/develop')
         uses: docker/build-push-action@v4.0.0
         with:
           context: .
@@ -70,10 +69,11 @@ jobs:
           push: true
           cache-from: type=gha
           cache-to: type=gha
-          tags: ${{ github.repository }}:${{ env.RELEASE_TAG }}
+          tags: makeplane/plane-frontend:develop
           labels: ${{ steps.ghmeta.outputs.labels }}
       
       - name: Build and Push to Docker Container Registry
+        if: startsWith(github.ref, 'refs/heads/develop')
         uses: docker/build-push-action@v4.0.0
         with:
           context: .
@@ -82,6 +82,31 @@ jobs:
           push: true
           cache-from: type=gha
           cache-to: type=gha
-          tags: ${{ github.repository }}:${{ env.RELEASE_TAG }}
+          tags: makeplane/plane-backend:develop
           labels: ${{ steps.dkrmeta.outputs.labels }}
 
+      - name: Build and Push to GitHub Container Registry Tags
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: docker/build-push-action@v4.0.0
+        with:
+          context: .
+          file: ./apps/app/Dockerfile.web
+          platforms: linux/arm64,linux/amd64
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha
+          tags: ${{ steps.ghmeta.outputs.tags }}
+          labels: ${{ steps.ghmeta.outputs.labels }}
+      
+      - name: Build and Push to Docker Container Registry
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: docker/build-push-action@v4.0.0
+        with:
+          context: .
+          file: ./apps/app/Dockerfile.web
+          platforms: linux/arm64,linux/amd64
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha
+          tags: ${{ steps.dkrmeta.outputs.tags }}
+          labels: ${{ steps.dkrmeta.outputs.labels }}

--- a/.github/workflows/push-image-proxy.yml
+++ b/.github/workflows/push-image-proxy.yml
@@ -1,0 +1,113 @@
+name: Build and Push Proxy Docker Image
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'develop'
+    tags:
+      - '*'
+
+jobs:
+  build_push_frontend:
+    name: Build Plane Proxy Docker Image
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3.3.0
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2.1.0
+        with:
+          platforms: linux/arm64,linux/amd64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2.5.0
+
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v2.1.0
+        with:
+          registry: "ghcr.io"
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2.1.0
+        with:
+          registry: "registry.hub.docker.com"
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      
+      - name: Extract metadata (tags, labels) for Docker (Docker Hub) Develop
+        id: ghmeta
+        uses: docker/metadata-action@v4.3.0
+        with:
+          images: makeplane/plane-proxy
+          flavor: |
+            latest=false
+          tags: |
+            type=semver,pattern={{version}}
+
+
+      - name: Extract metadata (tags, labels) for Docker (Github)
+        id: meta
+        uses: docker/metadata-action@v4.3.0
+        with:
+          images: ghcr.io/${{ github.repository }}-proxy
+          flavor: |
+            latest=false
+          tags: |
+            type=ref,event=tag
+
+      - name: Build and Push to GitHub Container Registry Develop
+        if: startsWith(github.ref, 'refs/heads/develop')
+        uses: docker/build-push-action@v4.0.0
+        with:
+          context: .
+          file: ./nginx/Dockerfile
+          platforms: linux/arm64,linux/amd64
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha
+          tags: makeplane/plane-proxy:develop
+          labels: ${{ steps.ghmeta.outputs.labels }}
+      
+      - name: Build and Push to Docker Container Registry
+        if: startsWith(github.ref, 'refs/heads/develop')
+        uses: docker/build-push-action@v4.0.0
+        with:
+          context: .
+          file: ./nginx/Dockerfile
+          platforms: linux/arm64,linux/amd64
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha
+          tags: makeplane/plane-proxy:develop
+          labels: ${{ steps.dkrmeta.outputs.labels }}
+
+      - name: Build and Push to GitHub Container Registry Tags
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: docker/build-push-action@v4.0.0
+        with:
+          context: .
+          file: ./nginx/Dockerfile
+          platforms: linux/arm64,linux/amd64
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha
+          tags: ${{ steps.ghmeta.outputs.tags }}
+          labels: ${{ steps.ghmeta.outputs.labels }}
+      
+      - name: Build and Push to Docker Container Registry
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: docker/build-push-action@v4.0.0
+        with:
+          context: .
+          file: ./nginx/Dockerfile
+          platforms: linux/arm64,linux/amd64
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha
+          tags: ${{ steps.dkrmeta.outputs.tags }}
+          labels: ${{ steps.dkrmeta.outputs.labels }}

--- a/.github/workflows/push-image-worker.yml
+++ b/.github/workflows/push-image-worker.yml
@@ -1,0 +1,113 @@
+name: Build and Push Plane Worker Docker Image
+
+on:
+  push:
+    branches:
+      - 'develop'
+    tags:
+      - '*.*.*'
+
+jobs:
+  build_push_backend:
+    name: Build and Push Api Server Docker Image
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3.3.0
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2.1.0
+        with:
+          platforms: linux/arm64,linux/amd64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2.5.0
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2.1.0
+        with:
+          registry: "ghcr.io"
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2.1.0
+        with:
+          registry: "registry.hub.docker.com"
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Extract metadata (tags, labels) for Docker (Docker Hub) Develop
+        id: ghmeta
+        uses: docker/metadata-action@v4.3.0
+        with:
+          images: makeplane/plane-worker
+          flavor: |
+            latest=false
+          tags: |
+            type=semver,pattern={{version}}
+
+      - name: Extract metadata (tags, labels) for Docker (Github)
+        id: dkrmeta
+        uses: docker/metadata-action@v4.3.0
+        with:
+          images: ghcr.io/${{ github.repository }}-worker
+          flavor: |
+            latest=false
+          tags: |
+            type=ref,event=tag
+
+      - name: Build and Push to GitHub Container Registry Develop
+        if: startsWith(github.ref, 'refs/heads/develop')
+        uses: docker/build-push-action@v4.0.0
+        with:
+          context: ./apiserver
+          file: ./apiserver/Dockerfile.api
+          platforms: linux/arm64,linux/amd64
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha
+          tags: makeplane/plane-worker:develop
+          labels: ${{ steps.ghmeta.outputs.labels }}
+
+      - name: Build and Push to Docker Hub
+        id: build-and-push-image-develop
+        if: startsWith(github.ref, 'refs/heads/develop')
+        uses: docker/build-push-action@v4.0.0
+        with:
+          context: ./apiserver
+          file: ./apiserver/Dockerfile.api
+          platforms: linux/arm64,linux/amd64
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha
+          tags: makeplane/plane-worker:develop
+          labels: ${{ steps.dkrmeta.outputs.labels }}
+
+      - name: Build and Push to GitHub Container Registry Tag 
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: docker/build-push-action@v4.0.0
+        with:
+          context: ./apiserver
+          file: ./apiserver/Dockerfile.api
+          platforms: linux/arm64,linux/amd64
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha
+          tags: ${{ steps.ghmeta.outputs.tags }}
+          labels: ${{ steps.ghmeta.outputs.labels }}
+
+      - name: Build and Push to Docker Hub
+        id: build-and-push-image-tag
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: docker/build-push-action@v4.0.0
+        with:
+          context: ./apiserver
+          file: ./apiserver/Dockerfile.api
+          platforms: linux/arm64,linux/amd64
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha
+          tags: ${{ steps.dkrmeta.outputs.tags }}
+          labels: ${{ steps.dkrmeta.outputs.labels }}

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,9 +1,9 @@
 FROM nginx:1.25.0-alpine
 
 RUN rm /etc/nginx/conf.d/default.conf
-COPY nginx.conf.template /etc/nginx/nginx.conf.template
+COPY ./nginx/nginx.conf.template /etc/nginx/nginx.conf.template
 
-COPY ./env.sh /docker-entrypoint.sh
+COPY ./nginx/env.sh /docker-entrypoint.sh
 
 RUN chmod +x /docker-entrypoint.sh
 # Update all environment variables


### PR DESCRIPTION
# Issue / feature
The aim is to introduce a configuration into the Github Actions CI, that distinguish a behaviour based on branches that allow us to build and push plane's core images ( backend / frontend ) to docker hub, with tag name as the release version for master and developer for develop branch.

## Underlying issue with the previous configuration
Previously tags based on docker/metadata-action were used for the images, which used to result in the version except the current released tag. [Referred](https://blog.derlin.ch/github-actions-reusable-workflow-docker-images)

# Proposed Solution
In the below mentioned Pull Request, I add up another step in the configuration, that explicitly fetches the latest release version of the repository, which is later exported as a variable `RELEASE_TAG`, which is used as tag for docker push.