### PR TITLE
fix: inline codes now exitable with right arrow key and inclusive

### DIFF
--- a/packages/editor/core/package.json
+++ b/packages/editor/core/package.json
@@ -30,7 +30,6 @@
   "dependencies": {
     "@tiptap/core": "^2.1.13",
     "@tiptap/extension-blockquote": "^2.1.13",
-    "@tiptap/extension-code": "^2.1.13",
     "@tiptap/extension-code-block-lowlight": "^2.1.13",
     "@tiptap/extension-color": "^2.1.13",
     "@tiptap/extension-image": "^2.1.13",

--- a/packages/editor/core/src/lib/editor-commands.ts
+++ b/packages/editor/core/src/lib/editor-commands.ts
@@ -34,8 +34,32 @@ export const toggleUnderline = (editor: Editor, range?: Range) => {
 };
 
 export const toggleCodeBlock = (editor: Editor, range?: Range) => {
-  if (range) editor.chain().focus().deleteRange(range).toggleCode().run();
-  else editor.chain().focus().toggleCode().run();
+  // Check if code block is active then toggle code block
+  if (editor.isActive("codeBlock")) {
+    if (range) {
+      editor.chain().focus().deleteRange(range).toggleCodeBlock().run();
+      return;
+    }
+    editor.chain().focus().toggleCodeBlock().run();
+    return;
+  }
+
+  // Check if user hasn't selected any text
+  const isSelectionEmpty = editor.state.selection.empty;
+
+  if (isSelectionEmpty) {
+    if (range) {
+      editor.chain().focus().deleteRange(range).toggleCodeBlock().run();
+      return;
+    }
+    editor.chain().focus().toggleCodeBlock().run();
+  } else {
+    if (range) {
+      editor.chain().focus().deleteRange(range).toggleCode().run();
+      return;
+    }
+    editor.chain().focus().toggleCode().run();
+  }
 };
 
 export const toggleOrderedList = (editor: Editor, range?: Range) => {

--- a/packages/editor/core/src/lib/editor-commands.ts
+++ b/packages/editor/core/src/lib/editor-commands.ts
@@ -34,8 +34,8 @@ export const toggleUnderline = (editor: Editor, range?: Range) => {
 };
 
 export const toggleCodeBlock = (editor: Editor, range?: Range) => {
-  if (range) editor.chain().focus().deleteRange(range).toggleCodeBlock().run();
-  else editor.chain().focus().toggleCodeBlock().run();
+  if (range) editor.chain().focus().deleteRange(range).toggleCode().run();
+  else editor.chain().focus().toggleCode().run();
 };
 
 export const toggleOrderedList = (editor: Editor, range?: Range) => {

--- a/packages/editor/core/src/lib/editor-commands.ts
+++ b/packages/editor/core/src/lib/editor-commands.ts
@@ -83,8 +83,8 @@ export const toggleStrike = (editor: Editor, range?: Range) => {
 };
 
 export const toggleBlockquote = (editor: Editor, range?: Range) => {
-  if (range) editor.chain().focus().deleteRange(range).toggleNode("paragraph", "paragraph").toggleBlockquote().run();
-  else editor.chain().focus().toggleNode("paragraph", "paragraph").toggleBlockquote().run();
+  if (range) editor.chain().focus().deleteRange(range).toggleBlockquote().run();
+  else editor.chain().focus().toggleBlockquote().run();
 };
 
 export const insertTableCommand = (editor: Editor, range?: Range) => {

--- a/packages/editor/core/src/ui/extensions/code-inline/index.tsx
+++ b/packages/editor/core/src/ui/extensions/code-inline/index.tsx
@@ -1,12 +1,80 @@
-import { markInputRule, markPasteRule } from "@tiptap/core";
-import Code from "@tiptap/extension-code";
+import { Mark, markInputRule, markPasteRule, mergeAttributes } from "@tiptap/core";
 
-export const inputRegex = /(?<!`)`([^`]*)`(?!`)/;
-export const pasteRegex = /(?<!`)`([^`]+)`(?!`)/g;
+export interface CodeOptions {
+  HTMLAttributes: Record<string, any>;
+}
 
-export const CustomCodeInlineExtension = Code.extend({
+declare module "@tiptap/core" {
+  interface Commands<ReturnType> {
+    code: {
+      /**
+       * Set a code mark
+       */
+      setCode: () => ReturnType;
+      /**
+       * Toggle inline code
+       */
+      toggleCode: () => ReturnType;
+      /**
+       * Unset a code mark
+       */
+      unsetCode: () => ReturnType;
+    };
+  }
+}
+
+export const inputRegex = /(?:^|\s)((?:`)((?:[^`]+))(?:`))$/;
+export const pasteRegex = /(?:^|\s)((?:`)((?:[^`]+))(?:`))/g;
+
+export const CustomCodeInlineExtension = Mark.create<CodeOptions>({
+  name: "code",
+
+  addOptions() {
+    return {
+      HTMLAttributes: {
+        class: "rounded-md bg-custom-primary-30 mx-1 px-1 py-[2px] font-mono font-medium text-custom-text-1000",
+        spellcheck: "false",
+      },
+    };
+  },
+
+  excludes: "_",
+
+  code: true,
+
   exitable: true,
-  inclusive: false,
+
+  parseHTML() {
+    return [{ tag: "code" }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ["code", mergeAttributes(this.options.HTMLAttributes, HTMLAttributes), 0];
+  },
+
+  addCommands() {
+    return {
+      setCode:
+        () =>
+        ({ commands }) =>
+          commands.setMark(this.name),
+      toggleCode:
+        () =>
+        ({ commands }) =>
+          commands.toggleMark(this.name),
+      unsetCode:
+        () =>
+        ({ commands }) =>
+          commands.unsetMark(this.name),
+    };
+  },
+
+  addKeyboardShortcuts() {
+    return {
+      "Mod-e": () => this.editor.commands.toggleCode(),
+    };
+  },
+
   addInputRules() {
     return [
       markInputRule({
@@ -15,6 +83,7 @@ export const CustomCodeInlineExtension = Code.extend({
       }),
     ];
   },
+
   addPasteRules() {
     return [
       markPasteRule({
@@ -22,10 +91,5 @@ export const CustomCodeInlineExtension = Code.extend({
         type: this.type,
       }),
     ];
-  },
-}).configure({
-  HTMLAttributes: {
-    class: "rounded-md bg-custom-primary-30 mx-1 px-1 py-[2px] font-mono font-medium text-custom-text-1000",
-    spellcheck: "false",
   },
 });

--- a/packages/editor/core/src/ui/menus/menu-items/index.tsx
+++ b/packages/editor/core/src/ui/menus/menu-items/index.tsx
@@ -106,7 +106,7 @@ export const TodoListItem = (editor: Editor): EditorMenuItem => ({
 
 export const CodeItem = (editor: Editor): EditorMenuItem => ({
   name: "code",
-  isActive: () => editor?.isActive("code"),
+  isActive: () => editor?.isActive("code") || editor?.isActive("codeBlock"),
   command: () => toggleCodeBlock(editor),
   icon: CodeIcon,
 });

--- a/packages/editor/core/src/ui/menus/menu-items/index.tsx
+++ b/packages/editor/core/src/ui/menus/menu-items/index.tsx
@@ -120,7 +120,7 @@ export const NumberedListItem = (editor: Editor): EditorMenuItem => ({
 
 export const QuoteItem = (editor: Editor): EditorMenuItem => ({
   name: "quote",
-  isActive: () => editor?.isActive("quote"),
+  isActive: () => editor?.isActive("blockquote"),
   command: () => toggleBlockquote(editor),
   icon: QuoteIcon,
 });


### PR DESCRIPTION
## Description

Inline code blocks are now exitable with the right arrow key and inclusive at the same time.

Key behaviours
1. Only recognises inline code blocks if typed in the format left prefix (backtick)--> inline code text --> right prefix(backtick), this is the intended behaviour incase as explained in https://github.com/makeplane/plane/pull/3318
2. Inline code blocks can be triggered by using the bubble menu on selecting text (regression) in Rich text editors.
3. To exit a code block, use the right arrow key and to get inside and start typing again use the left arrow key (backspace won't work as it's intended)
4. Added a behaviour in which-->
   1. If you select any amounts of text and then click on the button for toggling code, then it'll make it inline code. 
   2. If your cursor is just at some node and you click on button for toggling code then it'll make it a code block and if you click on it again it'll simply turn it into a paragraph node.
   3. If you select text inside a code block, then click on button for toggling code, it'll simply turn it into a paragraph node.

## Demo
1. For code blocks exiting

https://github.com/makeplane/plane/assets/73993394/b742a121-fe2c-4c8c-9ace-4e6b6c879258

2. For toggling code block in pages, issues and comments

https://github.com/makeplane/plane/assets/73993394/e77f7d1f-14f2-4906-a779-21b43725df46