### PR TITLE
[bug]: fix recent page hiding last item on scroll #1468

### DIFF
--- a/web/components/pages/pages-list/recent-pages-list.tsx
+++ b/web/components/pages/pages-list/recent-pages-list.tsx
@@ -43,7 +43,7 @@ export const RecentPagesList: React.FC<TPagesListProps> = ({ viewType }) => {
             if (pages[key].length === 0) return null;
 
             return (
-              <div key={key} className="h-full overflow-hidden">
+              <div key={key} className="h-full overflow-hidden pb-9">
                 <h2 className="text-xl font-semibold capitalize mb-2">
                   {replaceUnderscoreIfSnakeCase(key)}
                 </h2>


### PR DESCRIPTION
This pull request solves the hiding last item from pages > Recent tab
the container not scrolling till the bottom

issues was : 
![image](https://github.com/makeplane/plane/assets/32466796/36fd809a-255b-48ac-98b4-7343bdcbc009)

after Solve: 
![image](https://github.com/makeplane/plane/assets/32466796/ecb464bf-0bc7-4a81-b158-dad3344925e3)

thank you :)

fixes: #1468