### PR TITLE
chore: link modal validation

### DIFF
--- a/web/components/core/modals/link-modal.tsx
+++ b/web/components/core/modals/link-modal.tsx
@@ -118,6 +118,7 @@ export const LinkModal: FC<Props> = (props) => {
                                 ref={ref}
                                 hasError={Boolean(errors.url)}
                                 placeholder="https://..."
+                                pattern="^(https?://).*"
                                 className="w-full"
                               />
                             )}


### PR DESCRIPTION
### **Problem:**
The current link modal lacks validation for accepted link formats, causing potential issues when handling links entered by users.

### **Solution:**
Implemented validation logic to accept only 'http://' and 'https://' in the link modal.