### PR TITLE
fix: debug tool bar import

### DIFF
--- a/apiserver/plane/urls.py
+++ b/apiserver/plane/urls.py
@@ -19,8 +19,11 @@ urlpatterns = [
 
 
 if settings.DEBUG:
-    import debug_toolbar
+    try:
+        import debug_toolbar
 
-    urlpatterns = [
-        re_path(r"^__debug__/", include(debug_toolbar.urls)),
-    ] + urlpatterns
+        urlpatterns = [
+            re_path(r"^__debug__/", include(debug_toolbar.urls)),
+        ] + urlpatterns
+    except ImportError:
+        pass


### PR DESCRIPTION
fix: debug toolbar import error when running in production settings with `DEBUG=1`