### PR TITLE
fix: removing redundant env example variables from the .env.example file

### DIFF
--- a/apiserver/.env.example
+++ b/apiserver/.env.example
@@ -39,8 +39,6 @@ OPENAI_API_BASE="https://api.openai.com/v1" # deprecated
 OPENAI_API_KEY="sk-" # deprecated
 GPT_ENGINE="gpt-3.5-turbo" # deprecated
 
-# Github
-GITHUB_CLIENT_SECRET="" # For fetching release notes
 
 # Settings related to Docker
 DOCKERIZED=1 # deprecated


### PR DESCRIPTION
Fixes #3299