### PR TITLE
chore: made project-identifier rule consistent

### DIFF
--- a/web/components/project/create-project-modal.tsx
+++ b/web/components/project/create-project-modal.tsx
@@ -308,8 +308,8 @@ export const CreateProjectModal: FC<Props> = observer((props) => {
                               message: "Identifier must at least be of 1 character",
                             },
                             maxLength: {
-                              value: 12,
-                              message: "Identifier must at most be of 12 characters",
+                              value: 6,
+                              message: "Identifier must at most be of 6 characters",
                             },
                           }}
                           render={({ field: { value, onChange } }) => (

--- a/web/components/project/form.tsx
+++ b/web/components/project/form.tsx
@@ -232,7 +232,7 @@ export const ProjectDetailsForm: FC<IProjectDetailsForm> = (props) => {
           />
         </div>
 
-        <div className="flex w-full items-center justify-between gap-10">
+        <div className="flex w-full items-baseline justify-between gap-10">
           <div className="flex w-1/2 flex-col gap-1">
             <h4 className="text-sm">Identifier</h4>
             <Controller
@@ -246,8 +246,8 @@ export const ProjectDetailsForm: FC<IProjectDetailsForm> = (props) => {
                   message: "Identifier must at least be of 1 character",
                 },
                 maxLength: {
-                  value: 12,
-                  message: "Identifier must at most be of 5 characters",
+                  value: 6,
+                  message: "Identifier must at most be of 6 characters",
                 },
               }}
               render={({ field: { value, ref } }) => (
@@ -265,6 +265,7 @@ export const ProjectDetailsForm: FC<IProjectDetailsForm> = (props) => {
                 />
               )}
             />
+            <span className="text-xs text-red-500">{errors?.identifier?.message}</span>
           </div>
 
           <div className="flex w-1/2 flex-col gap-1">


### PR DESCRIPTION
This PR Fixes https://github.com/makeplane/plane/issues/2139

**Problem:**

- Project identifier rules are not consistent in the platform, somewhere shows 12 somewhere 5 characters limit.

**Solution:**

- Made it consistent with at most 6 characters long.

**Before:**

![image](https://github.com/makeplane/plane/assets/94619783/29610438-1ea6-463f-98df-975691fc84eb)

**After:**

![image](https://github.com/makeplane/plane/assets/94619783/0d20708e-ae49-45b3-ab1d-f7a0a2478ee2)

![image](https://github.com/makeplane/plane/assets/94619783/c8f0e9b9-8f09-4872-917f-4126df0f70c4)
