### PR TITLE
chore: modified dockerfiles for space and web

### DIFF
--- a/space/Dockerfile.space
+++ b/space/Dockerfile.space
@@ -14,8 +14,11 @@ RUN yarn
 # Rebuild the source code only when needed
 FROM base AS builder
 WORKDIR /space
-COPY --from=deps /space/node_modules ./node_modules
+
 COPY . .
+
+COPY --from=deps /space/node_modules ./node_modules
+COPY --from=deps /space/yarn.lock .
 
 ENV NEXT_TELEMETRY_DISABLED 1
 

--- a/web/Dockerfile.web
+++ b/web/Dockerfile.web
@@ -8,14 +8,21 @@ WORKDIR /app
 
 # Install dependencies based on the preferred package manager
 COPY package.json yarn.lock .npmrc ./
-RUN yarn
-
+RUN \
+  if [ -f yarn.lock ]; then yarn --frozen-lockfile; \
+  elif [ -f package-lock.json ]; then npm ci; \
+  else echo "Lockfile not found." && exit 1; \
+  fi
 
 # Rebuild the source code only when needed
 FROM base AS builder
+RUN apk add --no-cache libc6-compat
 WORKDIR /app
-COPY --from=deps /app/node_modules ./node_modules
+
 COPY . .
+
+COPY --from=deps /app/node_modules ./node_modules
+COPY --from=deps /app/yarn.lock .
 
 ENV NEXT_TELEMETRY_DISABLED 1
 
@@ -50,4 +57,4 @@ ENV PORT 3000
 # set hostname to localhost
 ENV HOSTNAME "0.0.0.0"
 
-CMD ["node", "web/server.js"]
+CMD ["node", "app/server.js"]


### PR DESCRIPTION
## Tasks
- [x] Updated Dockerfile for Plane-Web finishing up with a successful build.
- [x] Updated Dockerfile for Plane-Deploy finishing up with a successful build.

## Keep in mind 🏔️
- As we are not going forward with the monorepo architecture, the Docker Images are built in the context of the project, which means, that while building web, the context should not be `.` instead it should be `./web`, same for space, the context should be `./space`. Hence the build command will be `docker build ./web -f ./web/Dockerfile.web -t plane-web:latest` and `docker build ./space -f ./space/Dockerfile.space`

## Screenshots of the Builds
<img width="1250" alt="image" src="https://github.com/makeplane/plane/assets/72302948/955a1b80-5bd4-4210-a8f6-dd68e92e77a8">


