### PR TITLE
Consider adding repo-review badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ To chat with other community members you can join the [Plane Discord](https://di
 
 Our [Code of Conduct](https://github.com/makeplane/plane/blob/master/CODE_OF_CONDUCT.md) applies to all Plane community channels.
 
+<a href='https://github.com/repo-reviews/repo-reviews.github.io/blob/main/create.md' target="_blank"><img alt='Github' src='https://img.shields.io/badge/review_me-100000?style=flat&logo=Github&logoColor=white&labelColor=888888&color=555555'/></a>
+
 ## ⛓️ Security
 
 If you believe you have found a security vulnerability in Plane, we encourage you to responsibly disclose this and not open a public issue. We will investigate all legitimate reports. Email engineering@plane.so to disclose any security vulnerabilities.


### PR DESCRIPTION
Thanks for creating this repo!

Successful repos have added a **review** badge to their repo's README:

<a href='https://github.com/repo-reviews/repo-reviews.github.io/blob/main/create.md' target="_blank"><img alt='Github' src='https://img.shields.io/badge/review_me-100000?style=flat&logo=Github&logoColor=white&labelColor=888888&color=555555'/></a>

These help the open-source community collect and share UX stories via repo-reviews.github.io and thereby increase productivity, sponsorship, and cross-pollination on a global scale.

Please consider adding a review badge via this PR!