### PR TITLE
chore: email invite accept validation

### DIFF
--- a/web/components/onboarding/invitations.tsx
+++ b/web/components/onboarding/invitations.tsx
@@ -63,11 +63,11 @@ export const Invitations: React.FC<Props> = (props) => {
       .joinWorkspaces({ invitations: invitationsRespond })
       .then(async (res) => {
         postHogEventTracker("WORKSPACE_USER_INVITE_ACCEPT", { ...res, state: "SUCCESS" });
-        await mutateInvitations();
         await workspaceStore.fetchWorkspaces();
         await mutate(USER_WORKSPACES);
         await updateLastWorkspace();
         await handleNextStep();
+        await mutateInvitations();
       })
       .catch((error) => {
         console.log(error);

--- a/web/pages/invitations/index.tsx
+++ b/web/pages/invitations/index.tsx
@@ -213,10 +213,7 @@ const UserInvitationsPage: NextPageWithLayout = observer(() => {
               image={emptyInvitation}
               primaryButton={{
                 text: "Back to dashboard",
-                onClick: () => {
-                  if (user?.is_onboarded === false) router.push("/onboarding");
-                  else router.push(`/${redirectWorkspaceSlug}`);
-                },
+                onClick: () => router.push("/"),
               }}
             />
           </div>

--- a/web/pages/invitations/index.tsx
+++ b/web/pages/invitations/index.tsx
@@ -213,7 +213,10 @@ const UserInvitationsPage: NextPageWithLayout = observer(() => {
               image={emptyInvitation}
               primaryButton={{
                 text: "Back to dashboard",
-                onClick: () => router.push(`/${redirectWorkspaceSlug}`),
+                onClick: () => {
+                  if (user?.is_onboarded === false) router.push("/onboarding");
+                  else router.push(`/${redirectWorkspaceSlug}`);
+                },
               }}
             />
           </div>

--- a/web/pages/onboarding/index.tsx
+++ b/web/pages/onboarding/index.tsx
@@ -52,6 +52,10 @@ const OnboardingPage: NextPageWithLayout = observer(() => {
     },
   });
 
+  useSWR(`USER_WORKSPACES_LIST`, () => workspaceStore.fetchWorkspaces(), {
+    shouldRetryOnError: false,
+  });
+
   const { data: invitations } = useSWR("USER_WORKSPACE_INVITATIONS_LIST", () =>
     workspaceService.userWorkspaceInvitations()
   );
@@ -87,6 +91,19 @@ const OnboardingPage: NextPageWithLayout = observer(() => {
       if (!user || !invitations) return;
 
       const onboardingStep = user.onboarding_step;
+
+      if (!onboardingStep.workspace_join && !onboardingStep.workspace_create && workspaces && workspaces?.length > 0) {
+        await updateCurrentUser({
+          onboarding_step: {
+            ...user.onboarding_step,
+            workspace_join: true,
+            workspace_create: true,
+          },
+          last_workspace_id: workspaces[0].id,
+        });
+        setStep(2);
+        return;
+      }
 
       if (!onboardingStep.workspace_join && !onboardingStep.workspace_create && step !== 1) setStep(1);
 


### PR DESCRIPTION
### This PR includes:

**FIXES:**

1. Empty invitation state flickering on accepting the only invitation
2. Onboarding STEP 1 should be skipped after accepting an invite from email.
3. From `/invitations` user should be redirected to `/onboarding` if onboarding is not completed.