### PR TITLE
Fix .vertical-lr in Firefox

### DIFF
--- a/web/styles/globals.css
+++ b/web/styles/globals.css
@@ -420,6 +420,7 @@ body {
 .vertical-lr {
   -webkit-writing-mode: vertical-lr;
   -ms-writing-mode: vertical-lr;
+  writing-mode: vertical-lr;
 }
 
 div.web-view-spinner {


### PR DESCRIPTION
Firefox doesn't support prefixed versions of `writing-mode`:

<img width="231" alt="image" src="https://github.com/makeplane/plane/assets/1298948/c2d045ff-d4b9-4304-b304-00710b34ad07">

We can add an unprefixed version though. This way it does work as intended:

<img width="231" alt="image" src="https://github.com/makeplane/plane/assets/1298948/8ef1bbc3-3a85-42de-85fa-73865435231b">
