### PR TITLE
fix: remove get requests from the catch block

### DIFF
--- a/web/constants/swr-config.ts
+++ b/web/constants/swr-config.ts
@@ -1,0 +1,5 @@
+export const SWR_CONFIG = {
+  refreshWhenHidden: false,
+  revalidateIfStale: false,
+  errorRetryCount: 3,
+};

--- a/web/lib/app-provider.tsx
+++ b/web/lib/app-provider.tsx
@@ -12,6 +12,9 @@ import { THEMES } from "constants/themes";
 import InstanceLayout from "layouts/instance-layout";
 // contexts
 import { ToastContextProvider } from "contexts/toast.context";
+import { SWRConfig } from "swr";
+// constants
+import { SWR_CONFIG } from "constants/swr-config";
 // dynamic imports
 const StoreWrapper = dynamic(() => import("lib/wrappers/store-wrapper"), { ssr: false });
 const PosthogWrapper = dynamic(() => import("lib/wrappers/posthog-wrapper"), { ssr: false });
@@ -48,7 +51,7 @@ export const AppProvider: FC<IAppProvider> = observer((props) => {
                 posthogAPIKey={envConfig?.posthog_api_key || null}
                 posthogHost={envConfig?.posthog_host || null}
               >
-                {children}
+                <SWRConfig value={SWR_CONFIG}>{children}</SWRConfig>
               </PosthogWrapper>
             </CrispWrapper>
           </StoreWrapper>

--- a/web/store/issues/project-issues/cycle/filter.store.ts
+++ b/web/store/issues/project-issues/cycle/filter.store.ts
@@ -215,7 +215,7 @@ export class CycleIssuesFilterStore extends IssueFilterBaseStore implements ICyc
       await this.fetchCycleFilters(workspaceSlug, projectId, cycleId);
       return;
     } catch (error) {
-      this.fetchFilters(workspaceSlug, projectId, cycleId);
+      console.log("error in cycleFetchFilters", error);
       throw error;
     }
   };

--- a/web/store/issues/project-issues/cycle/filter.store.ts
+++ b/web/store/issues/project-issues/cycle/filter.store.ts
@@ -170,7 +170,7 @@ export class CycleIssuesFilterStore extends IssueFilterBaseStore implements ICyc
 
       return filters;
     } catch (error) {
-      this.fetchFilters(workspaceSlug, projectId, cycleId);
+      console.log("error in fetchCycleFilters", error);
       throw error;
     }
   };

--- a/web/store/issues/project-issues/module/filter.store.ts
+++ b/web/store/issues/project-issues/module/filter.store.ts
@@ -216,7 +216,7 @@ export class ModuleIssuesFilterStore extends IssueFilterBaseStore implements IMo
       await this.fetchModuleFilters(workspaceSlug, projectId, moduleId);
       return;
     } catch (error) {
-      this.fetchFilters(workspaceSlug, projectId, moduleId);
+      console.log("error in projectFetchFilters", error);
       throw error;
     }
   };

--- a/web/store/issues/project-issues/module/filter.store.ts
+++ b/web/store/issues/project-issues/module/filter.store.ts
@@ -170,7 +170,7 @@ export class ModuleIssuesFilterStore extends IssueFilterBaseStore implements IMo
 
       return filters;
     } catch (error) {
-      this.fetchFilters(workspaceSlug, projectId, moduleId);
+      console.log("error in moduleFetchFilters", error);
       throw error;
     }
   };

--- a/web/store/issues/project-issues/project-view/filter.store.ts
+++ b/web/store/issues/project-issues/project-view/filter.store.ts
@@ -170,7 +170,7 @@ export class ViewIssuesFilterStore extends IssueFilterBaseStore implements IView
 
       return filters;
     } catch (error) {
-      this.fetchFilters(workspaceSlug, projectId, viewId);
+      console.log("error in viewFetchFilters", error);
       throw error;
     }
   };

--- a/web/store/issues/project-issues/project-view/filter.store.ts
+++ b/web/store/issues/project-issues/project-view/filter.store.ts
@@ -216,7 +216,7 @@ export class ViewIssuesFilterStore extends IssueFilterBaseStore implements IView
       await this.fetchViewFilters(workspaceSlug, projectId, viewId);
       return;
     } catch (error) {
-      this.fetchFilters(workspaceSlug, projectId, viewId);
+      console.log("error in viewFetchFilters", error);
       throw error;
     }
   };


### PR DESCRIPTION
#### Problem:

1. Hitting `GET` requests in the catch blocks resulting in an infinite loop of API calls.

#### Solution:

1. Remove all the `GET` requests from the catch blocks.

#### Other improvements:

1. Added global SWRConfig with the following options-
    - `refreshWhenHidden: false`
    - `revalidateIfStale: false`
    - `errorRetryCount: 3`