### PR TITLE
fix: husky was removed in commit #2086, but prepare still uses it

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "packages/*"
   ],
   "scripts": {
-    "prepare": "husky install",
     "build": "turbo run build",
     "dev": "turbo run dev",
     "start": "turbo run start",


### PR DESCRIPTION
currently, _docker compose up -d_, triggers this error:
```
[4/4] Building fresh packages...
$ husky install
/bin/sh: husky: not found
error Command failed with exit code 127.
```