### PR TITLE
fix: don't render invalid dated blocks on the gantt chart

### DIFF
--- a/web/components/cycles/gantt-chart/cycles-list-layout.tsx
+++ b/web/components/cycles/gantt-chart/cycles-list-layout.tsx
@@ -63,7 +63,9 @@ export const CyclesListGanttChartView: FC<Props> = ({ cycles, mutateCycles }) =>
   const blockFormat = (blocks: ICycle[]) =>
     blocks && blocks.length > 0
       ? blocks
-          .filter((b) => b.start_date && b.end_date)
+          .filter(
+            (b) => b.start_date && b.end_date && new Date(b.start_date) <= new Date(b.end_date)
+          )
           .map((block) => ({
             data: block,
             id: block.id,

--- a/web/components/gantt-chart/helpers/block-structure.tsx
+++ b/web/components/gantt-chart/helpers/block-structure.tsx
@@ -4,11 +4,13 @@ import { IGanttBlock } from "components/gantt-chart";
 
 export const renderIssueBlocksStructure = (blocks: IIssue[]): IGanttBlock[] =>
   blocks && blocks.length > 0
-    ? blocks.map((block) => ({
-        data: block,
-        id: block.id,
-        sort_order: block.sort_order,
-        start_date: new Date(block.start_date ?? ""),
-        target_date: new Date(block.target_date ?? ""),
-      }))
+    ? blocks
+        .filter((b) => new Date(b?.start_date ?? "") <= new Date(b?.target_date ?? ""))
+        .map((block) => ({
+          data: block,
+          id: block.id,
+          sort_order: block.sort_order,
+          start_date: new Date(block.start_date ?? ""),
+          target_date: new Date(block.target_date ?? ""),
+        }))
     : [];

--- a/web/components/modules/gantt-chart/modules-list-layout.tsx
+++ b/web/components/modules/gantt-chart/modules-list-layout.tsx
@@ -69,7 +69,10 @@ export const ModulesListGanttChartView: FC<Props> = ({ modules, mutateModules })
   const blockFormat = (blocks: IModule[]) =>
     blocks && blocks.length > 0
       ? blocks
-          .filter((b) => b.start_date && b.target_date)
+          .filter(
+            (b) =>
+              b.start_date && b.target_date && new Date(b.start_date) <= new Date(b.target_date)
+          )
           .map((block) => ({
             data: block,
             id: block.id,


### PR DESCRIPTION
fix:

- blocks with start date greater than the target date won't be rendered on the Gantt chart.