### PR TITLE
fix: issues list modal not closing on escape key

### DIFF
--- a/web/components/core/modals/existing-issues-list-modal.tsx
+++ b/web/components/core/modals/existing-issues-list-modal.tsx
@@ -88,7 +88,7 @@ export const ExistingIssuesListModal: React.FC<Props> = (props) => {
   return (
     <>
       <Transition.Root show={isOpen} as={React.Fragment} afterLeave={() => setSearchTerm("")} appear>
-        <Dialog as="div" className="relative z-20" onClose={() => {}}>
+        <Dialog as="div" className="relative z-20" onClose={handleClose}>
           <Transition.Child
             as={React.Fragment}
             enter="ease-out duration-300"


### PR DESCRIPTION
#### Problem:

Existing issues list modal not closing on pressing the Escape key or on clicking outside.

#### Solution:

Added the missing `onClose` function to the `Dialog`.