### PR TITLE
chore: start date property for custom analytics' x-axis and group

### DIFF
--- a/apps/app/constants/analytics.ts
+++ b/apps/app/constants/analytics.ts
@@ -42,10 +42,10 @@ export const ANALYTICS_X_AXIS_VALUES: { value: TXAxisValues; label: string }[] =
     value: "target_date",
     label: "Due date",
   },
-  // {
-  //   value: "start_date",
-  //   label: "Start date",
-  // },
+  {
+    value: "start_date",
+    label: "Start date",
+  },
   {
     value: "created_at",
     label: "Created date",


### PR DESCRIPTION
chore:

- start date property for custom analytics' x-axis and group.