### PR TITLE
fix: input field value not changing in delete import modal.

### DIFF
--- a/web/components/integration/delete-import-modal.tsx
+++ b/web/components/integration/delete-import-modal.tsx
@@ -117,7 +117,6 @@ export const DeleteImportModal: React.FC<Props> = ({ isOpen, handleClose, data }
                       id="typeDelete"
                       type="text"
                       name="typeDelete"
-                      value=""
                       onChange={(e) => {
                         if (e.target.value === "delete import") setConfirmDeleteImport(true);
                         else setConfirmDeleteImport(false);


### PR DESCRIPTION
#### Problem
Users couldn't delete imports because the confirmation input field in the delete import modal wasn't updating.

#### Solution
Fixed by removing `value=""` from the input, enabling proper input updates and allowing users to delete imports smoothly.