### PR TITLE
fix: custom analytic grouped bar tooltip value as ID

### DIFF
--- a/web/components/analytics/custom-analytics/graph/custom-tooltip.tsx
+++ b/web/components/analytics/custom-analytics/graph/custom-tooltip.tsx
@@ -34,8 +34,11 @@ export const CustomTooltip: React.FC<Props> = ({ datum, analytics, params }) => 
       const cycle = analytics.extras.cycle_details.find((c) => c.issue_cycle__cycle_id === datum.id);
       tooltipValue = cycle && cycle.issue_cycle__cycle__name ? cycle.issue_cycle__cycle__name : "None";
     } else if (params.segment === "issue_module__module_id") {
-      const module = analytics.extras.module_details.find((m) => m.issue_module__module_id === datum.id);
-      tooltipValue = module && module.issue_module__module__name ? module.issue_module__module__name : "None";
+      const selectedModule = analytics.extras.module_details.find((m) => m.issue_module__module_id === datum.id);
+      tooltipValue =
+        selectedModule && selectedModule.issue_module__module__name
+          ? selectedModule.issue_module__module__name
+          : "None";
     } else tooltipValue = datum.id;
   } else {
     if (DATE_KEYS.includes(params.x_axis)) tooltipValue = datum.indexValue;

--- a/web/components/analytics/custom-analytics/graph/custom-tooltip.tsx
+++ b/web/components/analytics/custom-analytics/graph/custom-tooltip.tsx
@@ -24,7 +24,19 @@ export const CustomTooltip: React.FC<Props> = ({ datum, analytics, params }) => 
 
   if (params.segment) {
     if (DATE_KEYS.includes(params.segment)) tooltipValue = renderMonthAndYear(datum.id);
-    else tooltipValue = datum.id;
+    else if (params.segment === "labels__id") {
+      const label = analytics.extras.label_details.find((l) => l.labels__id === datum.id);
+      tooltipValue = label && label.labels__name ? label.labels__name : "None";
+    } else if (params.segment === "state_id") {
+      const state = analytics.extras.state_details.find((s) => s.state_id === datum.id);
+      tooltipValue = state && state.state__name ? state.state__name : "None";
+    } else if (params.segment === "issue_cycle__cycle_id") {
+      const cycle = analytics.extras.cycle_details.find((c) => c.issue_cycle__cycle_id === datum.id);
+      tooltipValue = cycle && cycle.issue_cycle__cycle__name ? cycle.issue_cycle__cycle__name : "None";
+    } else if (params.segment === "issue_module__module_id") {
+      const module = analytics.extras.module_details.find((m) => m.issue_module__module_id === datum.id);
+      tooltipValue = module && module.issue_module__module__name ? module.issue_module__module__name : "None";
+    } else tooltipValue = datum.id;
   } else {
     if (DATE_KEYS.includes(params.x_axis)) tooltipValue = datum.indexValue;
     else tooltipValue = datum.id === "count" ? "Issue count" : "Estimate";


### PR DESCRIPTION
### This PR includes a fix to the custom analytic grouped bar tooltip value:

**Before:**

![image](https://github.com/makeplane/plane/assets/94619783/068371f8-cf83-4bb5-81cc-13f0c4ebcc93)

**After:**

![image](https://github.com/makeplane/plane/assets/94619783/ebcda052-784c-432c-ade9-5673115e056d)

