### PR TITLE
chore: remove unused fields from the god mode

### DIFF
--- a/web/components/instance/email-form.tsx
+++ b/web/components/instance/email-form.tsx
@@ -20,7 +20,7 @@ export interface EmailFormValues {
   EMAIL_HOST_USER: string;
   EMAIL_HOST_PASSWORD: string;
   EMAIL_USE_TLS: string;
-  EMAIL_USE_SSL: string;
+  // EMAIL_USE_SSL: string;
 }
 
 export const InstanceEmailForm: FC<IInstanceEmailForm> = (props) => {
@@ -44,7 +44,7 @@ export const InstanceEmailForm: FC<IInstanceEmailForm> = (props) => {
       EMAIL_HOST_USER: config["EMAIL_HOST_USER"],
       EMAIL_HOST_PASSWORD: config["EMAIL_HOST_PASSWORD"],
       EMAIL_USE_TLS: config["EMAIL_USE_TLS"],
-      EMAIL_USE_SSL: config["EMAIL_USE_SSL"],
+      // EMAIL_USE_SSL: config["EMAIL_USE_SSL"],
     },
   });
 
@@ -194,7 +194,7 @@ export const InstanceEmailForm: FC<IInstanceEmailForm> = (props) => {
           </div>
         </div>
 
-        <div className="flex items-center gap-10 pt-4 mr-8">
+        {/* <div className="flex items-center gap-10 pt-4 mr-8">
           <div className="grow">
             <div className="text-custom-text-100 font-medium text-sm">
               Turn SSL {Boolean(parseInt(watch("EMAIL_USE_SSL"))) ? "off" : "on"}
@@ -218,7 +218,7 @@ export const InstanceEmailForm: FC<IInstanceEmailForm> = (props) => {
               )}
             />
           </div>
-        </div>
+        </div> */}
       </div>
 
       <div className="flex items-center py-1 max-w-4xl">

--- a/web/pages/god-mode/authorization.tsx
+++ b/web/pages/god-mode/authorization.tsx
@@ -75,7 +75,7 @@ const InstanceAdminAuthorizationPage: NextPageWithLayout = observer(() => {
       {formattedConfig ? (
         <>
           <div className="flex flex-col gap-12 w-full lg:w-2/5 pb-8 border-b border-custom-border-100">
-            <div className="flex items-center gap-14 mr-4">
+            <div className="flex items-center gap-14 mr-4 pointer-events-none opacity-50">
               <div className="grow">
                 <div className="text-custom-text-100 font-medium text-sm">
                   Turn Magic Links {Boolean(parseInt(enableMagicLogin)) ? "off" : "on"}
@@ -92,11 +92,12 @@ const InstanceAdminAuthorizationPage: NextPageWithLayout = observer(() => {
               <div className={`shrink-0 ${isSubmitting && "opacity-70"}`}>
                 <ToggleSwitch
                   value={Boolean(parseInt(enableMagicLogin))}
-                  onChange={() => {
-                    Boolean(parseInt(enableMagicLogin)) === true
-                      ? updateConfig("ENABLE_MAGIC_LINK_LOGIN", "0")
-                      : updateConfig("ENABLE_MAGIC_LINK_LOGIN", "1");
-                  }}
+                  // onChange={() => {
+                  //   Boolean(parseInt(enableMagicLogin)) === true
+                  //     ? updateConfig("ENABLE_MAGIC_LINK_LOGIN", "0")
+                  //     : updateConfig("ENABLE_MAGIC_LINK_LOGIN", "1");
+                  // }}
+                  onChange={() => {}}
                   size="sm"
                   disabled={isSubmitting}
                 />


### PR DESCRIPTION
### This PR focuses on removing unnecessary fields from the God mode

1. Disabled magic link toggle option from **SSO and OAuth** settings.
2. Removed SSL toggle option from **Email** settings.