### PR TITLE
fix websocket connection issue in docker makeplane/plane#3195

### DIFF
--- a/nginx/nginx.conf.dev
+++ b/nginx/nginx.conf.dev
@@ -18,6 +18,9 @@ http {
 
         location / {
             proxy_pass http://web:3000/;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
         }
 
         location /api/ {

--- a/nginx/nginx.conf.template
+++ b/nginx/nginx.conf.template
@@ -18,6 +18,9 @@ http {
 
         location / {
             proxy_pass http://web:3000/;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
         }
 
         location /api/ {

--- a/nginx/nginx.conf.template
+++ b/nginx/nginx.conf.template
@@ -18,9 +18,6 @@ http {
 
         location / {
             proxy_pass http://web:3000/;
-            proxy_http_version 1.1;
-            proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection "upgrade";
         }
 
         location /api/ {


### PR DESCRIPTION
Since the proxy server is running with Nginx, it is recommended to add the relevant proxy header to use Web Socket. The relevant documentation is shared below.

Reference: [Nginx WebSocket Proxying documentation](https://nginx.org/en/docs/http/websocket.html)