### PR TITLE
chore: renamed all the issues view tooltips content from View to Layout

### DIFF
--- a/web/components/core/filters/issues-view-filter.tsx
+++ b/web/components/core/filters/issues-view-filter.tsx
@@ -93,7 +93,7 @@ export const IssuesFilterView: React.FC = () => {
             <Tooltip
               key={option.type}
               tooltipContent={
-                <span className="capitalize">{replaceUnderscoreIfSnakeCase(option.type)} View</span>
+                <span className="capitalize">{replaceUnderscoreIfSnakeCase(option.type)} Layout</span>
               }
               position="bottom"
             >

--- a/web/components/issues/my-issues/my-issues-view-options.tsx
+++ b/web/components/issues/my-issues/my-issues-view-options.tsx
@@ -49,7 +49,7 @@ export const MyIssuesViewOptions: React.FC = () => {
           <Tooltip
             key={option.type}
             tooltipContent={
-              <span className="capitalize">{replaceUnderscoreIfSnakeCase(option.type)} View</span>
+              <span className="capitalize">{replaceUnderscoreIfSnakeCase(option.type)} Layout</span>
             }
             position="bottom"
           >

--- a/web/components/profile/profile-issues-view-options.tsx
+++ b/web/components/profile/profile-issues-view-options.tsx
@@ -81,7 +81,7 @@ export const ProfileIssuesViewOptions: React.FC = () => {
           <Tooltip
             key={option.type}
             tooltipContent={
-              <span className="capitalize">{replaceUnderscoreIfSnakeCase(option.type)} View</span>
+              <span className="capitalize">{replaceUnderscoreIfSnakeCase(option.type)} Layout</span>
             }
             position="bottom"
           >

--- a/web/pages/[workspaceSlug]/projects/[projectId]/modules/index.tsx
+++ b/web/pages/[workspaceSlug]/projects/[projectId]/modules/index.tsx
@@ -96,7 +96,7 @@ const ProjectModules: NextPage = () => {
             <Tooltip
               key={option.type}
               tooltipContent={
-                <span className="capitalize">{replaceUnderscoreIfSnakeCase(option.type)} View</span>
+                <span className="capitalize">{replaceUnderscoreIfSnakeCase(option.type)} Layout</span>
               }
               position="bottom"
             >


### PR DESCRIPTION
The PR includes renaming all tooltips that reflect the issue layouts across the platform from `View` to `Layout`.

<img width="961" alt="Issue layout" src="https://github.com/makeplane/plane/assets/65884341/d6a0d155-b852-4606-aa5f-2feab918e542">
