### PR TITLE
fix: fixed checklist scrolling on click

### DIFF
--- a/packages/editor/core/src/ui/components/editor-container.tsx
+++ b/packages/editor/core/src/ui/components/editor-container.tsx
@@ -12,7 +12,7 @@ export const EditorContainer = ({ editor, editorClassNames, hideDragHandle, chil
   <div
     id="editor-container"
     onClick={() => {
-      editor?.chain().focus().run();
+      editor?.chain().focus(undefined, { scrollIntoView: false }).run();
     }}
     onMouseLeave={() => {
       hideDragHandle?.();


### PR DESCRIPTION
## Description
When a user tried to check/uncheck of a todo inside the editor, the whole todolist scroll till the position of the cursor.

## Before Fix

https://github.com/makeplane/plane/assets/72302948/b44f54a2-1b60-4b2e-af27-c50f22438bfe

## Post Fix


https://github.com/makeplane/plane/assets/72302948/3701f88d-63cf-4e0e-a2d7-7bd4abdb80b1



