### PR TITLE
fix: workspace settings layout render in export

### DIFF
--- a/web/pages/[workspaceSlug]/settings/exports.tsx
+++ b/web/pages/[workspaceSlug]/settings/exports.tsx
@@ -9,16 +9,12 @@ import ExportGuide from "components/exporter/guide";
 import { NextPageWithLayout } from "types/app";
 
 const ExportsPage: NextPageWithLayout = () => (
-  <AppLayout header={<WorkspaceSettingHeader title="Export Settings" />}>
-    <WorkspaceSettingLayout>
       <div className="pr-9 py-8 w-full overflow-y-auto">
         <div className="flex items-center py-3.5 border-b border-custom-border-100">
           <h3 className="text-xl font-medium">Exports</h3>
         </div>
         <ExportGuide />
       </div>
-    </WorkspaceSettingLayout>
-  </AppLayout>
 );
 
 ExportsPage.getLayout = function getLayout(page: ReactElement) {


### PR DESCRIPTION
This PR contains the fix for the duplicate rendering of the workspace settings layout in the exports list screen.