### PR TITLE
handle email invitation urls in outlook clients properly

### DIFF
--- a/apiserver/templates/emails/auth/magic_signin.html
+++ b/apiserver/templates/emails/auth/magic_signin.html
@@ -89,8 +89,8 @@
                                                                         </tr>
                                                                         <tr>
                                                                            <td height="18" align="center" valign="top" class="r15-i nl2go-default-textstyle" style="color: #3b3f44; font-family: arial,helvetica,sans-serif; font-size: 16px; line-height: 1.5;">
-                                                                              <!--[if mso]> 
-                                                                              <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="https://app.plane.so/" style="v-text-anchor:middle; height: 33px; width: 301px;" arcsize="12%" fillcolor="#ffffff" strokecolor="#3f76ff" strokeweight="1px" data-btn="1">
+                                                                              <!--[if mso]>
+                                                                              <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href={{magic_url}} style="v-text-anchor:middle; height: 33px; width: 301px;" arcsize="12%" fillcolor="#ffffff" strokecolor="#3f76ff" strokeweight="1px" data-btn="1">
                                                                                  <w:anchorlock/>
                                                                                  <div style="display:none;">
                                                                                     <center class="default-button">
@@ -98,11 +98,11 @@
                                                                                     </center>
                                                                                  </div>
                                                                               </v:roundrect>
-                                                                              <![endif]-->  <!--[if !mso]><!-- --> 
+                                                                              <![endif]-->  <!--[if !mso]><!-- -->
                                                                               <a href={{magic_url}} class="r16-r default-button" target="_blank" data-btn="1" style="font-style: normal; font-weight: bold; line-height: 1.15; text-decoration: none; border-style: solid; word-wrap: break-word; display: inline-block; -webkit-text-size-adjust: none; mso-hide: all; background-color: #ffffff; border-color: #3f76ff; border-radius: 4px; border-width: 1px; color: #ffffff; font-family: arial,helvetica,sans-serif; font-size: 16px; height: 18px; padding-bottom: 7px; padding-left: 20px; padding-right: 20px; padding-top: 7px; width: 258px;">
                                                                                  <p style="margin: 0;"><span style="color: #3F76FF; font-size: 14px;">Open Plane</span></p>
                                                                               </a>
-                                                                              <!--<![endif]--> 
+                                                                              <!--<![endif]-->
                                                                            </td>
                                                                         </tr>
                                                                         <tr class="nl2go-responsive-hide">

--- a/apiserver/templates/emails/invitations/project_invitation.html
+++ b/apiserver/templates/emails/invitations/project_invitation.html
@@ -90,8 +90,8 @@
                                                                         </tr>
                                                                         <tr>
                                                                            <td height="18" align="center" valign="top" class="r15-i nl2go-default-textstyle" style="color: #3b3f44; font-family: arial,helvetica,sans-serif; font-size: 16px; line-height: 1.5;">
-                                                                              <!--[if mso]> 
-                                                                              <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="https://app.plane.so/" style="v-text-anchor:middle; height: 33px; width: 301px;" arcsize="12%" fillcolor="#ffffff" strokecolor="#3f76ff" strokeweight="1px" data-btn="1">
+                                                                              <!--[if mso]>
+                                                                              <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href={{invitation_url}} style="v-text-anchor:middle; height: 33px; width: 301px;" arcsize="12%" fillcolor="#ffffff" strokecolor="#3f76ff" strokeweight="1px" data-btn="1">
                                                                                  <w:anchorlock/>
                                                                                  <div style="display:none;">
                                                                                     <center class="default-button">
@@ -99,11 +99,11 @@
                                                                                     </center>
                                                                                  </div>
                                                                               </v:roundrect>
-                                                                              <![endif]-->  <!--[if !mso]><!-- --> 
+                                                                              <![endif]-->  <!--[if !mso]><!-- -->
                                                                               <a href={{invitation_url}} class="r16-r default-button" target="_blank" data-btn="1" style="font-style: normal; font-weight: bold; line-height: 1.15; text-decoration: none; border-style: solid; word-wrap: break-word; display: inline-block; -webkit-text-size-adjust: none; mso-hide: all; background-color: #ffffff; border-color: #3f76ff; border-radius: 4px; border-width: 1px; color: #ffffff; font-family: arial,helvetica,sans-serif; font-size: 16px; height: 18px; padding-bottom: 7px; padding-left: 20px; padding-right: 20px; padding-top: 7px; width: 258px;">
                                                                                  <p style="margin: 0;"><span style="color: #3F76FF;">Accept the invite</span></p>
                                                                               </a>
-                                                                              <!--<![endif]--> 
+                                                                              <!--<![endif]-->
                                                                            </td>
                                                                         </tr>
                                                                         <tr class="nl2go-responsive-hide">

--- a/apiserver/templates/emails/invitations/workspace_invitation.html
+++ b/apiserver/templates/emails/invitations/workspace_invitation.html
@@ -90,8 +90,8 @@
                                                                         </tr>
                                                                         <tr>
                                                                            <td height="18" align="center" valign="top" class="r15-i nl2go-default-textstyle" style="color: #3b3f44; font-family: arial,helvetica,sans-serif; font-size: 16px; line-height: 1.5;">
-                                                                              <!--[if mso]> 
-                                                                              <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="https://app.plane.so/" style="v-text-anchor:middle; height: 33px; width: 301px;" arcsize="12%" fillcolor="#ffffff" strokecolor="#3f76ff" strokeweight="1px" data-btn="1">
+                                                                              <!--[if mso]>
+                                                                              <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href={{invitation_url}} style="v-text-anchor:middle; height: 33px; width: 301px;" arcsize="12%" fillcolor="#ffffff" strokecolor="#3f76ff" strokeweight="1px" data-btn="1">
                                                                                  <w:anchorlock/>
                                                                                  <div style="display:none;">
                                                                                     <center class="default-button">
@@ -99,11 +99,11 @@
                                                                                     </center>
                                                                                  </div>
                                                                               </v:roundrect>
-                                                                              <![endif]-->  <!--[if !mso]><!-- --> 
+                                                                              <![endif]-->  <!--[if !mso]><!-- -->
                                                                               <a href={{invitation_url}} class="r16-r default-button" target="_blank" data-btn="1" style="font-style: normal; font-weight: bold; line-height: 1.15; text-decoration: none; border-style: solid; word-wrap: break-word; display: inline-block; -webkit-text-size-adjust: none; mso-hide: all; background-color: #ffffff; border-color: #3f76ff; border-radius: 4px; border-width: 1px; color: #ffffff; font-family: arial,helvetica,sans-serif; font-size: 16px; height: 18px; padding-bottom: 7px; padding-left: 20px; padding-right: 20px; padding-top: 7px; width: 258px;">
                                                                                  <p style="margin: 0;"><span style="color: #3F76FF;">Accept the invite</span></p>
                                                                               </a>
-                                                                              <!--<![endif]--> 
+                                                                              <!--<![endif]-->
                                                                            </td>
                                                                         </tr>
                                                                         <tr class="nl2go-responsive-hide">


### PR DESCRIPTION
The email invitation url's for self-hosted plane had a fixed `https://app.plane.so/` link instead of invitation url when viewed in Outlook or certain MS email clients.

This PR fixes the templates to use the appropriate template variables for the links