### PR TITLE
[FED-867] fix:modal overlapping issue

### DIFF
--- a/web/components/command-palette/command-pallette.tsx
+++ b/web/components/command-palette/command-pallette.tsx
@@ -33,7 +33,7 @@ export const CommandPalette: FC = observer(() => {
     commandPalette,
     theme: { toggleSidebar },
     user: { currentUser },
-    trackEvent: { setTrackElement }
+    trackEvent: { setTrackElement },
   } = useMobxStore();
   const {
     toggleCommandPaletteModal,
@@ -56,6 +56,18 @@ export const CommandPalette: FC = observer(() => {
     isDeleteIssueModalOpen,
     toggleDeleteIssueModal,
   } = commandPalette;
+
+  const isAnyModalOpen = Boolean(
+    isCreateIssueModalOpen ||
+      isCreateCycleModalOpen ||
+      isCreatePageModalOpen ||
+      isCreateProjectModalOpen ||
+      isCreateModuleModalOpen ||
+      isCreateViewModalOpen ||
+      isShortcutModalOpen ||
+      isBulkDeleteIssueModalOpen ||
+      isDeleteIssueModalOpen
+  );
 
   const { setToastAlert } = useToast();
 
@@ -111,7 +123,7 @@ export const CommandPalette: FC = observer(() => {
           e.preventDefault();
           toggleSidebar();
         }
-      } else {
+      } else if (!isAnyModalOpen) {
         if (keyPressed === "c") {
           setTrackElement("SHORTCUT_KEY");
           toggleCreateIssueModal(true);
@@ -148,6 +160,7 @@ export const CommandPalette: FC = observer(() => {
       toggleCreateIssueModal,
       projectId,
       workspaceSlug,
+      isAnyModalOpen,
     ]
   );
 


### PR DESCRIPTION
This PR contains a fix for the problem of modals overlapping. Previously, when one modal was open and we triggered a shortcut key for another modal, they overlap.