### PR TITLE
style: sidebar select date width

### DIFF
--- a/apps/app/components/issues/sidebar.tsx
+++ b/apps/app/components/issues/sidebar.tsx
@@ -396,7 +396,7 @@ export const IssueDetailsSidebar: React.FC<Props> = ({
                                 start_date: val,
                               })
                             }
-                            className="bg-custom-background-90"
+                            className="bg-custom-background-90 w-full"
                             maxDate={maxDate ?? undefined}
                             disabled={isNotAllowed || uneditable}
                           />
@@ -424,7 +424,7 @@ export const IssueDetailsSidebar: React.FC<Props> = ({
                                 target_date: val,
                               })
                             }
-                            className="bg-custom-background-90"
+                            className="bg-custom-background-90 w-full"
                             minDate={minDate ?? undefined}
                             disabled={isNotAllowed || uneditable}
                           />


### PR DESCRIPTION
This PR addresses the problem with issue sidebar date selection width inconsistency.

Before the fix:
![image](https://github.com/makeplane/plane/assets/121005188/6f2c15a9-fb93-402d-b133-73f5d1e714d5)

After the fix: 
![image](https://github.com/makeplane/plane/assets/121005188/55746d30-560e-42d6-8ce6-de8bd58f68f0)
