### PR TITLE
fix: role authorization for create project button in project empty state

### DIFF
--- a/web/components/page-views/workspace-dashboard.tsx
+++ b/web/components/page-views/workspace-dashboard.tsx
@@ -37,8 +37,7 @@ export const WorkspaceDashboardView = observer(() => {
     workspaceSlug ? `USER_WORKSPACE_DASHBOARD_${workspaceSlug}_${month}` : null,
     workspaceSlug ? () => userStore.fetchUserDashboardInfo(workspaceSlug.toString(), month) : null
   );
-
-  const isEditingAllowed = !!userStore.currentProjectRole && userStore.currentProjectRole >= EUserWorkspaceRoles.MEMBER;
+  const isEditingAllowed = !!userStore.currentWorkspaceRole && userStore.currentWorkspaceRole >= EUserWorkspaceRoles.MEMBER;
 
   const handleTourCompleted = () => {
     userStore

--- a/web/components/project/card-list.tsx
+++ b/web/components/project/card-list.tsx
@@ -23,12 +23,11 @@ export const ProjectCardList: FC<IProjectCardList> = observer((props) => {
     project: projectStore,
     commandPalette: commandPaletteStore,
     trackEvent: { setTrackElement },
-    user: { currentProjectRole },
+    user: { currentWorkspaceRole },
   } = useMobxStore();
 
   const projects = workspaceSlug ? projectStore.projects[workspaceSlug.toString()] : null;
-
-  const isEditingAllowed = !!currentProjectRole && currentProjectRole >= EUserWorkspaceRoles.MEMBER;
+  const isEditingAllowed = !!currentWorkspaceRole && currentWorkspaceRole >= EUserWorkspaceRoles.MEMBER;
 
   if (!projects) {
     return (


### PR DESCRIPTION
**Problem:**

- Admin & Member role not able access create project button in `dashboard` & `/projects` screen empty state.

**Solution:**

- Modified the condition used for role checking, and updated it with the `workspace role`.