### PR TITLE
chore: removed duplicate issues for multiple assignees or labels

### DIFF
--- a/apiserver/plane/api/views/issue.py
+++ b/apiserver/plane/api/views/issue.py
@@ -173,7 +173,7 @@ class IssueViewSet(BaseViewSet):
                     queryset=IssueReaction.objects.select_related("actor"),
                 )
             )
-        )
+        ).distinct()
 
     @method_decorator(gzip_page)
     def list(self, request, slug, project_id):


### PR DESCRIPTION
Removed duplicated issues for multiple assignees or labels

Steps to reproduce
- Go in the issues page
- Add multiple labels to a single issue
- apply filters -> labels -> select all the labels for that issue
 