### PR TITLE
[fix] `docker-compose` failing to build images

### DIFF
--- a/packages/editor/core/package.json
+++ b/packages/editor/core/package.json
@@ -27,6 +27,7 @@
     "next-themes": "^0.2.1"
   },
   "dependencies": {
+    "react-moveable" : "^0.54.2",
     "@blueprintjs/popover2": "^2.0.10",
     "@tiptap/core": "^2.1.7",
     "@tiptap/extension-color": "^2.1.11",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -16,6 +16,7 @@
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist"
   },
   "devDependencies": {
+    "@types/react-color" : "^3.0.9",
     "@types/node": "^20.5.2",
     "@types/react": "18.2.0",
     "@types/react-dom": "18.2.0",

--- a/space/package.json
+++ b/space/package.json
@@ -16,6 +16,8 @@
     "@emotion/styled": "^11.11.0",
     "@headlessui/react": "^1.7.13",
     "@mui/material": "^5.14.1",
+    "@plane/ui" : "*",
+    "@plane/lite-text-editor" : "*",
     "@plane/rich-text-editor": "*",
     "axios": "^1.3.4",
     "clsx": "^2.0.0",


### PR DESCRIPTION
## Description
While running `docker-compose` for building and running the docker setup for plane, the build was failing because of missing dependencies in the newely added, `plane-ui` and `editor-core` packages. 

## Tasks
- [x] Added all missing dependencies in the packages