### PR TITLE
fix: Sorting of cycles by date in cycle view

### DIFF
--- a/web/components/cycles/cycles-view.tsx
+++ b/web/components/cycles/cycles-view.tsx
@@ -10,6 +10,8 @@ import { Loader } from "@plane/ui";
 // types
 import { TCycleLayout } from "types";
 
+import dateSort from "./date-sort";
+
 export interface ICyclesView {
   filter: "all" | "current" | "upcoming" | "draft" | "completed" | "incomplete";
   layout: TCycleLayout;
@@ -32,12 +34,12 @@ export const CyclesView: FC<ICyclesView> = observer((props) => {
 
   const cyclesList =
     filter === "completed"
-      ? cycleStore.projectCompletedCycles
+      ? cycleStore.projectCompletedCycles.sort(dateSort)
       : filter === "draft"
-      ? cycleStore.projectDraftCycles
+      ? cycleStore.projectDraftCycles.sort(dateSort)
       : filter === "upcoming"
-      ? cycleStore.projectUpcomingCycles
-      : cycleStore.projectCycles;
+      ? cycleStore.projectUpcomingCycles.sort(dateSort)
+      : cycleStore.projectCycles.sort(dateSort);
 
   return (
     <>

--- a/web/components/cycles/cycles-view.tsx
+++ b/web/components/cycles/cycles-view.tsx
@@ -32,14 +32,16 @@ export const CyclesView: FC<ICyclesView> = observer((props) => {
     workspaceSlug && projectId && filter ? () => cycleStore.fetchCycles(workspaceSlug, projectId, filter) : null
   );
 
-  const cyclesList =
+  let cyclesList =
     filter === "completed"
-      ? cycleStore.projectCompletedCycles.sort(dateSort)
+      ? cycleStore.projectCompletedCycles
       : filter === "draft"
-      ? cycleStore.projectDraftCycles.sort(dateSort)
+      ? cycleStore.projectDraftCycles
       : filter === "upcoming"
-      ? cycleStore.projectUpcomingCycles.sort(dateSort)
-      : cycleStore.projectCycles.sort(dateSort);
+      ? cycleStore.projectUpcomingCycles
+      : cycleStore.projectCycles;
+
+  cyclesList = cyclesList.sort(dateSort);
 
   return (
     <>

--- a/web/components/cycles/date-sort.ts
+++ b/web/components/cycles/date-sort.ts
@@ -1,0 +1,7 @@
+// Sort cycles by start date, descending
+export default function dateSort(a, b) {
+  const dateA = new Date(a.start_date).getTime();
+  const dateB = new Date(b.start_date).getTime();
+
+  return dateB - dateA;
+}


### PR DESCRIPTION
This means the cycles will be in chronological order, making it easier to follow. Wasn't sure where to put date-sort, so it's in web/components/cycles.  