### PR TITLE
Fix: Fixed Issue Embeds Crashing Pages & Improvement in Issue Embed Suggestions

### DIFF
--- a/packages/editor/document-editor/src/ui/extensions/index.tsx
+++ b/packages/editor/document-editor/src/ui/extensions/index.tsx
@@ -26,7 +26,7 @@ export const DocumentEditorExtensions = (
           .focus()
           .insertContentAt(
             range,
-            "<p class='text-sm bg-gray-300 w-fit pl-3 pr-3 pt-1 pb-1 rounded shadow-sm'>#issue_</p>\n"
+            "<p class='text-sm bg-gray-300 w-fit pl-3 pr-3 pt-1 pb-1 rounded shadow-sm'>#issue_</p>"
           )
           .run();
       },

--- a/packages/editor/document-editor/src/ui/extensions/widgets/issue-embed-widget/issue-widget-card.tsx
+++ b/packages/editor/document-editor/src/ui/extensions/widgets/issue-embed-widget/issue-widget-card.tsx
@@ -9,15 +9,13 @@ export const IssueWidgetCard = (props) => {
   const [issueDetails, setIssueDetails] = useState();
 
   useEffect(() => {
-    props.issueEmbedConfig
-      .fetchIssue(props.node.attrs.entity_identifier)
-      .then((issue) => {
-        setIssueDetails(issue);
-        setLoading(0);
-      })
-      .catch(() => {
-        setLoading(-1);
-      });
+    const issue = props.issueEmbedConfig.fetchIssue(props.node.attrs.entity_identifier);
+    if (issue) {
+      setIssueDetails(issue);
+      setLoading(0);
+    } else {
+      setLoading(-1);
+    }
   }, []);
 
   const completeIssueEmbedAction = () => {

--- a/packages/editor/document-editor/src/ui/extensions/widgets/issue-embed-widget/types.ts
+++ b/packages/editor/document-editor/src/ui/extensions/widgets/issue-embed-widget/types.ts
@@ -3,7 +3,7 @@ export interface IEmbedConfig {
 }
 
 export interface IIssueEmbedConfig {
-  fetchIssue: (issueId: string) => Promise<any>;
+  fetchIssue: (issueId: string) => any;
   clickAction: (issueId: string, issueTitle: string) => void;
   issues: Array<any>;
 }

--- a/packages/editor/document-editor/src/ui/index.tsx
+++ b/packages/editor/document-editor/src/ui/index.tsx
@@ -145,11 +145,11 @@ const DocumentEditor = ({
         documentDetails={documentDetails}
         isSubmitting={isSubmitting}
       />
-      <div className="flex h-full w-full overflow-y-auto">
+      <div className="flex h-full w-full overflow-y-auto frame-renderer">
         <div className="sticky top-0 h-full w-56 flex-shrink-0 lg:w-72">
           <SummarySideBar editor={editor} markings={markings} sidePeekVisible={sidePeekVisible} />
         </div>
-        <div className="h-full w-[calc(100%-14rem)] lg:w-[calc(100%-18rem-18rem)]">
+        <div className="h-full w-[calc(100%-14rem)] lg:w-[calc(100%-18rem-18rem)] page-renderer">
           <PageRenderer
             onActionCompleteHandler={onActionCompleteHandler}
             readonly={false}

--- a/packages/editor/document-editor/src/ui/readonly/index.tsx
+++ b/packages/editor/document-editor/src/ui/readonly/index.tsx
@@ -105,11 +105,11 @@ const DocumentReadOnlyEditor = ({
         documentDetails={documentDetails}
         archivedAt={pageArchiveConfig && pageArchiveConfig.archived_at}
       />
-      <div className="flex h-full w-full overflow-y-auto">
+      <div className="flex h-full w-full overflow-y-auto frame-renderer">
         <div className="sticky top-0 h-full w-56 flex-shrink-0 lg:w-80">
           <SummarySideBar editor={editor} markings={markings} sidePeekVisible={sidePeekVisible} />
         </div>
-        <div className="h-full w-[calc(100%-14rem)] lg:w-[calc(100%-18rem-18rem)]">
+        <div className="h-full w-[calc(100%-14rem)] lg:w-[calc(100%-18rem-18rem)] page-renderer">
           <PageRenderer
             onActionCompleteHandler={onActionCompleteHandler}
             updatePageTitle={() => Promise.resolve()}

--- a/web/hooks/use-issue-embeds.tsx
+++ b/web/hooks/use-issue-embeds.tsx
@@ -19,7 +19,7 @@ export const useIssueEmbeds = () => {
   const { getStateById } = useProjectState();
   const { getUserDetails } = useMember();
 
-  const { data: issuesResponse } = useSWR(
+  const { data: issuesResponse, isLoading: issuesLoading } = useSWR(
     workspaceSlug && projectId ? PROJECT_ISSUES_LIST(workspaceSlug as string, projectId as string) : null,
     workspaceSlug && projectId ? () => issueService.getIssues(workspaceSlug as string, projectId as string) : null
   );
@@ -32,7 +32,7 @@ export const useIssueEmbeds = () => {
     assignee_details: issue.assignee_ids.map((assigneeid) => toJS(getUserDetails(assigneeid))),
   }));
 
-  const fetchIssue = async (issueId: string) => issuesWithStateAndProject.find((issue) => issue.id === issueId);
+  const fetchIssue = (issueId: string) => issuesWithStateAndProject.find((issue) => issue.id === issueId);
 
   const issueWidgetClickAction = (issueId: string) => {
     if (!workspaceSlug || !projectId) return;
@@ -42,6 +42,7 @@ export const useIssueEmbeds = () => {
 
   return {
     issues: issuesWithStateAndProject,
+    issuesLoading,
     fetchIssue,
     issueWidgetClickAction,
   };

--- a/web/pages/[workspaceSlug]/projects/[projectId]/pages/[pageId].tsx
+++ b/web/pages/[workspaceSlug]/projects/[projectId]/pages/[pageId].tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/router";
 import { ReactElement, useEffect, useRef, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 // hooks
-import { useApplication, useIssues, usePage, useUser } from "hooks/store";
+import { useApplication, usePage, useUser } from "hooks/store";
 import useReloadConfirmations from "hooks/use-reload-confirmation";
 import useToast from "hooks/use-toast";
 // services
@@ -88,7 +88,7 @@ const PageDetailsPage: NextPageWithLayout = observer(() => {
       : null
   );
 
-  const { issues, fetchIssue, issueWidgetClickAction } = useIssueEmbeds();
+  const { issues, issuesLoading, fetchIssue, issueWidgetClickAction } = useIssueEmbeds();
 
   const pageStore = usePage(pageId as string);
 
@@ -259,7 +259,7 @@ const PageDetailsPage: NextPageWithLayout = observer(() => {
   const userCanLock =
     currentProjectRole && [EUserProjectRoles.ADMIN, EUserProjectRoles.MEMBER].includes(currentProjectRole);
 
-  return pageIdMobx && issues ? (
+  return pageIdMobx && issues && !issuesLoading ? (
     <div className="flex h-full flex-col justify-between">
       <div className="h-full w-full overflow-hidden">
         {isPageReadOnly ? (


### PR DESCRIPTION
## Issues Addressed
- When you reload a page which includes an issue embed, the page crashes.
- On Arrow down when issue embed suggestions are open, selects the next node, instead of next issue.
- Pages crashing when issue doesn't exist in issue embeds.

## Fixed
- [x] Pages does't crash with any type of issue embed, either the embed exist or not.
- [x] When a page is reloaded, it waits till the issues are loaded for issue suggestions to work properly.
- [x] Issue Suggestions feels more sturdy than the previous version, it's precise and smooth.
- [x] Now on scroll if the Issue Suggestions are open, it will close. 

## TODO
- [ ] Flip not working in Issue Suggestion on the bottom of the document 