### PR TITLE
[chore] Updated web and deploy backend configuration for reverse proxy & decoupled Plane Deploy URL generation for web

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,6 +85,9 @@ services:
     env_file:
       - .env
     environment:
+      POSTGRES_USER: ${PGUSER}
+      POSTGRES_DB: ${PGDATABASE}
+      POSTGRES_PASSWORD: ${PGPASSWORD}
       PGDATA: /var/lib/postgresql/data
 
   plane-redis:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,6 @@ services:
       dockerfile: ./web/Dockerfile.web
       args:
         DOCKER_BUILDKIT: 1
-        NEXT_PUBLIC_API_BASE_URL: "http://localhost:8000"
     restart: always
     command: /usr/local/bin/start.sh web/server.js web
     depends_on:
@@ -22,7 +21,6 @@ services:
       dockerfile: ./space/Dockerfile.space
       args:
         DOCKER_BUILDKIT: 1
-        NEXT_PUBLIC_API_BASE_URL: http://localhost:8000
     restart: always
     command: /usr/local/bin/start.sh space/server.js space
     depends_on:

--- a/setup.sh
+++ b/setup.sh
@@ -12,8 +12,13 @@ cp ./apiserver/.env.example ./apiserver/.env
 # Generate the SECRET_KEY that will be used by django
 echo -e "SECRET_KEY=\"$(tr -dc 'a-z0-9' < /dev/urandom | head -c50)\""  >> ./apiserver/.env
 
-echo -e "\nNEXT_PUBLIC_API_BASE_URL=$1\nWEB_URL=$1"  >> ./web/.env
-echo -e "\nNEXT_PUBLIC_API_BASE_URL=$1\nWEB_URL=$1"  >> ./space/.env
+if [ -n "$1" ]
+then
+    echo "hello"
+    echo -e "\nNEXT_PUBLIC_API_BASE_URL=$1\nWEB_URL=$1"  >> ./web/.env
+    echo -e "\nNEXT_PUBLIC_API_BASE_URL=$1\nWEB_URL=$1"  >> ./space/.env
+fi
+
 
 # Generate Prompt for taking tiptap auth key
 echo -e "\n\e[1;38m Instructions for generating TipTap Pro Extensions Auth Token \e[0m \n"

--- a/setup.sh
+++ b/setup.sh
@@ -14,7 +14,6 @@ echo -e "SECRET_KEY=\"$(tr -dc 'a-z0-9' < /dev/urandom | head -c50)\""  >> ./api
 
 if [ -n "$1" ]
 then
-    echo "hello"
     echo -e "\nNEXT_PUBLIC_API_BASE_URL=$1\nWEB_URL=$1"  >> ./web/.env
     echo -e "\nNEXT_PUBLIC_API_BASE_URL=$1\nWEB_URL=$1"  >> ./space/.env
 fi

--- a/space/Dockerfile.space
+++ b/space/Dockerfile.space
@@ -21,7 +21,7 @@ COPY --from=builder /app/out/full/ .
 COPY turbo.json turbo.json
 USER root
 
-ARG NEXT_PUBLIC_API_BASE_URL=http://localhost:8000
+ARG NEXT_PUBLIC_API_BASE_URL=""
 ARG NEXT_PUBLIC_DEPLOY_WITH_NGINX=1
 
 ENV NEXT_PUBLIC_API_BASE_URL=$NEXT_PUBLIC_API_BASE_URL 
@@ -44,7 +44,7 @@ COPY --from=installer --chown=captain:plane /app/space/.next/standalone ./
 COPY --from=installer --chown=captain:plane /app/space/.next ./space/.next
 COPY --from=installer --chown=captain:plane /app/space/public ./space/public
 
-ARG NEXT_PUBLIC_API_BASE_URL=http://localhost:8000
+ARG NEXT_PUBLIC_API_BASE_URL=""
 ARG NEXT_PUBLIC_DEPLOY_WITH_NGINX=1
 
 ENV NEXT_PUBLIC_API_BASE_URL=$NEXT_PUBLIC_API_BASE_URL 

--- a/space/helpers/common.helper.ts
+++ b/space/helpers/common.helper.ts
@@ -1,0 +1,2 @@
+export const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_BASE_URL !== undefined ? process.env.NEXT_PUBLIC_API_BASE_URL : "http://localhost:8000";

--- a/space/services/authentication.service.ts
+++ b/space/services/authentication.service.ts
@@ -1,9 +1,10 @@
 // services
 import APIService from "services/api.service";
