### PR TITLE
Style: custom theme UI fixes

### DIFF
--- a/web/components/core/theme/theme-switch.tsx
+++ b/web/components/core/theme/theme-switch.tsx
@@ -46,7 +46,7 @@ export const ThemeSwitch: FC<Props> = (props) => {
       }
       onChange={onChange}
       input
-      width="w-full"
+      width="w-full z-20"
     >
       {THEME_OPTIONS.map((themeOption) => (
         <CustomSelect.Option key={themeOption.value} value={themeOption}>

--- a/web/components/issues/issue-layouts/roots/project-layout-root.tsx
+++ b/web/components/issues/issue-layouts/roots/project-layout-root.tsx
@@ -48,7 +48,7 @@ export const ProjectLayoutRoot: React.FC = observer(() => {
           {Object.keys(getIssues ?? {}).length == 0 ? (
             <ProjectEmptyState />
           ) : (
-            <div className="relative h-full w-full overflow-auto">
+            <div className="relative h-full w-full overflow-auto bg-custom-background-90">
               {activeLayout === "list" ? (
                 <ListLayout />
               ) : activeLayout === "kanban" ? (


### PR DESCRIPTION
### Problems
1. When using custom theming, the Background color is breaking in the Kanban layout leading to bad user experience.
2. Theme Dropdown is overlapping with the color picker icons.

### Solutions

1. Added correct background color to the layout.
#### Before
![image](https://github.com/makeplane/plane/assets/33979846/bb49fbd1-1f7a-478a-ac68-d066101caefe)
#### After
![image](https://github.com/makeplane/plane/assets/33979846/1f203c29-8009-4353-835d-28fbe40b6a6a)

2. Fixed `z-index` issue within the dropdown.
#### Before
![image](https://github.com/makeplane/plane/assets/33979846/e6b03b45-1cbe-4a0c-90e0-d50b1d43e44f)

#### After
![image](https://github.com/makeplane/plane/assets/33979846/b23695d7-334f-4f2d-bc03-f9d9748ec310)
![image](https://github.com/makeplane/plane/assets/33979846/aba0cd1e-efed-422d-accf-594eca17e35f)
