### PR TITLE
fix: self-hosting docker-compose doc link update

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Thats it!
 
 ## 🍙 Self Hosting
 
-For self hosting environment setup, visit the [Self Hosting](https://docs.plane.so/self-hosting/docker-compose) documentation page
+For self hosting environment setup, visit the [Self Hosting](https://docs.plane.so/docker-compose) documentation page
 
 ## 🚀 Features
 


### PR DESCRIPTION
Fixes the link as it leads to a 404 at the moment in the documentation / readme.