### PR TITLE
ui fix for onboarding & color scheme for datepicker 

### DIFF
--- a/apps/app/components/onboarding/invite-members.tsx
+++ b/apps/app/components/onboarding/invite-members.tsx
@@ -207,7 +207,7 @@ export const InviteMembers: React.FC<Props> = ({ workspace, user, stepChange }) 
         <PrimaryButton type="submit" disabled={!isValid} loading={isSubmitting} size="md">
           {isSubmitting ? "Sending..." : "Send Invite"}
         </PrimaryButton>
-        <SecondaryButton size="md" onClick={nextStep} outline>
+        <SecondaryButton className="border border-none bg-transparent" size="md" onClick={nextStep}>
           Skip this step
         </SecondaryButton>
       </div>

--- a/apps/app/components/onboarding/join-workspaces.tsx
+++ b/apps/app/components/onboarding/join-workspaces.tsx
@@ -146,7 +146,7 @@ export const JoinWorkspaces: React.FC<Props> = ({ stepChange }) => {
         >
           Accept & Join
         </PrimaryButton>
-        <SecondaryButton size="md" onClick={finishOnboarding} outline>
+        <SecondaryButton className="border border-none bg-transparent" size="md" onClick={finishOnboarding} >
           Skip for now
         </SecondaryButton>
       </div>

--- a/apps/app/components/onboarding/tour/root.tsx
+++ b/apps/app/components/onboarding/tour/root.tsx
@@ -93,7 +93,7 @@ export const TourRoot: React.FC<Props> = ({ onComplete }) => {
               <Image src={PlaneWhiteLogo} alt="Plane White Logo" />
             </div>
             <div className="h-2/5 overflow-y-auto p-6">
-              <h3 className="font-medium text-lg">
+              <h3 className="font-semibold sm:text-xl">
                 Welcome to Plane, {user?.first_name} {user?.last_name}
               </h3>
               <p className="text-custom-text-200 text-sm mt-3">

--- a/apps/app/styles/react-datepicker.css
+++ b/apps/app/styles/react-datepicker.css
@@ -113,7 +113,7 @@
 .react-datepicker__day--disabled,
 .react-datepicker__day--disabled:hover {
   background: transparent !important;
-  color: rgba(var(--color-text-200)) !important;
+  color: rgba(var(--color-text-400)) !important;
   cursor: default;
 }
 


### PR DESCRIPTION
- Invite people to collaborate: skip this step button must not have borders.
- Join a workspace: skip for now button must not have borders.
- welcome screen: the font/styling for greeting must be bold.
- fixed color code in the datepicker.