### PR TITLE
Add support for Claude-2, Cohere Llama2, CodeLlama, Azure OpenAI, Replicate LLMs (100+LLMs)

### DIFF
--- a/apiserver/plane/api/views/gpt.py
+++ b/apiserver/plane/api/views/gpt.py
@@ -5,6 +5,8 @@ import requests
 from rest_framework.response import Response
 from rest_framework import status
 import openai
+import litellm
+from litellm import completion
 from sentry_sdk import capture_exception
 
 # Django imports
@@ -40,8 +42,8 @@ class GPTIntegrationEndpoint(BaseAPIView):
 
             final_text = task + "\n" + prompt
 
-            openai.api_key = settings.OPENAI_API_KEY
-            response = openai.ChatCompletion.create(
+            litellm.api_key = settings.OPENAI_API_KEY
+            response = completion(
                 model=settings.GPT_ENGINE,
                 messages=[{"role": "user", "content": final_text}],
                 temperature=0.7,

--- a/apiserver/requirements/base.txt
+++ b/apiserver/requirements/base.txt
@@ -27,6 +27,7 @@ django-redis==5.3.0
 uvicorn==0.23.2
 channels==4.0.0
 openai==0.28.0
+litellm>=0.1.500
 slack-sdk==3.21.3
 celery==5.3.4
 django_celery_beat==2.5.0


### PR DESCRIPTION
This PR adds support for the above mentioned LLMs using LiteLLM https://github.com/BerriAI/litellm/ 
LiteLLM is a lightweight package to simplify LLM API calls - use any llm as a drop in replacement for gpt-3.5-turbo. 

Example
```python
from litellm import completion

## set ENV variables
os.environ["OPENAI_API_KEY"] = "openai key"
os.environ["COHERE_API_KEY"] = "cohere key"

messages = [{ "content": "Hello, how are you?","role": "user"}]

# openai call
response = completion(model="gpt-3.5-turbo", messages=messages)

# cohere call
response = completion(model="command-nightly", messages)

# anthropic call
response = completion(model="claude-instant-1", messages=messages)
```