+import { API_BASE_URL } from "helpers/common.helper";
 
 class AuthService extends APIService {
   constructor() {
-    super(process.env.NEXT_PUBLIC_API_BASE_URL !== undefined ? process.env.NEXT_PUBLIC_API_BASE_URL : "http://localhost:8000");
+    super(API_BASE_URL);
   }
 
   async emailLogin(data: any) {

--- a/space/services/authentication.service.ts
+++ b/space/services/authentication.service.ts
@@ -3,7 +3,7 @@ import APIService from "services/api.service";
 
 class AuthService extends APIService {
   constructor() {
-    super(process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:8000");
+    super(process.env.NEXT_PUBLIC_API_BASE_URL !== undefined ? process.env.NEXT_PUBLIC_API_BASE_URL : "http://localhost:8000");
   }
 
   async emailLogin(data: any) {

--- a/space/services/file.service.ts
+++ b/space/services/file.service.ts
@@ -1,7 +1,5 @@
-// services
 import APIService from "services/api.service";
-
-const { NEXT_PUBLIC_API_BASE_URL } = process.env;
+import { API_BASE_URL } from "helpers/common.helper";
 
 interface UnSplashImage {
   id: string;
@@ -29,7 +27,7 @@ interface UnSplashImageUrls {
 
 class FileServices extends APIService {
   constructor() {
-    super(NEXT_PUBLIC_API_BASE_URL !== undefined ? NEXT_PUBLIC_API_BASE_URL : "http://localhost:8000");
+    super(API_BASE_URL);
   }
 
   async uploadFile(workspaceSlug: string, file: FormData): Promise<any> {

--- a/space/services/file.service.ts
+++ b/space/services/file.service.ts
@@ -29,7 +29,7 @@ interface UnSplashImageUrls {
 
 class FileServices extends APIService {
   constructor() {
-    super(NEXT_PUBLIC_API_BASE_URL || "http://localhost:8000");
+    super(NEXT_PUBLIC_API_BASE_URL !== undefined ? NEXT_PUBLIC_API_BASE_URL : "http://localhost:8000");
   }
 
   async uploadFile(workspaceSlug: string, file: FormData): Promise<any> {

--- a/space/services/issue.service.ts
+++ b/space/services/issue.service.ts
@@ -1,9 +1,10 @@
 // services
 import APIService from "services/api.service";
+import { API_BASE_URL } from "helpers/common.helper";
 
 class IssueService extends APIService {
   constructor() {
-    super(process.env.NEXT_PUBLIC_API_BASE_URL !== undefined ? process.env.NEXT_PUBLIC_API_BASE_URL : "http://localhost:8000");
+    super(API_BASE_URL);
   }
 
   async getPublicIssues(workspace_slug: string, project_slug: string, params: any): Promise<any> {

--- a/space/services/issue.service.ts
+++ b/space/services/issue.service.ts
@@ -3,7 +3,7 @@ import APIService from "services/api.service";
 
 class IssueService extends APIService {
   constructor() {
-    super(process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:8000");
+    super(process.env.NEXT_PUBLIC_API_BASE_URL !== undefined ? process.env.NEXT_PUBLIC_API_BASE_URL : "http://localhost:8000");
   }
 
   async getPublicIssues(workspace_slug: string, project_slug: string, params: any): Promise<any> {

--- a/space/services/project.service.ts
+++ b/space/services/project.service.ts
@@ -3,7 +3,7 @@ import APIService from "services/api.service";
 
 class ProjectService extends APIService {
   constructor() {
-    super(process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:8000");
+    super(process.env.NEXT_PUBLIC_API_BASE_URL !== undefined ? process.env.NEXT_PUBLIC_API_BASE_URL : "http://localhost:8000");
   }
 
   async getProjectSettings(workspace_slug: string, project_slug: string): Promise<any> {

--- a/space/services/project.service.ts
+++ b/space/services/project.service.ts
@@ -1,9 +1,10 @@
 // services
 import APIService from "services/api.service";
+import { API_BASE_URL } from "helpers/common.helper";
 
 class ProjectService extends APIService {
   constructor() {
-    super(process.env.NEXT_PUBLIC_API_BASE_URL !== undefined ? process.env.NEXT_PUBLIC_API_BASE_URL : "http://localhost:8000");
+    super(API_BASE_URL);
   }
 
   async getProjectSettings(workspace_slug: string, project_slug: string): Promise<any> {

--- a/space/services/user.service.ts
+++ b/space/services/user.service.ts
@@ -3,7 +3,7 @@ import APIService from "services/api.service";
 
 class UserService extends APIService {
   constructor() {
-    super(process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:8000");
+    super(process.env.NEXT_PUBLIC_API_BASE_URL !== undefined ? process.env.NEXT_PUBLIC_API_BASE_URL : "http://localhost:8000");
   }
 
   async currentUser(): Promise<any> {

--- a/space/services/user.service.ts
+++ b/space/services/user.service.ts
@@ -1,9 +1,10 @@
 // services
 import APIService from "services/api.service";
+import { API_BASE_URL } from "helpers/common.helper";
 
 class UserService extends APIService {
   constructor() {
-    super(process.env.NEXT_PUBLIC_API_BASE_URL !== undefined ? process.env.NEXT_PUBLIC_API_BASE_URL : "http://localhost:8000");
+    super(API_BASE_URL);
   }
 
   async currentUser(): Promise<any> {

--- a/web/.env.example
+++ b/web/.env.example
@@ -23,4 +23,4 @@ NEXT_PUBLIC_SLACK_CLIENT_ID=""
 # For Telemetry, set it to "app.plane.so"
 NEXT_PUBLIC_PLAUSIBLE_DOMAIN=""
 # Public boards deploy URL
-NEXT_PUBLIC_DEPLOY_URL=""
+NEXT_PUBLIC_DEPLOY_URL="http://localhost:3000/spaces"

--- a/web/Dockerfile.web
+++ b/web/Dockerfile.web
@@ -14,6 +14,7 @@ FROM node:18-alpine AS installer
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
 ARG NEXT_PUBLIC_API_BASE_URL=""
+ARG NEXT_PUBLIC_DEPLOY_URL=""
 
 # First install the dependencies (as they change less often)
 COPY .gitignore .gitignore
@@ -26,6 +27,7 @@ COPY --from=builder /app/out/full/ .
 COPY turbo.json turbo.json
 USER root
 ENV NEXT_PUBLIC_API_BASE_URL=$NEXT_PUBLIC_API_BASE_URL
+ENV NEXT_PUBLIC_DEPLOY_URL=$NEXT_PUBLIC_DEPLOY_URL
 
 RUN yarn turbo run build --filter=web
 
@@ -46,7 +48,9 @@ COPY --from=installer --chown=captain:plane /app/web/.next/standalone ./
 COPY --from=installer --chown=captain:plane /app/web/.next ./web/.next
 
 ARG NEXT_PUBLIC_API_BASE_URL=""
+ARG NEXT_PUBLIC_DEPLOY_URL=""
 ENV NEXT_PUBLIC_API_BASE_URL=$NEXT_PUBLIC_API_BASE_URL
+ENV NEXT_PUBLIC_DEPLOY_URL=$NEXT_PUBLIC_DEPLOY_URL
 
 USER root
 COPY start.sh /usr/local/bin/

--- a/web/Dockerfile.web
+++ b/web/Dockerfile.web
@@ -13,7 +13,7 @@ FROM node:18-alpine AS installer
 
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
-ARG NEXT_PUBLIC_API_BASE_URL=http://localhost:8000
+ARG NEXT_PUBLIC_API_BASE_URL=""
 
 # First install the dependencies (as they change less often)
 COPY .gitignore .gitignore
@@ -45,7 +45,7 @@ COPY --from=installer /app/web/package.json .
 COPY --from=installer --chown=captain:plane /app/web/.next/standalone ./
 COPY --from=installer --chown=captain:plane /app/web/.next ./web/.next
 
-ARG NEXT_PUBLIC_API_BASE_URL=http://localhost:8000
+ARG NEXT_PUBLIC_API_BASE_URL=""
 ENV NEXT_PUBLIC_API_BASE_URL=$NEXT_PUBLIC_API_BASE_URL
 
 USER root

--- a/web/components/project/publish-project/modal.tsx
+++ b/web/components/project/publish-project/modal.tsx
@@ -63,7 +63,11 @@ export const PublishProjectModal: React.FC<Props> = observer(() => {
   const [isUnpublishing, setIsUnpublishing] = useState(false);
   const [isUpdateRequired, setIsUpdateRequired] = useState(false);
 
-  const plane_deploy_url = process.env.NEXT_PUBLIC_DEPLOY_URL ?? "http://localhost:4000";
+  let plane_deploy_url = process.env.NEXT_PUBLIC_DEPLOY_URL;
+
+  if (typeof window !== 'undefined' && !plane_deploy_url) {
+    plane_deploy_url= window.location.protocol + "//" + window.location.host + "/spaces";
+  }
 
   const router = useRouter();
   const { workspaceSlug } = router.query;

--- a/web/helpers/common.helper.ts
+++ b/web/helpers/common.helper.ts
@@ -16,3 +16,8 @@ export const debounce = (func: any, wait: number, immediate: boolean = false) =>
     if (callNow) func(...args);
   };
 };
+
+export const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_BASE_URL !== undefined
+    ? process.env.NEXT_PUBLIC_API_BASE_URL
+    : "http://localhost:8000";

--- a/web/layouts/app-layout/app-header.tsx
+++ b/web/layouts/app-layout/app-header.tsx
@@ -17,7 +17,11 @@ type Props = {
 };
 
 const { NEXT_PUBLIC_DEPLOY_URL } = process.env;
-const plane_deploy_url = NEXT_PUBLIC_DEPLOY_URL ? NEXT_PUBLIC_DEPLOY_URL : "http://localhost:3001";
+let plane_deploy_url = NEXT_PUBLIC_DEPLOY_URL
+
+if (typeof window !== 'undefined' && !plane_deploy_url) {
+  plane_deploy_url= window.location.protocol + "//" + window.location.host + "/spaces";
+}
 
 const Header: React.FC<Props> = ({ breadcrumbs, left, right, setToggleSidebar, noHeader }) => {
   const { projectDetails } = useProjectDetails();

--- a/web/lib/auth.ts
+++ b/web/lib/auth.ts
@@ -9,7 +9,7 @@ export const requiredAuth = async (cookie?: string) => {
 
   if (!token) return null;
 
-  const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL || "https://api.plane.so";
+  const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL !== undefined ?  process.env.NEXT_PUBLIC_API_BASE_URL : "https://api.plane.so";
 
   let user: IUser | null = null;
 
@@ -41,7 +41,7 @@ export const requiredAdmin = async (workspaceSlug: string, projectId: string, co
   const cookies = convertCookieStringToObject(cookie);
   const token = cookies?.accessToken;
 
-  const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL || "https://api.plane.so";
+  const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL !== undefined ?  process.env.NEXT_PUBLIC_API_BASE_URL : "https://api.plane.so";
 
   let memberDetail: IProjectMember | null = null;
 
@@ -75,7 +75,7 @@ export const requiredWorkspaceAdmin = async (workspaceSlug: string, cookie?: str
   const cookies = convertCookieStringToObject(cookie);
   const token = cookies?.accessToken;
 
-  const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL || "https://api.plane.so";
+  const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL !== undefined ?  process.env.NEXT_PUBLIC_API_BASE_URL : "https://api.plane.so";
 
   let memberDetail: IWorkspaceMember | null = null;
 
@@ -119,7 +119,7 @@ export const homePageRedirect = async (cookie?: string) => {
 
   let workspaces: IWorkspace[] = [];
 
-  const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL || "https://api.plane.so";
+  const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL !== undefined ?  process.env.NEXT_PUBLIC_API_BASE_URL : "https://api.plane.so";
 
   const cookies = convertCookieStringToObject(cookie);
   const token = cookies?.accessToken;

--- a/web/lib/auth.ts
+++ b/web/lib/auth.ts
@@ -2,6 +2,8 @@
 import { convertCookieStringToObject } from "./cookie";
 // types
 import type { IProjectMember, IUser, IWorkspace, IWorkspaceMember } from "types";
+// helper
+import { API_BASE_URL } from "helpers/common.helper";
 
 export const requiredAuth = async (cookie?: string) => {
   const cookies = convertCookieStringToObject(cookie);
@@ -9,12 +11,10 @@ export const requiredAuth = async (cookie?: string) => {
 
   if (!token) return null;
 
-  const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL !== undefined ?  process.env.NEXT_PUBLIC_API_BASE_URL : "https://api.plane.so";
-
   let user: IUser | null = null;
 
   try {
-    const data = await fetch(`${baseUrl}/api/users/me/`, {
+    const data = await fetch(`${API_BASE_URL}/api/users/me/`, {
       method: "GET",
       headers: {
         "Content-Type": "application/json",
@@ -41,13 +41,11 @@ export const requiredAdmin = async (workspaceSlug: string, projectId: string, co
   const cookies = convertCookieStringToObject(cookie);
   const token = cookies?.accessToken;
 
-  const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL !== undefined ?  process.env.NEXT_PUBLIC_API_BASE_URL : "https://api.plane.so";
-
   let memberDetail: IProjectMember | null = null;
 
   try {
     const data = await fetch(
-      `${baseUrl}/api/workspaces/${workspaceSlug}/projects/${projectId}/project-members/me/`,
+      `${API_BASE_URL}/api/workspaces/${workspaceSlug}/projects/${projectId}/project-members/me/`,
       {
         method: "GET",
         headers: {
@@ -75,17 +73,18 @@ export const requiredWorkspaceAdmin = async (workspaceSlug: string, cookie?: str
   const cookies = convertCookieStringToObject(cookie);
   const token = cookies?.accessToken;
 
-  const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL !== undefined ?  process.env.NEXT_PUBLIC_API_BASE_URL : "https://api.plane.so";
-
   let memberDetail: IWorkspaceMember | null = null;
 
   try {
-    const data = await fetch(`${baseUrl}/api/workspaces/${workspaceSlug}/workspace-members/me/`, {
-      method: "GET",
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-    })
+    const data = await fetch(
+      `${API_BASE_URL}/api/workspaces/${workspaceSlug}/workspace-members/me/`,
+      {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      }
+    )
       .then((res) => res.json())
       .then((data) => data);
 
@@ -119,13 +118,11 @@ export const homePageRedirect = async (cookie?: string) => {
 
   let workspaces: IWorkspace[] = [];
 
-  const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL !== undefined ?  process.env.NEXT_PUBLIC_API_BASE_URL : "https://api.plane.so";
-
   const cookies = convertCookieStringToObject(cookie);
   const token = cookies?.accessToken;
 
   try {
-    const data = await fetch(`${baseUrl}/api/users/me/workspaces/`, {
+    const data = await fetch(`${API_BASE_URL}/api/users/me/workspaces/`, {
       method: "GET",
       headers: {
         "Content-Type": "application/json",
@@ -166,7 +163,7 @@ export const homePageRedirect = async (cookie?: string) => {
     };
   }
 
-  const invitations = await fetch(`${baseUrl}/api/users/me/invitations/workspaces/`, {
+  const invitations = await fetch(`${API_BASE_URL}/api/users/me/invitations/workspaces/`, {
     method: "GET",
     headers: {
       "Content-Type": "application/json",

--- a/web/services/ai.service.ts
+++ b/web/services/ai.service.ts
@@ -1,18 +1,16 @@
-// services
 import APIService from "services/api.service";
 import trackEventServices from "services/track-event.service";
-
 // types
 import { ICurrentUserResponse, IGptResponse } from "types";
-
-const { NEXT_PUBLIC_API_BASE_URL } = process.env;
+// helpers
+import { API_BASE_URL } from "helpers/common.helper";
 
 const trackEvent =
   process.env.NEXT_PUBLIC_TRACK_EVENTS === "true" || process.env.NEXT_PUBLIC_TRACK_EVENTS === "1";
 
 class AiServices extends APIService {
   constructor() {
-    super(NEXT_PUBLIC_API_BASE_URL !== undefined ? NEXT_PUBLIC_API_BASE_URL : "http://localhost:8000");
+    super(API_BASE_URL);
   }
 
   async createGptTask(

--- a/web/services/ai.service.ts
+++ b/web/services/ai.service.ts
@@ -12,7 +12,7 @@ const trackEvent =
 
 class AiServices extends APIService {
   constructor() {
-    super(NEXT_PUBLIC_API_BASE_URL || "http://localhost:8000");
+    super(NEXT_PUBLIC_API_BASE_URL !== undefined ? NEXT_PUBLIC_API_BASE_URL : "http://localhost:8000");
   }
 
   async createGptTask(

--- a/web/services/analytics.service.ts
+++ b/web/services/analytics.service.ts
@@ -13,7 +13,7 @@ const { NEXT_PUBLIC_API_BASE_URL } = process.env;
 
 class AnalyticsServices extends APIService {
   constructor() {
-    super(NEXT_PUBLIC_API_BASE_URL || "http://localhost:8000");
+    super(NEXT_PUBLIC_API_BASE_URL !== undefined ? NEXT_PUBLIC_API_BASE_URL : "http://localhost:8000");
   }
 
   async getAnalytics(workspaceSlug: string, params: IAnalyticsParams): Promise<IAnalyticsResponse> {

--- a/web/services/analytics.service.ts
+++ b/web/services/analytics.service.ts
@@ -8,12 +8,11 @@ import {
   IExportAnalyticsFormData,
   ISaveAnalyticsFormData,
 } from "types";
-
-const { NEXT_PUBLIC_API_BASE_URL } = process.env;
+import { API_BASE_URL } from "helpers/common.helper";
 
 class AnalyticsServices extends APIService {
   constructor() {
-    super(NEXT_PUBLIC_API_BASE_URL !== undefined ? NEXT_PUBLIC_API_BASE_URL : "http://localhost:8000");
+    super(API_BASE_URL);
   }
 
   async getAnalytics(workspaceSlug: string, params: IAnalyticsParams): Promise<IAnalyticsResponse> {

--- a/web/services/app-installations.service.ts
+++ b/web/services/app-installations.service.ts
@@ -6,7 +6,7 @@ const { NEXT_PUBLIC_API_BASE_URL } = process.env;
 
 class AppInstallationsService extends APIService {
   constructor() {
-    super(NEXT_PUBLIC_API_BASE_URL || "http://localhost:8000");
+    super(NEXT_PUBLIC_API_BASE_URL !== undefined ? NEXT_PUBLIC_API_BASE_URL : "http://localhost:8000");
   }
 
   async addInstallationApp(workspaceSlug: string, provider: string, data: any): Promise<any> {

--- a/web/services/app-installations.service.ts
+++ b/web/services/app-installations.service.ts
@@ -1,12 +1,11 @@
 // services
 import axios from "axios";
 import APIService from "services/api.service";
-
-const { NEXT_PUBLIC_API_BASE_URL } = process.env;
+import { API_BASE_URL } from "helpers/common.helper";
 
 class AppInstallationsService extends APIService {
   constructor() {
-    super(NEXT_PUBLIC_API_BASE_URL !== undefined ? NEXT_PUBLIC_API_BASE_URL : "http://localhost:8000");
+    super(API_BASE_URL);
   }
 
   async addInstallationApp(workspaceSlug: string, provider: string, data: any): Promise<any> {

--- a/web/services/authentication.service.ts
+++ b/web/services/authentication.service.ts
@@ -6,7 +6,7 @@ const { NEXT_PUBLIC_API_BASE_URL } = process.env;
 
 class AuthService extends APIService {
   constructor() {
-    super(NEXT_PUBLIC_API_BASE_URL || "http://localhost:8000");
+    super(NEXT_PUBLIC_API_BASE_URL !== undefined ? NEXT_PUBLIC_API_BASE_URL : "http://localhost:8000");
   }
 
   async emailLogin(data: any) {

--- a/web/services/authentication.service.ts
+++ b/web/services/authentication.service.ts
@@ -1,12 +1,11 @@
 // services
 import APIService from "services/api.service";
 import { ICurrentUserResponse } from "types";
-
-const { NEXT_PUBLIC_API_BASE_URL } = process.env;
+import { API_BASE_URL } from "helpers/common.helper";
 
 class AuthService extends APIService {
   constructor() {
-    super(NEXT_PUBLIC_API_BASE_URL !== undefined ? NEXT_PUBLIC_API_BASE_URL : "http://localhost:8000");
+    super(API_BASE_URL);
   }
 
   async emailLogin(data: any) {

--- a/web/services/cycles.service.ts
+++ b/web/services/cycles.service.ts
@@ -12,7 +12,7 @@ const trackEvent =
 
 class ProjectCycleServices extends APIService {
   constructor() {
-    super(NEXT_PUBLIC_API_BASE_URL || "http://localhost:8000");
+    super(NEXT_PUBLIC_API_BASE_URL !== undefined ? NEXT_PUBLIC_API_BASE_URL : "http://localhost:8000");
   }
 
   async createCycle(

--- a/web/services/cycles.service.ts
+++ b/web/services/cycles.service.ts
@@ -1,18 +1,16 @@
 // services
 import APIService from "services/api.service";
 import trackEventServices from "services/track-event.service";
-
 // types
 import type { CycleDateCheckData, ICurrentUserResponse, ICycle, IIssue } from "types";
-
-const { NEXT_PUBLIC_API_BASE_URL } = process.env;
+import { API_BASE_URL } from "helpers/common.helper";
 
 const trackEvent =
   process.env.NEXT_PUBLIC_TRACK_EVENTS === "true" || process.env.NEXT_PUBLIC_TRACK_EVENTS === "1";
 
 class ProjectCycleServices extends APIService {
   constructor() {
-    super(NEXT_PUBLIC_API_BASE_URL !== undefined ? NEXT_PUBLIC_API_BASE_URL : "http://localhost:8000");
+    super(API_BASE_URL);
   }
 
   async createCycle(

--- a/web/services/estimates.service.ts
+++ b/web/services/estimates.service.ts
@@ -11,7 +11,7 @@ const trackEvent =
 
 class ProjectEstimateServices extends APIService {
   constructor() {
-    super(NEXT_PUBLIC_API_BASE_URL || "http://localhost:8000");
+    super(NEXT_PUBLIC_API_BASE_URL !== undefined ? NEXT_PUBLIC_API_BASE_URL : "http://localhost:8000");
   }
 
   async createEstimate(

--- a/web/services/estimates.service.ts
+++ b/web/services/estimates.service.ts
@@ -3,15 +3,14 @@ import APIService from "services/api.service";
 // types
 import type { ICurrentUserResponse, IEstimate, IEstimateFormData } from "types";
 import trackEventServices from "services/track-event.service";
-
-const { NEXT_PUBLIC_API_BASE_URL } = process.env;
+import { API_BASE_URL } from "helpers/common.helper";
 
 const trackEvent =
   process.env.NEXT_PUBLIC_TRACK_EVENTS === "true" || process.env.NEXT_PUBLIC_TRACK_EVENTS === "1";
 
 class ProjectEstimateServices extends APIService {
   constructor() {
-    super(NEXT_PUBLIC_API_BASE_URL !== undefined ? NEXT_PUBLIC_API_BASE_URL : "http://localhost:8000");
+    super(API_BASE_URL);
   }
 
   async createEstimate(

--- a/web/services/file.service.ts
+++ b/web/services/file.service.ts
@@ -1,7 +1,6 @@
 // services
 import APIService from "services/api.service";
-
-const { NEXT_PUBLIC_API_BASE_URL } = process.env;
+import { API_BASE_URL } from "helpers/common.helper";
 
 interface UnSplashImage {
   id: string;
@@ -29,7 +28,7 @@ interface UnSplashImageUrls {
 
 class FileServices extends APIService {
   constructor() {
-    super(NEXT_PUBLIC_API_BASE_URL !== undefined ? NEXT_PUBLIC_API_BASE_URL : "http://localhost:8000");
+    super(API_BASE_URL);
   }
 
   async uploadFile(workspaceSlug: string, file: FormData): Promise<any> {

--- a/web/services/file.service.ts
+++ b/web/services/file.service.ts
@@ -29,7 +29,7 @@ interface UnSplashImageUrls {
 
 class FileServices extends APIService {
   constructor() {
-    super(NEXT_PUBLIC_API_BASE_URL || "http://localhost:8000");
+    super(NEXT_PUBLIC_API_BASE_URL !== undefined ? NEXT_PUBLIC_API_BASE_URL : "http://localhost:8000");
   }
 
   async uploadFile(workspaceSlug: string, file: FormData): Promise<any> {

--- a/web/services/inbox.service.ts
+++ b/web/services/inbox.service.ts
@@ -1,7 +1,6 @@
 import APIService from "services/api.service";
 import trackEventServices from "services/track-event.service";
-
-const { NEXT_PUBLIC_API_BASE_URL } = process.env;
+import { API_BASE_URL } from "helpers/common.helper";
 
 const trackEvent =
   process.env.NEXT_PUBLIC_TRACK_EVENTS === "true" || process.env.NEXT_PUBLIC_TRACK_EVENTS === "1";
@@ -19,7 +18,7 @@ import type {
 
 class InboxServices extends APIService {
   constructor() {
-    super(NEXT_PUBLIC_API_BASE_URL !== undefined ? NEXT_PUBLIC_API_BASE_URL : "http://localhost:8000");
+    super(API_BASE_URL);
   }
 
   async getInboxes(workspaceSlug: string, projectId: string): Promise<IInbox[]> {

--- a/web/services/inbox.service.ts
+++ b/web/services/inbox.service.ts
@@ -19,7 +19,7 @@ import type {
 
 class InboxServices extends APIService {
   constructor() {
-    super(NEXT_PUBLIC_API_BASE_URL || "http://localhost:8000");
+    super(NEXT_PUBLIC_API_BASE_URL !== undefined ? NEXT_PUBLIC_API_BASE_URL : "http://localhost:8000");
   }
 
   async getInboxes(workspaceSlug: string, projectId: string): Promise<IInbox[]> {

--- a/web/services/integration/csv.services.ts
+++ b/web/services/integration/csv.services.ts
@@ -10,7 +10,7 @@ const trackEvent =
 
 class CSVIntegrationService extends APIService {
   constructor() {
-    super(NEXT_PUBLIC_API_BASE_URL || "http://localhost:8000");
+    super(NEXT_PUBLIC_API_BASE_URL !== undefined ? NEXT_PUBLIC_API_BASE_URL : "http://localhost:8000");
   }
 
   async exportCSVService(

--- a/web/services/integration/csv.services.ts
+++ b/web/services/integration/csv.services.ts
@@ -10,7 +10,7 @@ const trackEvent =
 
 class CSVIntegrationService extends APIService {
   constructor() {
-    super(NEXT_PUBLIC_API_BASE_URL !== undefined ? NEXT_PUBLIC_API_BASE_URL : "http://localhost:8000");
+    super(API_BASE_URL);
   }
 
   async exportCSVService(

--- a/web/services/integration/csv.services.ts
+++ b/web/services/integration/csv.services.ts
@@ -1,9 +1,7 @@
 import APIService from "services/api.service";
 import trackEventServices from "services/track-event.service";
-
 import { ICurrentUserResponse } from "types";
-
-const { NEXT_PUBLIC_API_BASE_URL } = process.env;
+import { API_BASE_URL } from "helpers/common.helper";
 
 const trackEvent =
   process.env.NEXT_PUBLIC_TRACK_EVENTS === "true" || process.env.NEXT_PUBLIC_TRACK_EVENTS === "1";

--- a/web/services/integration/github.service.ts
+++ b/web/services/integration/github.service.ts
@@ -1,5 +1,6 @@
 import APIService from "services/api.service";
 import trackEventServices from "services/track-event.service";
+import { API_BASE_URL } from "helpers/common.helper";
 
 import { ICurrentUserResponse, IGithubRepoInfo, IGithubServiceImportFormData } from "types";
 

--- a/web/services/integration/github.service.ts
+++ b/web/services/integration/github.service.ts
@@ -11,7 +11,7 @@ const trackEvent =
 const integrationServiceType: string = "github";
 class GithubIntegrationService extends APIService {
   constructor() {
-    super(NEXT_PUBLIC_API_BASE_URL || "http://localhost:8000");
+    super(NEXT_PUBLIC_API_BASE_URL !== undefined ? NEXT_PUBLIC_API_BASE_URL : "http://localhost:8000");
   }
 
   async listAllRepositories(workspaceSlug: string, integrationSlug: string): Promise<any> {

--- a/web/services/integration/github.service.ts
+++ b/web/services/integration/github.service.ts
@@ -11,7 +11,7 @@ const trackEvent =
 const integrationServiceType: string = "github";
 class GithubIntegrationService extends APIService {
   constructor() {
-    super(NEXT_PUBLIC_API_BASE_URL !== undefined ? NEXT_PUBLIC_API_BASE_URL : "http://localhost:8000");
+    super(API_BASE_URL);
   }
 
   async listAllRepositories(workspaceSlug: string, integrationSlug: string): Promise<any> {

--- a/web/services/integration/index.ts
+++ b/web/services/integration/index.ts
@@ -17,7 +17,7 @@ const trackEvent =
 
 class IntegrationService extends APIService {
   constructor() {
-    super(NEXT_PUBLIC_API_BASE_URL || "http://localhost:8000");
+    super(NEXT_PUBLIC_API_BASE_URL !== undefined ? NEXT_PUBLIC_API_BASE_URL : "http://localhost:8000");
   }
 
   async getAppIntegrationsList(): Promise<IAppIntegration[]> {

--- a/web/services/integration/index.ts
+++ b/web/services/integration/index.ts
@@ -17,7 +17,7 @@ const trackEvent =
 
 class IntegrationService extends APIService {
   constructor() {
-    super(NEXT_PUBLIC_API_BASE_URL !== undefined ? NEXT_PUBLIC_API_BASE_URL : "http://localhost:8000");
+    super(API_BASE_URL);
   }
 
   async getAppIntegrationsList(): Promise<IAppIntegration[]> {

--- a/web/services/integration/index.ts
+++ b/web/services/integration/index.ts
@@ -9,8 +9,7 @@ import {
   IWorkspaceIntegration,
   IExportServiceResponse,
 } from "types";
-
-const { NEXT_PUBLIC_API_BASE_URL } = process.env;
+import { API_BASE_URL } from "helpers/common.helper";
 
 const trackEvent =
   process.env.NEXT_PUBLIC_TRACK_EVENTS === "true" || process.env.NEXT_PUBLIC_TRACK_EVENTS === "1";

--- a/web/services/integration/jira.service.ts
+++ b/web/services/integration/jira.service.ts
@@ -1,6 +1,6 @@
 import APIService from "services/api.service";
 import trackEventServices from "services/track-event.service";
-
+import { API_BASE_URL } from "helpers/common.helper";
 // types
 import { IJiraMetadata, IJiraResponse, IJiraImporterForm, ICurrentUserResponse } from "types";
 

--- a/web/services/integration/jira.service.ts
+++ b/web/services/integration/jira.service.ts
@@ -11,7 +11,7 @@ const trackEvent =
 
 class JiraImportedService extends APIService {
   constructor() {
-    super(NEXT_PUBLIC_API_BASE_URL || "http://localhost:8000");
+    super(NEXT_PUBLIC_API_BASE_URL !== undefined ? NEXT_PUBLIC_API_BASE_URL : "http://localhost:8000");
   }
 
   async getJiraProjectInfo(workspaceSlug: string, params: IJiraMetadata): Promise<IJiraResponse> {

--- a/web/services/integration/jira.service.ts
+++ b/web/services/integration/jira.service.ts
@@ -11,7 +11,7 @@ const trackEvent =
 
 class JiraImportedService extends APIService {
   constructor() {
-    super(NEXT_PUBLIC_API_BASE_URL !== undefined ? NEXT_PUBLIC_API_BASE_URL : "http://localhost:8000");
+    super(API_BASE_URL);
   }
 
   async getJiraProjectInfo(workspaceSlug: string, params: IJiraMetadata): Promise<IJiraResponse> {

--- a/web/services/issues.service.ts
+++ b/web/services/issues.service.ts
@@ -19,7 +19,7 @@ const trackEvent =
 
 class ProjectIssuesServices extends APIService {
   constructor() {
-    super(NEXT_PUBLIC_API_BASE_URL || "http://localhost:8000");
+    super(NEXT_PUBLIC_API_BASE_URL !== undefined ? NEXT_PUBLIC_API_BASE_URL : "http://localhost:8000");
   }
 
   async createIssues(

--- a/web/services/issues.service.ts
+++ b/web/services/issues.service.ts
@@ -11,15 +11,14 @@ import type {
   IIssueViewOptions,
   ISubIssueResponse,
 } from "types";
-
-const { NEXT_PUBLIC_API_BASE_URL } = process.env;
+import { API_BASE_URL } from "helpers/common.helper";
 
 const trackEvent =
   process.env.NEXT_PUBLIC_TRACK_EVENTS === "true" || process.env.NEXT_PUBLIC_TRACK_EVENTS === "1";
 
 class ProjectIssuesServices extends APIService {
   constructor() {
-    super(NEXT_PUBLIC_API_BASE_URL !== undefined ? NEXT_PUBLIC_API_BASE_URL : "http://localhost:8000");
+    super(API_BASE_URL);
   }
 
   async createIssues(

--- a/web/services/modules.service.ts
+++ b/web/services/modules.service.ts
@@ -1,9 +1,9 @@
 // services
 import APIService from "services/api.service";
 import trackEventServices from "./track-event.service";
-
 // types
 import type { IIssueViewOptions, IModule, IIssue, ICurrentUserResponse } from "types";
+import { API_BASE_URL } from "helpers/common.helper";
 
 const { NEXT_PUBLIC_API_BASE_URL } = process.env;
 
@@ -12,7 +12,7 @@ const trackEvent =
 
 class ProjectIssuesServices extends APIService {
   constructor() {
-    super(NEXT_PUBLIC_API_BASE_URL !== undefined ? NEXT_PUBLIC_API_BASE_URL : "http://localhost:8000");
+    super(API_BASE_URL);
   }
 
   async getModules(workspaceSlug: string, projectId: string): Promise<IModule[]> {

--- a/web/services/modules.service.ts
+++ b/web/services/modules.service.ts
@@ -12,7 +12,7 @@ const trackEvent =
 
 class ProjectIssuesServices extends APIService {
   constructor() {
-    super(NEXT_PUBLIC_API_BASE_URL || "http://localhost:8000");
+    super(NEXT_PUBLIC_API_BASE_URL !== undefined ? NEXT_PUBLIC_API_BASE_URL : "http://localhost:8000");
   }
 
   async getModules(workspaceSlug: string, projectId: string): Promise<IModule[]> {

--- a/web/services/notifications.service.ts
+++ b/web/services/notifications.service.ts
@@ -14,7 +14,7 @@ import type {
 
 class UserNotificationsServices extends APIService {
   constructor() {
-    super(NEXT_PUBLIC_API_BASE_URL || "http://localhost:8000");
+    super(NEXT_PUBLIC_API_BASE_URL !== undefined ? NEXT_PUBLIC_API_BASE_URL : "http://localhost:8000");
   }
 
   async getUserNotifications(

--- a/web/services/notifications.service.ts
+++ b/web/services/notifications.service.ts
@@ -1,8 +1,5 @@
 // services
 import APIService from "services/api.service";
-
-const { NEXT_PUBLIC_API_BASE_URL } = process.env;
-
 // types
 import type {
   IUserNotification,
@@ -11,10 +8,12 @@ import type {
   PaginatedUserNotification,
   IMarkAllAsReadPayload,
 } from "types";
+// helpers
+import { API_BASE_URL } from "helpers/common.helper";
 
 class UserNotificationsServices extends APIService {
   constructor() {
-    super(NEXT_PUBLIC_API_BASE_URL !== undefined ? NEXT_PUBLIC_API_BASE_URL : "http://localhost:8000");
+    super(API_BASE_URL);
   }
 
   async getUserNotifications(

--- a/web/services/pages.service.ts
+++ b/web/services/pages.service.ts
@@ -1,18 +1,16 @@
+import { API_BASE_URL } from "helpers/common.helper";
 // services
 import APIService from "services/api.service";
 import trackEventServices from "services/track-event.service";
-
 // types
 import { IPage, IPageBlock, RecentPagesResponse, IIssue, ICurrentUserResponse } from "types";
-
-const { NEXT_PUBLIC_API_BASE_URL } = process.env;
 
 const trackEvent =
   process.env.NEXT_PUBLIC_TRACK_EVENTS === "true" || process.env.NEXT_PUBLIC_TRACK_EVENTS === "1";
 
 class PageServices extends APIService {
   constructor() {
-    super(NEXT_PUBLIC_API_BASE_URL !== undefined ? NEXT_PUBLIC_API_BASE_URL : "http://localhost:8000");
+    super(API_BASE_URL);
   }
 
   async createPage(

--- a/web/services/pages.service.ts
+++ b/web/services/pages.service.ts
@@ -12,7 +12,7 @@ const trackEvent =
 
 class PageServices extends APIService {
   constructor() {
-    super(NEXT_PUBLIC_API_BASE_URL || "http://localhost:8000");
+    super(NEXT_PUBLIC_API_BASE_URL !== undefined ? NEXT_PUBLIC_API_BASE_URL : "http://localhost:8000");
   }
 
   async createPage(

--- a/web/services/project-publish.service.ts
+++ b/web/services/project-publish.service.ts
@@ -1,3 +1,4 @@
+import { API_BASE_URL } from "helpers/common.helper";
 // services
 import APIService from "services/api.service";
 import trackEventServices from "services/track-event.service";
@@ -5,14 +6,12 @@ import trackEventServices from "services/track-event.service";
 import { ICurrentUserResponse } from "types";
 import { IProjectPublishSettings } from "store/project-publish";
 
-const { NEXT_PUBLIC_API_BASE_URL } = process.env;
-
 const trackEvent =
   process.env.NEXT_PUBLIC_TRACK_EVENTS === "true" || process.env.NEXT_PUBLIC_TRACK_EVENTS === "1";
 
 class ProjectServices extends APIService {
   constructor() {
-    super(NEXT_PUBLIC_API_BASE_URL !== undefined ? NEXT_PUBLIC_API_BASE_URL : "http://localhost:8000");
+    super(API_BASE_URL);
   }
 
   async getProjectSettingsAsync(

--- a/web/services/project-publish.service.ts
+++ b/web/services/project-publish.service.ts
@@ -12,7 +12,7 @@ const trackEvent =
 
 class ProjectServices extends APIService {
   constructor() {
-    super(NEXT_PUBLIC_API_BASE_URL || "http://localhost:8000");
+    super(NEXT_PUBLIC_API_BASE_URL !== undefined ? NEXT_PUBLIC_API_BASE_URL : "http://localhost:8000");
   }
 
   async getProjectSettingsAsync(

--- a/web/services/project.service.ts
+++ b/web/services/project.service.ts
@@ -23,7 +23,7 @@ const trackEvent =
 
 export class ProjectServices extends APIService {
   constructor() {
-    super(NEXT_PUBLIC_API_BASE_URL || "http://localhost:8000");
+    super(NEXT_PUBLIC_API_BASE_URL !== undefined ? NEXT_PUBLIC_API_BASE_URL : "http://localhost:8000");
   }
 
   async createProject(

--- a/web/services/project.service.ts
+++ b/web/services/project.service.ts
@@ -1,7 +1,7 @@
+import { API_BASE_URL } from "helpers/common.helper";
 // services
 import APIService from "services/api.service";
 import trackEventServices from "services/track-event.service";
-
 // types
 import type {
   GithubRepositoriesResponse,
@@ -16,14 +16,12 @@ import type {
   TProjectIssuesSearchParams,
 } from "types";
 
-const { NEXT_PUBLIC_API_BASE_URL } = process.env;
-
 const trackEvent =
   process.env.NEXT_PUBLIC_TRACK_EVENTS === "true" || process.env.NEXT_PUBLIC_TRACK_EVENTS === "1";
 
 export class ProjectServices extends APIService {
   constructor() {
-    super(NEXT_PUBLIC_API_BASE_URL !== undefined ? NEXT_PUBLIC_API_BASE_URL : "http://localhost:8000");
+    super(API_BASE_URL);
   }
 
   async createProject(

--- a/web/services/reaction.service.ts
+++ b/web/services/reaction.service.ts
@@ -1,7 +1,7 @@
+import { API_BASE_URL } from "helpers/common.helper";
 // services
 import APIService from "services/api.service";
 import trackEventServices from "services/track-event.service";
-
 // types
 import type {
   ICurrentUserResponse,
@@ -11,14 +11,12 @@ import type {
   IssueCommentReactionForm,
 } from "types";
 
-const { NEXT_PUBLIC_API_BASE_URL } = process.env;
-
 const trackEvent =
   process.env.NEXT_PUBLIC_TRACK_EVENTS === "true" || process.env.NEXT_PUBLIC_TRACK_EVENTS === "1";
 
 class ReactionService extends APIService {
   constructor() {
-    super(NEXT_PUBLIC_API_BASE_URL !== undefined ? NEXT_PUBLIC_API_BASE_URL : "http://localhost:8000");
+    super(API_BASE_URL);
   }
 
   async createIssueReaction(

--- a/web/services/reaction.service.ts
+++ b/web/services/reaction.service.ts
@@ -18,7 +18,7 @@ const trackEvent =
 
 class ReactionService extends APIService {
   constructor() {
-    super(NEXT_PUBLIC_API_BASE_URL || "http://localhost:8000");
+    super(NEXT_PUBLIC_API_BASE_URL !== undefined ? NEXT_PUBLIC_API_BASE_URL : "http://localhost:8000");
   }
 
   async createIssueReaction(

--- a/web/services/state.service.ts
+++ b/web/services/state.service.ts
@@ -1,8 +1,8 @@
 // services
 import APIService from "services/api.service";
 import trackEventServices from "services/track-event.service";
-
-const { NEXT_PUBLIC_API_BASE_URL } = process.env;
+// helpers
+import { API_BASE_URL } from "helpers/common.helper";
 
 const trackEvent =
   process.env.NEXT_PUBLIC_TRACK_EVENTS === "true" || process.env.NEXT_PUBLIC_TRACK_EVENTS === "1";
@@ -12,7 +12,7 @@ import type { ICurrentUserResponse, IState, IStateResponse } from "types";
 
 class ProjectStateServices extends APIService {
   constructor() {
-    super(NEXT_PUBLIC_API_BASE_URL !== undefined ? NEXT_PUBLIC_API_BASE_URL : "http://localhost:8000");
+    super(API_BASE_URL);
   }
 
   async createState(

--- a/web/services/state.service.ts
+++ b/web/services/state.service.ts
@@ -12,7 +12,7 @@ import type { ICurrentUserResponse, IState, IStateResponse } from "types";
 
 class ProjectStateServices extends APIService {
   constructor() {
-    super(NEXT_PUBLIC_API_BASE_URL || "http://localhost:8000");
+    super(NEXT_PUBLIC_API_BASE_URL !== undefined ? NEXT_PUBLIC_API_BASE_URL : "http://localhost:8000");
   }
 
   async createState(

--- a/web/services/user.service.ts
+++ b/web/services/user.service.ts
@@ -12,14 +12,14 @@ import type {
   IUserWorkspaceDashboard,
 } from "types";
 
-const { NEXT_PUBLIC_API_BASE_URL } = process.env;
+import { API_BASE_URL } from "helpers/common.helper";
 
 const trackEvent =
   process.env.NEXT_PUBLIC_TRACK_EVENTS === "true" || process.env.NEXT_PUBLIC_TRACK_EVENTS === "1";
 
 class UserService extends APIService {
   constructor() {
-    super(NEXT_PUBLIC_API_BASE_URL !== undefined ? NEXT_PUBLIC_API_BASE_URL : "http://localhost:8000");
+    super(API_BASE_URL);
   }
 
   currentUserConfig() {

--- a/web/services/user.service.ts
+++ b/web/services/user.service.ts
@@ -19,7 +19,7 @@ const trackEvent =
 
 class UserService extends APIService {
   constructor() {
-    super(NEXT_PUBLIC_API_BASE_URL || "http://localhost:8000");
+    super(NEXT_PUBLIC_API_BASE_URL !== undefined ? NEXT_PUBLIC_API_BASE_URL : "http://localhost:8000");
   }
 
   currentUserConfig() {

--- a/web/services/views.service.ts
+++ b/web/services/views.service.ts
@@ -6,6 +6,8 @@ import { ICurrentUserResponse } from "types";
 // types
 import { IView } from "types/views";
 
+import { API_BASE_URL } from "helpers/common.helper";
+
 const { NEXT_PUBLIC_API_BASE_URL } = process.env;
 
 const trackEvent =
@@ -13,7 +15,7 @@ const trackEvent =
 
 class ViewServices extends APIService {
   constructor() {
-    super(NEXT_PUBLIC_API_BASE_URL !== undefined ? NEXT_PUBLIC_API_BASE_URL : "http://localhost:8000");
+    super(API_BASE_URL);
   }
 
   async createView(

--- a/web/services/views.service.ts
+++ b/web/services/views.service.ts
@@ -13,7 +13,7 @@ const trackEvent =
 
 class ViewServices extends APIService {
   constructor() {
-    super(NEXT_PUBLIC_API_BASE_URL || "http://localhost:8000");
+    super(NEXT_PUBLIC_API_BASE_URL !== undefined ? NEXT_PUBLIC_API_BASE_URL : "http://localhost:8000");
   }
 
   async createView(

--- a/web/services/workspace.service.ts
+++ b/web/services/workspace.service.ts
@@ -1,9 +1,8 @@
 // services
 import APIService from "services/api.service";
 import trackEventServices from "services/track-event.service";
-
-const { NEXT_PUBLIC_API_BASE_URL } = process.env;
-
+// helpers
+import { API_BASE_URL } from "helpers/common.helper";
 // types
 import {
   IWorkspace,
@@ -22,7 +21,7 @@ const trackEvent =
 
 class WorkspaceService extends APIService {
   constructor() {
-    super(NEXT_PUBLIC_API_BASE_URL !== undefined ? NEXT_PUBLIC_API_BASE_URL : "http://localhost:8000");
+    super(API_BASE_URL);
   }
 
   async userWorkspaces(): Promise<IWorkspace[]> {

--- a/web/services/workspace.service.ts
+++ b/web/services/workspace.service.ts
@@ -22,7 +22,7 @@ const trackEvent =
 
 class WorkspaceService extends APIService {
   constructor() {
-    super(NEXT_PUBLIC_API_BASE_URL || "http://localhost:8000");
+    super(NEXT_PUBLIC_API_BASE_URL !== undefined ? NEXT_PUBLIC_API_BASE_URL : "http://localhost:8000");
   }
 
   async userWorkspaces(): Promise<IWorkspace[]> {


### PR DESCRIPTION
## Tasks accomplished:
- [x] Changed the request URL for web and deploy containers from "localhost:8000" and arbitrary URLs to the same URL the application is running on.
- [x] Updated the docker-compose configuration to use reverse proxy for backend requests.
- [x] Decoupled the URL for Plane Deploy in the web environment variable.
- [x] Generated the Plane Deploy link using the host URL of the web project with a suffix, If the URL is explicitly specified, the web project will use that URL for Plane Deploy.

## Previous state:
- Containers in the docker-compose configuration did not use reverse proxy for backend requests.
- The web and deploy containers made requests to "localhost:8000" and arbitrary URLs.
- The URL for Plane Deploy had to be manually specified in the web environment variable.

## Current state:
- The web and plane deploy projects has been updated to use reverse proxy for backend requests, making request to `/api` on the same host .
- The web and deploy containers now make request on the same host.
- The URL for Plane Deploy is decoupled from the web project and is generated using the host URL of the web project with a suffix `spaces` in case if the URL is explicitly specified, the web project will use that URL for Plane Deploy.

## How I tested the changes
✅ Ran Individual Builds for all three projects
✅ Ran Individual Containers and tested them with environment variables provided and without giving any environment variables for self hosted deployments
✅ Built Individual Docker Compose Services for testing individually with the given environment variables
✅ Built complete docker compose with the given set of environment variables.

## Keep this in mind
- When working with self hosted part, the `NEXT_PUBLIC_API_BASE_URL` and `NEXT_PUBLIC_DEPLOY_URL` are given as empty strings at the time of the build, which means that the request for both `API` and `DEPLOY` should be made on the same host as web.
- In case of changes in the above two variables, or defining explicit endpoint for `NEXT_PUBLIC_API_BASE_URL` & `NEXT_PUBLIC_DEPLOY_URL`,  these envs can be passed as build args in docker-compose file.