### PR TITLE
[FED-1185] fix: analytics modal's size not changing when switching between modes

### DIFF
--- a/web/components/analytics/project-modal/modal.tsx
+++ b/web/components/analytics/project-modal/modal.tsx
@@ -27,18 +27,17 @@ export const ProjectAnalyticsModal: React.FC<Props> = observer((props) => {
   return (
     <Transition.Root appear show={isOpen} as={React.Fragment}>
       <Dialog as="div" className="relative z-20" onClose={handleClose}>
-        <div className="fixed inset-0 z-20 h-full w-full overflow-y-auto">
-          <Transition.Child
-            as={React.Fragment}
-            enter="transition-transform duration-300"
-            enterFrom="translate-x-full"
-            enterTo="translate-x-0"
-            leave="transition-transform duration-200"
-            leaveFrom="translate-x-0"
-            leaveTo="translate-x-full"
-          >
-            {/* TODO: fix full screen mode */}
-            <Dialog.Panel
+        <Transition.Child
+          as={React.Fragment}
+          enter="transition-transform duration-300"
+          enterFrom="translate-x-full"
+          enterTo="translate-x-0"
+          leave="transition-transform duration-200"
+          leaveFrom="translate-x-0"
+          leaveTo="translate-x-full"
+        >
+          <Dialog.Panel className="fixed inset-0 z-20 h-full w-full overflow-y-auto">
+            <div
               className={`fixed right-0 top-0 z-20 h-full bg-custom-background-100 shadow-custom-shadow-md ${
                 fullScreen ? "w-full p-2" : "w-1/2"
               }`}
@@ -61,9 +60,9 @@ export const ProjectAnalyticsModal: React.FC<Props> = observer((props) => {
                   projectDetails={projectDetails}
                 />
               </div>
-            </Dialog.Panel>
-          </Transition.Child>
-        </div>
+            </div>
+          </Dialog.Panel>
+        </Transition.Child>
       </Dialog>
     </Transition.Root>
   );


### PR DESCRIPTION
#### Problem:

1. Analytics modal's size not changing when switching from full screen to side peek mode.

#### Solution:

1. Moved the size logic from `headlessui`'s `Dialog.Panel` to the `div` tag.

#### Media:

Before fix-

https://github.com/makeplane/plane/assets/65252264/63111c9a-81c8-488d-b27c-6f52d283b2db

****

After fix-

https://github.com/makeplane/plane/assets/65252264/ef108b9d-83c6-461c-b31d-a91ee0bc2d03

