### PR TITLE
fix: project identifier cursor behaviour in create project modal.

### DIFF
--- a/web/components/project/create-project-modal.tsx
+++ b/web/components/project/create-project-modal.tsx
@@ -126,6 +126,8 @@ export const CreateProjectModal: FC<Props> = observer((props) => {
     else payload.emoji = formData.emoji_and_icon;
 
     payload.project_lead = formData.project_lead_member;
+    // Upper case identifier
+    payload.identifier = payload.identifier.toUpperCase();
 
     return createProject(workspaceSlug.toString(), payload)
       .then((res) => {
@@ -176,14 +178,7 @@ export const CreateProjectModal: FC<Props> = observer((props) => {
       return;
     }
     if (e.target.value === "") setValue("identifier", "");
-    else
-      setValue(
-        "identifier",
-        e.target.value
-          .replace(/[^ÇŞĞIİÖÜA-Za-z0-9]/g, "")
-          .toUpperCase()
-          .substring(0, 5)
-      );
+    else setValue("identifier", e.target.value.replace(/[^ÇŞĞIİÖÜA-Za-z0-9]/g, "").substring(0, 5));
     onChange(e);
   };
 
@@ -191,7 +186,7 @@ export const CreateProjectModal: FC<Props> = observer((props) => {
     const { value } = e.target;
     const alphanumericValue = value.replace(/[^ÇŞĞIİÖÜA-Za-z0-9]/g, "");
     setIsChangeInIdentifierRequired(false);
-    onChange(alphanumericValue.toUpperCase());
+    onChange(alphanumericValue);
   };
 
   return (
@@ -301,7 +296,8 @@ export const CreateProjectModal: FC<Props> = observer((props) => {
                             required: "Identifier is required",
                             // allow only alphanumeric & non-latin characters
                             validate: (value) =>
-                              /^[ÇŞĞIİÖÜA-Z0-9]+$/.test(value.toUpperCase()) || "Identifier must be in uppercase.",
+                              /^[ÇŞĞIİÖÜA-Z0-9]+$/.test(value.toUpperCase()) ||
+                              "Only Alphanumeric & Non-latin characters are allowed.",
                             minLength: {
                               value: 1,
                               message: "Identifier must at least be of 1 character",
@@ -321,7 +317,7 @@ export const CreateProjectModal: FC<Props> = observer((props) => {
                               onChange={handleIdentifierChange(onChange)}
                               hasError={Boolean(errors.identifier)}
                               placeholder="Identifier"
-                              className="w-full text-xs focus:border-blue-400"
+                              className="w-full text-xs focus:border-blue-400 uppercase"
                             />
                           )}
                         />


### PR DESCRIPTION
#### Problem
Steps to reproduce:
- Type an Identifier in the Project create modal
- Put the cursor in the beginning of the typed identifier
- Observe - it will automatically move to end if you type anything

The cursor is behaving weird when typing happens and user puts it at the beginning of the Identifier.
#### Solution
The issue occured because of using `toUpperCase` on every change mutated the entire identifier to uppercase, causing the cursor to move unexpectedly. To solve this, I removed all toUpperCase methods to prevent unintended changes. Instead, I applied the uppercase Tailwind class to visually display the identifier in uppercase for users. And before sending it to our API endpoint, we still convert the data to uppercase, ensuring consistency without disrupting user input.

https://github.com/makeplane/plane/assets/33979846/dc8b8c7f-d702-46bc-9258-55640263c321




