### PR TITLE
fix: Resolved page not saving/not copying contents bug

### DIFF
--- a/web/pages/[workspaceSlug]/projects/[projectId]/pages/[pageId].tsx
+++ b/web/pages/[workspaceSlug]/projects/[projectId]/pages/[pageId].tsx
@@ -246,6 +246,11 @@ const PageDetailsPage: NextPageWithLayout = observer(() => {
   // ================ Page Menu Actions ==================
   const duplicate_page = async () => {
     const currentPageValues = getValues();
+
+    if (!currentPageValues?.description_html) {
+      currentPageValues.description_html = pageDetails?.description_html as string;
+    }
+
     const formData: Partial<IPage> = {
       name: "Copy of " + pageDetails?.name,
       description_html: currentPageValues.description_html,
@@ -336,7 +341,7 @@ const PageDetailsPage: NextPageWithLayout = observer(() => {
     debounce(async () => {
       handleSubmit(updatePage)().finally(() => setIsSubmitting("submitted"));
     }, 1500),
-    [handleSubmit]
+    [handleSubmit, pageDetails]
   );
 
   if (error)


### PR DESCRIPTION
# Description

- Fixes https://github.com/makeplane/plane/issues/3120

1. This PR adds fix to the duplicate_page function of the PageDetailsPage component, which allows users to duplicate a page even before they start typing in the editor i.e. if the current page's form does not have a `description_html` value yet i.e. on initialisation, it will be set to the default value from the pageDetails object fetched from the backend via SWR. The `formData` object is updated with the necessary values for duplication, including the new/updated page name and description.

2. Additionally to fix the patch call not being made on typing, the handleSubmit dependency of `pageDetails` is included in the useEffect hook to ensure proper form submission such that the `name` field is always updated for the `updatePage` function as it's wrapped in useCallback.