### PR TITLE
fix: profile pic dimension bug fix

### DIFF
--- a/web/components/issues/activity.tsx
+++ b/web/components/issues/activity.tsx
@@ -82,7 +82,7 @@ export const IssueActivitySection: React.FC<Props> = ({
                                 alt={activityItem.actor_detail.display_name}
                                 height={24}
                                 width={24}
-                                className="rounded-full"
+                                className="rounded-full h-full w-full object-cover"
                               />
                             ) : (
                               <div

--- a/web/components/profile/sidebar.tsx
+++ b/web/components/profile/sidebar.tsx
@@ -86,7 +86,7 @@ export const ProfileSidebar = () => {
                 <img
                   src={userProjectsData.user_data.avatar}
                   alt={userProjectsData.user_data.display_name}
-                  className="rounded"
+                  className="rounded h-full w-full object-cover"
                 />
               ) : (
                 <div className="bg-custom-background-90 flex justify-center items-center w-[52px] h-[52px] rounded text-custom-text-100">

--- a/web/components/web-view/issue-activity.tsx
+++ b/web/components/web-view/issue-activity.tsx
@@ -133,7 +133,7 @@ export const IssueActivity: React.FC<Props> = (props) => {
                                   alt={activityItem.actor_detail.display_name}
                                   height={24}
                                   width={24}
-                                  className="rounded-full"
+                                  className="rounded-full h-full w-full object-cover"
                                 />
                               ) : (
                                 <div

--- a/web/pages/[workspaceSlug]/me/profile/activity.tsx
+++ b/web/pages/[workspaceSlug]/me/profile/activity.tsx
@@ -149,7 +149,7 @@ const ProfileActivity = () => {
                                           alt={activityItem.actor_detail.display_name}
                                           height={24}
                                           width={24}
-                                          className="rounded-full"
+                                          className="rounded-full h-full w-full object-cover"
                                         />
                                       ) : (
                                         <div


### PR DESCRIPTION
This PR addresses the profile picture dimension issue that was causing problems when users set a longer profile picture.

Before:
<img width="1511" alt="image" src="https://github.com/makeplane/plane/assets/121005188/3bab3298-1344-400f-871f-e4fdcdbcb63c">
<img width="1511" alt="image" src="https://github.com/makeplane/plane/assets/121005188/0cef4ec3-a92b-450e-a627-d58b09c6755e">
<img width="1511" alt="image" src="https://github.com/makeplane/plane/assets/121005188/90c16f96-8a50-4454-a79f-cae677c91573">

---

After:
<img width="1511" alt="image" src="https://github.com/makeplane/plane/assets/121005188/d47f6ad1-fc70-495d-bfdd-184c9d093010">
<img width="1511" alt="image" src="https://github.com/makeplane/plane/assets/121005188/f27ea042-c9f4-4937-b19b-a25b33b15daa">
<img width="1511" alt="image" src="https://github.com/makeplane/plane/assets/121005188/bb39d15d-51e8-42d7-972b-e0f187d76c94">

