### PR TITLE
🔧 fix: Pages mutation on component mount

### DIFF
--- a/packages/editor/core/src/ui/extensions/index.tsx
+++ b/packages/editor/core/src/ui/extensions/index.tsx
@@ -49,12 +49,12 @@ export const CoreEditorExtensions = (
         class: "leading-normal -mb-2",
       },
     },
-    // blockquote: {
-    //   HTMLAttributes: {
-    //     class: "border-l-4 border-custom-border-300",
-    //   },
-    // },
-    code: false,
+    code: {
+      HTMLAttributes: {
+        class: "rounded-md bg-custom-primary-30 mx-1 px-1 py-1 font-mono font-medium text-custom-text-1000",
+        spellcheck: "false",
+      },
+    },
     codeBlock: false,
     horizontalRule: false,
     dropcursor: {

--- a/web/pages/[workspaceSlug]/projects/[projectId]/pages/[pageId].tsx
+++ b/web/pages/[workspaceSlug]/projects/[projectId]/pages/[pageId].tsx
@@ -177,7 +177,7 @@ const PageDetailsPage: NextPageWithLayout = observer(() => {
     onErrorAction: () => void
   ) => {
     const commonSwrOptions: MutatorOptions = {
-      revalidate: true,
+      revalidate: false,
       populateCache: false,
       rollbackOnError: () => {
         onErrorAction();
@@ -200,6 +200,22 @@ const PageDetailsPage: NextPageWithLayout = observer(() => {
       ...commonSwrOptions,
     });
   };
+
+  useEffect(() => {
+    mutatePageDetails(undefined, {
+      revalidate: true,
+      populateCache: true,
+      rollbackOnError: () => {
+        actionCompleteAlert({
+          title: `Page could not be updated`,
+          message: `Sorry, page could not be updated, please try again later`,
+          type: "error",
+        });
+        return true;
+      },
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const updatePage = async (formData: IPage) => {
     if (!workspaceSlug || !projectId || !pageId) return;


### PR DESCRIPTION
## Description

- Set the `revalidate` option to `false` in the `commonSwrOptions` object to fix issues with Locking, Archiving, etc.
- Add an `useEffect` hook that calls the `mutatePageDetails` function with specific options as temporary fix to update cache.
- Inside the `useEffect` hook, set `revalidate` to `true`, `populateCache` to `true` to update cache on component mount and define a rollback function for error handling.
- Added code support for `` markdown syntax