### PR TITLE
fix: custom theme validation added

### DIFF
--- a/web/helpers/theme.helper.ts
+++ b/web/helpers/theme.helper.ts
@@ -60,6 +60,7 @@ const calculateShades = (hexValue: string): TShades => {
 };
 
 export const applyTheme = (palette: string, isDarkPalette: boolean) => {
+  if (!palette) return;
   const dom = document?.querySelector<HTMLElement>("[data-theme='custom']");
   // palette: [bg, text, primary, sidebarBg, sidebarText]
   const values: string[] = palette.split(",");


### PR DESCRIPTION
## **Problem:**
New users encounter an application error when they attempt to switch to a custom theme. To reproduce this issue:
- Access profile settings.
- Navigate to preferences and select a custom theme, then reload or change the navigation.

## **Resolution:**
The problem occurs from a recent code refactoring, causing the removal of necessary default values. I've rectified this by implementing a validation: if no palette is available, the theme won't be applied.

These issues are associated with [[PLE-154]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/c7eb51e0-721f-472e-9a80-389066136285)