### PR TITLE
chore: esc to close peek overview 

### DIFF
--- a/web/components/issues/peek-overview/view.tsx
+++ b/web/components/issues/peek-overview/view.tsx
@@ -4,6 +4,7 @@ import { observer } from "mobx-react-lite";
 import { MoveRight, MoveDiagonal, Link2, Trash2 } from "lucide-react";
 // hooks
 import useOutsideClickDetector from "hooks/use-outside-click-detector";
+import useKeypress from "hooks/use-keypress";
 // store hooks
 import { useIssueDetail, useUser } from "hooks/store";
 import useToast from "hooks/use-toast";
@@ -98,6 +99,9 @@ export const IssueView: FC<IIssueView> = observer((props) => {
       });
     });
   };
+
+  const handleKeyDown = () => !isAnyModalOpen && removeRoutePeekId();
+  useKeypress("Escape", handleKeyDown);
 
   return (
     <>


### PR DESCRIPTION
This PR includes implementation of the ESC to close functionality for the Peek Overview.