### PR TITLE
fix: google auth button content alignment

### DIFF
--- a/web/components/account/email-code-form.tsx
+++ b/web/components/account/email-code-form.tsx
@@ -153,7 +153,7 @@ export const EmailCodeForm: React.FC<Props> = (Props) => {
               <p className="text-center text-sm text-onboarding-text-200 mt-1">Promise!</p>
             </div>
           ) : (
-            <p className="text-center text-sm text-onboarding-text-200 px-20 mt-3">
+            <p className="text-center text-sm text-onboarding-text-200 px-10 sm:px-20 mt-3">
               Sign in with the email you used to sign up for Plane
             </p>
           )}

--- a/web/components/account/google-login.tsx
+++ b/web/components/account/google-login.tsx
@@ -29,7 +29,6 @@ export const GoogleLoginButton: FC<IGoogleLoginButton> = (props) => {
           theme: "outline",
           size: "large",
           logo_alignment: "center",
-          width: 384,
           text: "signin_with",
         } as GsiButtonConfiguration // customization attributes
       );


### PR DESCRIPTION
### This PR includes:

- Added alignment to Google auth button content.
- Added responsiveness to sign-in heading paragraph text.

**When a Google account exists:**

![image](https://github.com/makeplane/plane/assets/94619783/065b658c-c0be-4fa0-98f5-d5a03d677706)

**When a Google account doesn't exist:**

![image](https://github.com/makeplane/plane/assets/94619783/33086f63-7d7e-4b0a-a6d5-a7923a3fa47c)

