### PR TITLE
chore: set order by to manual on gantt chart

### DIFF
--- a/apps/app/contexts/issue-view.context.tsx
+++ b/apps/app/contexts/issue-view.context.tsx
@@ -362,7 +362,13 @@ export const IssueViewContextProvider: React.FC<{ children: React.ReactNode }> =
         },
       });
 
-      if (property === "kanban") {
+      const additionalProperties = {
+        groupByProperty: state.groupByProperty,
+        orderBy: state.orderBy,
+      };
+
+      if (property === "kanban" && state.groupByProperty === null) {
+        additionalProperties.groupByProperty = "state";
         dispatch({
           type: "SET_GROUP_BY_PROPERTY",
           payload: {
@@ -371,10 +377,20 @@ export const IssueViewContextProvider: React.FC<{ children: React.ReactNode }> =
         });
       }
       if (property === "calendar") {
+        additionalProperties.groupByProperty = null;
         dispatch({
           type: "SET_GROUP_BY_PROPERTY",
           payload: {
             groupByProperty: null,
+          },
+        });
+      }
+      if (property === "gantt_chart") {
+        additionalProperties.orderBy = "sort_order";
+        dispatch({
+          type: "SET_ORDER_BY_PROPERTY",
+          payload: {
+            orderBy: "sort_order",
           },
         });
       }
@@ -384,7 +400,7 @@ export const IssueViewContextProvider: React.FC<{ children: React.ReactNode }> =
       saveDataToServer(workspaceSlug as string, projectId as string, {
         ...state,
         issueView: property,
-        groupByProperty: "state",
+        ...additionalProperties,
       });
     },
     [workspaceSlug, projectId, state]


### PR DESCRIPTION
### Chore: Set order by property to `Manual` by default on the Gantt chart.

https://github.com/makeplane/plane/assets/65252264/0096a66c-532f-4f4a-9696-133bc8e02278


### Fix: Group by property changing to `State` on changing the issue view

https://github.com/makeplane/plane/assets/65252264/d6ca3652-709d-4fa0-9897-a44dfb17c35a

