### PR TITLE
refactor: project estimates store

### DIFF
--- a/web/components/estimates/create-update-estimate-modal.tsx
+++ b/web/components/estimates/create-update-estimate-modal.tsx
@@ -89,7 +89,7 @@ export const CreateUpdateEstimateModal: React.FC<Props> = observer((props) => {
     await projectEstimatesStore
       .updateEstimate(workspaceSlug.toString(), projectId.toString(), data.id, payload)
       .then(() => {
-        handleClose();
+        onClose();
       })
       .catch((err) => {
         const error = err?.error;
@@ -101,8 +101,6 @@ export const CreateUpdateEstimateModal: React.FC<Props> = observer((props) => {
           message: errorString ?? "Estimate could not be updated. Please try again.",
         });
       });
-
-    onClose();
   };
 
   const onSubmit = async (formData: FormValues) => {

--- a/web/components/estimates/estimate-list-item.tsx
+++ b/web/components/estimates/estimate-list-item.tsx
@@ -69,7 +69,7 @@ export const EstimateListItem: React.FC<Props> = observer((props) => {
           </div>
           <div className="flex items-center gap-2">
             {currentProjectDetails?.estimate !== estimate?.id && estimate?.points?.length > 0 && (
-              <Button variant="neutral-primary" onClick={handleUseEstimate}>
+              <Button variant="neutral-primary" onClick={handleUseEstimate} size="sm">
                 Use
               </Button>
             )}

--- a/web/components/estimates/estimates-list.tsx
+++ b/web/components/estimates/estimates-list.tsx
@@ -23,7 +23,7 @@ export const EstimatesList: React.FC = observer(() => {
   const { workspaceSlug, projectId } = router.query;
 
   // store
-  const { project: projectStore } = useMobxStore();
+  const { project: projectStore, projectEstimates: projectEstimatesStore } = useMobxStore();
   const { currentProjectDetails } = projectStore;
   // states
   const [estimateFormOpen, setEstimateFormOpen] = useState(false);
@@ -32,7 +32,7 @@ export const EstimatesList: React.FC = observer(() => {
   // hooks
   const { setToastAlert } = useToast();
   // derived values
-  const estimatesList = projectStore.projectEstimates;
+  const estimatesList = projectEstimatesStore.projectEstimates;
 
   const editEstimate = (estimate: IEstimate) => {
     setEstimateFormOpen(true);
@@ -68,7 +68,7 @@ export const EstimatesList: React.FC = observer(() => {
       <DeleteEstimateModal
         isOpen={!!estimateToDelete}
         handleClose={() => setEstimateToDelete(null)}
-        data={projectStore.getProjectEstimateById(estimateToDelete!)}
+        data={projectEstimatesStore.getProjectEstimateById(estimateToDelete!)}
       />
 
       <section className="flex items-center justify-between py-3.5 border-b border-custom-border-100">
@@ -81,11 +81,12 @@ export const EstimatesList: React.FC = observer(() => {
                 setEstimateFormOpen(true);
                 setEstimateToUpdate(undefined);
               }}
+              size="sm"
             >
               Add Estimate
             </Button>
             {currentProjectDetails?.estimate && (
-              <Button variant="neutral-primary" onClick={disableEstimates}>
+              <Button variant="neutral-primary" onClick={disableEstimates} size="sm">
                 Disable Estimates
               </Button>
             )}

--- a/web/components/estimates/index.ts
+++ b/web/components/estimates/index.ts
@@ -1,4 +1,5 @@
 export * from "./create-update-estimate-modal";
 export * from "./delete-estimate-modal";
-export * from "./estimate-select";
 export * from "./estimate-list-item";
+export * from "./estimate-select";
+export * from "./estimates-list";

--- a/web/components/issues/issue-layouts/list/roots/archived-issue-root.tsx
+++ b/web/components/issues/issue-layouts/list/roots/archived-issue-root.tsx
@@ -22,6 +22,7 @@ export const ArchivedIssueListLayout: FC = observer(() => {
     projectLabel: { projectLabels },
     projectMember: { projectMembers },
     projectState: projectStateStore,
+    projectEstimates: { projectEstimates },
     archivedIssues: archivedIssueStore,
     archivedIssueFilters: archivedIssueFiltersStore,
   } = useMobxStore();
@@ -46,9 +47,7 @@ export const ArchivedIssueListLayout: FC = observer(() => {
   const stateGroups = ISSUE_STATE_GROUPS || null;
   const projects = workspaceSlug ? projectStore?.projects[workspaceSlug.toString()] || null : null;
   const estimates =
-    projectDetails?.estimate !== null
-      ? projectStore.projectEstimates?.find((e) => e.id === projectDetails?.estimate) || null
-      : null;
+    projectDetails?.estimate !== null ? projectEstimates?.find((e) => e.id === projectDetails?.estimate) || null : null;
 
   return (
     <div className="relative w-full h-full bg-custom-background-90">

--- a/web/components/issues/issue-layouts/list/roots/cycle-root.tsx
+++ b/web/components/issues/issue-layouts/list/roots/cycle-root.tsx
@@ -24,6 +24,7 @@ export const CycleListLayout: React.FC = observer(() => {
     projectLabel: { projectLabels },
     projectMember: { projectMembers },
     projectState: projectStateStore,
+    projectEstimates: { projectEstimates },
     issueFilter: issueFilterStore,
     cycleIssue: cycleIssueStore,
     issueDetail: issueDetailStore,
@@ -64,7 +65,7 @@ export const CycleListLayout: React.FC = observer(() => {
   const projects = workspaceSlug ? projectStore?.projects[workspaceSlug.toString()] || null : null;
   const estimates =
     currentProjectDetails?.estimate !== null
-      ? projectStore.projectEstimates?.find((e) => e.id === currentProjectDetails?.estimate) || null
+      ? projectEstimates?.find((e) => e.id === currentProjectDetails?.estimate) || null
       : null;
 
   return (

--- a/web/components/issues/issue-layouts/list/roots/module-root.tsx
+++ b/web/components/issues/issue-layouts/list/roots/module-root.tsx
@@ -24,6 +24,7 @@ export const ModuleListLayout: React.FC = observer(() => {
     projectLabel: { projectLabels },
     projectMember: { projectMembers },
     projectState: projectStateStore,
+    projectEstimates: { projectEstimates },
     issueFilter: issueFilterStore,
     moduleIssue: moduleIssueStore,
     issueDetail: issueDetailStore,
@@ -64,7 +65,7 @@ export const ModuleListLayout: React.FC = observer(() => {
   const projects = workspaceSlug ? projectStore?.projects[workspaceSlug.toString()] || null : null;
   const estimates =
     currentProjectDetails?.estimate !== null
-      ? projectStore.projectEstimates?.find((e) => e.id === currentProjectDetails?.estimate) || null
+      ? projectEstimates?.find((e) => e.id === currentProjectDetails?.estimate) || null
       : null;
 
   return (

--- a/web/components/issues/issue-layouts/list/roots/project-root.tsx
+++ b/web/components/issues/issue-layouts/list/roots/project-root.tsx
@@ -23,6 +23,7 @@ export const ListLayout: FC = observer(() => {
     projectLabel: { projectLabels },
     projectMember: { projectMembers },
     projectState: projectStateStore,
+    projectEstimates: { projectEstimates },
     issue: issueStore,
     issueDetail: issueDetailStore,
     issueFilter: issueFilterStore,
@@ -54,7 +55,7 @@ export const ListLayout: FC = observer(() => {
   const projects = workspaceSlug ? projectStore?.projects[workspaceSlug.toString()] || null : null;
   const estimates =
     currentProjectDetails?.estimate !== null
-      ? projectStore.projectEstimates?.find((e) => e.id === currentProjectDetails?.estimate) || null
+      ? projectEstimates?.find((e) => e.id === currentProjectDetails?.estimate) || null
       : null;
 
   return (

--- a/web/components/issues/issue-layouts/properties/estimates.tsx
+++ b/web/components/issues/issue-layouts/properties/estimates.tsx
@@ -52,11 +52,14 @@ export const IssuePropertyEstimates: React.FC<IIssuePropertyEstimates> = observe
     ],
   });
 
-  const { project: projectStore } = useMobxStore();
+  const {
+    project: projectStore,
+    projectEstimates: { projectEstimates },
+  } = useMobxStore();
 
   const projectDetails = projectId ? projectStore.project_details[projectId] : null;
   const isEstimateEnabled = projectDetails?.estimate !== null;
-  const estimates = projectId ? projectStore.estimates?.[projectId] : null;
+  const estimates = projectEstimates;
   const estimatePoints =
     projectDetails && isEstimateEnabled ? estimates?.find((e) => e.id === projectDetails.estimate)?.points : null;
 

--- a/web/layouts/auth-layout/project-wrapper.tsx
+++ b/web/layouts/auth-layout/project-wrapper.tsx
@@ -20,10 +20,11 @@ export const ProjectAuthWrapper: FC<IProjectAuthWrapper> = observer((props) => {
   // store
   const {
     user: { fetchUserProjectInfo, projectMemberInfo, hasPermissionToProject },
-    project: { fetchProjectDetails, fetchProjectEstimates, workspaceProjects },
+    project: { fetchProjectDetails, workspaceProjects },
     projectLabel: { fetchProjectLabels },
     projectMember: { fetchProjectMembers },
     projectState: { fetchProjectStates },
+    projectEstimates: { fetchProjectEstimates },
     cycle: { fetchCycles },
     module: { fetchModules },
     projectViews: { fetchAllViews },

--- a/web/pages/[workspaceSlug]/projects/[projectId]/settings/estimates.tsx
+++ b/web/pages/[workspaceSlug]/projects/[projectId]/settings/estimates.tsx
@@ -4,7 +4,7 @@ import { AppLayout } from "layouts/app-layout";
 import { ProjectSettingLayout } from "layouts/settings-layout";
 // components
 import { ProjectSettingHeader } from "components/headers";
-import { EstimatesList } from "components/estimates/estimate-list";
+import { EstimatesList } from "components/estimates";
 // types
 import { NextPageWithLayout } from "types/app";
 

--- a/web/store/project/project-estimates.store.ts
+++ b/web/store/project/project-estimates.store.ts
@@ -1,4 +1,4 @@
-import { observable, action, makeObservable, runInAction } from "mobx";
+import { observable, action, makeObservable, runInAction, computed } from "mobx";
 // types
 import { RootStore } from "../root";
 import { IEstimate, IEstimateFormData } from "types";
@@ -9,7 +9,14 @@ export interface IProjectEstimateStore {
   loader: boolean;
   error: any | null;
 
-  // estimates
+  // observables
+  estimates: {
+    [projectId: string]: IEstimate[] | null; // project_id: members
+  } | null;
+
+  // actions
+  getProjectEstimateById: (estimateId: string) => IEstimate | null;
+  fetchProjectEstimates: (workspaceSlug: string, projectId: string) => Promise<void>;
   createEstimate: (workspaceSlug: string, projectId: string, data: IEstimateFormData) => Promise<IEstimate>;
   updateEstimate: (
     workspaceSlug: string,
@@ -18,14 +25,23 @@ export interface IProjectEstimateStore {
     data: IEstimateFormData
   ) => Promise<IEstimate>;
   deleteEstimate: (workspaceSlug: string, projectId: string, estimateId: string) => Promise<void>;
+
+  // computed
+  projectEstimates: IEstimate[] | undefined;
 }
 
 export class ProjectEstimatesStore implements IProjectEstimateStore {
   loader: boolean = false;
   error: any | null = null;
 
+  // observables
+  estimates: {
+    [projectId: string]: IEstimate[]; // projectId: estimates
+  } | null = {};
+
   // root store
   rootStore;
+
   // service
   projectService;
   estimateService;
@@ -36,16 +52,60 @@ export class ProjectEstimatesStore implements IProjectEstimateStore {
       loader: observable,
       error: observable,
 
-      // estimates
+      estimates: observable.ref,
+
+      // actions
+      getProjectEstimateById: action,
+      fetchProjectEstimates: action,
       createEstimate: action,
       updateEstimate: action,
       deleteEstimate: action,
+
+      // computed
+      projectEstimates: computed,
     });
 
     this.rootStore = _rootStore;
     this.projectService = new ProjectService();
     this.estimateService = new ProjectEstimateService();
   }
+
+  get projectEstimates() {
+    const projectId = this.rootStore.project.projectId;
+
+    if (!projectId) return undefined;
+    return this.estimates?.[projectId] || undefined;
+  }
+
+  getProjectEstimateById = (estimateId: string) => {
+    const estimates = this.projectEstimates;
+    if (!estimates) return null;
+    const estimateInfo: IEstimate | null = estimates.find((estimate) => estimate.id === estimateId) || null;
+    return estimateInfo;
+  };
+
+  fetchProjectEstimates = async (workspaceSlug: string, projectId: string) => {
+    try {
+      this.loader = true;
+      this.error = null;
+
+      const estimatesResponse = await this.estimateService.getEstimatesList(workspaceSlug, projectId);
+      const _estimates = {
+        ...this.estimates,
+        [projectId]: estimatesResponse,
+      };
+
+      runInAction(() => {
+        this.estimates = _estimates;
+        this.loader = false;
+        this.error = null;
+      });
+    } catch (error) {
+      console.error(error);
+      this.loader = false;
+      this.error = error;
+    }
+  };
 
   createEstimate = async (workspaceSlug: string, projectId: string, data: IEstimateFormData) => {
     try {
@@ -62,9 +122,9 @@ export class ProjectEstimatesStore implements IProjectEstimateStore {
       };
 
       runInAction(() => {
-        this.rootStore.project.estimates = {
-          ...this.rootStore.project.estimates,
-          [projectId]: [responseEstimate, ...(this.rootStore.project.estimates?.[projectId] || [])],
+        this.estimates = {
+          ...this.estimates,
+          [projectId]: [responseEstimate, ...(this.estimates?.[projectId] || [])],
         };
       });
 
@@ -76,12 +136,12 @@ export class ProjectEstimatesStore implements IProjectEstimateStore {
   };
 
   updateEstimate = async (workspaceSlug: string, projectId: string, estimateId: string, data: IEstimateFormData) => {
-    const originalEstimates = this.rootStore.project.getProjectEstimateById(estimateId);
+    const originalEstimates = this.getProjectEstimateById(estimateId);
 
     runInAction(() => {
-      this.rootStore.project.estimates = {
-        ...this.rootStore.project.estimates,
-        [projectId]: (this.rootStore.project.estimates?.[projectId] || [])?.map((estimate) =>
+      this.estimates = {
+        ...this.estimates,
+        [projectId]: (this.estimates?.[projectId] || [])?.map((estimate) =>
           estimate.id === estimateId ? { ...estimate, ...data.estimate } : estimate
         ),
       };
@@ -95,15 +155,15 @@ export class ProjectEstimatesStore implements IProjectEstimateStore {
         data,
         this.rootStore.user.currentUser!
       );
-      await this.rootStore.project.fetchProjectEstimates(workspaceSlug, projectId);
+      await this.fetchProjectEstimates(workspaceSlug, projectId);
 
       return response;
     } catch (error) {
       console.log("Failed to update estimate from project store");
       runInAction(() => {
-        this.rootStore.project.estimates = {
-          ...this.rootStore.project.estimates,
-          [projectId]: (this.rootStore.project.estimates?.[projectId] || [])?.map((estimate) =>
+        this.estimates = {
+          ...this.estimates,
+          [projectId]: (this.estimates?.[projectId] || [])?.map((estimate) =>
             estimate.id === estimateId ? { ...estimate, ...originalEstimates } : estimate
           ),
         };
@@ -113,14 +173,12 @@ export class ProjectEstimatesStore implements IProjectEstimateStore {
   };
 
   deleteEstimate = async (workspaceSlug: string, projectId: string, estimateId: string) => {
-    const originalEstimateList = this.rootStore.project.projectEstimates || [];
+    const originalEstimateList = this.projectEstimates || [];
 
     runInAction(() => {
-      this.rootStore.project.estimates = {
-        ...this.rootStore.project.estimates,
-        [projectId]: (this.rootStore.project.estimates?.[projectId] || [])?.filter(
-          (estimate) => estimate.id !== estimateId
-        ),
+      this.estimates = {
+        ...this.estimates,
+        [projectId]: (this.estimates?.[projectId] || [])?.filter((estimate) => estimate.id !== estimateId),
       };
     });
 
@@ -131,8 +189,8 @@ export class ProjectEstimatesStore implements IProjectEstimateStore {
       console.log("Failed to delete estimate from project store");
       // reverting back to original estimate list
       runInAction(() => {
-        this.rootStore.project.estimates = {
-          ...this.rootStore.project.estimates,
+        this.estimates = {
+          ...this.estimates,
           [projectId]: originalEstimateList,
         };
       });


### PR DESCRIPTION
This PR moves all the project estimates `actions`, `observables` and `computed` from the project store to the project estimates store.