### PR TITLE
style: fixed display name coming twice on the profile page

### DIFF
--- a/apps/app/components/profile/sidebar.tsx
+++ b/apps/app/components/profile/sidebar.tsx
@@ -105,9 +105,11 @@ export const ProfileSidebar = () => {
           </div>
           <div className="px-5">
             <div className="mt-[38px]">
-              <h4 className="text-lg font-semibold">{userProjectsData.user_data.display_name}</h4>
+              <h4 className="text-lg font-semibold">
+                {userProjectsData.user_data.first_name} {userProjectsData.user_data.last_name}
+              </h4>
               <h6 className="text-custom-text-200 text-sm">
-                {userProjectsData.user_data.display_name}
+                ({userProjectsData.user_data.display_name})
               </h6>
             </div>
             <div className="mt-6 space-y-5">


### PR DESCRIPTION
style: 

- fixed display name coming twice on the profile page

Before:
![image](https://github.com/makeplane/plane/assets/65905942/d5ddefa1-68cb-4843-8ddb-f973018e8340)

After:
![image](https://github.com/makeplane/plane/assets/65905942/67a6aeca-4f3f-45cc-aff2-54a113cc8e57)
