### PR TITLE
fix: create issue modal project deselecting

### DIFF
--- a/web/components/issues/form.tsx
+++ b/web/components/issues/form.tsx
@@ -227,6 +227,7 @@ export const IssueForm: FC<IssueFormProps> = observer((props) => {
     reset({
       ...defaultValues,
       ...initialData,
+      project: projectId,
     });
   }, [setFocus, initialData, reset]);
 


### PR DESCRIPTION
**Problem:**

- In the create issue modal, the project is getting selected & deselected in a second.

**Solution:**

- updated the `project ID` of form values in useEffect.