### PR TITLE
fix: create new project as favourite

### DIFF
--- a/apps/app/components/project/sidebar-list.tsx
+++ b/apps/app/components/project/sidebar-list.tsx
@@ -31,6 +31,7 @@ import { useMobxStore } from "lib/mobx/store-provider";
 export const ProjectSidebarList: FC = () => {
   const store: any = useMobxStore();
 
+  const [isFavoriteProjectCreate, setIsFavoriteProjectCreate] = useState(false);
   const [isProjectModalOpen, setIsProjectModalOpen] = useState(false);
   const [deleteProjectModal, setDeleteProjectModal] = useState(false);
   const [projectToDelete, setProjectToDelete] = useState<IProject | null>(null);
@@ -151,7 +152,7 @@ export const ProjectSidebarList: FC = () => {
       <CreateProjectModal
         isOpen={isProjectModalOpen}
         setIsOpen={setIsProjectModalOpen}
-        setToFavorite
+        setToFavorite={isFavoriteProjectCreate}
         user={user}
       />
       <DeleteProjectModal
@@ -189,7 +190,10 @@ export const ProjectSidebarList: FC = () => {
                             </Disclosure.Button>
                             <button
                               className="group-hover:opacity-100 opacity-0"
-                              onClick={() => setIsProjectModalOpen(true)}
+                              onClick={() => {
+                                setIsFavoriteProjectCreate(true);
+                                setIsProjectModalOpen(true);
+                              }}
                             >
                               <Icon iconName="add" />
                             </button>
@@ -252,7 +256,10 @@ export const ProjectSidebarList: FC = () => {
                             </Disclosure.Button>
                             <button
                               className="group-hover:opacity-100 opacity-0"
-                              onClick={() => setIsProjectModalOpen(true)}
+                              onClick={() => {
+                                setIsFavoriteProjectCreate(false);
+                                setIsProjectModalOpen(true);
+                              }}
                             >
                               <Icon iconName="add" />
                             </button>


### PR DESCRIPTION
Before:

Every project in the sidebar is created as a favourite project, even when we click on the Plus icon on the project section.

After:

Only when you create a project from the plus icon from your favourite project will you create a favourite project. 