### PR TITLE
chore: update members endpoint

### DIFF
--- a/web/components/integration/github/single-user-select.tsx
+++ b/web/components/integration/github/single-user-select.tsx
@@ -44,7 +44,7 @@ export const SingleUserSelect: React.FC<Props> = ({ collaborator, index, users, 
 
   const { data: members } = useSWR(
     workspaceSlug ? WORKSPACE_MEMBERS(workspaceSlug.toString()) : null,
-    workspaceSlug ? () => workspaceService.workspaceMembers(workspaceSlug.toString()) : null
+    workspaceSlug ? () => workspaceService.fetchWorkspaceMembers(workspaceSlug.toString()) : null
   );
 
   const options = members?.map((member) => ({

--- a/web/components/integration/jira/import-users.tsx
+++ b/web/components/integration/jira/import-users.tsx
@@ -3,7 +3,7 @@ import { useRouter } from "next/router";
 import useSWR from "swr";
 import { useFormContext, useFieldArray, Controller } from "react-hook-form";
 // fetch keys
-import { WORKSPACE_MEMBERS_WITH_EMAIL } from "constants/fetch-keys";
+import { WORKSPACE_MEMBERS } from "constants/fetch-keys";
 // services
 import { WorkspaceService } from "services/workspace.service";
 // components
@@ -30,8 +30,8 @@ export const JiraImportUsers: FC = () => {
   });
 
   const { data: members } = useSWR(
-    workspaceSlug ? WORKSPACE_MEMBERS_WITH_EMAIL(workspaceSlug?.toString() ?? "") : null,
-    workspaceSlug ? () => workspaceService.workspaceMembers(workspaceSlug?.toString() ?? "") : null
+    workspaceSlug ? WORKSPACE_MEMBERS(workspaceSlug?.toString() ?? "") : null,
+    workspaceSlug ? () => workspaceService.fetchWorkspaceMembers(workspaceSlug?.toString() ?? "") : null
   );
 
   const options = members?.map((member) => ({

--- a/web/components/issues/attachment/attachments.tsx
+++ b/web/components/issues/attachment/attachments.tsx
@@ -44,7 +44,7 @@ export const IssueAttachments = () => {
   const { data: people } = useSWR(
     workspaceSlug && projectId ? PROJECT_MEMBERS(projectId as string) : null,
     workspaceSlug && projectId
-      ? () => projectService.projectMembers(workspaceSlug as string, projectId as string)
+      ? () => projectService.fetchProjectMembers(workspaceSlug as string, projectId as string)
       : null
   );
 

--- a/web/components/issues/select/assignee.tsx
+++ b/web/components/issues/select/assignee.tsx
@@ -26,7 +26,7 @@ export const IssueAssigneeSelect: React.FC<Props> = ({ projectId, value = [], on
   const { data: members } = useSWR(
     workspaceSlug && projectId ? PROJECT_MEMBERS(projectId as string) : null,
     workspaceSlug && projectId
-      ? () => projectService.projectMembers(workspaceSlug as string, projectId as string)
+      ? () => projectService.fetchProjectMembers(workspaceSlug as string, projectId as string)
       : null
   );
 

--- a/web/components/issues/sidebar-select/assignee.tsx
+++ b/web/components/issues/sidebar-select/assignee.tsx
@@ -28,7 +28,7 @@ export const SidebarAssigneeSelect: React.FC<Props> = ({ value, onChange, disabl
   const { data: members } = useSWR(
     workspaceSlug && projectId ? PROJECT_MEMBERS(projectId as string) : null,
     workspaceSlug && projectId
-      ? () => projectService.projectMembers(workspaceSlug as string, projectId as string)
+      ? () => projectService.fetchProjectMembers(workspaceSlug as string, projectId as string)
       : null
   );
 

--- a/web/components/modules/select/lead.tsx
+++ b/web/components/modules/select/lead.tsx
@@ -25,7 +25,7 @@ export const ModuleLeadSelect: React.FC<Props> = ({ value, onChange }) => {
   const { data: members } = useSWR(
     workspaceSlug && projectId ? PROJECT_MEMBERS(projectId as string) : null,
     workspaceSlug && projectId
-      ? () => projectService.projectMembers(workspaceSlug as string, projectId as string)
+      ? () => projectService.fetchProjectMembers(workspaceSlug as string, projectId as string)
       : null
   );
 

--- a/web/components/modules/select/members.tsx
+++ b/web/components/modules/select/members.tsx
@@ -24,7 +24,7 @@ export const ModuleMembersSelect: React.FC<Props> = ({ value, onChange }) => {
   const { data: members } = useSWR(
     workspaceSlug && projectId ? PROJECT_MEMBERS(projectId as string) : null,
     workspaceSlug && projectId
-      ? () => projectService.projectMembers(workspaceSlug as string, projectId as string)
+      ? () => projectService.fetchProjectMembers(workspaceSlug as string, projectId as string)
       : null
   );
   const options = members?.map((member) => ({

--- a/web/components/modules/sidebar-select/select-lead.tsx
+++ b/web/components/modules/sidebar-select/select-lead.tsx
@@ -27,7 +27,7 @@ export const SidebarLeadSelect: FC<Props> = (props) => {
   const { data: members } = useSWR(
     workspaceSlug && projectId ? PROJECT_MEMBERS(projectId as string) : null,
     workspaceSlug && projectId
-      ? () => projectService.projectMembers(workspaceSlug as string, projectId as string)
+      ? () => projectService.fetchProjectMembers(workspaceSlug as string, projectId as string)
       : null
   );
 

--- a/web/components/modules/sidebar-select/select-members.tsx
+++ b/web/components/modules/sidebar-select/select-members.tsx
@@ -29,7 +29,7 @@ export const SidebarMembersSelect: React.FC<Props> = ({ value, onChange }) => {
   const { data: members } = useSWR(
     workspaceSlug && projectId ? PROJECT_MEMBERS(projectId as string) : null,
     workspaceSlug && projectId
-      ? () => projectService.projectMembers(workspaceSlug as string, projectId as string)
+      ? () => projectService.fetchProjectMembers(workspaceSlug as string, projectId as string)
       : null
   );
 

--- a/web/components/pages/pages-view.tsx
+++ b/web/components/pages/pages-view.tsx
@@ -54,7 +54,7 @@ export const PagesView: React.FC<Props> = ({ pages, viewType }) => {
   const { data: people } = useSWR(
     workspaceSlug && projectId ? PROJECT_MEMBERS(projectId.toString()) : null,
     workspaceSlug && projectId
-      ? () => projectService.projectMembers(workspaceSlug.toString(), projectId.toString())
+      ? () => projectService.fetchProjectMembers(workspaceSlug.toString(), projectId.toString())
       : null
   );
 

--- a/web/components/project/member-select.tsx
+++ b/web/components/project/member-select.tsx
@@ -30,7 +30,7 @@ export const MemberSelect: React.FC<Props> = ({ value, onChange, isDisabled = fa
   const { data: members } = useSWR(
     workspaceSlug && projectId ? PROJECT_MEMBERS(projectId as string) : null,
     workspaceSlug && projectId
-      ? () => projectService.projectMembers(workspaceSlug as string, projectId as string)
+      ? () => projectService.fetchProjectMembers(workspaceSlug as string, projectId as string)
       : null
   );
 

--- a/web/components/project/send-project-invitation-modal.tsx
+++ b/web/components/project/send-project-invitation-modal.tsx
@@ -67,7 +67,7 @@ const SendProjectInvitationModal: React.FC<Props> = (props) => {
 
   const { data: people } = useSWR(
     workspaceSlug ? WORKSPACE_MEMBERS(workspaceSlug as string) : null,
-    workspaceSlug ? () => workspaceService.workspaceMembers(workspaceSlug as string) : null
+    workspaceSlug ? () => workspaceService.fetchWorkspaceMembers(workspaceSlug as string) : null
   );
 
   const {
@@ -90,9 +90,11 @@ const SendProjectInvitationModal: React.FC<Props> = (props) => {
 
   const onSubmit = async (formData: FormValues) => {
     if (!workspaceSlug || !projectId || isSubmitting) return;
+
     const payload = { ...formData };
+
     await projectService
-      .inviteProject(workspaceSlug as string, projectId as string, payload, user)
+      .bulkAddMembersToProject(workspaceSlug.toString(), projectId.toString(), payload, user)
       .then(() => {
         setIsOpen(false);
         setToastAlert({

--- a/web/components/ui/avatar.tsx
+++ b/web/components/ui/avatar.tsx
@@ -95,7 +95,7 @@ export const AssigneesList: React.FC<AsigneesListProps> = ({
 
   const { data: people } = useSWR(
     workspaceSlug ? WORKSPACE_MEMBERS(workspaceSlug as string) : null,
-    workspaceSlug ? () => workspaceService.workspaceMembers(workspaceSlug as string) : null
+    workspaceSlug ? () => workspaceService.fetchWorkspaceMembers(workspaceSlug as string) : null
   );
 
   if ((users && users.length === 0) || (userIds && userIds.length === 0))

--- a/web/components/views/select-filters.tsx
+++ b/web/components/views/select-filters.tsx
@@ -54,7 +54,7 @@ export const SelectFilters: React.FC<Props> = ({ filters, onSelect, direction = 
   const { data: members } = useSWR(
     projectId ? PROJECT_MEMBERS(projectId as string) : null,
     workspaceSlug && projectId
-      ? () => projectService.projectMembers(workspaceSlug as string, projectId as string)
+      ? () => projectService.fetchProjectMembers(workspaceSlug as string, projectId as string)
       : null
   );
 

--- a/web/components/web-view/select-assignee.tsx
+++ b/web/components/web-view/select-assignee.tsx
@@ -33,7 +33,7 @@ export const AssigneeSelect: React.FC<Props> = (props) => {
   const { data: members } = useSWR(
     workspaceSlug && projectId ? PROJECT_MEMBERS(projectId as string) : null,
     workspaceSlug && projectId
-      ? () => projectService.projectMembers(workspaceSlug as string, projectId as string)
+      ? () => projectService.fetchProjectMembers(workspaceSlug as string, projectId as string)
       : null
   );
 

--- a/web/constants/fetch-keys.ts
+++ b/web/constants/fetch-keys.ts
@@ -47,19 +47,6 @@ const paramsToKey = (params: any) => {
   return `${layoutKey}_${projectKey}_${stateGroupKey}_${stateKey}_${priorityKey}_${assigneesKey}_${createdByKey}_${type}_${groupBy}_${orderBy}_${labelsKey}_${startDateKey}_${targetDateKey}_${sub_issue}_${startTargetDate}_${subscriberKey}`;
 };
 
-const inboxParamsToKey = (params: any) => {
-  const { priority, inbox_status } = params;
-
-  let priorityKey = priority ? priority.split(",") : [];
-  let inboxStatusKey = inbox_status ? inbox_status.split(",") : [];
-
-  // sorting each keys in ascending order
-  priorityKey = priorityKey.sort().join("_");
-  inboxStatusKey = inboxStatusKey.sort().join("_");
-
-  return `${priorityKey}_${inboxStatusKey}`;
-};
-
 const myIssuesParamsToKey = (params: any) => {
   const { assignees, created_by, labels, priority, state_group, subscriber, start_date, target_date } = params;
 
@@ -93,13 +80,9 @@ export const USER_WORKSPACES = "USER_WORKSPACES";
 export const WORKSPACE_DETAILS = (workspaceSlug: string) => `WORKSPACE_DETAILS_${workspaceSlug.toUpperCase()}`;
 
 export const WORKSPACE_MEMBERS = (workspaceSlug: string) => `WORKSPACE_MEMBERS_${workspaceSlug.toUpperCase()}`;
-export const WORKSPACE_MEMBERS_WITH_EMAIL = (workspaceSlug: string) =>
-  `WORKSPACE_MEMBERS_WITH_EMAIL_${workspaceSlug.toUpperCase()}`;
 export const WORKSPACE_MEMBERS_ME = (workspaceSlug: string) => `WORKSPACE_MEMBERS_ME${workspaceSlug.toUpperCase()}`;
-export const WORKSPACE_INVITATIONS = "WORKSPACE_INVITATIONS";
-export const WORKSPACE_INVITATION_WITH_EMAIL = (workspaceSlug: string) =>
-  `WORKSPACE_INVITATION_WITH_EMAIL_${workspaceSlug.toUpperCase()}`;
-export const WORKSPACE_INVITATION = "WORKSPACE_INVITATION";
+export const WORKSPACE_INVITATIONS = (workspaceSlug: string) => `WORKSPACE_INVITATIONS_${workspaceSlug.toString()}`;
+export const WORKSPACE_INVITATION = (invitationId: string) => `WORKSPACE_INVITATION_${invitationId}`;
 export const LAST_ACTIVE_WORKSPACE_AND_PROJECTS = "LAST_ACTIVE_WORKSPACE_AND_PROJECTS";
 
 export const PROJECTS_LIST = (
@@ -115,11 +98,7 @@ export const PROJECTS_LIST = (
 export const PROJECT_DETAILS = (projectId: string) => `PROJECT_DETAILS_${projectId.toUpperCase()}`;
 
 export const PROJECT_MEMBERS = (projectId: string) => `PROJECT_MEMBERS_${projectId.toUpperCase()}`;
-export const PROJECT_MEMBERS_WITH_EMAIL = (workspaceSlug: string, projectId: string) =>
-  `PROJECT_MEMBERS_WITH_EMAIL_${workspaceSlug}_${projectId.toUpperCase()}`;
-export const PROJECT_INVITATIONS = "PROJECT_INVITATIONS";
-export const PROJECT_INVITATIONS_WITH_EMAIL = (workspaceSlug: string, projectId: string) =>
-  `PROJECT_INVITATIONS_WITH_EMAIL_${workspaceSlug}_${projectId.toUpperCase()}`;
+export const PROJECT_INVITATIONS = (projectId: string) => `PROJECT_INVITATIONS_${projectId.toString()}`;
 
 export const PROJECT_ISSUES_LIST = (workspaceSlug: string, projectId: string) =>
   `PROJECT_ISSUES_LIST_${workspaceSlug.toUpperCase()}_${projectId.toUpperCase()}`;

--- a/web/hooks/use-project-members.tsx
+++ b/web/hooks/use-project-members.tsx
@@ -19,7 +19,9 @@ const useProjectMembers = (
   // fetching project members
   const { data: members } = useSWR(
     workspaceSlug && projectId && fetchCondition ? PROJECT_MEMBERS(projectId) : null,
-    workspaceSlug && projectId && fetchCondition ? () => projectService.projectMembers(workspaceSlug, projectId) : null
+    workspaceSlug && projectId && fetchCondition
+      ? () => projectService.fetchProjectMembers(workspaceSlug, projectId)
+      : null
   );
 
   const hasJoined = members?.some((item: any) => item.member.id === (user as any)?.id);

--- a/web/hooks/use-workspace-members.tsx
+++ b/web/hooks/use-workspace-members.tsx
@@ -15,7 +15,7 @@ const useWorkspaceMembers = (workspaceSlug: string | undefined, fetchCondition?:
 
   const { data: workspaceMembers, error: workspaceMemberErrors } = useSWR(
     workspaceSlug && fetchCondition ? WORKSPACE_MEMBERS(workspaceSlug) : null,
-    workspaceSlug && fetchCondition ? () => workspaceService.workspaceMembers(workspaceSlug) : null
+    workspaceSlug && fetchCondition ? () => workspaceService.fetchWorkspaceMembers(workspaceSlug) : null
   );
 
   const hasJoined = workspaceMembers?.some((item: any) => item.member.id === (user as any)?.id);

--- a/web/layouts/auth-layout/project-wrapper.tsx
+++ b/web/layouts/auth-layout/project-wrapper.tsx
@@ -38,7 +38,7 @@ export const ProjectAuthWrapper: FC<IProjectAuthWrapper> = observer((props) => {
       : null
   );
   // fetching user project member information
-  useSWR(
+  const { data: projectMemberInfo } = useSWR(
     workspaceSlug && projectId ? `PROJECT_MEMBERS_ME_${workspaceSlug}_${projectId}` : null,
     workspaceSlug && projectId
       ? () => userStore.fetchUserProjectInfo(workspaceSlug.toString(), projectId.toString())
@@ -53,8 +53,10 @@ export const ProjectAuthWrapper: FC<IProjectAuthWrapper> = observer((props) => {
   );
   // fetching project members
   useSWR(
-    workspaceSlug && projectId ? `PROJECT_MEMBERS_${workspaceSlug}_${projectId}` : null,
-    workspaceSlug && projectId
+    workspaceSlug && projectId && projectMemberInfo && [20, 15].includes(projectMemberInfo.role)
+      ? `PROJECT_MEMBERS_${workspaceSlug}_${projectId}`
+      : null,
+    workspaceSlug && projectId && projectMemberInfo && [20, 15].includes(projectMemberInfo.role)
       ? () => projectStore.fetchProjectMembers(workspaceSlug.toString(), projectId.toString())
       : null
   );

--- a/web/layouts/auth-layout/workspace-wrapper.tsx
+++ b/web/layouts/auth-layout/workspace-wrapper.tsx
@@ -12,8 +12,6 @@ export interface IWorkspaceAuthWrapper {
   children: ReactNode;
 }
 
-const HIGHER_ROLES = [20, 15];
-
 export const WorkspaceAuthWrapper: FC<IWorkspaceAuthWrapper> = observer((props) => {
   const { children } = props;
   // store
@@ -35,10 +33,10 @@ export const WorkspaceAuthWrapper: FC<IWorkspaceAuthWrapper> = observer((props) 
   );
   // fetch workspace members
   useSWR(
-    workspaceSlug && workspaceMemberInfo && HIGHER_ROLES.includes(workspaceMemberInfo.role)
+    workspaceSlug && workspaceMemberInfo && [20, 15].includes(workspaceMemberInfo.role)
       ? `WORKSPACE_MEMBERS_${workspaceSlug}`
       : null,
-    workspaceSlug && workspaceMemberInfo && HIGHER_ROLES.includes(workspaceMemberInfo.role)
+    workspaceSlug && workspaceMemberInfo && [20, 15].includes(workspaceMemberInfo.role)
       ? () => workspaceStore.fetchWorkspaceMembers(workspaceSlug.toString())
       : null
   );

--- a/web/pages/[workspaceSlug]/projects/[projectId]/settings/members.tsx
+++ b/web/pages/[workspaceSlug]/projects/[projectId]/settings/members.tsx
@@ -30,8 +30,8 @@ import { IProject, IUserLite, IWorkspace } from "types";
 import {
   PROJECTS_LIST,
   PROJECT_DETAILS,
-  PROJECT_INVITATIONS_WITH_EMAIL,
-  PROJECT_MEMBERS_WITH_EMAIL,
+  PROJECT_INVITATIONS,
+  PROJECT_MEMBERS,
   USER_PROJECT_VIEW,
   WORKSPACE_DETAILS,
 } from "constants/fetch-keys";
@@ -68,21 +68,21 @@ const MembersSettings: NextPage = () => {
 
   const { reset, control } = useForm<IProject>({ defaultValues });
 
-  const { data: activeWorkspace } = useSWR(workspaceSlug ? WORKSPACE_DETAILS(workspaceSlug as string) : null, () =>
-    workspaceSlug ? workspaceService.getWorkspace(workspaceSlug as string) : null
+  const { data: activeWorkspace } = useSWR(workspaceSlug ? WORKSPACE_DETAILS(workspaceSlug.toString()) : null, () =>
+    workspaceSlug ? workspaceService.getWorkspace(workspaceSlug.toString()) : null
   );
 
   const { data: projectMembers, mutate: mutateMembers } = useSWR(
-    workspaceSlug && projectId ? PROJECT_MEMBERS_WITH_EMAIL(workspaceSlug.toString(), projectId.toString()) : null,
+    workspaceSlug && projectId ? PROJECT_MEMBERS(projectId.toString()) : null,
     workspaceSlug && projectId
-      ? () => projectService.projectMembersWithEmail(workspaceSlug as string, projectId as string)
+      ? () => projectService.fetchProjectMembers(workspaceSlug.toString(), projectId.toString())
       : null
   );
 
   const { data: projectInvitations, mutate: mutateInvitations } = useSWR(
-    workspaceSlug && projectId ? PROJECT_INVITATIONS_WITH_EMAIL(workspaceSlug.toString(), projectId.toString()) : null,
+    workspaceSlug && projectId ? PROJECT_INVITATIONS(projectId.toString()) : null,
     workspaceSlug && projectId
-      ? () => projectInvitationService.projectInvitationsWithEmail(workspaceSlug as string, projectId as string)
+      ? () => projectInvitationService.fetchProjectInvitations(workspaceSlug.toString(), projectId.toString())
       : null
   );
 
@@ -133,12 +133,12 @@ const MembersSettings: NextPage = () => {
   //   };
 
   //   await projectService
-  //     .updateProject(workspaceSlug as string, projectId as string, payload, user)
+  //     .updateProject(workspaceSlug.toString(), projectId.toString(), payload, user)
   //     .then((res) => {
-  //       mutate(PROJECT_DETAILS(projectId as string));
+  //       mutate(PROJECT_DETAILS(projectId.toString()));
 
   //       mutate(
-  //         PROJECTS_LIST(workspaceSlug as string, {
+  //         PROJECTS_LIST(workspaceSlug.toString(), {
   //           is_favorite: "all",
   //         })
   //       );
@@ -173,12 +173,12 @@ const MembersSettings: NextPage = () => {
     };
 
     await projectService
-      .updateProject(workspaceSlug as string, projectId as string, payload, user)
+      .updateProject(workspaceSlug.toString(), projectId.toString(), payload, user)
       .then(() => {
-        mutate(PROJECT_DETAILS(projectId as string));
+        mutate(PROJECT_DETAILS(projectId.toString()));
 
         mutate(
-          PROJECTS_LIST(workspaceSlug as string, {
+          PROJECTS_LIST(workspaceSlug.toString(), {
             is_favorite: "all",
           })
         );

--- a/web/pages/workspace-invitations/index.tsx
+++ b/web/pages/workspace-invitations/index.tsx
@@ -30,8 +30,9 @@ const WorkspaceInvitation: NextPage = () => {
 
   const { user } = useUser();
 
-  const { data: invitationDetail, error } = useSWR(invitation_id && WORKSPACE_INVITATION, () =>
-    invitation_id ? workspaceService.getWorkspaceInvitation(invitation_id as string) : null
+  const { data: invitationDetail, error } = useSWR(
+    invitation_id && WORKSPACE_INVITATION(invitation_id.toString()),
+    () => (invitation_id ? workspaceService.getWorkspaceInvitation(invitation_id as string) : null)
   );
 
   const handleAccept = () => {

--- a/web/services/project/project.service.ts
+++ b/web/services/project/project.service.ts
@@ -7,7 +7,7 @@ import type {
   GithubRepositoriesResponse,
   IUser,
   IProject,
-  IProjectBulkInviteFormData,
+  IProjectBulkAddFormData,
   IProjectMember,
   ISearchIssueResponse,
   ProjectPreferences,
@@ -83,32 +83,6 @@ export class ProjectService extends APIService {
       });
   }
 
-  async inviteProject(
-    workspaceSlug: string,
-    projectId: string,
-    data: IProjectBulkInviteFormData,
-    user: IUser | undefined
-  ): Promise<any> {
-    return this.post(`/api/workspaces/${workspaceSlug}/projects/${projectId}/members/add/`, data)
-      .then((response) => {
-        trackEventService.trackProjectEvent(
-          {
-            workspaceId: response?.data?.workspace?.id,
-            workspaceSlug,
-            projectId,
-            projectName: response?.data?.project?.name,
-            memberEmail: response?.data?.member?.email,
-          },
-          "PROJECT_MEMBER_INVITE",
-          user as IUser
-        );
-        return response?.data;
-      })
-      .catch((error) => {
-        throw error?.response?.data;
-      });
-  }
-
   async joinProject(workspaceSlug: string, project_ids: string[]): Promise<any> {
     return this.post(`/api/workspaces/${workspaceSlug}/projects/join/`, { project_ids })
       .then((response) => response?.data)
@@ -136,17 +110,35 @@ export class ProjectService extends APIService {
       });
   }
 
-  async projectMembers(workspaceSlug: string, projectId: string): Promise<IProjectMember[]> {
-    return this.get(`/api/workspaces/${workspaceSlug}/projects/${projectId}/project-members/`)
+  async fetchProjectMembers(workspaceSlug: string, projectId: string): Promise<IProjectMember[]> {
+    return this.get(`/api/workspaces/${workspaceSlug}/projects/${projectId}/members/`)
       .then((response) => response?.data)
       .catch((error) => {
         throw error?.response?.data;
       });
   }
 
-  async projectMembersWithEmail(workspaceSlug: string, projectId: string): Promise<IProjectMember[]> {
-    return this.get(`/api/workspaces/${workspaceSlug}/projects/${projectId}/members/`)
-      .then((response) => response?.data)
+  async bulkAddMembersToProject(
+    workspaceSlug: string,
+    projectId: string,
+    data: IProjectBulkAddFormData,
+    user: IUser | undefined
+  ): Promise<any> {
+    return this.post(`/api/workspaces/${workspaceSlug}/projects/${projectId}/members/`, data)
+      .then((response) => {
+        trackEventService.trackProjectEvent(
+          {
+            workspaceId: response?.data?.workspace?.id,
+            workspaceSlug,
+            projectId,
+            projectName: response?.data?.project?.name,
+            memberEmail: response?.data?.member?.email,
+          },
+          "PROJECT_MEMBER_INVITE",
+          user as IUser
+        );
+        return response?.data;
+      })
       .catch((error) => {
         throw error?.response?.data;
       });

--- a/web/services/project/project_invitation.service.ts
+++ b/web/services/project/project_invitation.service.ts
@@ -9,15 +9,7 @@ export class ProjectInvitationService extends APIService {
     super(API_BASE_URL);
   }
 
-  async projectInvitations(workspaceSlug: string, projectId: string): Promise<IProjectMemberInvitation[]> {
-    return this.get(`/api/workspaces/${workspaceSlug}/projects/${projectId}/invitations/`)
-      .then((response) => response?.data)
-      .catch((error) => {
-        throw error?.response?.data;
-      });
-  }
-
-  async projectInvitationsWithEmail(workspaceSlug: string, projectId: string): Promise<IProjectMemberInvitation[]> {
+  async fetchProjectInvitations(workspaceSlug: string, projectId: string): Promise<IProjectMemberInvitation[]> {
     return this.get(`/api/workspaces/${workspaceSlug}/projects/${projectId}/invitations/`)
       .then((response) => response?.data)
       .catch((error) => {

--- a/web/services/workspace.service.ts
+++ b/web/services/workspace.service.ts
@@ -132,14 +132,6 @@ export class WorkspaceService extends APIService {
       });
   }
 
-  async workspaceMembers(workspaceSlug: string): Promise<IWorkspaceMember[]> {
-    return this.get(`/api/workspaces/${workspaceSlug}/workspace-members/`)
-      .then((response) => response?.data)
-      .catch((error) => {
-        throw error?.response?.data;
-      });
-  }
-
   async workspaceMemberMe(workspaceSlug: string): Promise<IWorkspaceMemberMe> {
     return this.get(`/api/workspaces/${workspaceSlug}/workspace-members/me/`)
       .then((response) => response?.data)
@@ -150,6 +142,14 @@ export class WorkspaceService extends APIService {
 
   async updateWorkspaceView(workspaceSlug: string, data: { view_props: IWorkspaceViewProps }): Promise<any> {
     return this.post(`/api/workspaces/${workspaceSlug}/workspace-views/`, data)
+      .then((response) => response?.data)
+      .catch((error) => {
+        throw error?.response?.data;
+      });
+  }
+
+  async fetchWorkspaceMembers(workspaceSlug: string): Promise<IWorkspaceMember[]> {
+    return this.get(`/api/workspaces/${workspaceSlug}/members/`)
       .then((response) => response?.data)
       .catch((error) => {
         throw error?.response?.data;

--- a/web/store/project/project.store.ts
+++ b/web/store/project/project.store.ts
@@ -78,21 +78,21 @@ export class ProjectStore implements IProjectStore {
 
   searchQuery: string = "";
   projectId: string | null = null;
-  projects: { [workspaceSlug: string]: IProject[] } = {}; // workspace_id: project[]
+  projects: { [workspaceSlug: string]: IProject[] } = {}; // workspaceSlug: project[]
   project_details: {
-    [key: string]: IProject; // project_id: project
+    [projectId: string]: IProject; // projectId: project
   } = {};
   states: {
-    [key: string]: IStateResponse; // project_id: states
+    [projectId: string]: IStateResponse; // projectId: states
   } | null = {};
   labels: {
-    [key: string]: IIssueLabels[]; // project_id: labels
+    [projectId: string]: IIssueLabels[]; // projectId: labels
   } | null = {};
   members: {
-    [key: string]: IProjectMember[]; // project_id: members
+    [projectId: string]: IProjectMember[]; // projectId: members
   } | null = {};
   estimates: {
-    [key: string]: IEstimate[]; // project_id: estimates
+    [projectId: string]: IEstimate[]; // projectId: estimates
   } | null = {};
 
   // root store
@@ -370,7 +370,7 @@ export class ProjectStore implements IProjectStore {
       this.loader = true;
       this.error = null;
 
-      const membersResponse = await this.projectService.projectMembers(workspaceSlug, projectId);
+      const membersResponse = await this.projectService.fetchProjectMembers(workspaceSlug, projectId);
       const _members = {
         ...this.members,
         [projectId]: membersResponse,

--- a/web/store/workspace/workspace.store.ts
+++ b/web/store/workspace/workspace.store.ts
@@ -49,7 +49,7 @@ export class WorkspaceStore implements IWorkspaceStore {
   // observables
   workspaceSlug: string | null = null;
   workspaces: IWorkspace[] = [];
-  projects: { [workspaceSlug: string]: IProject[] } = {}; // workspace_id: project[]
+  projects: { [workspaceSlug: string]: IProject[] } = {}; // workspaceSlug: project[]
   labels: { [workspaceSlug: string]: IIssueLabels[] } = {};
   members: { [workspaceSlug: string]: IWorkspaceMember[] } = {};
 
@@ -214,7 +214,7 @@ export class WorkspaceStore implements IWorkspaceStore {
         this.error = null;
       });
 
-      const membersResponse = await this.workspaceService.workspaceMembers(workspaceSlug);
+      const membersResponse = await this.workspaceService.fetchWorkspaceMembers(workspaceSlug);
 
       runInAction(() => {
         this.members = {

--- a/web/types/projects.d.ts
+++ b/web/types/projects.d.ts
@@ -108,7 +108,7 @@ export interface IProjectMemberInvitation {
   updated_by: string;
 }
 
-export interface IProjectBulkInviteFormData {
+export interface IProjectBulkAddFormData {
   members: { role: 5 | 10 | 15 | 20; member_id: string }[];
 }
 


### PR DESCRIPTION
### This PR focuses on updating the members' list endpoints-

1. Only one endpoint to fetch members list for workspace and members.
2. Updated bulk add members to project endpoint and naming convention.
3. Added auth to fetch member request so that only admin and members can access it.
4. Removed unnecessary fetch keys.