### PR TITLE
fix: quick add positioning

### DIFF
--- a/web/components/issues/issue-layouts/kanban/default.tsx
+++ b/web/components/issues/issue-layouts/kanban/default.tsx
@@ -102,7 +102,7 @@ const GroupByKanBan: React.FC<IGroupByKanBan> = observer((props) => {
             )}
 
             <div
-              className={`min-h-[150px] h-full ${
+              className={`min-h-[150px] ${
                 verticalAlignPosition(_list) ? `w-[0px] overflow-hidden` : `w-full transition-all`
               }`}
             >

--- a/web/components/issues/issue-layouts/kanban/quick-add-issue-form.tsx
+++ b/web/components/issues/issue-layouts/kanban/quick-add-issue-form.tsx
@@ -15,7 +15,7 @@ import { createIssuePayload } from "helpers/issue.helper";
 import { IIssue, IProject } from "types";
 
 const Inputs = (props: any) => {
-  const { register, setFocus, projectDetails } = props;
+  const { register, setFocus, projectDetail } = props;
 
   useEffect(() => {
     setFocus("name");
@@ -23,7 +23,7 @@ const Inputs = (props: any) => {
 
   return (
     <div>
-      <h4 className="text-xs font-medium leading-5 text-custom-text-300">{projectDetails?.identifier ?? "..."}</h4>
+      <h4 className="text-xs font-medium leading-5 text-custom-text-300">{projectDetail?.identifier ?? "..."}</h4>
       <input
         autoComplete="off"
         placeholder="Issue Title"

--- a/web/components/issues/issue-layouts/spreadsheet/spreadsheet-view.tsx
+++ b/web/components/issues/issue-layouts/spreadsheet/spreadsheet-view.tsx
@@ -84,7 +84,7 @@ export const SpreadsheetView: React.FC<Props> = observer((props) => {
       <div className="h-full w-full flex flex-col">
         <div
           ref={containerRef}
-          className="flex max-h-full h-full overflow-y-auto divide-x-[0.5px] divide-custom-border-200 horizontal-scroll-enable"
+          className="flex overflow-y-auto divide-x-[0.5px] divide-custom-border-200 horizontal-scroll-enable"
         >
           {issues && issues.length > 0 ? (
             <>


### PR DESCRIPTION
This fixes the positioning of the quick add for kanban and speadsheet view.

Before:
<img width="1158" alt="image" src="https://github.com/makeplane/plane/assets/71900764/c62e433f-537e-4e08-94ba-08f65c73c1e1">
<img width="1122" alt="image" src="https://github.com/makeplane/plane/assets/71900764/1cfc8ddb-e74f-4960-ac99-4c7b84193471">
<img width="1152" alt="image" src="https://github.com/makeplane/plane/assets/71900764/cbfe4a8a-c64b-4547-a6e5-0e81d4f6fd07">

After:
<img width="1158" alt="image" src="https://github.com/makeplane/plane/assets/71900764/39d3bf76-8f4b-46b7-8571-e66ed81d20f5">
<img width="1150" alt="image" src="https://github.com/makeplane/plane/assets/71900764/dd43e856-d1ee-4ddc-b563-fd193be92e7d">
<img width="1156" alt="image" src="https://github.com/makeplane/plane/assets/71900764/76f7879c-f5df-4237-a1b5-b632ceab8835">
