### PR TITLE
fix: remove triage issue status from public boards

### DIFF
--- a/apiserver/plane/api/views/issue.py
+++ b/apiserver/plane/api/views/issue.py
@@ -2189,6 +2189,7 @@ class ProjectIssuesPublicEndpoint(BaseAPIView):
 
             states = (
                 State.objects.filter(
+                    ~Q(name="Triage"),
                     workspace__slug=slug,
                     project_id=project_id,
                 )


### PR DESCRIPTION
fix: remove triage issue status from public boards