### PR TITLE
chore: error handling for user permission while issue drag & drop

### DIFF
--- a/web/components/issues/issue-layouts/calendar/roots/cycle-root.tsx
+++ b/web/components/issues/issue-layouts/calendar/roots/cycle-root.tsx
@@ -41,9 +41,9 @@ export const CycleCalendarLayout: React.FC = observer(() => {
     },
   };
 
-  const handleDragDrop = (source: any, destination: any, issues: IIssue[], issueWithIds: any) => {
+  const handleDragDrop = async (source: any, destination: any, issues: IIssue[], issueWithIds: any) => {
     if (workspaceSlug && projectId && cycleId)
-      handleCalenderDragDrop(
+      await handleCalenderDragDrop(
         source,
         destination,
         workspaceSlug.toString(),

--- a/web/components/issues/issue-layouts/calendar/roots/module-root.tsx
+++ b/web/components/issues/issue-layouts/calendar/roots/module-root.tsx
@@ -38,8 +38,8 @@ export const ModuleCalendarLayout: React.FC = observer(() => {
     },
   };
 
-  const handleDragDrop = (source: any, destination: any, issues: IIssue[], issueWithIds: any) => {
-    handleCalenderDragDrop(
+  const handleDragDrop = async (source: any, destination: any, issues: IIssue[], issueWithIds: any) => {
+    await handleCalenderDragDrop(
       source,
       destination,
       workspaceSlug,

--- a/web/components/issues/issue-layouts/calendar/roots/project-root.tsx
+++ b/web/components/issues/issue-layouts/calendar/roots/project-root.tsx
@@ -31,9 +31,9 @@ export const CalendarLayout: React.FC = observer(() => {
     },
   };
 
-  const handleDragDrop = (source: any, destination: any, issues: IIssue[], issueWithIds: any) => {
+  const handleDragDrop = async (source: any, destination: any, issues: IIssue[], issueWithIds: any) => {
     if (workspaceSlug && projectId)
-      handleCalenderDragDrop(
+      await handleCalenderDragDrop(
         source,
         destination,
         workspaceSlug.toString(),

--- a/web/components/issues/issue-layouts/calendar/roots/project-view-root.tsx
+++ b/web/components/issues/issue-layouts/calendar/roots/project-view-root.tsx
@@ -32,9 +32,9 @@ export const ProjectViewCalendarLayout: React.FC = observer(() => {
     },
   };
 
-  const handleDragDrop = (source: any, destination: any, issues: IIssue[], issueWithIds: any) => {
+  const handleDragDrop = async (source: any, destination: any, issues: IIssue[], issueWithIds: any) => {
     if (workspaceSlug && projectId)
-      handleCalenderDragDrop(
+      await handleCalenderDragDrop(
         source,
         destination,
         workspaceSlug.toString(),

--- a/web/components/issues/issue-layouts/gantt/quick-add-issue-form.tsx
+++ b/web/components/issues/issue-layouts/gantt/quick-add-issue-form.tsx
@@ -121,8 +121,9 @@ export const GanttInlineCreateIssueForm: React.FC<Props> = observer((props) => {
     });
 
     try {
-      quickAddCallback && quickAddCallback(workspaceSlug, projectId, payload, viewId);
-
+      if (quickAddCallback) {
+        await quickAddCallback(workspaceSlug, projectId, payload, viewId);
+      }
       setToastAlert({
         type: "success",
         title: "Success!",

--- a/web/components/issues/issue-layouts/kanban/base-kanban-root.tsx
+++ b/web/components/issues/issue-layouts/kanban/base-kanban-root.tsx
@@ -147,7 +147,7 @@ export const BaseKanBanRoot: React.FC<IBaseKanBanLayout> = observer((props: IBas
     setIsDragStarted(true);
   };
 
-  const onDragEnd = (result: DropResult) => {
+  const onDragEnd = async (result: DropResult) => {
     setIsDragStarted(false);
 
     if (!result) return;
@@ -171,7 +171,15 @@ export const BaseKanBanRoot: React.FC<IBaseKanBanLayout> = observer((props: IBas
         });
         setDeleteIssueModal(true);
       } else {
-        handleDragDrop(result.source, result.destination, sub_group_by, group_by, issues, issueIds);
+        await handleDragDrop(result.source, result.destination, sub_group_by, group_by, issues, issueIds).catch(
+          (err) => {
+            setToastAlert({
+              title: "Error",
+              type: "error",
+              message: err.detail ?? "Failed to perform this action",
+            });
+          }
+        );
       }
     }
   };

--- a/web/store/issues/base-issue-calendar-helper.store.ts
+++ b/web/store/issues/base-issue-calendar-helper.store.ts
@@ -45,8 +45,8 @@ export class CalendarHelpers implements ICalendarHelpers {
           target_date: destinationColumnId,
         };
 
-        if (viewId) store?.updateIssue(workspaceSlug, projectId, updateIssue.id, updateIssue, viewId);
-        else store?.updateIssue(workspaceSlug, projectId, updateIssue.id, updateIssue);
+        if (viewId) return await store?.updateIssue(workspaceSlug, projectId, updateIssue.id, updateIssue, viewId);
+        else return await store?.updateIssue(workspaceSlug, projectId, updateIssue.id, updateIssue);
       }
     }
   };


### PR DESCRIPTION
### This PR includes error handling for user permission while issue drag & drop:

1. Calendar layout drag & drop for **GUEST/VIEWER** roles, not showing failed toast.
2. Kanban layout drag & drop for **GUEST/VIEWER** roles, not showing failed toast.