### PR TITLE
patch: docker-compose-hub fix

### DIFF
--- a/docker-compose-hub.yml
+++ b/docker-compose-hub.yml
@@ -41,10 +41,10 @@ services:
                         - PGPASSWORD=${PGPASSWORD:-plane}
                         - PGHOST=${PGHOST:-plane-db}
                         - PGDATABASE=${PGDATABASE:-plane}
-                        - DATABASE_URL=${DATABASE_URL:-postgresql://${PGUSER}:${PGPASSWORD}@${PGHOST}/${PGDATABASE}}
+                        - DATABASE_URL=${DATABASE_URL:-postgresql://${PGUSER:-plane}:${PGPASSWORD:-plane}@${PGHOST:-plane-db}/${PGDATABASE:-plane}}
                         - REDIS_HOST=${REDIS_HOST:-plane-redis}
                         - REDIS_PORT=${REDIS_PORT:-6379}
-                        - REDIS_URL=${REDIS_URL:-redis://${REDIS_HOST}:6379/}
+                        - REDIS_URL=${REDIS_URL:-redis://${REDIS_HOST:-plane-redis}:6379/}
                         - EMAIL_HOST=${EMAIL_HOST:-""}
                         - EMAIL_HOST_USER=${EMAIL_HOST_USER:-""}
                         - EMAIL_HOST_PASSWORD=${EMAIL_HOST_PASSWORD:-""}
@@ -71,6 +71,7 @@ services:
                         - ENABLE_EMAIL_PASSWORD=${ENABLE_EMAIL_PASSWORD:-1}
                         - ENABLE_MAGIC_LINK_LOGIN=${ENABLE_MAGIC_LINK_LOGIN:-0}
                         - SECRET_KEY=${SECRET_KEY:-60gp0byfz2dvffa45cxl20p1scy9xbpf6d8c5y0geejgkyp1b5}
+                        - WEB_URL=${WEB_URL:-http://localhost}
                 depends_on:
                         - plane-db
                         - plane-redis
@@ -89,10 +90,10 @@ services:
                         - PGPASSWORD=${PGPASSWORD:-plane}
                         - PGHOST=${PGHOST:-plane-db}
                         - PGDATABASE=${PGDATABASE:-plane}
-                        - DATABASE_URL=${DATABASE_URL:-postgresql://${PGUSER}:${PGPASSWORD}@${PGHOST}/${PGDATABASE}}
+                        - DATABASE_URL=${DATABASE_URL:-postgresql://${PGUSER:-plane}:${PGPASSWORD:-plane}@${PGHOST:-plane-db}/${PGDATABASE:-plane}}
                         - REDIS_HOST=${REDIS_HOST:-plane-redis}
                         - REDIS_PORT=${REDIS_PORT:-6379}
-                        - REDIS_URL=${REDIS_URL:-redis://${REDIS_HOST}:6379/}
+                        - REDIS_URL=${REDIS_URL:-redis://${REDIS_HOST:-plane-redis}:6379/}
                         - EMAIL_HOST=${EMAIL_HOST:-""}
                         - EMAIL_HOST_USER=${EMAIL_HOST_USER:-""}
                         - EMAIL_HOST_PASSWORD=${EMAIL_HOST_PASSWORD:-""}
@@ -136,10 +137,10 @@ services:
                         - PGPASSWORD=${PGPASSWORD:-plane}
                         - PGHOST=${PGHOST:-plane-db}
                         - PGDATABASE=${PGDATABASE:-plane}
-                        - DATABASE_URL=${DATABASE_URL:-postgresql://${PGUSER}:${PGPASSWORD}@${PGHOST}/${PGDATABASE}}
+                        - DATABASE_URL=${DATABASE_URL:-postgresql://${PGUSER:-plane}:${PGPASSWORD:-plane}@${PGHOST:-plane-db}/${PGDATABASE:-plane}}
                         - REDIS_HOST=${REDIS_HOST:-plane-redis}
                         - REDIS_PORT=${REDIS_PORT:-6379}
-                        - REDIS_URL=${REDIS_URL:-redis://${REDIS_HOST}:6379/}
+                        - REDIS_URL=${REDIS_URL:-redis://${REDIS_HOST:-plane-redis}:6379/}
                         - EMAIL_HOST=${EMAIL_HOST:-""}
                         - EMAIL_HOST_USER=${EMAIL_HOST_USER:-""}
                         - EMAIL_HOST_PASSWORD=${EMAIL_HOST_PASSWORD:-""}
@@ -218,7 +219,7 @@ services:
                 platform: linux/amd64
                 image: makeplane/plane-proxy:latest
                 ports:
-                        - ${NGINX_PORT}:80
+                        - ${NGINX_PORT:-80}:80
                 environment:
                         - NGINX_PORT=${NGINX_PORT:-80}
                         - FILE_SIZE_LIMIT=${FILE_SIZE_LIMIT:-5242880}


### PR DESCRIPTION
Instructions to selfhost Plane instance using docker-compose

Download docker-compose-hub.yaml
```
curl -o docker-compose.yaml https://raw.githubusercontent.com/makeplane/plane/master/docker-compose-hub.yml
```

Set the Environment Variable before starting. 
```
export APP_DOMAIN=app.example.com
export NGINX_PORT=80
export WEB_URL=http://${APP_DOMAIN}:${NGINX_PORT}
export MINIO_ROOT_USER=access-key
export MINIO_ROOT_PASSWORD=secret-key
export AWS_ACCESS_KEY_ID=${MINIO_ROOT_USER}
export AWS_SECRET_ACCESS_KEY=${MINIO_ROOT_PASSWORD}
export AWS_S3_BUCKET_NAME=uploads
```

Start the services
```
docker compose up -d
```
