### PR TITLE
fix: access creation in comments

### DIFF
--- a/apiserver/plane/api/serializers/issue.py
+++ b/apiserver/plane/api/serializers/issue.py
@@ -584,7 +584,6 @@ class IssueCommentSerializer(BaseSerializer):
             "updated_by",
             "created_at",
             "updated_at",
-            "access",
         ]
 
 


### PR DESCRIPTION
fix:
- Comments are categorised into two types internal and external  that are only visible to external public