### PR TITLE
chore: hide the new issue button from my subscribed issues page

### DIFF
--- a/apps/app/components/issues/my-issues/my-issues-view.tsx
+++ b/apps/app/components/issues/my-issues/my-issues-view.tsx
@@ -270,16 +270,18 @@ export const MyIssuesView: React.FC<Props> = ({
             ? "You have not created any issue yet."
             : "You have not subscribed to any issue yet.",
           description: "Keep track of your work in a single place.",
-          primaryButton: {
-            icon: <PlusIcon className="h-4 w-4" />,
-            text: "New Issue",
-            onClick: () => {
-              const e = new KeyboardEvent("keydown", {
-                key: "c",
-              });
-              document.dispatchEvent(e);
-            },
-          },
+          primaryButton: filters.subscriber
+            ? undefined
+            : {
+                icon: <PlusIcon className="h-4 w-4" />,
+                text: "New Issue",
+                onClick: () => {
+                  const e = new KeyboardEvent("keydown", {
+                    key: "c",
+                  });
+                  document.dispatchEvent(e);
+                },
+              },
         }}
         handleOnDragEnd={handleOnDragEnd}
         handleIssueAction={handleIssueAction}


### PR DESCRIPTION
chore:

- hide the new issue button from my subscribed issues page.

![image](https://github.com/makeplane/plane/assets/65252264/3a33f869-8c76-45f0-b1f8-69e898d500d6)
