### PR TITLE
[chore]: Removed explicit dependencies and cleaned up turbo config

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "prettier": "latest",
     "prettier-plugin-tailwindcss": "^0.5.4",
     "tailwindcss": "^3.3.3",
-    "turbo": "^1.11.2"
+    "turbo": "^1.11.3"
   },
   "resolutions": {
     "@types/react": "18.2.42"

--- a/turbo.json
+++ b/turbo.json
@@ -29,63 +29,18 @@
         "dist/**"
       ]
     },
-    "web#develop": {
+    "develop": {
       "cache": false,
       "persistent": true,
       "dependsOn": [
-        "@plane/lite-text-editor#build",
-        "@plane/rich-text-editor#build",
-        "@plane/document-editor#build",
-        "@plane/ui#build"
+        "^build"
       ]
     },
-    "space#develop": {
+    "dev": {
       "cache": false,
       "persistent": true,
       "dependsOn": [
-        "@plane/lite-text-editor#build",
-        "@plane/rich-text-editor#build",
-        "@plane/document-editor#build",
-        "@plane/ui#build"
-      ]
-    },
-    "web#build": {
-      "cache": true,
-      "dependsOn": [
-        "@plane/lite-text-editor#build",
-        "@plane/rich-text-editor#build",
-        "@plane/document-editor#build",
-        "@plane/ui#build"
-      ]
-    },
-    "space#build": {
-      "cache": true,
-      "dependsOn": [
-        "@plane/lite-text-editor#build",
-        "@plane/rich-text-editor#build",
-        "@plane/document-editor#build",
-        "@plane/ui#build"
-      ]
-    },
-    "@plane/lite-text-editor#build": {
-      "cache": true,
-      "dependsOn": [
-        "@plane/editor-core#build",
-        "@plane/editor-extensions#build"
-      ]
-    },
-    "@plane/rich-text-editor#build": {
-      "cache": true,
-      "dependsOn": [
-        "@plane/editor-core#build",
-        "@plane/editor-extensions#build"
-      ]
-    },
-    "@plane/document-editor#build": {
-      "cache": true,
-      "dependsOn": [
-        "@plane/editor-core#build",
-        "@plane/editor-extensions#build"
+        "^build"
       ]
     },
     "test": {
@@ -96,12 +51,6 @@
     },
     "lint": {
       "outputs": []
-    },
-    "dev": {
-      "cache": false
-    },
-    "develop": {
-      "cache": false
     },
     "start": {
       "cache": false

--- a/yarn.lock
+++ b/yarn.lock
@@ -8650,47 +8650,47 @@ tunnel-agent@^0.6.0:
   dependencies:
     safe-buffer "^5.0.1"
 
-turbo-darwin-64@1.11.2:
-  version "1.11.2"
-  resolved "https://registry.yarnpkg.com/turbo-darwin-64/-/turbo-darwin-64-1.11.2.tgz#fc3d4d74b325a27aef11b6a52a61f07d466846b9"
-  integrity sha512-toFmRG/adriZY3hOps7nYCfqHAS+Ci6xqgX3fbo82kkLpC6OBzcXnleSwuPqjHVAaRNhVoB83L5njcE9Qwi2og==
+turbo-darwin-64@1.11.3:
+  version "1.11.3"
+  resolved "https://registry.yarnpkg.com/turbo-darwin-64/-/turbo-darwin-64-1.11.3.tgz#fb51f6fa030ee7a169d383b5f4f7641df6a3bdb8"
+  integrity sha512-IsOOg2bVbIt3o/X8Ew9fbQp5t1hTHN3fGNQYrPQwMR2W1kIAC6RfbVD4A9OeibPGyEPUpwOH79hZ9ydFH5kifw==
 
-turbo-darwin-arm64@1.11.2:
-  version "1.11.2"
-  resolved "https://registry.yarnpkg.com/turbo-darwin-arm64/-/turbo-darwin-arm64-1.11.2.tgz#583a4d0025bc3f953a9eeb7065cb173f481a9965"
-  integrity sha512-FCsEDZ8BUSFYEOSC3rrARQrj7x2VOrmVcfrMUIhexTxproRh4QyMxLfr6LALk4ymx6jbDCxWa6Szal8ckldFbA==
+turbo-darwin-arm64@1.11.3:
+  version "1.11.3"
+  resolved "https://registry.yarnpkg.com/turbo-darwin-arm64/-/turbo-darwin-arm64-1.11.3.tgz#f936cc7ba5565bd9be1ddc8ef4f15284044a63a5"
+  integrity sha512-FsJL7k0SaPbJzI/KCnrf/fi3PgCDCjTliMc/kEFkuWVA6Httc3Q4lxyLIIinz69q6JTx8wzh6yznUMzJRI3+dg==
 
-turbo-linux-64@1.11.2:
-  version "1.11.2"
-  resolved "https://registry.yarnpkg.com/turbo-linux-64/-/turbo-linux-64-1.11.2.tgz#55ef996d856cb397b9fb2855a554ccef1cee9dd7"
-  integrity sha512-Vzda/o/QyEske5CxLf0wcu7UUS+7zB90GgHZV4tyN+WZtoouTvbwuvZ3V6b5Wgd3OJ/JwWR0CXDK7Sf4VEMr7A==
+turbo-linux-64@1.11.3:
+  version "1.11.3"
+  resolved "https://registry.yarnpkg.com/turbo-linux-64/-/turbo-linux-64-1.11.3.tgz#86f56a91c05eea512a187079f7f7f860d8168be6"
+  integrity sha512-SvW7pvTVRGsqtSkII5w+wriZXvxqkluw5FO/MNAdFw0qmoov+PZ237+37/NgArqE3zVn1GX9P6nUx9VO+xcQAg==
 
-turbo-linux-arm64@1.11.2:
-  version "1.11.2"
-  resolved "https://registry.yarnpkg.com/turbo-linux-arm64/-/turbo-linux-arm64-1.11.2.tgz#64d6093c9a2f32f410624564fd10685c847d947e"
-  integrity sha512-bRLwovQRz0yxDZrM4tQEAYV0fBHEaTzUF0JZ8RG1UmZt/CqtpnUrJpYb1VK8hj1z46z9YehARpYCwQ2K0qU4yw==
+turbo-linux-arm64@1.11.3:
+  version "1.11.3"
+  resolved "https://registry.yarnpkg.com/turbo-linux-arm64/-/turbo-linux-arm64-1.11.3.tgz#0001dab6ded89154e2a5be21e87720daba953056"
+  integrity sha512-YhUfBi1deB3m+3M55X458J6B7RsIS7UtM3P1z13cUIhF+pOt65BgnaSnkHLwETidmhRh8Dl3GelaQGrB3RdCDw==
 
-turbo-windows-64@1.11.2:
-  version "1.11.2"
-  resolved "https://registry.yarnpkg.com/turbo-windows-64/-/turbo-windows-64-1.11.2.tgz#f4164be9c42796c86ca3929e27f1992a4310b9ed"
-  integrity sha512-LgTWqkHAKgyVuLYcEPxZVGPInTjjeCnN5KQMdJ4uQZ+xMDROvMFS2rM93iQl4ieDJgidwHCxxCxaU9u8c3d/Kg==
+turbo-windows-64@1.11.3:
+  version "1.11.3"
+  resolved "https://registry.yarnpkg.com/turbo-windows-64/-/turbo-windows-64-1.11.3.tgz#8d03c4fd8a46b81f2aecf60fc9845674c84d15a8"
+  integrity sha512-s+vEnuM2TiZuAUUUpmBHDr6vnNbJgj+5JYfnYmVklYs16kXh+EppafYQOAkcRIMAh7GjV3pLq5/uGqc7seZeHA==
 
-turbo-windows-arm64@1.11.2:
-  version "1.11.2"
-  resolved "https://registry.yarnpkg.com/turbo-windows-arm64/-/turbo-windows-arm64-1.11.2.tgz#ca1b4d7ac6fe8c931baef1a270ac07bbd924277b"
-  integrity sha512-829aVBU7IX0c/B4G7g1VI8KniAGutHhIupkYMgF6xPkYVev2G3MYe6DMS/vsLt9GGM9ulDtdWxWrH5P2ngK8IQ==
+turbo-windows-arm64@1.11.3:
+  version "1.11.3"
+  resolved "https://registry.yarnpkg.com/turbo-windows-arm64/-/turbo-windows-arm64-1.11.3.tgz#cc436d1462f5450e97f985ba6d8d447272bb97db"
+  integrity sha512-ZR5z5Zpc7cASwfdRAV5yNScCZBsgGSbcwiA/u3farCacbPiXsfoWUkz28iyrx21/TRW0bi6dbsB2v17swa8bjw==
 
-turbo@^1.11.2:
-  version "1.11.2"
-  resolved "https://registry.yarnpkg.com/turbo/-/turbo-1.11.2.tgz#7bae6df12c210e9b12973aad8f0e7b077039d4ce"
-  integrity sha512-jPC7LVQJzebs5gWf8FmEvsvXGNyKbN+O9qpvv98xpNaM59aS0/Irhd0H0KbcqnXfsz7ETlzOC3R+xFWthC4Z8A==
+turbo@^1.11.3:
+  version "1.11.3"
+  resolved "https://registry.yarnpkg.com/turbo/-/turbo-1.11.3.tgz#3bd823043585e1acfe125727bcecd4f91ef2103b"
+  integrity sha512-RCJOUFcFMQNIGKSjC9YmA5yVP1qtDiBA0Lv9VIgrXraI5Da1liVvl3VJPsoDNIR9eFMyA/aagx1iyj6UWem5hA==
   optionalDependencies:
-    turbo-darwin-64 "1.11.2"
-    turbo-darwin-arm64 "1.11.2"
-    turbo-linux-64 "1.11.2"
-    turbo-linux-arm64 "1.11.2"
-    turbo-windows-64 "1.11.2"
-    turbo-windows-arm64 "1.11.2"
+    turbo-darwin-64 "1.11.3"
+    turbo-darwin-arm64 "1.11.3"
+    turbo-linux-64 "1.11.3"
+    turbo-linux-arm64 "1.11.3"
+    turbo-windows-64 "1.11.3"
+    turbo-windows-arm64 "1.11.3"
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"


### PR DESCRIPTION
## Why?

We have a number of explicit dependencies in our turbo.json, which isn't necessary to do as it'll get very difficulty to maintain as no of dependencies go up since turborepo automatically manages it using it's task dependency graph.

## What?
This PR uses the topological relationship provided by the `^` operator in `turbo.json`

```json
"build": {
      "dependsOn": [
        "^build"
      ],
},
```

The `^build` syntax means that when we run `turbo run build`, then this `build` command of a particular package (be it web/space/editor/ui, first run the `build` commands of their respective dependencies. 

## Other changes
I've done the same with `develop` command (that helps us run `yarn dev` to automatically run `turbo run develop` in web and space projects for better DX) and the `dev` command (for other packages) to automatically first run their dependencies' build commands.

```json
"develop": {
      "cache": false,
      "persistent": true,
      "dependsOn": [
        "^build"
      ]
}


 "dev": {
      "cache": false,
      "persistent": true,
      "dependsOn": [
        "^build"
      ]
},
```
Also this pr includes the turbo upgrade changes