### PR TITLE
fix: start date filter not working on the platform

### DIFF
--- a/apps/app/hooks/gantt-chart/cycle-issues-view.tsx
+++ b/apps/app/hooks/gantt-chart/cycle-issues-view.tsx
@@ -23,6 +23,7 @@ const useGanttChartCycleIssues = (
     priority: filters?.priority ? filters?.priority.join(",") : undefined,
     labels: filters?.labels ? filters?.labels.join(",") : undefined,
     created_by: filters?.created_by ? filters?.created_by.join(",") : undefined,
+    start_date: filters?.start_date ? filters?.start_date.join(",") : undefined,
     target_date: filters?.target_date ? filters?.target_date.join(",") : undefined,
     start_target_date: true, // to fetch only issues with a start and target date
   };

--- a/apps/app/hooks/gantt-chart/issue-view.tsx
+++ b/apps/app/hooks/gantt-chart/issue-view.tsx
@@ -19,6 +19,7 @@ const useGanttChartIssues = (workspaceSlug: string | undefined, projectId: strin
     priority: filters?.priority ? filters?.priority.join(",") : undefined,
     labels: filters?.labels ? filters?.labels.join(",") : undefined,
     created_by: filters?.created_by ? filters?.created_by.join(",") : undefined,
+    start_date: filters?.start_date ? filters?.start_date.join(",") : undefined,
     target_date: filters?.target_date ? filters?.target_date.join(",") : undefined,
     start_target_date: true, // to fetch only issues with a start and target date
   };

--- a/apps/app/hooks/gantt-chart/module-issues-view.tsx
+++ b/apps/app/hooks/gantt-chart/module-issues-view.tsx
@@ -23,6 +23,7 @@ const useGanttChartModuleIssues = (
     priority: filters?.priority ? filters?.priority.join(",") : undefined,
     labels: filters?.labels ? filters?.labels.join(",") : undefined,
     created_by: filters?.created_by ? filters?.created_by.join(",") : undefined,
+    start_date: filters?.start_date ? filters?.start_date.join(",") : undefined,
     target_date: filters?.target_date ? filters?.target_date.join(",") : undefined,
     start_target_date: true, // to fetch only issues with a start and target date
   };

--- a/apps/app/hooks/use-calendar-issues-view.tsx
+++ b/apps/app/hooks/use-calendar-issues-view.tsx
@@ -42,6 +42,7 @@ const useCalendarIssuesView = () => {
     type: filters?.type ? filters?.type : undefined,
     labels: filters?.labels ? filters?.labels.join(",") : undefined,
     created_by: filters?.created_by ? filters?.created_by.join(",") : undefined,
+    start_date: filters?.start_date ? filters?.start_date.join(",") : undefined,
     target_date: calendarDateRange,
   };
 

--- a/apps/app/hooks/use-spreadsheet-issues-view.tsx
+++ b/apps/app/hooks/use-spreadsheet-issues-view.tsx
@@ -43,6 +43,8 @@ const useSpreadsheetIssuesView = () => {
     type: filters?.type ? filters?.type : undefined,
     labels: filters?.labels ? filters?.labels.join(",") : undefined,
     created_by: filters?.created_by ? filters?.created_by.join(",") : undefined,
+    start_date: filters?.start_date ? filters?.start_date.join(",") : undefined,
+    target_date: filters?.target_date ? filters?.target_date.join(",") : undefined,
     sub_issue: "false",
   };
 


### PR DESCRIPTION
fix:

- start date filter not working on the gantt chart, spreadsheet view.