### PR TITLE
chore: kanban card state name and its dropdown text overflow

### DIFF
--- a/web/components/issues/issue-layouts/properties/state.tsx
+++ b/web/components/issues/issue-layouts/properties/state.tsx
@@ -66,9 +66,9 @@ export const IssuePropertyState: React.FC<IIssuePropertyState> = observer((props
     value: state.id,
     query: state.name,
     content: (
-      <div className="flex items-center gap-2">
+      <div className="flex items-center gap-2 w-full overflow-hidden">
         <StateGroupIcon stateGroup={state.group} color={state.color} />
-        {state.name}
+        <div className="truncate inline-block line-clamp-1 w-full">{state.name}</div>
       </div>
     ),
   }));
@@ -94,7 +94,7 @@ export const IssuePropertyState: React.FC<IIssuePropertyState> = observer((props
     <Tooltip tooltipHeading="State" tooltipContent={value?.name ?? ""} position="top">
       <div className="flex items-center cursor-pointer w-full gap-2 text-custom-text-200">
         {value && <StateGroupIcon stateGroup={value.group} color={value.color} />}
-        <span className="truncate">{value?.name ?? "State"}</span>
+        <span className="truncate line-clamp-1 inline-block">{value?.name ?? "State"}</span>
       </div>
     </Tooltip>
   );
@@ -104,7 +104,7 @@ export const IssuePropertyState: React.FC<IIssuePropertyState> = observer((props
       {workspaceSlug && projectId && (
         <Combobox
           as="div"
-          className={`flex-shrink-0 text-left ${className}`}
+          className={`flex-shrink-0 text-left w-auto max-w-full ${className}`}
           value={value.id}
           onChange={(data: string) => {
             const selectedState = projectStates?.find((state) => state.id === data);
@@ -159,7 +159,11 @@ export const IssuePropertyState: React.FC<IIssuePropertyState> = observer((props
                       {({ selected }) => (
                         <>
                           {option.content}
-                          {selected && <Check className="h-3.5 w-3.5" />}
+                          {selected && (
+                            <div className="flex-shrink-0">
+                              <Check className="h-3.5 w-3.5" />
+                            </div>
+                          )}
                         </>
                       )}
                     </Combobox.Option>

--- a/web/components/issues/issue-layouts/roots/project-layout-root.tsx
+++ b/web/components/issues/issue-layouts/roots/project-layout-root.tsx
@@ -32,10 +32,6 @@ export const ProjectLayoutRoot: React.FC = observer(() => {
     }
   );
 
-  console.log("--");
-  console.log("isLoading -- -->", isLoading);
-  console.log("--");
-
   const activeLayout = issueFilterStore.userDisplayFilters.layout;
 
   const issueCount = issueStore.getIssuesCount;


### PR DESCRIPTION
This PR contains the fix for the overflowing issue of the text of the state name on the Kanban card and the items in its dropdown.