### PR TITLE
document: Update local setup document 

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,16 @@ chmod +x setup.sh
 
 > If running in a cloud env replace localhost with public facing IP address of the VM
 
+- Setup Tiptap Pro
+
+  Visit [Tiptap Pro](https://collab.tiptap.dev/pro-extensions) and signup (it is free).
+
+  Create a **`.npmrc`** file, copy the following and replace your registry token generated from Tiptap Pro. 
+
+```
+@tiptap-pro:registry=https://registry.tiptap.dev/
+//registry.tiptap.dev/:_authToken=YOUR_REGISTRY_TOKEN
+```
 - Run Docker compose up
 
 ```bash


### PR DESCRIPTION
This PR adds a new section in the Quick Start Setup document to include an installation guide for Tiptap Pro. 

I have created an issue for this,(#1869) since I was stuck on the Tiptap Pro installation error. Got some help and feedback on the issue and was able to resolve it.