### PR TITLE
chore: set an expiry of 30 days for the access and refresh tokens

### DIFF
--- a/web/services/api.service.ts
+++ b/web/services/api.service.ts
@@ -10,7 +10,7 @@ export abstract class APIService {
   }
 
   setRefreshToken(token: string) {
-    Cookies.set("refreshToken", token);
+    Cookies.set("refreshToken", token, { expires: 30 });
   }
 
   getRefreshToken() {
@@ -22,7 +22,7 @@ export abstract class APIService {
   }
 
   setAccessToken(token: string) {
-    Cookies.set("accessToken", token);
+    Cookies.set("accessToken", token, { expires: 30 });
   }
 
   getAccessToken() {


### PR DESCRIPTION
#### Problem:

1. Access and refresh tokens getting removed from the cookies on closing the browser.

#### Solution:

1. Set an expiry of 30 days for the tokens while setting them.