### PR TITLE
fix: workspace members reordering

### DIFF
--- a/apps/app/pages/[workspaceSlug]/settings/members.tsx
+++ b/apps/app/pages/[workspaceSlug]/settings/members.tsx
@@ -69,19 +69,6 @@ const MembersSettings: NextPage = () => {
   );
 
   const members = [
-    ...(workspaceMembers?.map((item) => ({
-      id: item.id,
-      memberId: item.member?.id,
-      avatar: item.member?.avatar,
-      first_name: item.member?.first_name,
-      last_name: item.member?.last_name,
-      email: item.member?.email,
-      display_name: item.member?.display_name,
-      role: item.role,
-      status: true,
-      member: true,
-      accountCreated: true,
-    })) || []),
     ...(workspaceInvitations?.map((item) => ({
       id: item.id,
       memberId: item.id,
@@ -94,6 +81,19 @@ const MembersSettings: NextPage = () => {
       status: item.accepted,
       member: false,
       accountCreated: item?.accepted ? false : true,
+    })) || []),
+    ...(workspaceMembers?.map((item) => ({
+      id: item.id,
+      memberId: item.member?.id,
+      avatar: item.member?.avatar,
+      first_name: item.member?.first_name,
+      last_name: item.member?.last_name,
+      email: item.member?.email,
+      display_name: item.member?.display_name,
+      role: item.role,
+      status: true,
+      member: true,
+      accountCreated: true,
     })) || []),
   ];
 


### PR DESCRIPTION
Fixing the order of members visibility, Moving invited members to be rendered at the top of the list instead of bottom.

before:

![Screenshot 2023-08-25 at 1 17 35 PM](https://github.com/makeplane/plane/assets/9498163/b3312d7a-1a50-438a-977c-cf8f181d0b80)


after:

![Screenshot 2023-08-25 at 1 17 01 PM](https://github.com/makeplane/plane/assets/9498163/c7520e46-9291-4a9a-844d-01e338e8ecd8)
