### PR TITLE
[FIX] Editor making multiple `Patch` calls on editing text

### DIFF
--- a/web/components/issues/description-form.tsx
+++ b/web/components/issues/description-form.tsx
@@ -100,9 +100,13 @@ export const IssueDescriptionForm: FC<IssueDetailsProps> = (props) => {
     });
   }, [issue, reset]);
 
-  const debouncedFormSave = debounce(async () => {
-    handleSubmit(handleDescriptionFormSubmit)().finally(() => setIsSubmitting("submitted"));
-  }, 1500);
+  // ADDING handleDescriptionFormSubmit TO DEPENDENCY ARRAY PRODUCES ADVERSE EFFECTS
+  const debouncedFormSave = useCallback(
+    debounce(async () => {
+      handleSubmit(handleDescriptionFormSubmit)().finally(() => setIsSubmitting("submitted"));
+    }, 1500),
+    [handleSubmit]
+  );
 
   return (
     <div className="relative">

--- a/web/components/issues/peek-overview/issue-detail.tsx
+++ b/web/components/issues/peek-overview/issue-detail.tsx
@@ -94,9 +94,13 @@ export const PeekOverviewIssueDetails: FC<IPeekOverviewIssueDetails> = (props) =
     }
   }, [issue.id, issue.description_html, issue.name]);
 
-  const debouncedFormSave = debounce(async () => {
-    handleSubmit(handleDescriptionFormSubmit)().finally(() => setIsSubmitting("submitted"));
-  }, 1500);
+  // ADDING handleDescriptionFormSubmit TO DEPENDENCY ARRAY PRODUCES ADVERSE EFFECTS
+  const debouncedFormSave = useCallback(
+    debounce(async () => {
+      handleSubmit(handleDescriptionFormSubmit)().finally(() => setIsSubmitting("submitted"));
+    }, 1500),
+    [handleSubmit]
+  );
 
   useEffect(() => {
     if (isSubmitting === "submitted") {

--- a/web/pages/[workspaceSlug]/projects/[projectId]/pages/[pageId].tsx
+++ b/web/pages/[workspaceSlug]/projects/[projectId]/pages/[pageId].tsx
@@ -326,6 +326,7 @@ const PageDetailsPage: NextPageWithLayout = observer(() => {
     description_html: "",
   });
 
+  // ADDING updatePage TO DEPENDENCY ARRAY PRODUCES ADVERSE EFFECTS
   const debouncedFormSave = useCallback(
     debounce(async () => {
       handleSubmit(updatePage)().finally(() => setIsSubmitting("submitted"));

--- a/web/pages/[workspaceSlug]/projects/[projectId]/pages/[pageId].tsx
+++ b/web/pages/[workspaceSlug]/projects/[projectId]/pages/[pageId].tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState, ReactElement } from "react";
+import React, { useEffect, useRef, useState, ReactElement, useCallback } from "react";
 import { useRouter } from "next/router";
 import useSWR, { MutatorOptions } from "swr";
 import { Controller, useForm } from "react-hook-form";
@@ -59,7 +59,7 @@ const PageDetailsPage: NextPageWithLayout = observer(() => {
 
   const { user } = useUser();
 
-  const { handleSubmit, reset, setValue, watch, getValues, control } = useForm<IPage>({
+  const { handleSubmit, setValue, watch, getValues, control } = useForm<IPage>({
     defaultValues: { name: "", description_html: "" },
   });
 
@@ -326,9 +326,12 @@ const PageDetailsPage: NextPageWithLayout = observer(() => {
     description_html: "",
   });
 
-  const debouncedFormSave = debounce(async () => {
-    handleSubmit(updatePage)().finally(() => setIsSubmitting("submitted"));
-  }, 1500);
+  const debouncedFormSave = useCallback(
+    debounce(async () => {
+      handleSubmit(updatePage)().finally(() => setIsSubmitting("submitted"));
+    }, 1500),
+    [handleSubmit]
+  );
 
   if (error)
     return (


### PR DESCRIPTION
## Broken Behaviour 

https://github.com/makeplane/plane/assets/72302948/24d1edf0-b6b0-4dcc-a4ee-e02721803142

### Solution Description
Added a useCallback function, which helps keeping only one version of the debounce function, what happens is that when we type in the editor, the rerenders produces multiple debounce function, which all triggers together after the specifier amount of time, making many request to backend, consiquently failing the debounce. Now useCallback will give only one function even if the rerenders are happening which fixes the issue

## Fixed Behaviour 

https://github.com/makeplane/plane/assets/72302948/0cacc611-238d-4622-90ff-bf76ddc73139

