### PR TITLE
chore: estimates and issue parent id fixes

### DIFF
--- a/apiserver/plane/app/serializers/estimate.py
+++ b/apiserver/plane/app/serializers/estimate.py
@@ -4,6 +4,7 @@ from .base import BaseSerializer
 from plane.db.models import Estimate, EstimatePoint
 from plane.app.serializers import WorkspaceLiteSerializer, ProjectLiteSerializer
 
+from rest_framework import serializers
 
 class EstimateSerializer(BaseSerializer):
     workspace_detail = WorkspaceLiteSerializer(read_only=True, source="workspace")
@@ -19,6 +20,15 @@ class EstimateSerializer(BaseSerializer):
 
 
 class EstimatePointSerializer(BaseSerializer):
+
+    def validate(self, data):
+        if not data:
+            raise serializers.ValidationError("Estimate points are required")
+        value = data.get("value")
+        if value and len(value) > 20:
+            raise serializers.ValidationError("Value can't be more than 20 characters")
+        return data
+
     class Meta:
         model = EstimatePoint
         fields = "__all__"

--- a/apiserver/plane/app/views/estimate.py
+++ b/apiserver/plane/app/views/estimate.py
@@ -53,11 +53,11 @@ class BulkEstimatePointEndpoint(BaseViewSet):
             )
 
         estimate_points = request.data.get("estimate_points", [])
-
-        if not len(estimate_points) or len(estimate_points) > 8:
+        
+        serializer = EstimatePointSerializer(data=request.data.get("estimate_points"), many=True)
+        if not serializer.is_valid():
             return Response(
-                {"error": "Estimate points are required"},
-                status=status.HTTP_400_BAD_REQUEST,
+                serializer.errors, status=status.HTTP_400_BAD_REQUEST
             )
 
         estimate_serializer = EstimateSerializer(data=request.data.get("estimate"))

--- a/apiserver/plane/app/views/search.py
+++ b/apiserver/plane/app/views/search.py
@@ -50,7 +50,8 @@ class GlobalSearchEndpoint(BaseAPIView):
         q = Q()
         for field in fields:
             if field == "sequence_id":
-                sequences = re.findall(r"\d+\.\d+|\d+", query)
+                # Match whole integers only (exclude decimal numbers)
+                sequences = re.findall(r"\b\d+\b", query)
                 for sequence_id in sequences:
                     q |= Q(**{"sequence_id": sequence_id})
             else:

--- a/apiserver/plane/bgtasks/issue_activites_task.py
+++ b/apiserver/plane/bgtasks/issue_activites_task.py
@@ -112,8 +112,8 @@ def track_parent(
     epoch,
 ):
     if current_instance.get("parent") != requested_data.get("parent"):
-        old_parent = Issue.objects.filter(pk=current_instance.get("parent")).first()
-        new_parent = Issue.objects.filter(pk=requested_data.get("parent")).first()
+        old_parent = Issue.objects.filter(pk=current_instance.get("parent")).first() if current_instance.get("parent") is not None else None
+        new_parent = Issue.objects.filter(pk=requested_data.get("parent")).first() if requested_data.get("parent") is not None else None
 
         issue_activities.append(
             IssueActivity(

--- a/web/components/estimates/create-update-estimate-modal.tsx
+++ b/web/components/estimates/create-update-estimate-modal.tsx
@@ -130,6 +130,22 @@ export const CreateUpdateEstimateModal: React.FC<Props> = observer((props) => {
     }
 
     if (
+      formData.value1.length > 20 ||
+      formData.value2.length > 20 ||
+      formData.value3.length > 20 ||
+      formData.value4.length > 20 ||
+      formData.value5.length > 20 ||
+      formData.value6.length > 20
+    ) {
+      setToastAlert({
+        type: "error",
+        title: "Error!",
+        message: "Estimate point cannot have more than 20 characters.",
+      });
+      return;
+    }
+
+    if (
       checkDuplicates([
         formData.value1,
         formData.value2,
@@ -269,6 +285,12 @@ export const CreateUpdateEstimateModal: React.FC<Props> = observer((props) => {
                                   <Controller
                                     control={control}
                                     name={`value${i + 1}` as keyof FormValues}
+                                    rules={{
+                                      maxLength: {
+                                        value: 20,
+                                        message: "Estimate point must at most be of 20 characters",
+                                      },
+                                    }}
                                     render={({ field: { value, onChange, ref } }) => (
                                       <Input
                                         ref={ref}
@@ -299,8 +321,8 @@ export const CreateUpdateEstimateModal: React.FC<Props> = observer((props) => {
                             ? "Updating Estimate..."
                             : "Update Estimate"
                           : isSubmitting
-                            ? "Creating Estimate..."
-                            : "Create Estimate"}
+                          ? "Creating Estimate..."
+                          : "Create Estimate"}
                       </Button>
                     </div>
                   </form>


### PR DESCRIPTION
This PR resolves the following issues:

**Backend:**

- Implemented a validation for estimate points, limiting the value to a maximum of 20 characters.
- Enforced that the sequence ID accepts only whole numbers, excluding decimals (in the search endpoint).
- Included a validation to verify the issue's parent ID.

**Frontend:**

- Added validation while creating/updating estimates, if estimate point characters are more than 20 characters, then toast will be shown with this message:  `Estimate point cannot have more than 20 characters.`