### PR TITLE
fix: external api serializer

### DIFF
--- a/apiserver/plane/api/serializers/issue.py
+++ b/apiserver/plane/api/serializers/issue.py
@@ -96,7 +96,7 @@ class IssueSerializer(BaseSerializer):
         if (
             data.get("state")
             and not State.objects.filter(
-                project_id=self.context.get("project_id"), pk=data.get("state")
+                project_id=self.context.get("project_id"), pk=data.get("state").id
             ).exists()
         ):
             raise serializers.ValidationError(
@@ -107,7 +107,7 @@ class IssueSerializer(BaseSerializer):
         if (
             data.get("parent")
             and not Issue.objects.filter(
-                workspace_id=self.context.get("workspace_id"), pk=data.get("parent")
+                workspace_id=self.context.get("workspace_id"), pk=data.get("parent").id
             ).exists()
         ):
             raise serializers.ValidationError(

--- a/apiserver/plane/api/serializers/module.py
+++ b/apiserver/plane/api/serializers/module.py
@@ -65,18 +65,18 @@ class ModuleSerializer(BaseSerializer):
     def create(self, validated_data):
         members = validated_data.pop("members", None)
 
-        project = self.context["project"]
+        project_id = self.context["project_id"]
+        workspace_id = self.context["workspace_id"]
 
-        module = Module.objects.create(**validated_data, project=project)
-
+        module = Module.objects.create(**validated_data, project_id=project_id)
         if members is not None:
             ModuleMember.objects.bulk_create(
                 [
                     ModuleMember(
                         module=module,
-                        member=member,
-                        project=project,
-                        workspace=project.workspace,
+                        member_id=str(member),
+                        project_id=project_id,
+                        workspace_id=workspace_id,
                         created_by=module.created_by,
                         updated_by=module.updated_by,
                     )
@@ -97,7 +97,7 @@ class ModuleSerializer(BaseSerializer):
                 [
                     ModuleMember(
                         module=instance,
-                        member=member,
+                        member_id=str(member),
                         project=instance.project,
                         workspace=instance.project.workspace,
                         created_by=instance.created_by,

--- a/apiserver/plane/api/views/issue.py
+++ b/apiserver/plane/api/views/issue.py
@@ -207,20 +207,14 @@ class IssueAPIEndpoint(WebhookMixin, BaseAPIView):
             serializer.save()
 
             # Track the issue
-            issue_activity.apply_async(
-                args=[],  # If no positional arguments are required
-                kwargs={
-                    "type": "issue.activity.created",
-                    "requested_data": json.dumps(
-                        self.request.data, cls=DjangoJSONEncoder
-                    ),
-                    "actor_id": str(request.user.id),
-                    "issue_id": str(serializer.data.get("id", None)),
-                    "project_id": str(project_id),
-                    "current_instance": None,
-                    "epoch": int(timezone.now().timestamp()),
-                },
-                routing_key="external",
+            issue_activity.delay(
+                type="issue.activity.created",
+                requested_data=json.dumps(self.request.data, cls=DjangoJSONEncoder),
+                actor_id=str(request.user.id),
+                issue_id=str(serializer.data.get("id", None)),
+                project_id=str(project_id),
+                current_instance=None,
+                epoch=int(timezone.now().timestamp()),
             )
             return Response(serializer.data, status=status.HTTP_201_CREATED)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
@@ -243,18 +237,14 @@ class IssueAPIEndpoint(WebhookMixin, BaseAPIView):
         )
         if serializer.is_valid():
             serializer.save()
-            issue_activity.apply_async(
-                args=[],
-                kwargs={
-                    "type": "issue.activity.updated",
-                    "requested_data": requested_data,
-                    "actor_id": str(request.user.id),
-                    "issue_id": str(pk),
-                    "project_id": str(project_id),
-                    "current_instance": current_instance,
-                    "epoch": int(timezone.now().timestamp()),
-                },
-                routing_key="external",
+            issue_activity.delay(
+                type="issue.activity.updated",
+                requested_data=requested_data,
+                actor_id=str(request.user.id),
+                issue_id=str(pk),
+                project_id=str(project_id),
+                current_instance=current_instance,
+                epoch=int(timezone.now().timestamp()),
             )
             return Response(serializer.data, status=status.HTTP_200_OK)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
@@ -265,19 +255,14 @@ class IssueAPIEndpoint(WebhookMixin, BaseAPIView):
             IssueSerializer(issue).data, cls=DjangoJSONEncoder
         )
         issue.delete()
-        issue_activity.apply_async(
-            args=[],
-            kwargs={
-                "type": "issue.activity.deleted",
-                "requested_data": json.dumps({"issue_id": str(pk)}),
-                "actor_id": str(request.user.id),
-                "issue_id": str(pk),
-                "project_id": str(project_id),
-                "current_instance": current_instance,
-                "epoch": int(timezone.now().timestamp()),
-            },
-            routing_key="your_routing_key",
-            queue="your_queue_name",
+        issue_activity.delay(
+            type="issue.activity.deleted",
+            requested_data=json.dumps({"issue_id": str(pk)}),
+            actor_id=str(request.user.id),
+            issue_id=str(pk),
+            project_id=str(project_id),
+            current_instance=current_instance,
+            epoch=int(timezone.now().timestamp()),
         )
         return Response(status=status.HTTP_204_NO_CONTENT)
 
@@ -408,20 +393,14 @@ class IssueLinkAPIEndpoint(BaseAPIView):
                 project_id=project_id,
                 issue_id=issue_id,
             )
-            issue_activity.apply_async(
-                args=[],  # If no positional arguments are required
-                kwargs={
-                    "type": "link.activity.created",
-                    "requested_data": json.dumps(
-                        serializer.data, cls=DjangoJSONEncoder
-                    ),
-                    "actor_id": str(self.request.user.id),
-                    "issue_id": str(self.kwargs.get("issue_id")),
-                    "project_id": str(self.kwargs.get("project_id")),
-                    "current_instance": None,
-                    "epoch": int(timezone.now().timestamp()),
-                },
-                routing_key="external",
+            issue_activity.delay(
+                type="link.activity.created",
+                requested_data=json.dumps(serializer.data, cls=DjangoJSONEncoder),
+                actor_id=str(self.request.user.id),
+                issue_id=str(self.kwargs.get("issue_id")),
+                project_id=str(self.kwargs.get("project_id")),
+                current_instance=None,
+                epoch=int(timezone.now().timestamp()),
             )
             return Response(serializer.data, status=status.HTTP_201_CREATED)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
@@ -438,18 +417,14 @@ class IssueLinkAPIEndpoint(BaseAPIView):
         serializer = IssueLinkSerializer(issue_link, data=request.data, partial=True)
         if serializer.is_valid():
             serializer.save()
-            issue_activity.apply_async(
-                args=[],  # If no positional arguments are required
-                kwargs={
-                    "type": "link.activity.updated",
-                    "requested_data": requested_data,
-                    "actor_id": str(request.user.id),
-                    "issue_id": str(issue_id),
-                    "project_id": str(project_id),
-                    "current_instance": current_instance,
-                    "epoch": int(timezone.now().timestamp()),
-                },
-                routing_key="external",
+            issue_activity.delay(
+                type="link.activity.updated",
+                requested_data=requested_data,
+                actor_id=str(request.user.id),
+                issue_id=str(issue_id),
+                project_id=str(project_id),
+                current_instance=current_instance,
+                epoch=int(timezone.now().timestamp()),
             )
             return Response(serializer.data, status=status.HTTP_200_OK)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
@@ -462,18 +437,14 @@ class IssueLinkAPIEndpoint(BaseAPIView):
             IssueLinkSerializer(issue_link).data,
             cls=DjangoJSONEncoder,
         )
-        issue_activity.apply_async(
-            args=[],  # If no positional arguments are required
-            kwargs={
-                "type": "link.activity.deleted",
-                "requested_data": json.dumps({"link_id": str(pk)}),
-                "actor_id": str(request.user.id),
-                "issue_id": str(issue_id),
-                "project_id": str(project_id),
-                "current_instance": current_instance,
-                "epoch": int(timezone.now().timestamp()),
-            },
-            routing_key="external",
+        issue_activity.delay(
+            type="link.activity.deleted",
+            requested_data=json.dumps({"link_id": str(pk)}),
+            actor_id=str(request.user.id),
+            issue_id=str(issue_id),
+            project_id=str(project_id),
+            current_instance=current_instance,
+            epoch=int(timezone.now().timestamp()),
         )
         issue_link.delete()
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/apiserver/plane/api/views/module.py
+++ b/apiserver/plane/api/views/module.py
@@ -121,8 +121,8 @@ class ModuleAPIEndpoint(WebhookMixin, BaseAPIView):
         )
 
     def post(self, request, slug, project_id):
-        project = Project.objects.get(workspace__slug=slug, pk=project_id)
-        serializer = ModuleSerializer(data=request.data, context={"project": project})
+        project = Project.objects.get(pk=project_id, workspace__slug=slug)
+        serializer = ModuleSerializer(data=request.data, context={"project_id": project_id, "workspace_id": project.workspace_id})
         if serializer.is_valid():
             serializer.save()
             module = Module.objects.get(pk=serializer.data["id"])
@@ -132,7 +132,7 @@ class ModuleAPIEndpoint(WebhookMixin, BaseAPIView):
     
     def patch(self, request, slug, project_id, pk):
         module = Module.objects.get(pk=pk, project_id=project_id, workspace__slug=slug)
-        serializer = ModuleSerializer(module, data=request.data)
+        serializer = ModuleSerializer(module, data=request.data, context={"project_id": project_id}, partial=True)
         if serializer.is_valid():
             serializer.save()
             return Response(serializer.data, status=status.HTTP_201_CREATED)


### PR DESCRIPTION
This PR resolve the issues mentioned in the #3238 
- project id and workspace id are passed as the context in the serializers so that the state of the issue can be updated.