### PR TITLE
fix: enabling the nextjs static site generation for web and space

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,8 @@ node_modules
 
 # Production
 /build
-dist
+dist/
+out/
 
 # Misc
 .DS_Store

--- a/space/next.config.js
+++ b/space/next.config.js
@@ -8,6 +8,9 @@ const nextConfig = {
   experimental: {
     outputFileTracingRoot: path.join(__dirname, "../"),
   },
+  images: {
+    unoptimized: true,
+  },
   output: "standalone",
 };
 

--- a/space/package.json
+++ b/space/package.json
@@ -7,7 +7,8 @@
     "develop": "next dev -p 4000",
     "build": "next build",
     "start": "next start -p 4000",
-    "lint": "next lint"
+    "lint": "next lint",
+    "export": "next export"
   },
   "dependencies": {
     "@blueprintjs/core": "^4.16.3",
@@ -16,8 +17,8 @@
     "@emotion/styled": "^11.11.0",
     "@headlessui/react": "^1.7.13",
     "@mui/material": "^5.14.1",
-    "@plane/ui" : "*",
-    "@plane/lite-text-editor" : "*",
+    "@plane/ui": "*",
+    "@plane/lite-text-editor": "*",
     "@plane/rich-text-editor": "*",
     "axios": "^1.3.4",
     "clsx": "^2.0.0",

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -21,6 +21,7 @@ const nextConfig = {
       "localhost",
       ...extraImageDomains,
     ],
+    unoptimized: true,
   },
   output: "standalone",
   experimental: {

--- a/web/package.json
+++ b/web/package.json
@@ -7,7 +7,8 @@
     "develop": "next dev --port 3000",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "export": "next export"
   },
   "dependencies": {
     "@blueprintjs/core": "^4.16.3",


### PR DESCRIPTION
This enables the user to build and configure nextjs applications using SSG, which works like a single-page application.

By running the following command
```
next export 
```
Out folder will be generated with a static site build, which enables users to configure their app directly in Nginx. 
