### PR TITLE
chore: disable API calls for un-authorized users

### DIFF
--- a/web/components/core/modals/bulk-delete-issues-modal.tsx
+++ b/web/components/core/modals/bulk-delete-issues-modal.tsx
@@ -1,14 +1,14 @@
 import React, { useState } from "react";
 import { useRouter } from "next/router";
-import useSWR from "swr";
-// react hook form
+import { observer } from "mobx-react-lite";
 import { SubmitHandler, useForm } from "react-hook-form";
-// headless ui
 import { Combobox, Dialog, Transition } from "@headlessui/react";
+import useSWR from "swr";
+// hooks
+import { useMobxStore } from "lib/mobx/store-provider";
+import useToast from "hooks/use-toast";
 // services
 import { IssueService } from "services/issue";
-// hooks
-import useToast from "hooks/use-toast";
 // ui
 import { Button, LayersIcon } from "@plane/ui";
 // icons
@@ -17,8 +17,6 @@ import { Search } from "lucide-react";
 import { IUser, IIssue } from "types";
 // fetch keys
 import { PROJECT_ISSUES_LIST } from "constants/fetch-keys";
-import { observer } from "mobx-react-lite";
-import { useMobxStore } from "lib/mobx/store-provider";
 
 type FormInput = {
   delete_issue_ids: string[];

--- a/web/components/core/modals/bulk-delete-issues-modal.tsx
+++ b/web/components/core/modals/bulk-delete-issues-modal.tsx
@@ -17,6 +17,8 @@ import { Search } from "lucide-react";
 import { IUser, IIssue } from "types";
 // fetch keys
 import { PROJECT_ISSUES_LIST } from "constants/fetch-keys";
+import { observer } from "mobx-react-lite";
+import { useMobxStore } from "lib/mobx/store-provider";
 
 type FormInput = {
   delete_issue_ids: string[];
@@ -30,17 +32,25 @@ type Props = {
 
 const issueService = new IssueService();
 
-export const BulkDeleteIssuesModal: React.FC<Props> = (props) => {
+export const BulkDeleteIssuesModal: React.FC<Props> = observer((props) => {
   const { isOpen, onClose } = props;
+  // states
+  const [query, setQuery] = useState("");
   // router
   const router = useRouter();
   const { workspaceSlug, projectId } = router.query;
-  // states
-  const [query, setQuery] = useState("");
+  // store hooks
+  const {
+    user: { hasPermissionToCurrentProject },
+  } = useMobxStore();
   // fetching project issues.
   const { data: issues } = useSWR(
-    workspaceSlug && projectId ? PROJECT_ISSUES_LIST(workspaceSlug as string, projectId as string) : null,
-    workspaceSlug && projectId ? () => issueService.getIssues(workspaceSlug as string, projectId as string) : null
+    workspaceSlug && projectId && hasPermissionToCurrentProject
+      ? PROJECT_ISSUES_LIST(workspaceSlug.toString(), projectId.toString())
+      : null,
+    workspaceSlug && projectId && hasPermissionToCurrentProject
+      ? () => issueService.getIssues(workspaceSlug.toString(), projectId.toString())
+      : null
   );
 
   const { setToastAlert } = useToast();
@@ -222,4 +232,4 @@ export const BulkDeleteIssuesModal: React.FC<Props> = (props) => {
       </Dialog>
     </Transition.Root>
   );
-};
+});

--- a/web/components/issues/issue-layouts/roots/archived-issue-layout-root.tsx
+++ b/web/components/issues/issue-layouts/roots/archived-issue-layout-root.tsx
@@ -9,19 +9,25 @@ import { ArchivedIssueListLayout, ArchivedIssueAppliedFiltersRoot } from "compon
 
 export const ArchivedIssueLayoutRoot: React.FC = observer(() => {
   const router = useRouter();
-  const { workspaceSlug, projectId } = router.query as { workspaceSlug: string; projectId: string };
+  const { workspaceSlug, projectId } = router.query;
 
   const {
+    user: { hasPermissionToCurrentProject },
     projectArchivedIssues: { getIssues, fetchIssues },
     projectArchivedIssuesFilter: { fetchFilters },
   } = useMobxStore();
 
-  useSWR(workspaceSlug && projectId ? `ARCHIVED_FILTERS_AND_ISSUES_${projectId.toString()}` : null, async () => {
-    if (workspaceSlug && projectId) {
-      await fetchFilters(workspaceSlug, projectId);
-      await fetchIssues(workspaceSlug, projectId, getIssues ? "mutation" : "init-loader");
+  useSWR(
+    workspaceSlug && projectId && hasPermissionToCurrentProject
+      ? `ARCHIVED_FILTERS_AND_ISSUES_${projectId.toString()}`
+      : null,
+    async () => {
+      if (workspaceSlug && projectId && hasPermissionToCurrentProject) {
+        await fetchFilters(workspaceSlug.toString(), projectId.toString());
+        await fetchIssues(workspaceSlug.toString(), projectId.toString(), getIssues ? "mutation" : "init-loader");
+      }
     }
-  });
+  );
 
   return (
     <div className="relative flex h-full w-full flex-col overflow-hidden">

--- a/web/components/issues/issue-layouts/roots/archived-issue-layout-root.tsx
+++ b/web/components/issues/issue-layouts/roots/archived-issue-layout-root.tsx
@@ -12,22 +12,16 @@ export const ArchivedIssueLayoutRoot: React.FC = observer(() => {
   const { workspaceSlug, projectId } = router.query;
 
   const {
-    user: { hasPermissionToCurrentProject },
     projectArchivedIssues: { getIssues, fetchIssues },
     projectArchivedIssuesFilter: { fetchFilters },
   } = useMobxStore();
 
-  useSWR(
-    workspaceSlug && projectId && hasPermissionToCurrentProject
-      ? `ARCHIVED_FILTERS_AND_ISSUES_${projectId.toString()}`
-      : null,
-    async () => {
-      if (workspaceSlug && projectId && hasPermissionToCurrentProject) {
-        await fetchFilters(workspaceSlug.toString(), projectId.toString());
-        await fetchIssues(workspaceSlug.toString(), projectId.toString(), getIssues ? "mutation" : "init-loader");
-      }
+  useSWR(workspaceSlug && projectId ? `ARCHIVED_FILTERS_AND_ISSUES_${projectId.toString()}` : null, async () => {
+    if (workspaceSlug && projectId) {
+      await fetchFilters(workspaceSlug.toString(), projectId.toString());
+      await fetchIssues(workspaceSlug.toString(), projectId.toString(), getIssues ? "mutation" : "init-loader");
     }
-  );
+  });
 
   return (
     <div className="relative flex h-full w-full flex-col overflow-hidden">

--- a/web/components/issues/issue-layouts/roots/cycle-layout-root.tsx
+++ b/web/components/issues/issue-layouts/roots/cycle-layout-root.tsx
@@ -24,24 +24,28 @@ export const CycleLayoutRoot: React.FC = observer(() => {
   const [transferIssuesModal, setTransferIssuesModal] = useState(false);
 
   const router = useRouter();
-  const { workspaceSlug, projectId, cycleId } = router.query as {
-    workspaceSlug: string;
-    projectId: string;
-    cycleId: string;
-  };
+  const { workspaceSlug, projectId, cycleId } = router.query;
 
   const {
+    user: { hasPermissionToCurrentProject },
     cycle: cycleStore,
     cycleIssues: { loader, getIssues, fetchIssues },
     cycleIssuesFilter: { issueFilters, fetchFilters },
   } = useMobxStore();
 
   useSWR(
-    workspaceSlug && projectId && cycleId ? `CYCLE_ISSUES_V3_${workspaceSlug}_${projectId}_${cycleId}` : null,
+    workspaceSlug && projectId && hasPermissionToCurrentProject && cycleId
+      ? `CYCLE_ISSUES_V3_${workspaceSlug}_${projectId}_${cycleId}`
+      : null,
     async () => {
-      if (workspaceSlug && projectId && cycleId) {
-        await fetchFilters(workspaceSlug, projectId, cycleId);
-        await fetchIssues(workspaceSlug, projectId, getIssues ? "mutation" : "init-loader", cycleId);
+      if (workspaceSlug && projectId && hasPermissionToCurrentProject && cycleId) {
+        await fetchFilters(workspaceSlug.toString(), projectId.toString(), cycleId.toString());
+        await fetchIssues(
+          workspaceSlug.toString(),
+          projectId.toString(),
+          getIssues ? "mutation" : "init-loader",
+          cycleId.toString()
+        );
       }
     }
   );
@@ -69,7 +73,11 @@ export const CycleLayoutRoot: React.FC = observer(() => {
         ) : (
           <>
             {Object.keys(getIssues ?? {}).length == 0 ? (
-              <CycleEmptyState workspaceSlug={workspaceSlug} projectId={projectId} cycleId={cycleId} />
+              <CycleEmptyState
+                workspaceSlug={workspaceSlug?.toString()}
+                projectId={projectId?.toString()}
+                cycleId={cycleId?.toString()}
+              />
             ) : (
               <div className="h-full w-full overflow-auto">
                 {activeLayout === "list" ? (

--- a/web/components/issues/issue-layouts/roots/cycle-layout-root.tsx
+++ b/web/components/issues/issue-layouts/roots/cycle-layout-root.tsx
@@ -27,18 +27,15 @@ export const CycleLayoutRoot: React.FC = observer(() => {
   const { workspaceSlug, projectId, cycleId } = router.query;
 
   const {
-    user: { hasPermissionToCurrentProject },
     cycle: cycleStore,
     cycleIssues: { loader, getIssues, fetchIssues },
     cycleIssuesFilter: { issueFilters, fetchFilters },
   } = useMobxStore();
 
   useSWR(
-    workspaceSlug && projectId && hasPermissionToCurrentProject && cycleId
-      ? `CYCLE_ISSUES_V3_${workspaceSlug}_${projectId}_${cycleId}`
-      : null,
+    workspaceSlug && projectId && cycleId ? `CYCLE_ISSUES_V3_${workspaceSlug}_${projectId}_${cycleId}` : null,
     async () => {
-      if (workspaceSlug && projectId && hasPermissionToCurrentProject && cycleId) {
+      if (workspaceSlug && projectId && cycleId) {
         await fetchFilters(workspaceSlug.toString(), projectId.toString(), cycleId.toString());
         await fetchIssues(
           workspaceSlug.toString(),

--- a/web/components/issues/issue-layouts/roots/draft-issue-layout-root.tsx
+++ b/web/components/issues/issue-layouts/roots/draft-issue-layout-root.tsx
@@ -14,22 +14,16 @@ export const DraftIssueLayoutRoot: React.FC = observer(() => {
   const { workspaceSlug, projectId } = router.query;
 
   const {
-    user: { hasPermissionToCurrentProject },
     projectDraftIssuesFilter: { issueFilters, fetchFilters },
     projectDraftIssues: { loader, getIssues, fetchIssues },
   } = useMobxStore();
 
-  useSWR(
-    workspaceSlug && projectId && hasPermissionToCurrentProject
-      ? `DRAFT_FILTERS_AND_ISSUES_${projectId.toString()}`
-      : null,
-    async () => {
-      if (workspaceSlug && projectId && hasPermissionToCurrentProject) {
-        await fetchFilters(workspaceSlug.toString(), projectId.toString());
-        await fetchIssues(workspaceSlug.toString(), projectId.toString(), getIssues ? "mutation" : "init-loader");
-      }
+  useSWR(workspaceSlug && projectId ? `DRAFT_FILTERS_AND_ISSUES_${projectId.toString()}` : null, async () => {
+    if (workspaceSlug && projectId) {
+      await fetchFilters(workspaceSlug.toString(), projectId.toString());
+      await fetchIssues(workspaceSlug.toString(), projectId.toString(), getIssues ? "mutation" : "init-loader");
     }
-  );
+  });
 
   const activeLayout = issueFilters?.displayFilters?.layout || undefined;
 

--- a/web/components/issues/issue-layouts/roots/draft-issue-layout-root.tsx
+++ b/web/components/issues/issue-layouts/roots/draft-issue-layout-root.tsx
@@ -11,19 +11,25 @@ import { DraftKanBanLayout } from "../kanban/roots/draft-issue-root";
 
 export const DraftIssueLayoutRoot: React.FC = observer(() => {
   const router = useRouter();
-  const { workspaceSlug, projectId } = router.query as { workspaceSlug: string; projectId: string };
+  const { workspaceSlug, projectId } = router.query;
 
   const {
+    user: { hasPermissionToCurrentProject },
     projectDraftIssuesFilter: { issueFilters, fetchFilters },
     projectDraftIssues: { loader, getIssues, fetchIssues },
   } = useMobxStore();
 
-  useSWR(workspaceSlug && projectId ? `DRAFT_FILTERS_AND_ISSUES_${projectId.toString()}` : null, async () => {
-    if (workspaceSlug && projectId) {
-      await fetchFilters(workspaceSlug, projectId);
-      await fetchIssues(workspaceSlug, projectId, getIssues ? "mutation" : "init-loader");
+  useSWR(
+    workspaceSlug && projectId && hasPermissionToCurrentProject
+      ? `DRAFT_FILTERS_AND_ISSUES_${projectId.toString()}`
+      : null,
+    async () => {
+      if (workspaceSlug && projectId && hasPermissionToCurrentProject) {
+        await fetchFilters(workspaceSlug.toString(), projectId.toString());
+        await fetchIssues(workspaceSlug.toString(), projectId.toString(), getIssues ? "mutation" : "init-loader");
+      }
     }
-  });
+  );
 
   const activeLayout = issueFilters?.displayFilters?.layout || undefined;
 

--- a/web/components/issues/issue-layouts/roots/module-layout-root.tsx
+++ b/web/components/issues/issue-layouts/roots/module-layout-root.tsx
@@ -23,17 +23,14 @@ export const ModuleLayoutRoot: React.FC = observer(() => {
   const { workspaceSlug, projectId, moduleId } = router.query;
 
   const {
-    user: { hasPermissionToCurrentProject },
     moduleIssues: { loader, getIssues, fetchIssues },
     moduleIssuesFilter: { issueFilters, fetchFilters },
   } = useMobxStore();
 
   useSWR(
-    workspaceSlug && projectId && hasPermissionToCurrentProject && moduleId
-      ? `MODULE_ISSUES_V3_${workspaceSlug}_${projectId}_${moduleId}`
-      : null,
+    workspaceSlug && projectId && moduleId ? `MODULE_ISSUES_V3_${workspaceSlug}_${projectId}_${moduleId}` : null,
     async () => {
-      if (workspaceSlug && projectId && hasPermissionToCurrentProject && moduleId) {
+      if (workspaceSlug && projectId && moduleId) {
         await fetchFilters(workspaceSlug.toString(), projectId.toString(), moduleId.toString());
         await fetchIssues(
           workspaceSlug.toString(),

--- a/web/components/issues/issue-layouts/roots/module-layout-root.tsx
+++ b/web/components/issues/issue-layouts/roots/module-layout-root.tsx
@@ -20,23 +20,27 @@ import { Spinner } from "@plane/ui";
 
 export const ModuleLayoutRoot: React.FC = observer(() => {
   const router = useRouter();
-  const { workspaceSlug, projectId, moduleId } = router.query as {
-    workspaceSlug: string;
-    projectId: string;
-    moduleId: string;
-  };
+  const { workspaceSlug, projectId, moduleId } = router.query;
 
   const {
+    user: { hasPermissionToCurrentProject },
     moduleIssues: { loader, getIssues, fetchIssues },
     moduleIssuesFilter: { issueFilters, fetchFilters },
   } = useMobxStore();
 
   useSWR(
-    workspaceSlug && projectId && moduleId ? `MODULE_ISSUES_V3_${workspaceSlug}_${projectId}_${moduleId}` : null,
+    workspaceSlug && projectId && hasPermissionToCurrentProject && moduleId
+      ? `MODULE_ISSUES_V3_${workspaceSlug}_${projectId}_${moduleId}`
+      : null,
     async () => {
-      if (workspaceSlug && projectId && moduleId) {
-        await fetchFilters(workspaceSlug, projectId, moduleId);
-        await fetchIssues(workspaceSlug, projectId, getIssues ? "mutation" : "init-loader", moduleId);
+      if (workspaceSlug && projectId && hasPermissionToCurrentProject && moduleId) {
+        await fetchFilters(workspaceSlug.toString(), projectId.toString(), moduleId.toString());
+        await fetchIssues(
+          workspaceSlug.toString(),
+          projectId.toString(),
+          getIssues ? "mutation" : "init-loader",
+          moduleId.toString()
+        );
       }
     }
   );
@@ -54,7 +58,11 @@ export const ModuleLayoutRoot: React.FC = observer(() => {
       ) : (
         <>
           {Object.keys(getIssues ?? {}).length == 0 ? (
-            <ModuleEmptyState workspaceSlug={workspaceSlug} projectId={projectId} moduleId={moduleId} />
+            <ModuleEmptyState
+              workspaceSlug={workspaceSlug?.toString()}
+              projectId={projectId?.toString()}
+              moduleId={moduleId?.toString()}
+            />
           ) : (
             <div className="h-full w-full overflow-auto">
               {activeLayout === "list" ? (

--- a/web/components/issues/issue-layouts/roots/project-layout-root.tsx
+++ b/web/components/issues/issue-layouts/roots/project-layout-root.tsx
@@ -22,22 +22,16 @@ export const ProjectLayoutRoot: React.FC = observer(() => {
   const { workspaceSlug, projectId } = router.query;
 
   const {
-    user: { hasPermissionToCurrentProject },
     projectIssues: { loader, getIssues, fetchIssues },
     projectIssuesFilter: { issueFilters, fetchFilters },
   } = useMobxStore();
 
-  useSWR(
-    workspaceSlug && projectId && hasPermissionToCurrentProject
-      ? `PROJECT_ISSUES_V3_${workspaceSlug}_${projectId}`
-      : null,
-    async () => {
-      if (workspaceSlug && projectId && hasPermissionToCurrentProject) {
-        await fetchFilters(workspaceSlug.toString(), projectId.toString());
-        await fetchIssues(workspaceSlug.toString(), projectId.toString(), getIssues ? "mutation" : "init-loader");
-      }
+  useSWR(workspaceSlug && projectId ? `PROJECT_ISSUES_V3_${workspaceSlug}_${projectId}` : null, async () => {
+    if (workspaceSlug && projectId) {
+      await fetchFilters(workspaceSlug.toString(), projectId.toString());
+      await fetchIssues(workspaceSlug.toString(), projectId.toString(), getIssues ? "mutation" : "init-loader");
     }
-  );
+  });
 
   const activeLayout = issueFilters?.displayFilters?.layout;
 

--- a/web/components/issues/issue-layouts/roots/project-layout-root.tsx
+++ b/web/components/issues/issue-layouts/roots/project-layout-root.tsx
@@ -19,19 +19,25 @@ import { Spinner } from "@plane/ui";
 export const ProjectLayoutRoot: React.FC = observer(() => {
   // router
   const router = useRouter();
-  const { workspaceSlug, projectId } = router.query as { workspaceSlug: string; projectId: string };
+  const { workspaceSlug, projectId } = router.query;
 
   const {
+    user: { hasPermissionToCurrentProject },
     projectIssues: { loader, getIssues, fetchIssues },
     projectIssuesFilter: { issueFilters, fetchFilters },
   } = useMobxStore();
 
-  useSWR(workspaceSlug && projectId ? `PROJECT_ISSUES_V3_${workspaceSlug}_${projectId}` : null, async () => {
-    if (workspaceSlug && projectId) {
-      await fetchFilters(workspaceSlug, projectId);
-      await fetchIssues(workspaceSlug, projectId, getIssues ? "mutation" : "init-loader");
+  useSWR(
+    workspaceSlug && projectId && hasPermissionToCurrentProject
+      ? `PROJECT_ISSUES_V3_${workspaceSlug}_${projectId}`
+      : null,
+    async () => {
+      if (workspaceSlug && projectId && hasPermissionToCurrentProject) {
+        await fetchFilters(workspaceSlug.toString(), projectId.toString());
+        await fetchIssues(workspaceSlug.toString(), projectId.toString(), getIssues ? "mutation" : "init-loader");
+      }
     }
-  });
+  );
 
   const activeLayout = issueFilters?.displayFilters?.layout;
 

--- a/web/components/issues/issue-layouts/roots/project-view-layout-root.tsx
+++ b/web/components/issues/issue-layouts/roots/project-view-layout-root.tsx
@@ -21,22 +21,16 @@ export const ProjectViewLayoutRoot: React.FC = observer(() => {
   const { workspaceSlug, projectId, viewId } = router.query;
 
   const {
-    user: { hasPermissionToCurrentProject },
     viewIssues: { loader, getIssues, fetchIssues },
     viewIssuesFilter: { issueFilters, fetchFilters },
   } = useMobxStore();
 
-  useSWR(
-    workspaceSlug && projectId && hasPermissionToCurrentProject && viewId
-      ? `PROJECT_ISSUES_V3_${workspaceSlug}_${projectId}`
-      : null,
-    async () => {
-      if (workspaceSlug && projectId && hasPermissionToCurrentProject && viewId) {
-        await fetchFilters(workspaceSlug.toString(), projectId.toString(), viewId.toString());
-        await fetchIssues(workspaceSlug.toString(), projectId.toString(), getIssues ? "mutation" : "init-loader");
-      }
+  useSWR(workspaceSlug && projectId && viewId ? `PROJECT_ISSUES_V3_${workspaceSlug}_${projectId}` : null, async () => {
+    if (workspaceSlug && projectId && viewId) {
+      await fetchFilters(workspaceSlug.toString(), projectId.toString(), viewId.toString());
+      await fetchIssues(workspaceSlug.toString(), projectId.toString(), getIssues ? "mutation" : "init-loader");
     }
-  );
+  });
 
   const activeLayout = issueFilters?.displayFilters?.layout;
 

--- a/web/components/issues/issue-layouts/roots/project-view-layout-root.tsx
+++ b/web/components/issues/issue-layouts/roots/project-view-layout-root.tsx
@@ -18,23 +18,25 @@ import { Spinner } from "@plane/ui";
 
 export const ProjectViewLayoutRoot: React.FC = observer(() => {
   const router = useRouter();
-  const { workspaceSlug, projectId, viewId } = router.query as {
-    workspaceSlug: string;
-    projectId: string;
-    viewId?: string;
-  };
+  const { workspaceSlug, projectId, viewId } = router.query;
 
   const {
+    user: { hasPermissionToCurrentProject },
     viewIssues: { loader, getIssues, fetchIssues },
     viewIssuesFilter: { issueFilters, fetchFilters },
   } = useMobxStore();
 
-  useSWR(workspaceSlug && projectId && viewId ? `PROJECT_ISSUES_V3_${workspaceSlug}_${projectId}` : null, async () => {
-    if (workspaceSlug && projectId && viewId) {
-      await fetchFilters(workspaceSlug, projectId, viewId);
-      await fetchIssues(workspaceSlug, projectId, getIssues ? "mutation" : "init-loader");
+  useSWR(
+    workspaceSlug && projectId && hasPermissionToCurrentProject && viewId
+      ? `PROJECT_ISSUES_V3_${workspaceSlug}_${projectId}`
+      : null,
+    async () => {
+      if (workspaceSlug && projectId && hasPermissionToCurrentProject && viewId) {
+        await fetchFilters(workspaceSlug.toString(), projectId.toString(), viewId.toString());
+        await fetchIssues(workspaceSlug.toString(), projectId.toString(), getIssues ? "mutation" : "init-loader");
+      }
     }
-  });
+  );
 
   const activeLayout = issueFilters?.displayFilters?.layout;
 

--- a/web/layouts/auth-layout/project-wrapper.tsx
+++ b/web/layouts/auth-layout/project-wrapper.tsx
@@ -19,7 +19,7 @@ export const ProjectAuthWrapper: FC<IProjectAuthWrapper> = observer((props) => {
   const { children } = props;
   // store
   const {
-    user: { fetchUserProjectInfo, projectMemberInfo, hasPermissionToProject },
+    user: { fetchUserProjectInfo, projectMemberInfo, hasPermissionToCurrentProject },
     project: { fetchProjectDetails, workspaceProjects },
     projectLabel: { fetchProjectLabels },
     projectMember: { fetchProjectMembers },
@@ -35,6 +35,8 @@ export const ProjectAuthWrapper: FC<IProjectAuthWrapper> = observer((props) => {
   const router = useRouter();
   const { workspaceSlug, projectId } = router.query;
 
+  console.log("hasPermissionToCurrentProject", hasPermissionToCurrentProject);
+
   // fetching project details
   useSWR(
     workspaceSlug && projectId ? `PROJECT_DETAILS_${workspaceSlug.toString()}_${projectId.toString()}` : null,
@@ -47,44 +49,67 @@ export const ProjectAuthWrapper: FC<IProjectAuthWrapper> = observer((props) => {
   );
   // fetching project labels
   useSWR(
-    workspaceSlug && projectId ? `PROJECT_LABELS_${workspaceSlug}_${projectId}` : null,
-    workspaceSlug && projectId ? () => fetchProjectLabels(workspaceSlug.toString(), projectId.toString()) : null
+    workspaceSlug && projectId && hasPermissionToCurrentProject ? `PROJECT_LABELS_${workspaceSlug}_${projectId}` : null,
+    workspaceSlug && projectId && hasPermissionToCurrentProject
+      ? () => fetchProjectLabels(workspaceSlug.toString(), projectId.toString())
+      : null
   );
   // fetching project members
   useSWR(
-    workspaceSlug && projectId ? `PROJECT_MEMBERS_${workspaceSlug}_${projectId}` : null,
-    workspaceSlug && projectId ? () => fetchProjectMembers(workspaceSlug.toString(), projectId.toString()) : null
+    workspaceSlug && projectId && hasPermissionToCurrentProject
+      ? `PROJECT_MEMBERS_${workspaceSlug}_${projectId}`
+      : null,
+    workspaceSlug && projectId && hasPermissionToCurrentProject
+      ? () => fetchProjectMembers(workspaceSlug.toString(), projectId.toString())
+      : null
   );
   // fetching project states
   useSWR(
-    workspaceSlug && projectId ? `PROJECT_STATES_${workspaceSlug}_${projectId}` : null,
-    workspaceSlug && projectId ? () => fetchProjectStates(workspaceSlug.toString(), projectId.toString()) : null
+    workspaceSlug && projectId && hasPermissionToCurrentProject ? `PROJECT_STATES_${workspaceSlug}_${projectId}` : null,
+    workspaceSlug && projectId && hasPermissionToCurrentProject
+      ? () => fetchProjectStates(workspaceSlug.toString(), projectId.toString())
+      : null
   );
   // fetching project estimates
   useSWR(
-    workspaceSlug && projectId ? `PROJECT_ESTIMATES_${workspaceSlug}_${projectId}` : null,
-    workspaceSlug && projectId ? () => fetchProjectEstimates(workspaceSlug.toString(), projectId.toString()) : null
+    workspaceSlug && projectId && hasPermissionToCurrentProject
+      ? `PROJECT_ESTIMATES_${workspaceSlug}_${projectId}`
+      : null,
+    workspaceSlug && projectId && hasPermissionToCurrentProject
+      ? () => fetchProjectEstimates(workspaceSlug.toString(), projectId.toString())
+      : null
   );
   // fetching project cycles
   useSWR(
-    workspaceSlug && projectId ? `PROJECT_ALL_CYCLES_${workspaceSlug}_${projectId}` : null,
-    workspaceSlug && projectId ? () => fetchCycles(workspaceSlug.toString(), projectId.toString(), "all") : null
+    workspaceSlug && projectId && hasPermissionToCurrentProject
+      ? `PROJECT_ALL_CYCLES_${workspaceSlug}_${projectId}`
+      : null,
+    workspaceSlug && projectId && hasPermissionToCurrentProject
+      ? () => fetchCycles(workspaceSlug.toString(), projectId.toString(), "all")
+      : null
   );
   // fetching project modules
   useSWR(
-    workspaceSlug && projectId ? `PROJECT_MODULES_${workspaceSlug}_${projectId}` : null,
-    workspaceSlug && projectId ? () => fetchModules(workspaceSlug.toString(), projectId.toString()) : null
+    workspaceSlug && projectId && hasPermissionToCurrentProject
+      ? `PROJECT_MODULES_${workspaceSlug}_${projectId}`
+      : null,
+    workspaceSlug && projectId && hasPermissionToCurrentProject
+      ? () => fetchModules(workspaceSlug.toString(), projectId.toString())
+      : null
   );
   // fetching project views
   useSWR(
-    workspaceSlug && projectId ? `PROJECT_VIEWS_${workspaceSlug}_${projectId}` : null,
-    workspaceSlug && projectId ? () => fetchAllViews(workspaceSlug.toString(), projectId.toString()) : null
+    workspaceSlug && projectId && hasPermissionToCurrentProject ? `PROJECT_VIEWS_${workspaceSlug}_${projectId}` : null,
+    workspaceSlug && projectId && hasPermissionToCurrentProject
+      ? () => fetchAllViews(workspaceSlug.toString(), projectId.toString())
+      : null
   );
-  // TODO: fetching project pages
   // fetching project inboxes if inbox is enabled
   useSWR(
-    workspaceSlug && projectId && isInboxEnabled ? `PROJECT_INBOXES_${workspaceSlug}_${projectId}` : null,
-    workspaceSlug && projectId && isInboxEnabled
+    workspaceSlug && projectId && hasPermissionToCurrentProject && isInboxEnabled
+      ? `PROJECT_INBOXES_${workspaceSlug}_${projectId}`
+      : null,
+    workspaceSlug && projectId && hasPermissionToCurrentProject && isInboxEnabled
       ? () => fetchInboxesList(workspaceSlug.toString(), projectId.toString())
       : null,
     {
@@ -97,7 +122,7 @@ export const ProjectAuthWrapper: FC<IProjectAuthWrapper> = observer((props) => {
   const projectExists = projectId ? projectsList?.find((project) => project.id === projectId.toString()) : null;
 
   // check if the project member apis is loading
-  if (!projectMemberInfo && projectId && hasPermissionToProject[projectId.toString()] === null)
+  if (!projectMemberInfo && projectId && hasPermissionToCurrentProject === null)
     return (
       <div className="grid h-screen place-items-center bg-custom-background-100 p-4">
         <div className="flex flex-col items-center gap-3 text-center">
@@ -107,10 +132,10 @@ export const ProjectAuthWrapper: FC<IProjectAuthWrapper> = observer((props) => {
     );
 
   // check if the user don't have permission to access the project
-  if (projectExists && projectId && hasPermissionToProject[projectId.toString()] === false) return <JoinProject />;
+  if (projectExists && projectId && hasPermissionToCurrentProject === false) return <JoinProject />;
 
   // check if the project info is not found.
-  if (!projectExists && projectId && hasPermissionToProject[projectId.toString()] === false)
+  if (!projectExists && projectId && hasPermissionToCurrentProject === false)
     return (
       <div className="container grid h-screen place-items-center bg-custom-background-100">
         <EmptyState

--- a/web/layouts/auth-layout/project-wrapper.tsx
+++ b/web/layouts/auth-layout/project-wrapper.tsx
@@ -35,8 +35,6 @@ export const ProjectAuthWrapper: FC<IProjectAuthWrapper> = observer((props) => {
   const router = useRouter();
   const { workspaceSlug, projectId } = router.query;
 
-  console.log("hasPermissionToCurrentProject", hasPermissionToCurrentProject);
-
   // fetching project details
   useSWR(
     workspaceSlug && projectId ? `PROJECT_DETAILS_${workspaceSlug.toString()}_${projectId.toString()}` : null,

--- a/web/layouts/auth-layout/user-wrapper.tsx
+++ b/web/layouts/auth-layout/user-wrapper.tsx
@@ -1,6 +1,7 @@
 import { FC, ReactNode } from "react";
 import { useRouter } from "next/router";
 import useSWR from "swr";
+import useSWRImmutable from "swr/immutable";
 // ui
 import { Spinner } from "@plane/ui";
 // store
@@ -31,7 +32,7 @@ export const UserAuthWrapper: FC<IUserAuthWrapper> = observer((props) => {
     shouldRetryOnError: false,
   });
   // fetching current user instance admin status
-  useSWR("CURRENT_USER_INSTANCE_ADMIN_STATUS", () => fetchCurrentUserInstanceAdminStatus(), {
+  useSWRImmutable("CURRENT_USER_INSTANCE_ADMIN_STATUS", () => fetchCurrentUserInstanceAdminStatus(), {
     shouldRetryOnError: false,
   });
   // fetching user settings

--- a/web/layouts/auth-layout/workspace-wrapper.tsx
+++ b/web/layouts/auth-layout/workspace-wrapper.tsx
@@ -32,23 +32,25 @@ export const WorkspaceAuthWrapper: FC<IWorkspaceAuthWrapper> = observer((props) 
   );
   // fetching workspace projects
   useSWR(
-    workspaceSlug ? `WORKSPACE_PROJECTS_${workspaceSlug}` : null,
-    workspaceSlug ? () => fetchProjects(workspaceSlug.toString()) : null
+    workspaceSlug && hasPermissionToCurrentWorkspace ? `WORKSPACE_PROJECTS_${workspaceSlug}` : null,
+    workspaceSlug && hasPermissionToCurrentWorkspace ? () => fetchProjects(workspaceSlug.toString()) : null
   );
   // fetch workspace members
   useSWR(
-    workspaceSlug ? `WORKSPACE_MEMBERS_${workspaceSlug}` : null,
-    workspaceSlug ? () => fetchWorkspaceMembers(workspaceSlug.toString()) : null
+    workspaceSlug && hasPermissionToCurrentWorkspace ? `WORKSPACE_MEMBERS_${workspaceSlug}` : null,
+    workspaceSlug && hasPermissionToCurrentWorkspace ? () => fetchWorkspaceMembers(workspaceSlug.toString()) : null
   );
   // fetch workspace labels
   useSWR(
-    workspaceSlug ? `WORKSPACE_LABELS_${workspaceSlug}` : null,
-    workspaceSlug ? () => fetchWorkspaceLabels(workspaceSlug.toString()) : null
+    workspaceSlug && hasPermissionToCurrentWorkspace ? `WORKSPACE_LABELS_${workspaceSlug}` : null,
+    workspaceSlug && hasPermissionToCurrentWorkspace ? () => fetchWorkspaceLabels(workspaceSlug.toString()) : null
   );
   // fetch workspace user projects role
   useSWR(
-    workspaceSlug ? `WORKSPACE_PROJECTS_ROLE_${workspaceSlug}` : null,
-    workspaceSlug ? () => fetchWorkspaceUserProjectsRole(workspaceSlug.toString()) : null
+    workspaceSlug && hasPermissionToCurrentWorkspace ? `WORKSPACE_PROJECTS_ROLE_${workspaceSlug}` : null,
+    workspaceSlug && hasPermissionToCurrentWorkspace
+      ? () => fetchWorkspaceUserProjectsRole(workspaceSlug.toString())
+      : null
   );
 
   // while data is being loaded

--- a/web/store/archived-issues/issue.store.ts
+++ b/web/store/archived-issues/issue.store.ts
@@ -87,10 +87,12 @@ export class ArchivedIssueStore implements IArchivedIssueStore {
     autorun(() => {
       const workspaceSlug = this.rootStore.workspace.workspaceSlug;
       const projectId = this.rootStore.project.projectId;
+      const hasPermissionToCurrentProject = this.rootStore.user.hasPermissionToCurrentProject;
 
       if (
         workspaceSlug &&
         projectId &&
+        hasPermissionToCurrentProject &&
         this.rootStore.archivedIssueFilters.userDisplayFilters &&
         this.rootStore.archivedIssueFilters.userFilters
       )

--- a/web/store/cycle/cycle_issue.store.ts
+++ b/web/store/cycle/cycle_issue.store.ts
@@ -89,10 +89,12 @@ export class CycleIssueStore implements ICycleIssueStore {
       const workspaceSlug = this.rootStore.workspace.workspaceSlug;
       const projectId = this.rootStore.project.projectId;
       const cycleId = this.rootStore.cycle.cycleId;
+      const hasPermissionToCurrentProject = this.rootStore.user.hasPermissionToCurrentProject;
 
       if (
         workspaceSlug &&
         projectId &&
+        hasPermissionToCurrentProject &&
         cycleId &&
         this.rootStore.cycleIssueFilter.cycleFilters &&
         this.rootStore.issueFilter.userDisplayFilters
@@ -115,8 +117,8 @@ export class CycleIssueStore implements ICycleIssueStore {
         ? "groupWithSubGroups"
         : "grouped"
       : ungroupedLayouts.includes(issueLayout)
-        ? "ungrouped"
-        : null;
+      ? "ungrouped"
+      : null;
 
     return _issueState || null;
   }

--- a/web/store/issue/issue.store.ts
+++ b/web/store/issue/issue.store.ts
@@ -82,9 +82,11 @@ export class IssueStore implements IIssueStore {
     autorun(() => {
       const workspaceSlug = this.rootStore.workspace.workspaceSlug;
       const projectId = this.rootStore.project.projectId;
+      const hasPermissionToCurrentProject = this.rootStore.user.hasPermissionToCurrentProject;
       if (
         workspaceSlug &&
         projectId &&
+        hasPermissionToCurrentProject &&
         this.rootStore.issueFilter.userFilters &&
         this.rootStore.issueFilter.userDisplayFilters
       )
@@ -108,8 +110,8 @@ export class IssueStore implements IIssueStore {
           : "grouped"
         : "ungrouped"
       : ungroupedLayouts.includes(issueLayout)
-        ? "ungrouped"
-        : null;
+      ? "ungrouped"
+      : null;
 
     return _issueState || null;
   }

--- a/web/store/issues/project-issues/archived/issue.store.ts
+++ b/web/store/issues/project-issues/archived/issue.store.ts
@@ -60,7 +60,8 @@ export class ProjectArchivedIssuesStore extends IssueBaseStore implements IProje
     autorun(() => {
       const workspaceSlug = this.rootStore.workspace.workspaceSlug;
       const projectId = this.rootStore.project.projectId;
-      if (!workspaceSlug || !projectId) return;
+      const hasPermissionToCurrentProject = this.rootStore.user.hasPermissionToCurrentProject;
+      if (!workspaceSlug || !projectId || !hasPermissionToCurrentProject) return;
 
       const userFilters = this.rootStore?.projectArchivedIssuesFilter?.issueFilters?.filters;
       if (userFilters) this.fetchIssues(workspaceSlug, projectId, "mutation");

--- a/web/store/issues/project-issues/cycle/issue.store.ts
+++ b/web/store/issues/project-issues/cycle/issue.store.ts
@@ -119,7 +119,8 @@ export class CycleIssuesStore extends IssueBaseStore implements ICycleIssuesStor
       const workspaceSlug = this.rootStore.workspace.workspaceSlug;
       const projectId = this.rootStore.project.projectId;
       const cycleId = this.rootStore.cycle.cycleId;
-      if (!workspaceSlug || !projectId || !cycleId) return;
+      const hasPermissionToCurrentProject = this.rootStore.user.hasPermissionToCurrentProject;
+      if (!workspaceSlug || !projectId || !hasPermissionToCurrentProject || !cycleId) return;
 
       const userFilters = this.rootStore?.cycleIssuesFilter?.issueFilters?.filters;
       if (userFilters) this.fetchIssues(workspaceSlug, projectId, "mutation", cycleId);

--- a/web/store/issues/project-issues/draft/issue.store.ts
+++ b/web/store/issues/project-issues/draft/issue.store.ts
@@ -63,7 +63,8 @@ export class ProjectDraftIssuesStore extends IssueBaseStore implements IProjectD
     autorun(() => {
       const workspaceSlug = this.rootStore.workspace.workspaceSlug;
       const projectId = this.rootStore.project.projectId;
-      if (!workspaceSlug || !projectId) return;
+      const hasPermissionToCurrentProject = this.rootStore.user.hasPermissionToCurrentProject;
+      if (!workspaceSlug || !projectId || !hasPermissionToCurrentProject) return;
 
       const userFilters = this.rootStore?.projectDraftIssuesFilter?.issueFilters?.filters;
       if (userFilters) this.fetchIssues(workspaceSlug, projectId, "mutation");

--- a/web/store/issues/project-issues/module/issue.store.ts
+++ b/web/store/issues/project-issues/module/issue.store.ts
@@ -111,7 +111,8 @@ export class ModuleIssuesStore extends IssueBaseStore implements IModuleIssuesSt
       const workspaceSlug = this.rootStore.workspace.workspaceSlug;
       const projectId = this.rootStore.project.projectId;
       const moduleId = this.rootStore.module.moduleId;
-      if (!workspaceSlug || !projectId || !moduleId) return;
+      const hasPermissionToCurrentProject = this.rootStore.user.hasPermissionToCurrentProject;
+      if (!workspaceSlug || !projectId || !hasPermissionToCurrentProject || !moduleId) return;
 
       const userFilters = this.rootStore?.moduleIssuesFilter?.issueFilters?.filters;
       if (userFilters) this.fetchIssues(workspaceSlug, projectId, "mutation", moduleId);

--- a/web/store/issues/project-issues/project-view/issue.store.ts
+++ b/web/store/issues/project-issues/project-view/issue.store.ts
@@ -65,7 +65,8 @@ export class ViewIssuesStore extends IssueBaseStore implements IViewIssuesStore 
     autorun(() => {
       const workspaceSlug = this.rootStore.workspace.workspaceSlug;
       const projectId = this.rootStore.project.projectId;
-      if (!workspaceSlug || !projectId) return;
+      const hasPermissionToCurrentProject = this.rootStore.user.hasPermissionToCurrentProject;
+      if (!workspaceSlug || !projectId || !hasPermissionToCurrentProject) return;
 
       const userFilters = this.rootStore?.viewIssuesFilter?.issueFilters?.filters;
       if (userFilters) this.fetchIssues(workspaceSlug, projectId, "mutation");

--- a/web/store/issues/project-issues/project/issue.store.ts
+++ b/web/store/issues/project-issues/project/issue.store.ts
@@ -65,7 +65,8 @@ export class ProjectIssuesStore extends IssueBaseStore implements IProjectIssues
     autorun(() => {
       const workspaceSlug = this.rootStore.workspace.workspaceSlug;
       const projectId = this.rootStore.project.projectId;
-      if (!workspaceSlug || !projectId) return;
+      const hasPermissionToCurrentProject = this.rootStore.user.hasPermissionToCurrentProject;
+      if (!workspaceSlug || !projectId || !hasPermissionToCurrentProject) return;
 
       const userFilters = this.rootStore?.projectIssuesFilter?.issueFilters?.filters;
       if (userFilters) this.fetchIssues(workspaceSlug, projectId, "mutation");

--- a/web/store/module/module_issue.store.ts
+++ b/web/store/module/module_issue.store.ts
@@ -91,10 +91,12 @@ export class ModuleIssueStore implements IModuleIssueStore {
       const workspaceSlug = this.rootStore.workspace.workspaceSlug;
       const projectId = this.rootStore.project.projectId;
       const moduleId = this.rootStore.module.moduleId;
+      const hasPermissionToCurrentProject = this.rootStore.user.hasPermissionToCurrentProject;
 
       if (
         workspaceSlug &&
         projectId &&
+        hasPermissionToCurrentProject &&
         moduleId &&
         this.rootStore.moduleFilter.moduleFilters &&
         this.rootStore.issueFilter.userDisplayFilters
@@ -117,8 +119,8 @@ export class ModuleIssueStore implements IModuleIssueStore {
         ? "groupWithSubGroups"
         : "grouped"
       : ungroupedLayouts.includes(issueLayout)
-        ? "ungrouped"
-        : null;
+      ? "ungrouped"
+      : null;
 
     return _issueState || null;
   }

--- a/web/store/profile-issues/issue_filters.store.ts
+++ b/web/store/profile-issues/issue_filters.store.ts
@@ -68,7 +68,6 @@ export class ProfileIssueFilterStore implements IProfileIssueFilterStore {
         const workspaceSlug = this.rootStore.workspace.workspaceSlug;
         const userId = this.rootStore.profileIssues?.userId;
         if (workspaceSlug && userId && this.rootStore.profileIssues.currentProfileTab && this.appliedFilters) {
-          console.log("autorun triggered");
           this.rootStore.profileIssues.fetchIssues(
             workspaceSlug,
             userId,


### PR DESCRIPTION
#### Problem:

1. If a user doesn't have access to a workspace/project, API calls to fetch workspace/project related data were still being made.

#### Solution:

1. Added `hasPermissionToWorkspace` flag to all the API calls in the workspace wrapper and `autorun` of workspace stores to check for permission before making the request.
2. Added `hasPermissionToProject` flag to all the API calls in the project wrapper and `autorun` of project stores to check for permission before making the request.

#### Other improvements:

1. Removed type declarations for `router.query` at the declaration level.
2. Use `useSWRImmutable` to fetch user's instance admin status, disabling revalidation.