### PR TITLE
fix: profile layout flicker

### DIFF
--- a/web/layouts/user-profile-layout/layout.tsx
+++ b/web/layouts/user-profile-layout/layout.tsx
@@ -1,11 +1,7 @@
-import useSWR from "swr";
-import { useRouter } from "next/router";
-// services
-import { WorkspaceService } from "services/workspace.service";
 // components
 import { ProfileNavbar, ProfileSidebar } from "components/profile";
-// constants
-import { WORKSPACE_MEMBERS_ME } from "constants/fetch-keys";
+import { useMobxStore } from "lib/mobx/store-provider";
+import { observer } from "mobx-react-lite";
 
 type Props = {
   children: React.ReactNode;
@@ -13,21 +9,18 @@ type Props = {
   showProfileIssuesFilter?: boolean;
 };
 
-// services
-const workspaceService = new WorkspaceService();
+const AUTHORIZED_ROLES = [20, 15, 10];
 
-export const ProfileAuthWrapper: React.FC<Props> = (props) => {
+export const ProfileAuthWrapper: React.FC<Props> = observer((props) => {
   const { children, className, showProfileIssuesFilter } = props;
 
-  const router = useRouter();
-  const { workspaceSlug } = router.query;
+  const {
+    user: { currentWorkspaceRole },
+  } = useMobxStore();
 
-  const { data: memberDetails } = useSWR(
-    workspaceSlug ? WORKSPACE_MEMBERS_ME(workspaceSlug.toString()) : null,
-    workspaceSlug ? () => workspaceService.workspaceMemberMe(workspaceSlug.toString()) : null
-  );
+  if (!currentWorkspaceRole) return null;
 
-  const isAuthorized = memberDetails?.role === 20 || memberDetails?.role === 15 || memberDetails?.role === 10;
+  const isAuthorized = AUTHORIZED_ROLES.includes(currentWorkspaceRole);
 
   return (
     <div className="h-full w-full md:flex md:flex-row-reverse md:overflow-hidden">
@@ -44,4 +37,4 @@ export const ProfileAuthWrapper: React.FC<Props> = (props) => {
       </div>
     </div>
   );
-};
+});

--- a/web/layouts/user-profile-layout/layout.tsx
+++ b/web/layouts/user-profile-layout/layout.tsx
@@ -1,7 +1,8 @@
+import { observer } from "mobx-react-lite";
+// mobx store
+import { useMobxStore } from "lib/mobx/store-provider";
 // components
 import { ProfileNavbar, ProfileSidebar } from "components/profile";
-import { useMobxStore } from "lib/mobx/store-provider";
-import { observer } from "mobx-react-lite";
 
 type Props = {
   children: React.ReactNode;


### PR DESCRIPTION
### This PR fixes the flicker happening in the user profile layout.

**Before-**  User role was earlier fetched using `useSWR`.

https://github.com/makeplane/plane/assets/65252264/771ddcae-d343-4f3e-805a-ac35c7b3ef22

****

**After-** Using the user role from the user store.

https://github.com/makeplane/plane/assets/65252264/e6ed6d05-bdd2-4d30-a401-a5d4db014d69

