### PR TITLE
fix: bugs & improvements

### DIFF
--- a/web/components/profile/sidebar.tsx
+++ b/web/components/profile/sidebar.tsx
@@ -89,8 +89,8 @@ export const ProfileSidebar = () => {
                   className="h-full w-full rounded object-cover"
                 />
               ) : (
-                <div className="flex h-[52px] w-[52px] items-center justify-center rounded bg-custom-background-90 text-custom-text-100">
-                  {userProjectsData.user_data.display_name?.[0]}
+                <div className="flex h-[52px] w-[52px] items-center justify-center rounded bg-custom-background-90 text-custom-text-100 capitalize">
+                  {userProjectsData.user_data.first_name?.[0]}
                 </div>
               )}
             </div>
@@ -149,8 +149,8 @@ export const ProfileSidebar = () => {
                                     completedIssuePercentage <= 35
                                       ? "bg-red-500/10 text-red-500"
                                       : completedIssuePercentage <= 70
-                                        ? "bg-yellow-500/10 text-yellow-500"
-                                        : "bg-green-500/10 text-green-500"
+                                      ? "bg-yellow-500/10 text-yellow-500"
+                                      : "bg-green-500/10 text-green-500"
                                   }`}
                                 >
                                   {completedIssuePercentage}%

--- a/web/components/workspace/send-workspace-invitation-modal.tsx
+++ b/web/components/workspace/send-workspace-invitation-modal.tsx
@@ -68,6 +68,12 @@ export const SendWorkspaceInvitationModal: React.FC<Props> = observer((props) =>
     append({ email: "", role: 15 });
   };
 
+  const onSubmitForm = async (data: FormValues) => {
+    await onSubmit(data)?.then(() => {
+      reset(defaultValues);
+    });
+  };
+
   useEffect(() => {
     if (fields.length === 0) append([{ email: "", role: 15 }]);
   }, [fields, append]);
@@ -100,7 +106,7 @@ export const SendWorkspaceInvitationModal: React.FC<Props> = observer((props) =>
             >
               <Dialog.Panel className="relative translate-y-0 transform rounded-lg bg-custom-background-100 p-5 text-left opacity-100 shadow-custom-shadow-md transition-all sm:w-full sm:max-w-2xl sm:scale-100">
                 <form
-                  onSubmit={handleSubmit(onSubmit)}
+                  onSubmit={handleSubmit(onSubmitForm)}
                   onKeyDown={(e) => {
                     if (e.code === "Enter") e.preventDefault();
                   }}


### PR DESCRIPTION
Problem:

1. Workspace invitation modal form values were not resetting after the invitation.
2. The user avatar in the profile sidebar, should contain the first letter of `first_name`, not the display name.

Solution:

1. Explicitly resetting the values.
2. replaced the first letter of `display_name` with `first_name`.