### PR TITLE
fix: progress panel default open

### DIFF
--- a/web/components/cycles/sidebar.tsx
+++ b/web/components/cycles/sidebar.tsx
@@ -477,7 +477,7 @@ export const CycleDetailsSidebar: React.FC<Props> = observer((props) => {
 
         <div className="flex flex-col">
           <div className="flex w-full flex-col items-center justify-start gap-2 border-t border-custom-border-200 py-5 px-1.5">
-            <Disclosure>
+            <Disclosure defaultOpen>
               {({ open }) => (
                 <div className={`relative  flex  h-full w-full flex-col ${open ? "" : "flex-row"}`}>
                   <Disclosure.Button

--- a/web/components/modules/sidebar.tsx
+++ b/web/components/modules/sidebar.tsx
@@ -470,7 +470,7 @@ export const ModuleDetailsSidebar: React.FC<Props> = observer((props) => {
 
         <div className="flex flex-col">
           <div className="flex w-full flex-col items-center justify-start gap-2 border-t border-custom-border-200 py-5 px-1.5">
-            <Disclosure>
+            <Disclosure defaultOpen>
               {({ open }) => (
                 <div className={`relative  flex  h-full w-full flex-col ${open ? "" : "flex-row"}`}>
                   <Disclosure.Button


### PR DESCRIPTION
### This PR fixes :

- By default cycle & module sidebar progress panel will be open.