### PR TITLE
fix: themening  validation in store init.

### DIFF
--- a/web/lib/mobx/store-init.tsx
+++ b/web/lib/mobx/store-init.tsx
@@ -24,9 +24,12 @@ const MobxStoreInit = () => {
       );
 
     // theme
-    if (store.theme.theme === null && store?.user?.currentUserSettings) {
+    if (
+      (store.theme.theme === null || store.theme.theme === "undefined") &&
+      store?.user?.currentUserSettings
+    ) {
       let currentTheme = localStorage.getItem("theme");
-      currentTheme = currentTheme ? currentTheme : "system";
+      currentTheme = currentTheme && currentTheme != "undefined" ? currentTheme : "system";
 
       // validating the theme and applying for initial state
       if (currentTheme) {


### PR DESCRIPTION
In this pull request, we have addressed the issue of theming not being set to undefined.