### PR TITLE
fix: notification card not redirecting to archive issue detail for archived issue

### DIFF
--- a/apps/app/components/notifications/notification-card.tsx
+++ b/apps/app/components/notifications/notification-card.tsx
@@ -53,7 +53,9 @@ export const NotificationCard: React.FC<NotificationCardProps> = (props) => {
       onClick={() => {
         markNotificationReadStatus(notification.id);
         router.push(
-          `/${workspaceSlug}/projects/${notification.project}/issues/${notification.data.issue.id}`
+          `/${workspaceSlug}/projects/${notification.project}/${
+            notification.data.issue_activity.field === "archived_at" ? "archived-issues" : "issues"
+          }/${notification.data.issue.id}`
         );
       }}
       className={`group w-full flex items-center gap-4 p-3 pl-6 relative cursor-pointer ${


### PR DESCRIPTION
fix: 

- notification card not redirecting to archive issue detail for archived issue

![image](https://github.com/makeplane/plane/assets/65905942/780076be-25e8-4a12-8102-56c6fcc305ba)
