### PR TITLE
chore: Added Workflow for Updating Development Images on Dockerhub

### DIFF
--- a/.github/workflows/Update_Dev_Docker_Image.yml
+++ b/.github/workflows/Update_Dev_Docker_Image.yml
@@ -1,12 +1,12 @@
-name: Update Docker Images for Plane on Release
+name: Update Docker Development Docker Images
 
 on:
-  release:
-    types: [released]
+  schedule:
+    - cron: '0 0 * * 6'
 
 jobs:
-  build_push_release_docker_images:
-    name: Build and Push Release Docker Images
+  build_push_dev_docker_images:
+    name: Build and Push Docker Development Images
     runs-on: ubuntu-20.04
 
     steps:
@@ -26,49 +26,13 @@ jobs:
         run: |
             echo -e "@tiptap-pro:registry=https://registry.tiptap.dev/\n//registry.tiptap.dev/:_authToken=${{ secrets.TIPTAP_TOKEN }}" > .npmrc
 
-      - name: Extract metadata (tags, labels) for Docker (Docker Hub) from Github Release
-        id: metaFrontend
-        uses: docker/metadata-action@v4.3.0
-        if: ${{ github.event_name == 'release' }}
-        with:
-          images: ${{ secrets.DOCKERHUB_USERNAME }}/plane-frontend
-          tags: |
-            type=ref,event=tag
-      
-      - name: Extract metadata (tags, labels) for Docker (Docker Hub) from Github Release
-        id: metaBackend
-        uses: docker/metadata-action@v4.3.0
-        if: ${{ github.event_name == 'release' }}
-        with:
-          images: ${{ secrets.DOCKERHUB_USERNAME }}/plane-backend
-          tags: |
-            type=ref,event=tag
-
-      - name: Extract metadata (tags, labels) for Docker (Docker Hub) from Github Release
-        id: metaDeploy
-        if: ${{ github.event_name == 'release' }}
-        uses: docker/metadata-action@v4.3.0
-        with:
-          images: ${{ secrets.DOCKERHUB_USERNAME }}/plane-deploy
-          tags: |
-            type=ref,event=tag
-
-      - name: Extract metadata (tags, labels) for Docker (Docker Hub) from Github Release
-        id: metaProxy
-        uses: docker/metadata-action@v4.3.0
-        if: ${{ github.event_name == 'release' }}
-        with:
-          images: ${{ secrets.DOCKERHUB_USERNAME }}/plane-proxy
-          tags: |
-            type=ref,event=tag
-
       - name: Build and Push Frontend to Docker Container Registry
         uses: docker/build-push-action@v4.0.0
         with:
           context: .
           file: ./apps/app/Dockerfile.web
           platforms: linux/amd64
-          tags: ${{ steps.metaFrontend.outputs.tags }}
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/plane-frontend:develop
           push: true
         env:
           DOCKER_BUILDKIT: 1
@@ -82,7 +46,7 @@ jobs:
           file: ./apiserver/Dockerfile.api
           platforms: linux/amd64
           push: true
-          tags: ${{ steps.metaBackend.outputs.tags }}
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/plane-backend:develop
         env:
           DOCKER_BUILDKIT: 1
           DOCKER_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -95,7 +59,7 @@ jobs:
           file: ./apps/space/Dockerfile.space
           platforms: linux/amd64
           push: true
-          tags: ${{ steps.metaDeploy.outputs.tags }}
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/plane-deploy:develop
         env:
           DOCKER_BUILDKIT: 1
           DOCKER_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -108,7 +72,7 @@ jobs:
           file: ./nginx/Dockerfile
           platforms: linux/amd64
           push: true
-          tags: ${{ steps.metaProxy.outputs.tags }}
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/plane-proxy:develop
         env:
           DOCKER_BUILDKIT: 1
           DOCKER_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
## Tasks 
- [x] Added CRON Job for updating plane's dev images on Dockerhub

## Workflow
The workflow uses cron scheduling as a trigger, to publish images from the codebase as development, every week saturday at 12 AM, as the week ends.