### PR TITLE
fix: slack project integration

### DIFF
--- a/apiserver/plane/api/views/integration/slack.py
+++ b/apiserver/plane/api/views/integration/slack.py
@@ -59,6 +59,7 @@ class SlackProjectSyncViewSet(BaseViewSet):
                 team_id=slack_response.get("team", {}).get("id"),
                 team_name=slack_response.get("team", {}).get("name"),
                 workspace_integration=workspace_integration,
+                project_id=project_id,
             )
             _ = ProjectMember.objects.get_or_create(
                 member=workspace_integration.actor, role=20, project_id=project_id


### PR DESCRIPTION
fix:
- Slack Integration on project level due to missing project_id when creating the sync object.