### PR TITLE
fix: user deactivation if instance admin and remove auto assigning of user on workspace and project

### DIFF
--- a/apiserver/Dockerfile.dev
+++ b/apiserver/Dockerfile.dev
@@ -27,7 +27,8 @@ WORKDIR /code
 COPY requirements.txt ./requirements.txt
 ADD requirements ./requirements
 
-RUN pip install -r requirements.txt --compile --no-cache-dir
+# Install the local development settings
+RUN pip install -r requirements/local.txt --compile --no-cache-dir
 
 RUN addgroup -S plane && \
     adduser -S captain -G plane

--- a/apiserver/plane/app/views/config.py
+++ b/apiserver/plane/app/views/config.py
@@ -90,8 +90,8 @@ class ConfigurationEndpoint(BaseAPIView):
 
         data = {}
         # Authentication
-        data["google_client_id"] = GOOGLE_CLIENT_ID
-        data["github_client_id"] = GITHUB_CLIENT_ID
+        data["google_client_id"] = GOOGLE_CLIENT_ID if GOOGLE_CLIENT_ID else None
+        data["github_client_id"] = GITHUB_CLIENT_ID if GITHUB_CLIENT_ID else None
         data["github_app_name"] = GITHUB_APP_NAME
         data["magic_login"] = (
             bool(EMAIL_HOST_USER) and bool(EMAIL_HOST_PASSWORD)

--- a/apiserver/plane/app/views/oauth.py
+++ b/apiserver/plane/app/views/oauth.py
@@ -86,7 +86,14 @@ def get_access_token(request_token: str, client_id: str) -> str:
     if not request_token:
         raise ValueError("The request token has to be supplied!")
 
-    CLIENT_SECRET = os.environ.get("GITHUB_CLIENT_SECRET")
+    (CLIENT_SECRET,) = get_configuration_value(
+        [
+            {
+                "key": "GITHUB_CLIENT_SECRET",
+                "default": os.environ.get("GITHUB_CLIENT_SECRET", None),
+            },
+        ]
+    )
 
     url = f"https://github.com/login/oauth/access_token?client_id={client_id}&client_secret={CLIENT_SECRET}&code={request_token}"
     headers = {"accept": "application/json"}
@@ -299,7 +306,7 @@ class OauthEndpoint(BaseAPIView):
             return Response(data, status=status.HTTP_200_OK)
 
         except User.DoesNotExist:
-            ENABLE_SIGNUP, = get_configuration_value(
+            (ENABLE_SIGNUP,) = get_configuration_value(
                 [
                     {
                         "key": "ENABLE_SIGNUP",

--- a/apiserver/plane/app/views/user.py
+++ b/apiserver/plane/app/views/user.py
@@ -49,6 +49,10 @@ class UserEndpoint(BaseViewSet):
         # Check all workspace user is active
         user = self.get_object()
 
+        # Instance admin check
+        if InstanceAdmin.objects.filter(user=user).exists():
+            return Response({"error": "You cannot deactivate your account since you are an instance admin"}, status=status.HTTP_400_BAD_REQUEST)
+
         projects_to_deactivate = []
         workspaces_to_deactivate = []
 

--- a/apiserver/plane/license/api/views/instance.py
+++ b/apiserver/plane/license/api/views/instance.py
@@ -221,37 +221,6 @@ class InstanceAdminSignInEndpoint(BaseAPIView):
                 is_password_autoset=False,
             )
 
-        # if the current user is not using captain then add the current all users to workspace and projects
-        if user.email != "captain@plane.so":
-            # Add the current user also as a workspace member and project memeber to all the workspaces and projects
-            captain = User.objects.filter(email="captain@plane.so")
-            # Workspace members
-            workspace_members = WorkspaceMember.objects.filter(member=captain)
-            WorkspaceMember.objects.bulk_create(
-                [
-                    WorkspaceMember(
-                        workspace=member.workspace_id,
-                        member=user,
-                        role=member.role,
-                    )
-                    for member in workspace_members
-                ],
-                batch_size=100,
-            )
-            # project members
-            project_members = ProjectMember.objects.filter(member=captain)
-            ProjectMember.objects.bulk_create(
-                [
-                    ProjectMember(
-                        workspace=member.workspace_id,
-                        member=user,
-                        role=member.role,
-                    )
-                    for member in project_members
-                ],
-                batch_size=100,
-            )
-
         # settings last active for the user
         user.is_active = True
         user.last_active = timezone.now()


### PR DESCRIPTION
- user cannot deactivate himself if he is an instance admin and the only admin for the instance.
- remove logic for auto assigning of user to workspace and project if the email is different from `captain@plane.so`.