### PR TITLE
chore: update self hosted sign in form cta in the web and space apps

### DIFF
--- a/space/components/accounts/sign-in-forms/self-hosted-sign-in.tsx
+++ b/space/components/accounts/sign-in-forms/self-hosted-sign-in.tsx
@@ -130,7 +130,7 @@ export const SelfHostedSignInForm: React.FC<Props> = (props) => {
           />
         </div>
         <Button type="submit" variant="primary" className="w-full" size="xl" loading={isSubmitting}>
-          Go to board
+          Continue
         </Button>
         <p className="text-xs text-onboarding-text-200">
           When you click the button above, you agree with our{" "}

--- a/web/components/account/sign-in-forms/self-hosted-sign-in.tsx
+++ b/web/components/account/sign-in-forms/self-hosted-sign-in.tsx
@@ -130,7 +130,7 @@ export const SelfHostedSignInForm: React.FC<Props> = (props) => {
           />
         </div>
         <Button type="submit" variant="primary" className="w-full" size="xl" loading={isSubmitting}>
-          Go to workspace
+          Continue
         </Button>
         <p className="text-xs text-onboarding-text-200">
           When you click the button above, you agree with our{" "}


### PR DESCRIPTION
#### Problem:

1. Self-hosted instances' sign in form button text.

#### Solution:

1. Updated the button text to `Continue`.