### PR TITLE
Fix: Custom menu item not automatically closing, affecting delete popup behavior.

### DIFF
--- a/packages/ui/src/dropdowns/custom-menu.tsx
+++ b/packages/ui/src/dropdowns/custom-menu.tsx
@@ -138,7 +138,10 @@ const MenuItem: React.FC<ICustomMenuItemProps> = (props) => {
           className={`w-full select-none truncate rounded px-1 py-1.5 text-left text-custom-text-200 hover:bg-custom-background-80 ${
             active ? "bg-custom-background-80" : ""
           } ${className}`}
-          onClick={onClick}
+          onClick={(e) => {
+            close();
+            onClick && onClick(e);
+          }}
         >
           {children}
         </button>


### PR DESCRIPTION
This PR fixes issue with delete popup not closing by resolving custom menu item closure.

Before Fix:
https://github.com/makeplane/plane/assets/33979846/5c92702b-32fd-41c2-9893-87485c3ade63

After Fix:
https://github.com/makeplane/plane/assets/33979846/234cdab4-e9a0-4cb9-b248-00ba9ed01183

