### PR TITLE
fix: drag and delete issue

### DIFF
--- a/web/components/issues/issue-layouts/kanban/base-kanban-root.tsx
+++ b/web/components/issues/issue-layouts/kanban/base-kanban-root.tsx
@@ -202,6 +202,7 @@ export const BaseKanBanRoot: React.FC<IBaseKanBanLayout> = observer((props: IBas
       issueIds,
       viewId
     ).finally(() => {
+      handleIssues(issueMap[dragState.draggedIssueId!], EIssueActions.DELETE);
       setDeleteIssueModal(false);
       setDragState({});
     });


### PR DESCRIPTION
This PR addresses issues with the drag and delete functionality in kanban that wasn't working as expected. I've added the necessary changes to ensure they now function correctly.