### PR TITLE
fix: stack integration disable button mutation issue in project settings.

### DIFF
--- a/web/components/integration/slack/select-channel.tsx
+++ b/web/components/integration/slack/select-channel.tsx
@@ -66,8 +66,9 @@ export const SelectChannel: React.FC<Props> = observer(({ integration }) => {
   }, [projectIntegration, projectId]);
 
   const handleDelete = async () => {
+    if (!workspaceSlug || !projectId) return;
     if (projectIntegration.length === 0) return;
-    mutate(SLACK_CHANNEL_INFO, (prevData: any) => {
+    mutate(SLACK_CHANNEL_INFO(workspaceSlug?.toString(), projectId?.toString()), (prevData: any) => {
       if (!prevData) return;
       return prevData.id !== integration.id;
     }).then(() => {


### PR DESCRIPTION
#### Problem
Slack's "Disable Integration" button wasn't working due to missing parameters in the `SLACK_CHANNEL_INFO` fetch key.

#### Solution
Fixed by adding `workspaceSlug` and `projectId` parameters to the fetch key, enabling the correct mutation and resolving the issue.