### PR TITLE
[FED-1116] bug: cycle and module change not working from the peek overview 

### DIFF
--- a/web/components/issues/peek-overview/properties.tsx
+++ b/web/components/issues/peek-overview/properties.tsx
@@ -48,10 +48,11 @@ export const PeekOverviewProperties: FC<IPeekOverviewProperties> = observer((pro
   const {
     user: { currentProjectRole },
     issueDetail: { fetchPeekIssueDetails },
+    project: { getProjectById },
   } = useMobxStore();
 
   const router = useRouter();
-  const { workspaceSlug, projectId } = router.query as { workspaceSlug: string; projectId: string };
+  const { workspaceSlug, projectId } = router.query;
 
   const { setToastAlert } = useToast();
 
@@ -138,7 +139,7 @@ export const PeekOverviewProperties: FC<IPeekOverviewProperties> = observer((pro
   const handleCycleOrModuleChange = async () => {
     if (!workspaceSlug || !projectId) return;
 
-    await fetchPeekIssueDetails(workspaceSlug, projectId, issue.id);
+    await fetchPeekIssueDetails(workspaceSlug.toString(), projectId.toString(), issue.id);
   };
 
   const handleEditLink = (link: ILinkDetails) => {
@@ -166,6 +167,9 @@ export const PeekOverviewProperties: FC<IPeekOverviewProperties> = observer((pro
         console.log(err);
       });
   };
+
+  const projectDetails = workspaceSlug ? getProjectById(workspaceSlug.toString(), issue.project) : null;
+  const isEstimateEnabled = projectDetails?.estimate;
 
   const minDate = issue.start_date ? new Date(issue.start_date) : null;
   minDate?.setDate(minDate.getDate());
@@ -230,19 +234,21 @@ export const PeekOverviewProperties: FC<IPeekOverviewProperties> = observer((pro
           </div>
 
           {/* estimate */}
-          <div className="flex items-center gap-2 w-full">
-            <div className="flex items-center gap-2 w-40 text-sm flex-shrink-0">
-              <Triangle className="h-4 w-4 flex-shrink-0 " />
-              <p>Estimate</p>
+          {isEstimateEnabled && (
+            <div className="flex items-center gap-2 w-full">
+              <div className="flex items-center gap-2 w-40 text-sm flex-shrink-0">
+                <Triangle className="h-4 w-4 flex-shrink-0 " />
+                <p>Estimate</p>
+              </div>
+              <div>
+                <SidebarEstimateSelect
+                  value={issue.estimate_point}
+                  onChange={handleEstimate}
+                  disabled={disableUserActions}
+                />
+              </div>
             </div>
-            <div>
-              <SidebarEstimateSelect
-                value={issue.estimate_point}
-                onChange={handleEstimate}
-                disabled={disableUserActions}
-              />
-            </div>
-          </div>
+          )}
 
           {/* start date */}
           <div className="flex items-center gap-2 w-full">

--- a/web/store/issues/project-issues/cycle/issue.store.ts
+++ b/web/store/issues/project-issues/cycle/issue.store.ts
@@ -5,7 +5,7 @@ import { IssueBaseStore } from "store/issues";
 import { IssueService } from "services/issue";
 import { CycleService } from "services/cycle.service";
 // types
-import { CycleIssueResponse, TIssueGroupByOptions } from "types";
+import { TIssueGroupByOptions } from "types";
 import { IIssue } from "types/issues";
 import { IIssueResponse, TLoader, IGroupedIssues, ISubGroupedIssues, TUnGroupedIssues, ViewFlags } from "../../types";
 import { RootStore } from "store/root";
@@ -82,9 +82,6 @@ export class CycleIssuesStore extends IssueBaseStore implements ICycleIssuesStor
   // service
   cycleService;
   issueService;
-
-  //projectId
-  currentProjectId: string | undefined;
 
   //viewData
   viewFlags = {
@@ -173,8 +170,6 @@ export class CycleIssuesStore extends IssueBaseStore implements ICycleIssuesStor
 
     try {
       this.loader = loadType;
-
-      this.currentProjectId = projectId;
 
       const params = this.rootStore?.cycleIssuesFilter?.appliedFilters;
       const response = await this.cycleService.getCycleIssuesWithParams(workspaceSlug, projectId, cycleId, params);
@@ -322,9 +317,10 @@ export class CycleIssuesStore extends IssueBaseStore implements ICycleIssuesStor
     fetchAfterAddition = true,
     projectId?: string
   ) => {
-    if (!this.currentProjectId && !projectId) return;
+    const activeProjectId = this.rootStore.project.projectId;
+    if (!activeProjectId && !projectId) return;
 
-    const projectIdToUpdate: string = this.currentProjectId || projectId || "";
+    const projectIdToUpdate: string = projectId || activeProjectId || "";
 
     try {
       const issueToCycle = await this.issueService.addIssueToCycle(workspaceSlug, projectIdToUpdate, cycleId, {

--- a/web/store/issues/project-issues/module/issue.store.ts
+++ b/web/store/issues/project-issues/module/issue.store.ts
@@ -76,8 +76,6 @@ export class ModuleIssuesStore extends IssueBaseStore implements IModuleIssuesSt
   moduleService;
   issueService;
 
-  currentProjectId: string | undefined;
-
   //viewData
   viewFlags = {
     enableQuickAdd: true,
@@ -162,7 +160,6 @@ export class ModuleIssuesStore extends IssueBaseStore implements IModuleIssuesSt
   ) => {
     if (!moduleId) return undefined;
 
-    this.currentProjectId = projectId;
     try {
       this.loader = loadType;
 
@@ -314,9 +311,10 @@ export class ModuleIssuesStore extends IssueBaseStore implements IModuleIssuesSt
     fetchAfterAddition = true,
     projectId?: string
   ) => {
-    if (!this.currentProjectId && !projectId) return;
+    const activeProjectId = this.rootStore.project.projectId;
+    if (!activeProjectId && !projectId) return;
 
-    const projectIdToUpdate: string = this.currentProjectId || projectId || "";
+    const projectIdToUpdate: string = projectId || activeProjectId || "";
 
     try {
       const issueToModule = await this.moduleService.addIssuesToModule(workspaceSlug, projectIdToUpdate, moduleId, {


### PR DESCRIPTION
#### Problem:

1. Unable to update cycle and module of an issue from the peek overview.
2. Estimates field is displayed in the peek overview even if it is disabled for the project.

#### Solution:

1. Updated the cycle and module store logic to add/update cycle and module of an issue.
2. Conditionally render the estimates field.