### PR TITLE
fix: custom analytics bar graph index alignment

### DIFF
--- a/web/components/analytics/custom-analytics/graph/index.tsx
+++ b/web/components/analytics/custom-analytics/graph/index.tsx
@@ -112,7 +112,7 @@ export const AnalyticsGraph: React.FC<Props> = ({ analytics, barGraphData, param
                   <text
                     x={0}
                     y={datum.y}
-                    textAnchor="end"
+                    textAnchor={`${barGraphData.data.length > 7 ? "end" : "middle"}`}
                     fontSize={10}
                     fill="rgb(var(--color-text-200))"
                     className={`${barGraphData.data.length > 7 ? "-rotate-45" : ""}`}


### PR DESCRIPTION
**fix:**

Fixed the alignment of custom analytics bar graph indexes.

**Before:**

![image](https://github.com/makeplane/plane/assets/94619783/70c150c5-3ffb-40f9-831c-b0cbd164b10f)

**After:**

![image](https://github.com/makeplane/plane/assets/94619783/466d439d-672b-4680-b279-d583f0ebf8a6)
