### PR TITLE
fix: empty groups not appearing on the my issues Kanban board

### DIFF
--- a/apps/app/hooks/my-issues/use-my-issues.tsx
+++ b/apps/app/hooks/my-issues/use-my-issues.tsx
@@ -52,8 +52,23 @@ const useMyIssues = (workspaceSlug: string | undefined) => {
         allIssues: myIssues,
       };
 
+    if (groupBy === "state_detail.group") {
+      return myIssues
+        ? Object.assign(
+            {
+              backlog: [],
+              unstarted: [],
+              started: [],
+              completed: [],
+              cancelled: [],
+            },
+            myIssues
+          )
+        : undefined;
+    }
+
     return myIssues;
-  }, [myIssues]);
+  }, [groupBy, myIssues]);
 
   const isEmpty =
     Object.values(groupedIssues ?? {}).every((group) => group.length === 0) ||


### PR DESCRIPTION
This PR fixes empty state groups not appearing on the My Issues page Kanban board.

Before the fix-

![image](https://github.com/makeplane/plane/assets/65252264/3b370430-acba-4699-88f7-a660ec7fd52e)

After the fix-
![image](https://github.com/makeplane/plane/assets/65252264/244fd24d-6e66-4141-9dec-3d28dfaeeacd)
