### PR TITLE
feat: workspace and project members endpoint

### DIFF
--- a/apiserver/plane/app/serializers/__init__.py
+++ b/apiserver/plane/app/serializers/__init__.py
@@ -31,6 +31,7 @@ from .project import (
     ProjectDeployBoardSerializer,
     ProjectMemberAdminSerializer,
     ProjectPublicMemberSerializer,
+    ProjectMemberRoleSerializer,
 )
 from .state import StateSerializer, StateLiteSerializer
 from .view import GlobalViewSerializer, IssueViewSerializer, IssueViewFavoriteSerializer

--- a/apiserver/plane/app/serializers/project.py
+++ b/apiserver/plane/app/serializers/project.py
@@ -159,6 +159,11 @@ class ProjectMemberAdminSerializer(BaseSerializer):
         model = ProjectMember
         fields = "__all__"
 
+class ProjectMemberRoleSerializer(DynamicBaseSerializer):
+
+    class Meta:
+        model = ProjectMember
+        fields = ("id", "role", "member", "project")
 
 class ProjectMemberInviteSerializer(BaseSerializer):
     project = ProjectLiteSerializer(read_only=True)

--- a/apiserver/plane/app/serializers/workspace.py
+++ b/apiserver/plane/app/serializers/workspace.py
@@ -2,7 +2,7 @@
 from rest_framework import serializers
 
 # Module imports
-from .base import BaseSerializer
+from .base import BaseSerializer, DynamicBaseSerializer
 from .user import UserLiteSerializer, UserAdminLiteSerializer
 
 from plane.db.models import (
@@ -62,7 +62,7 @@ class WorkspaceLiteSerializer(BaseSerializer):
 
 
 
-class WorkSpaceMemberSerializer(BaseSerializer):
+class WorkSpaceMemberSerializer(DynamicBaseSerializer):
     member = UserLiteSerializer(read_only=True)
     workspace = WorkspaceLiteSerializer(read_only=True)
 
@@ -78,7 +78,7 @@ class WorkspaceMemberMeSerializer(BaseSerializer):
         fields = "__all__"
 
 
-class WorkspaceMemberAdminSerializer(BaseSerializer):
+class WorkspaceMemberAdminSerializer(DynamicBaseSerializer):
     member = UserAdminLiteSerializer(read_only=True)
     workspace = WorkspaceLiteSerializer(read_only=True)
 

--- a/apiserver/plane/app/urls/workspace.py
+++ b/apiserver/plane/app/urls/workspace.py
@@ -18,6 +18,7 @@ from plane.app.views import (
     WorkspaceUserProfileEndpoint,
     WorkspaceUserProfileIssuesEndpoint,
     WorkspaceLabelsEndpoint,
+    WorkspaceProjectMemberEndpoint,
 )
 
 
@@ -91,6 +92,11 @@ urlpatterns = [
         "workspaces/<str:slug>/members/",
         WorkSpaceMemberViewSet.as_view({"get": "list"}),
         name="workspace-member",
+    ),
+    path(
+        "workspaces/<str:slug>/project-members/",
+        WorkspaceProjectMemberEndpoint.as_view(),
+        name="workspace-member-roles",
     ),
     path(
         "workspaces/<str:slug>/members/<uuid:pk>/",

--- a/apiserver/plane/app/views/__init__.py
+++ b/apiserver/plane/app/views/__init__.py
@@ -45,6 +45,7 @@ from .workspace import (
     WorkspaceUserProfileEndpoint,
     WorkspaceUserProfileIssuesEndpoint,
     WorkspaceLabelsEndpoint,
+    WorkspaceProjectMemberEndpoint
 )
 from .state import StateViewSet
 from .view import (

--- a/apiserver/plane/app/views/project.py
+++ b/apiserver/plane/app/views/project.py
@@ -36,6 +36,7 @@ from plane.app.serializers import (
     ProjectFavoriteSerializer,
     ProjectDeployBoardSerializer,
     ProjectMemberAdminSerializer,
+    ProjectMemberRoleSerializer,
 )
 
 from plane.app.permissions import (
@@ -681,13 +682,7 @@ class ProjectMemberViewSet(BaseViewSet):
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 
     def list(self, request, slug, project_id):
-        project_member = ProjectMember.objects.get(
-            member=request.user,
-            workspace__slug=slug,
-            project_id=project_id,
-            is_active=True,
-        )
-
+        # Get the list of project members for the project
         project_members = ProjectMember.objects.filter(
             project_id=project_id,
             workspace__slug=slug,
@@ -695,10 +690,7 @@ class ProjectMemberViewSet(BaseViewSet):
             is_active=True,
         ).select_related("project", "member", "workspace")
 
-        if project_member.role > 10:
-            serializer = ProjectMemberAdminSerializer(project_members, many=True)
-        else:
-            serializer = ProjectMemberSerializer(project_members, many=True)
+        serializer = ProjectMemberRoleSerializer(project_members, fields=("id", "member", "role"), many=True)
         return Response(serializer.data, status=status.HTTP_200_OK)
 
     def partial_update(self, request, slug, project_id, pk):


### PR DESCRIPTION
- Updated the workspace member endpoint payload by modifying the ID, member details, and roles.
- Adjusted the project member list endpoint payload to include member IDs, user IDs, and roles.
- Additionally, introduced a new endpoint to retrieve all projects associated with a user's membership.