### PR TITLE
fix: user dashboard greeting timezone

### DIFF
--- a/web/components/core/filters/issues-view-filter.tsx
+++ b/web/components/core/filters/issues-view-filter.tsx
@@ -93,7 +93,9 @@ export const IssuesFilterView: React.FC = () => {
             <Tooltip
               key={option.type}
               tooltipContent={
-                <span className="capitalize">{replaceUnderscoreIfSnakeCase(option.type)} Layout</span>
+                <span className="capitalize">
+                  {replaceUnderscoreIfSnakeCase(option.type)} Layout
+                </span>
               }
               position="bottom"
             >
@@ -318,7 +320,7 @@ export const IssuesFilterView: React.FC = () => {
                       displayFilters.layout !== "spreadsheet" &&
                       displayFilters.layout !== "gantt_chart" && (
                         <div className="flex items-center justify-between">
-                          <h4 className="text-custom-text-200">Show empty states</h4>
+                          <h4 className="text-custom-text-200">Show empty groups</h4>
                           <div className="w-28">
                             <ToggleSwitch
                               value={displayFilters.show_empty_groups ?? true}

--- a/web/components/core/views/board-view/board-header.tsx
+++ b/web/components/core/views/board-view/board-header.tsx
@@ -20,7 +20,7 @@ import { renderEmoji } from "helpers/emoji.helper";
 // types
 import { IIssueViewProps, IState, TIssuePriorities, TStateGroups } from "types";
 // fetch-keys
-import { PROJECT_ISSUE_LABELS, PROJECT_MEMBERS } from "constants/fetch-keys";
+import { PROJECT_ISSUE_LABELS, PROJECT_MEMBERS, WORKSPACE_LABELS } from "constants/fetch-keys";
 // constants
 import { STATE_GROUP_COLORS } from "constants/state";
 
@@ -59,6 +59,15 @@ export const BoardHeader: React.FC<Props> = ({
       : null
   );
 
+  const { data: workspaceLabels } = useSWR(
+    workspaceSlug && displayFilters?.group_by === "labels"
+      ? WORKSPACE_LABELS(workspaceSlug.toString())
+      : null,
+    workspaceSlug && displayFilters?.group_by === "labels"
+      ? () => issuesService.getWorkspaceLabels(workspaceSlug.toString())
+      : null
+  );
+
   const { data: members } = useSWR(
     workspaceSlug &&
       projectId &&
@@ -82,7 +91,10 @@ export const BoardHeader: React.FC<Props> = ({
         title = addSpaceIfCamelCase(currentState?.name ?? "");
         break;
       case "labels":
-        title = issueLabels?.find((label) => label.id === groupTitle)?.name ?? "None";
+        title =
+          [...(issueLabels ?? []), ...(workspaceLabels ?? [])]?.find(
+            (label) => label.id === groupTitle
+          )?.name ?? "None";
         break;
       case "project":
         title = projects?.find((p) => p.id === groupTitle)?.name ?? "None";
@@ -137,7 +149,9 @@ export const BoardHeader: React.FC<Props> = ({
         break;
       case "labels":
         const labelColor =
-          issueLabels?.find((label) => label.id === groupTitle)?.color ?? "#000000";
+          [...(issueLabels ?? []), ...(workspaceLabels ?? [])]?.find(
+            (label) => label.id === groupTitle
+          )?.color ?? "#000000";
         icon = (
           <span
             className="h-3.5 w-3.5 flex-shrink-0 rounded-full"

--- a/web/components/issues/my-issues/my-issues-view-options.tsx
+++ b/web/components/issues/my-issues/my-issues-view-options.tsx
@@ -234,7 +234,7 @@ export const MyIssuesViewOptions: React.FC = () => {
                       displayFilters?.layout !== "spreadsheet" && (
                         <>
                           <div className="flex items-center justify-between">
-                            <h4 className="text-custom-text-200">Show empty states</h4>
+                            <h4 className="text-custom-text-200">Show empty groups</h4>
                             <div className="w-28">
                               <ToggleSwitch
                                 value={displayFilters?.show_empty_groups ?? true}

--- a/web/components/profile/profile-issues-view-options.tsx
+++ b/web/components/profile/profile-issues-view-options.tsx
@@ -266,7 +266,7 @@ export const ProfileIssuesViewOptions: React.FC = () => {
                       displayFilters?.layout !== "spreadsheet" && (
                         <>
                           <div className="flex items-center justify-between">
-                            <h4 className="text-custom-text-200">Show empty states</h4>
+                            <h4 className="text-custom-text-200">Show empty groups</h4>
                             <div className="w-28">
                               <ToggleSwitch
                                 value={displayFilters?.show_empty_groups ?? true}

--- a/web/pages/[workspaceSlug]/index.tsx
+++ b/web/pages/[workspaceSlug]/index.tsx
@@ -31,15 +31,53 @@ import { BoltOutlined, GridViewOutlined } from "@mui/icons-material";
 import emptyDashboard from "public/empty-state/dashboard.svg";
 import githubBlackImage from "/public/logos/github-black.png";
 import githubWhiteImage from "/public/logos/github-white.png";
-// helpers
-import { render12HourFormatTime, renderShortDate } from "helpers/date-time.helper";
 // types
 import { ICurrentUserResponse } from "types";
 import type { NextPage } from "next";
 // fetch-keys
 import { CURRENT_USER, USER_WORKSPACE_DASHBOARD } from "constants/fetch-keys";
-// constants
-import { DAYS } from "constants/project";
+
+const Greeting = ({ user }: { user: ICurrentUserResponse | undefined }) => {
+  const currentTime = new Date();
+
+  const hour = new Intl.DateTimeFormat("en-US", {
+    hour12: false,
+    hour: "numeric",
+  }).format(currentTime);
+
+  const date = new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+  }).format(currentTime);
+
+  const weekDay = new Intl.DateTimeFormat("en-US", {
+    weekday: "long",
+  }).format(currentTime);
+
+  const timeString = new Intl.DateTimeFormat("en-US", {
+    timeZone: user?.user_timezone,
+    hour12: false, // Use 24-hour format
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(currentTime);
+
+  const greeting =
+    parseInt(hour, 10) < 12 ? "morning" : parseInt(hour, 10) < 18 ? "afternoon" : "evening";
+
+  return (
+    <div>
+      <h3 className="text-2xl font-semibold">
+        Good {greeting}, {user?.first_name} {user?.last_name}
+      </h3>
+      <h6 className="text-custom-text-400 font-medium flex items-center gap-2">
+        <div>{greeting === "morning" ? "🌤️" : greeting === "afternoon" ? "🌥️" : "🌙️"}</div>
+        <div>
+          {weekDay}, {date} {timeString}
+        </div>
+      </h6>
+    </div>
+  );
+};
 
 const WorkspacePage: NextPage = () => {
   const [month, setMonth] = useState(new Date().getMonth() + 1);
@@ -57,10 +95,6 @@ const WorkspacePage: NextPage = () => {
     workspaceSlug ? USER_WORKSPACE_DASHBOARD(workspaceSlug as string) : null,
     workspaceSlug ? () => userService.userWorkspaceDashboard(workspaceSlug as string, month) : null
   );
-
-  const today = new Date();
-  const greeting =
-    today.getHours() < 12 ? "morning" : today.getHours() < 18 ? "afternoon" : "evening";
 
   useEffect(() => {
     if (!workspaceSlug) return;
@@ -128,17 +162,7 @@ const WorkspacePage: NextPage = () => {
         </div>
       )}
       <div className="p-8 space-y-8">
-        <div>
-          <h3 className="text-2xl font-semibold">
-            Good {greeting}, {user?.first_name} {user?.last_name}
-          </h3>
-          <h6 className="text-custom-text-400 font-medium flex items-center gap-2">
-            <div>{greeting === "morning" ? "🌤️" : greeting === "afternoon" ? "🌥️" : "🌙️"}</div>
-            <div>
-              {DAYS[today.getDay()]}, {renderShortDate(today)} {render12HourFormatTime(today)}
-            </div>
-          </h6>
-        </div>
+        <Greeting user={user} />
 
         {projects ? (
           projects.length > 0 ? (


### PR DESCRIPTION
fix:

- Dashboard greeting time to be in the user selected timezone.
- Group by labels not working on the my issues and user profile pages.
- Rename `Show empty states` to `Show empty groups` on the display filters dropdown.