### PR TITLE
fix: estimate order not maintained in create/ update modal.

### DIFF
--- a/web/components/estimates/estimates-list.tsx
+++ b/web/components/estimates/estimates-list.tsx
@@ -14,6 +14,8 @@ import { EmptyState } from "components/common";
 import emptyEstimate from "public/empty-state/estimate.svg";
 // types
 import { IEstimate } from "@plane/types";
+// helpers
+import { orderArrayBy } from "helpers/array.helper";
 
 export const EstimatesList: React.FC = observer(() => {
   // states
@@ -31,7 +33,11 @@ export const EstimatesList: React.FC = observer(() => {
 
   const editEstimate = (estimate: IEstimate) => {
     setEstimateFormOpen(true);
-    setEstimateToUpdate(estimate);
+    // Order the points array by key before updating the estimate to update state
+    setEstimateToUpdate({
+      ...estimate,
+      points: orderArrayBy(estimate.points, "key"),
+    });
   };
 
   const disableEstimates = () => {

--- a/web/store/estimate.store.ts
+++ b/web/store/estimate.store.ts
@@ -172,7 +172,7 @@ export class EstimateStore implements IEstimateStore {
   updateEstimate = async (workspaceSlug: string, projectId: string, estimateId: string, data: IEstimateFormData) =>
     await this.estimateService.patchEstimate(workspaceSlug, projectId, estimateId, data).then((response) => {
       const updatedEstimates = (this.estimates?.[projectId] ?? []).map((estimate) =>
-        estimate.id === estimateId ? { ...estimate, ...data.estimate } : estimate
+        estimate.id === estimateId ? { ...estimate, ...data.estimate, points: [...data.estimate_points] } : estimate
       );
       runInAction(() => {
         set(this.estimates, projectId, updatedEstimates);


### PR DESCRIPTION
#### Problem
Following the update to version v0.14-dev, there's a bug affecting the order of estimates. Users have reported that despite setting estimates in a specific order, the system automatically reorders them alphabetically upon saving. This behavior is a deviation from previous versions where the user-defined order was maintained.

**Steps to Reproduce**:

1. Go to the estimates page.
2. Create a new estimate or edit an existing one.
3. Enter estimates in a non-alphabetical order (e.g., 1, 2, 3, 5, 8, 12).
4. Save the estimates.
5. Reopen or edit the estimates and observe the reordering has changed. (1, 12, 2, 3, 5, 8)

#### Solution
The issue was due to unsorted data in the create/ update modal. The backend sends estimate points in `{key, value}` pairs, with keys indicating order. To resolve it, I sorted these pairs by key value for proper ordering.

#### Reference
https://github.com/makeplane/plane/assets/33979846/ce386808-865a-463b-84ab-81bb89935d7b

#### Other Issues Fixed:
* Estimate Points were not mutation on update.