### PR TITLE
fix: disable label combining for labels inside a group

### DIFF
--- a/web/components/labels/project-setting-label-group.tsx
+++ b/web/components/labels/project-setting-label-group.tsx
@@ -77,7 +77,6 @@ export const ProjectSettingLabelGroup: React.FC<Props> = observer((props) => {
           <Droppable
             key={`label.group.droppable.${label.id}`}
             droppableId={`label.group.droppable.${label.id}`}
-            isCombineEnabled={!groupDragSnapshot.isDragging && !isUpdating}
             isDropDisabled={groupDragSnapshot.isDragging || isUpdating || isDropDisabled}
           >
             {(droppableProvided) => (

--- a/web/components/labels/project-setting-label-list.tsx
+++ b/web/components/labels/project-setting-label-list.tsx
@@ -10,11 +10,17 @@ import {
   DropResult,
   Droppable,
 } from "@hello-pangea/dnd";
-
 // store
 import { useMobxStore } from "lib/mobx/store-provider";
+// hooks
+import useDraggableInPortal from "hooks/use-draggable-portal";
 // components
-import { CreateUpdateLabelInline, DeleteLabelModal, ProjectSettingLabelGroup } from "components/labels";
+import {
+  CreateUpdateLabelInline,
+  DeleteLabelModal,
+  ProjectSettingLabelGroup,
+  ProjectSettingLabelItem,
+} from "components/labels";
 // ui
 import { Button, Loader } from "@plane/ui";
 import { EmptyState } from "components/common";
@@ -22,9 +28,6 @@ import { EmptyState } from "components/common";
 import emptyLabel from "public/empty-state/label.svg";
 // types
 import { IIssueLabel } from "types";
-//component
-import { ProjectSettingLabelItem } from "./project-setting-label-item";
-import useDraggableInPortal from "hooks/use-draggable-portal";
 
 const LABELS_ROOT = "labels.root";
 
@@ -137,7 +140,7 @@ export const ProjectSettingsLabelList: React.FC = observer(() => {
                 isDropDisabled={isUpdating}
               >
                 {(droppableProvided, droppableSnapshot) => (
-                  <div className={`mt-3`} ref={droppableProvided.innerRef} {...droppableProvided.droppableProps}>
+                  <div className="mt-3" ref={droppableProvided.innerRef} {...droppableProvided.droppableProps}>
                     {projectLabelsTree.map((label, index) => {
                       if (label.children && label.children.length) {
                         return (


### PR DESCRIPTION
#### Problems:

1. Dropping a label into a child label made the dragged label disappear.

#### Solutions:

1. Disabled combining labels inside a group.

#### Media:

Before fix:

https://github.com/makeplane/plane/assets/65252264/5e7a7601-8f89-4dca-b872-0b07f0b214db

After fix:

https://github.com/makeplane/plane/assets/65252264/769ec15f-ef98-4c5c-aff7-7cb0eedfdf84