### PR TITLE
style: image upload modal aspect ratio

### DIFF
--- a/apps/app/components/core/modals/image-upload-modal.tsx
+++ b/apps/app/components/core/modals/image-upload-modal.tsx
@@ -131,10 +131,10 @@ export const ImageUploadModal: React.FC<Props> = ({
                     Upload Image
                   </Dialog.Title>
                   <div className="space-y-3">
-                    <div className="flex items-center gap-3">
+                    <div className="flex items-center justify-center gap-3">
                       <div
                         {...getRootProps()}
-                        className={`relative grid h-80 w-full cursor-pointer place-items-center rounded-lg p-12 text-center focus:outline-none focus:ring-2 focus:ring-custom-primary focus:ring-offset-2 ${
+                        className={`relative grid h-80 w-80 cursor-pointer place-items-center rounded-lg p-12 text-center focus:outline-none focus:ring-2 focus:ring-custom-primary focus:ring-offset-2 ${
                           (image === null && isDragActive) || !value
                             ? "border-2 border-dashed border-custom-border-200 hover:bg-custom-background-90"
                             : ""


### PR DESCRIPTION
This PR addresses the aspect ratio issue within the image uploader for the workspace logo and profile picture.

Before the fix:-
![image](https://github.com/makeplane/plane/assets/121005188/0fa5012c-55e5-4878-90f5-de9aba2480fd)


After the fix:-
![image](https://github.com/makeplane/plane/assets/121005188/5e7cce96-3fd0-45f5-9bf0-4afdbcbd1073)

