### PR TITLE
chore: add tolltips to properties with no value

### DIFF
--- a/web/components/issues/issue-layouts/properties/date.tsx
+++ b/web/components/issues/issue-layouts/properties/date.tsx
@@ -12,11 +12,11 @@ import { Tooltip } from "@plane/ui";
 // hooks
 import useDynamicDropdownPosition from "hooks/use-dynamic-dropdown";
 // helpers
-import { renderDateFormat } from "helpers/date-time.helper";
+import { renderDateFormat, renderFormattedDate } from "helpers/date-time.helper";
 
 export interface IIssuePropertyDate {
-  value: any;
-  onChange: (date: any) => void;
+  value: string | null;
+  onChange: (date: string | null) => void;
   disabled?: boolean;
   type: "start_date" | "target_date";
 }
@@ -57,33 +57,40 @@ export const IssuePropertyDate: React.FC<IIssuePropertyDate> = observer((props) 
           <>
             <Popover.Button
               as="button"
+              type="button"
               ref={dropdownBtn}
-              className={`flex h-5 w-full items-center rounded border-[0.5px] border-custom-border-300 px-2.5 py-1 outline-none duration-300 ${
-                disabled
-                  ? "pointer-events-none cursor-not-allowed text-custom-text-200"
-                  : "cursor-pointer hover:bg-custom-background-80"
-              }`}
+              className="border-none outline-none"
               onClick={(e) => e.stopPropagation()}
             >
-              <div className="flex items-center justify-center gap-2 overflow-hidden">
-                <dateOptionDetails.icon className="h-3 w-3" strokeWidth={2} />
-                {value && (
-                  <>
-                    <Tooltip tooltipHeading={dateOptionDetails.placeholder} tooltipContent={value ?? "None"}>
-                      <div className="text-xs">{value}</div>
-                    </Tooltip>
-
-                    <div
-                      className="flex flex-shrink-0 items-center justify-center"
-                      onClick={() => {
-                        if (onChange) onChange(null);
-                      }}
-                    >
-                      <X className="h-2.5 w-2.5" strokeWidth={2} />
-                    </div>
-                  </>
-                )}
-              </div>
+              <Tooltip
+                tooltipHeading={dateOptionDetails.placeholder}
+                tooltipContent={value ? renderFormattedDate(value) : "None"}
+              >
+                <div
+                  className={`flex h-5 w-full items-center rounded border-[0.5px] border-custom-border-300 px-2.5 py-1 outline-none duration-300 ${
+                    disabled
+                      ? "pointer-events-none cursor-not-allowed text-custom-text-200"
+                      : "cursor-pointer hover:bg-custom-background-80"
+                  }`}
+                >
+                  <div className="flex items-center justify-center gap-2 overflow-hidden">
+                    <dateOptionDetails.icon className="h-3 w-3" strokeWidth={2} />
+                    {value && (
+                      <>
+                        <div className="text-xs">{value}</div>
+                        <div
+                          className="flex flex-shrink-0 items-center justify-center"
+                          onClick={() => {
+                            if (onChange) onChange(null);
+                          }}
+                        >
+                          <X className="h-2.5 w-2.5" strokeWidth={2} />
+                        </div>
+                      </>
+                    )}
+                  </div>
+                </div>
+              </Tooltip>
             </Popover.Button>
 
             <div className={`${open ? "fixed left-0 top-0 z-20 h-full w-full cursor-auto" : ""}`}>
@@ -94,7 +101,7 @@ export const IssuePropertyDate: React.FC<IIssuePropertyDate> = observer((props) 
                 {({ close }) => (
                   <DatePicker
                     selected={value ? new Date(value) : new Date()}
-                    onChange={(val: any, e) => {
+                    onChange={(val, e) => {
                       e?.stopPropagation();
                       if (onChange && val) {
                         onChange(renderDateFormat(val));

--- a/web/components/issues/issue-layouts/properties/labels.tsx
+++ b/web/components/issues/issue-layouts/properties/labels.tsx
@@ -107,7 +107,7 @@ export const IssuePropertyLabels: React.FC<IIssuePropertyLabels> = observer((pro
             {projectLabels
               ?.filter((l) => value.includes(l.id))
               .map((label) => (
-                <Tooltip position="top" tooltipHeading="Labels" tooltipContent={label.name ?? ""}>
+                <Tooltip position="top" tooltipHeading="Label" tooltipContent={label.name ?? ""}>
                   <div
                     key={label.id}
                     className={`flex overflow-hidden hover:bg-custom-background-80 ${
@@ -145,14 +145,16 @@ export const IssuePropertyLabels: React.FC<IIssuePropertyLabels> = observer((pro
           </div>
         )
       ) : (
-        <div
-          className={`h-full flex items-center justify-center gap-2 rounded px-2.5 py-1 text-xs hover:bg-custom-background-80 ${
-            noLabelBorder ? "" : "border-[0.5px] border-custom-border-300"
-          }`}
-        >
-          <Tags className="h-3.5 w-3.5" strokeWidth={2} />
-          {placeholderText}
-        </div>
+        <Tooltip position="top" tooltipHeading="Labels" tooltipContent="None">
+          <div
+            className={`h-full flex items-center justify-center gap-2 rounded px-2.5 py-1 text-xs hover:bg-custom-background-80 ${
+              noLabelBorder ? "" : "border-[0.5px] border-custom-border-300"
+            }`}
+          >
+            <Tags className="h-3.5 w-3.5" strokeWidth={2} />
+            {placeholderText}
+          </div>
+        </Tooltip>
       )}
     </div>
   );


### PR DESCRIPTION
#### Problem:

1. Tooltip is not visible on issue properties(start date, target date and label) with no value in the list and kanban layouts.

#### Solution:

1. Added tooltips for the empty states of the mentioned issue properties.

#### Media:

Before fix-

https://github.com/makeplane/plane/assets/65252264/70d8e2bc-90d8-455c-8580-0ccaede62bd5

After fix-

https://github.com/makeplane/plane/assets/65252264/3be25cbe-7660-4613-b541-f0ea94465427