### PR TITLE
fix: restrict notifications for created by when the actor is same

### DIFF
--- a/apiserver/plane/bgtasks/issue_activites_task.py
+++ b/apiserver/plane/bgtasks/issue_activites_task.py
@@ -1129,6 +1129,7 @@ def issue_activity(
                 issue is not None
                 and issue.created_by_id is not None
                 and not issue.created_by.is_bot
+                and str(issue.created_by_id) != str(actor_id)
             ):
                 issue_subscribers = issue_subscribers + [issue.created_by_id]
 


### PR DESCRIPTION
fix: restrict notifications for created by when the actor is same