### PR TITLE
chore: fix authorization for new projects in the peek overview

### DIFF
--- a/web/components/issues/peek-overview/root.tsx
+++ b/web/components/issues/peek-overview/root.tsx
@@ -2,7 +2,7 @@ import { FC, Fragment, useEffect, useState, useMemo } from "react";
 import { observer } from "mobx-react-lite";
 // hooks
 import useToast from "hooks/use-toast";
-import { useIssueDetail, useIssues, useMember, useUser } from "hooks/store";
+import { useIssueDetail, useIssues, useUser } from "hooks/store";
 // components
 import { IssueView } from "components/issues";
 // types
@@ -37,7 +37,7 @@ export const IssuePeekOverview: FC<IIssuePeekOverview> = observer((props) => {
   // hooks
   const { setToastAlert } = useToast();
   const {
-    membership: { currentWorkspaceAllProjectsRole },
+    membership: { currentProjectRole },
   } = useUser();
   const {
     issues: { removeIssue: removeArchivedIssue },
@@ -195,7 +195,6 @@ export const IssuePeekOverview: FC<IIssuePeekOverview> = observer((props) => {
 
   const issue = getIssueById(peekIssue.issueId) || undefined;
 
-  const currentProjectRole = currentWorkspaceAllProjectsRole?.[peekIssue?.projectId];
   // Check if issue is editable, based on user role
   const is_editable = !!currentProjectRole && currentProjectRole >= EUserProjectRoles.MEMBER;
   const isLoading = !issue || loader ? true : false;

--- a/web/components/issues/peek-overview/root.tsx
+++ b/web/components/issues/peek-overview/root.tsx
@@ -37,7 +37,7 @@ export const IssuePeekOverview: FC<IIssuePeekOverview> = observer((props) => {
   // hooks
   const { setToastAlert } = useToast();
   const {
-    membership: { currentProjectRole },
+    membership: { currentWorkspaceAllProjectsRole },
   } = useUser();
   const {
     issues: { removeIssue: removeArchivedIssue },
@@ -195,6 +195,7 @@ export const IssuePeekOverview: FC<IIssuePeekOverview> = observer((props) => {
 
   const issue = getIssueById(peekIssue.issueId) || undefined;
 
+  const currentProjectRole = currentWorkspaceAllProjectsRole?.[peekIssue?.projectId];
   // Check if issue is editable, based on user role
   const is_editable = !!currentProjectRole && currentProjectRole >= EUserProjectRoles.MEMBER;
   const isLoading = !issue || loader ? true : false;

--- a/web/components/project/card-list.tsx
+++ b/web/components/project/card-list.tsx
@@ -9,7 +9,7 @@ import emptyProject from "public/empty-state/empty_project.webp";
 // icons
 import { NewEmptyState } from "components/common/new-empty-state";
 // constants
-import { EUserProjectRoles } from "constants/project";
+import { EUserWorkspaceRoles } from "constants/workspace";
 
 export const ProjectCardList = observer(() => {
   // store hooks
@@ -18,11 +18,11 @@ export const ProjectCardList = observer(() => {
     eventTracker: { setTrackElement },
   } = useApplication();
   const {
-    membership: { currentProjectRole },
+    membership: { currentWorkspaceRole },
   } = useUser();
   const { workspaceProjectIds, searchedProjects, getProjectById } = useProject();
 
-  const isEditingAllowed = !!currentProjectRole && currentProjectRole >= EUserProjectRoles.MEMBER;
+  const isEditingAllowed = !!currentWorkspaceRole && currentWorkspaceRole >= EUserWorkspaceRoles.MEMBER;
 
   if (!workspaceProjectIds)
     return (

--- a/web/store/project/project.store.ts
+++ b/web/store/project/project.store.ts
@@ -317,6 +317,7 @@ export class ProjectStore implements IProjectStore {
       const response = await this.projectService.createProject(workspaceSlug, data);
       runInAction(() => {
         set(this.projectMap, [response.id], response);
+        set(this.rootStore.user.membership.workspaceProjectsRole, [workspaceSlug, response.id], response.member_role);
       });
       return response;
     } catch (error) {


### PR DESCRIPTION
#### Problem:

1. After creating a new project, user is not able to update issue properties from the peek overview until the app is refreshed.

#### Solution:

1. 'workspaceProjectRole' observable needs to be updated after creating a new project.

#### Other fixes:

1. Fixed the authorization for projects list empty state.

#### Media:

https://github.com/makeplane/plane/assets/65252264/aeecaeb6-06c5-425c-a0d6-168f04c255d9

