### PR TITLE
fix: add issue to store only if the issue doesn't exist

### DIFF
--- a/web/components/dropdowns/types.d.ts
+++ b/web/components/dropdowns/types.d.ts
@@ -18,5 +18,6 @@ export type TDropdownProps = {
   placeholder?: string;
   placement?: Placement;
   tabIndex?: number;
+  // TODO: rename this prop to showTooltip
   tooltip?: boolean;
 };

--- a/web/store/issue/issue-details/issue.store.ts
+++ b/web/store/issue/issue-details/issue.store.ts
@@ -90,6 +90,7 @@ export class IssueStore implements IIssueStore {
       this.rootIssueDetailStore.relation.fetchRelations(workspaceSlug, projectId, issueId);
 
       // fetching states
+      // TODO: check if this function is required
       this.rootIssueDetailStore.rootIssueStore.state.fetchProjectStates(workspaceSlug, projectId);
 
       return issue;

--- a/web/store/issue/issue.store.ts
+++ b/web/store/issue/issue.store.ts
@@ -43,7 +43,7 @@ export class IssueStore implements IIssueStore {
     if (issues && issues.length <= 0) return;
     runInAction(() => {
       issues.forEach((issue) => {
-        set(this.issuesMap, issue.id, issue);
+        if (!this.issuesMap[issue.id]) set(this.issuesMap, issue.id, issue);
       });
     });
   };


### PR DESCRIPTION
#### Problem:

Fetching issue relations(which have minimal issue information) was replacing all the information related to that issue in the `issueMap`.

#### Solution:

Update the `addIssue` function to only add issue to the `issueMap` if the issue doesn't exist already.