### PR TITLE
fix: oauth configuration check

### DIFF
--- a/apiserver/plane/app/views/oauth.py
+++ b/apiserver/plane/app/views/oauth.py
@@ -167,12 +167,6 @@ class OauthEndpoint(BaseAPIView):
                 ]
             )
 
-            if not GOOGLE_CLIENT_ID or not GITHUB_CLIENT_ID:
-                return Response(
-                    {"error": "Github or Google login is not configured"},
-                    status=status.HTTP_400_BAD_REQUEST,
-                )
-
             if not medium or not id_token:
                 return Response(
                     {


### PR DESCRIPTION
- oauth configuration check at medium level instead of global level so even if one is configured it should not throw error.