### PR TITLE
chore: issue relation modal and issue peek overview mutation fix

### DIFF
--- a/web/components/core/modals/existing-issues-list-modal.tsx
+++ b/web/components/core/modals/existing-issues-list-modal.tsx
@@ -12,8 +12,8 @@ import { Button, LayersIcon, Loader, ToggleSwitch, Tooltip } from "@plane/ui";
 import { ISearchIssueResponse, TProjectIssuesSearchParams } from "@plane/types";
 
 type Props = {
-  workspaceSlug: string;
-  projectId: string;
+  workspaceSlug: string | undefined;
+  projectId: string | undefined;
   isOpen: boolean;
   handleClose: () => void;
   searchParams: Partial<TProjectIssuesSearchParams>;

--- a/web/components/core/modals/existing-issues-list-modal.tsx
+++ b/web/components/core/modals/existing-issues-list-modal.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from "react";
-import { useRouter } from "next/router";
 import { Combobox, Dialog, Transition } from "@headlessui/react";
 import { Rocket, Search, X } from "lucide-react";
 // services
@@ -13,6 +12,8 @@ import { Button, LayersIcon, Loader, ToggleSwitch, Tooltip } from "@plane/ui";
 import { ISearchIssueResponse, TProjectIssuesSearchParams } from "@plane/types";
 
 type Props = {
+  workspaceSlug: string;
+  projectId: string;
   isOpen: boolean;
   handleClose: () => void;
   searchParams: Partial<TProjectIssuesSearchParams>;
@@ -23,7 +24,15 @@ type Props = {
 const projectService = new ProjectService();
 
 export const ExistingIssuesListModal: React.FC<Props> = (props) => {
-  const { isOpen, handleClose: onClose, searchParams, handleOnSubmit, workspaceLevelToggle = false } = props;
+  const {
+    workspaceSlug,
+    projectId,
+    isOpen,
+    handleClose: onClose,
+    searchParams,
+    handleOnSubmit,
+    workspaceLevelToggle = false,
+  } = props;
   // states
   const [searchTerm, setSearchTerm] = useState("");
   const [issues, setIssues] = useState<ISearchIssueResponse[]>([]);
@@ -33,9 +42,6 @@ export const ExistingIssuesListModal: React.FC<Props> = (props) => {
   const [isWorkspaceLevel, setIsWorkspaceLevel] = useState(false);
 
   const debouncedSearchTerm: string = useDebounce(searchTerm, 500);
-
-  const router = useRouter();
-  const { workspaceSlug, projectId } = router.query;
 
   const { setToastAlert } = useToast();
 

--- a/web/components/issues/issue-detail/relation-select.tsx
+++ b/web/components/issues/issue-detail/relation-select.tsx
@@ -90,6 +90,8 @@ export const IssueRelationSelect: React.FC<TIssueRelationSelect> = observer((pro
   return (
     <>
       <ExistingIssuesListModal
+        workspaceSlug={workspaceSlug}
+        projectId={projectId}
         isOpen={isRelationModalOpen === relationKey}
         handleClose={() => toggleRelationModal(null)}
         searchParams={{ issue_relation: true, issue_id: issueId }}

--- a/web/components/issues/issue-detail/root.tsx
+++ b/web/components/issues/issue-detail/root.tsx
@@ -120,10 +120,17 @@ export const IssueDetailRoot: FC<TIssueDetailRoot> = (props) => {
       },
       addIssueToCycle: async (workspaceSlug: string, projectId: string, cycleId: string, issueIds: string[]) => {
         try {
+          console.log("init");
+          console.log("workspaceSlug", workspaceSlug);
+          console.log("projectId", projectId);
+          console.log("cycleId", cycleId);
+          console.log("issueIds", issueIds);
           await addIssueToCycle(workspaceSlug, projectId, cycleId, issueIds)
-            .then((res) => {
-              updateIssue(workspaceSlug, projectId, res.id, res);
-              fetchIssue(workspaceSlug, projectId, res.id);
+            .then(() => {
+              issueIds.map((issueId) => {
+                updateIssue(workspaceSlug, projectId, issueId, { cycle_id: cycleId });
+                fetchIssue(workspaceSlug, projectId, issueId, is_archived);
+              });
               setToastAlert({
                 title: "Cycle added to issue successfully",
                 type: "success",
@@ -164,9 +171,11 @@ export const IssueDetailRoot: FC<TIssueDetailRoot> = (props) => {
       addIssueToModule: async (workspaceSlug: string, projectId: string, moduleId: string, issueIds: string[]) => {
         try {
           await addIssueToModule(workspaceSlug, projectId, moduleId, issueIds)
-            .then((res) => {
-              updateIssue(workspaceSlug, projectId, res.id, res);
-              fetchIssue(workspaceSlug, projectId, res.id);
+            .then(() => {
+              issueIds.map((issueId) => {
+                updateIssue(workspaceSlug, projectId, issueId, { module_id: moduleId });
+                fetchIssue(workspaceSlug, projectId, issueId, is_archived);
+              });
               setToastAlert({
                 title: "Module added to issue successfully",
                 type: "success",

--- a/web/components/issues/issue-detail/root.tsx
+++ b/web/components/issues/issue-detail/root.tsx
@@ -120,21 +120,12 @@ export const IssueDetailRoot: FC<TIssueDetailRoot> = (props) => {
       },
       addIssueToCycle: async (workspaceSlug: string, projectId: string, cycleId: string, issueIds: string[]) => {
         try {
-          await addIssueToCycle(workspaceSlug, projectId, cycleId, issueIds)
-            .then(() => {
-              setToastAlert({
-                title: "Cycle added to issue successfully",
-                type: "success",
-                message: "Issue added to issue successfully",
-              });
-            })
-            .catch(() => {
-              setToastAlert({
-                type: "error",
-                title: "Error!",
-                message: "Selected issues could not be added to the cycle. Please try again.",
-              });
-            });
+          await addIssueToCycle(workspaceSlug, projectId, cycleId, issueIds);
+          setToastAlert({
+            title: "Cycle added to issue successfully",
+            type: "success",
+            message: "Issue added to issue successfully",
+          });
         } catch (error) {
           setToastAlert({
             title: "Cycle add to issue failed",
@@ -161,21 +152,12 @@ export const IssueDetailRoot: FC<TIssueDetailRoot> = (props) => {
       },
       addIssueToModule: async (workspaceSlug: string, projectId: string, moduleId: string, issueIds: string[]) => {
         try {
-          await addIssueToModule(workspaceSlug, projectId, moduleId, issueIds)
-            .then(() => {
-              setToastAlert({
-                title: "Module added to issue successfully",
-                type: "success",
-                message: "Module added to issue successfully",
-              });
-            })
-            .catch(() =>
-              setToastAlert({
-                type: "error",
-                title: "Error!",
-                message: "Selected issues could not be added to the module. Please try again.",
-              })
-            );
+          await addIssueToModule(workspaceSlug, projectId, moduleId, issueIds);
+          setToastAlert({
+            title: "Module added to issue successfully",
+            type: "success",
+            message: "Module added to issue successfully",
+          });
         } catch (error) {
           setToastAlert({
             title: "Module add to issue failed",

--- a/web/components/issues/issue-detail/root.tsx
+++ b/web/components/issues/issue-detail/root.tsx
@@ -120,17 +120,8 @@ export const IssueDetailRoot: FC<TIssueDetailRoot> = (props) => {
       },
       addIssueToCycle: async (workspaceSlug: string, projectId: string, cycleId: string, issueIds: string[]) => {
         try {
-          console.log("init");
-          console.log("workspaceSlug", workspaceSlug);
-          console.log("projectId", projectId);
-          console.log("cycleId", cycleId);
-          console.log("issueIds", issueIds);
           await addIssueToCycle(workspaceSlug, projectId, cycleId, issueIds)
             .then(() => {
-              issueIds.map((issueId) => {
-                updateIssue(workspaceSlug, projectId, issueId, { cycle_id: cycleId });
-                fetchIssue(workspaceSlug, projectId, issueId, is_archived);
-              });
               setToastAlert({
                 title: "Cycle added to issue successfully",
                 type: "success",
@@ -172,10 +163,6 @@ export const IssueDetailRoot: FC<TIssueDetailRoot> = (props) => {
         try {
           await addIssueToModule(workspaceSlug, projectId, moduleId, issueIds)
             .then(() => {
-              issueIds.map((issueId) => {
-                updateIssue(workspaceSlug, projectId, issueId, { module_id: moduleId });
-                fetchIssue(workspaceSlug, projectId, issueId, is_archived);
-              });
               setToastAlert({
                 title: "Module added to issue successfully",
                 type: "success",

--- a/web/components/issues/issue-layouts/empty-states/cycle.tsx
+++ b/web/components/issues/issue-layouts/empty-states/cycle.tsx
@@ -65,6 +65,8 @@ export const CycleEmptyState: React.FC<Props> = observer((props) => {
   return (
     <>
       <ExistingIssuesListModal
+        workspaceSlug={workspaceSlug}
+        projectId={projectId}
         isOpen={cycleIssuesListModal}
         handleClose={() => setCycleIssuesListModal(false)}
         searchParams={{ cycle: true }}

--- a/web/components/issues/issue-layouts/empty-states/module.tsx
+++ b/web/components/issues/issue-layouts/empty-states/module.tsx
@@ -65,6 +65,8 @@ export const ModuleEmptyState: React.FC<Props> = observer((props) => {
   return (
     <>
       <ExistingIssuesListModal
+        workspaceSlug={workspaceSlug}
+        projectId={projectId}
         isOpen={moduleIssuesListModal}
         handleClose={() => setModuleIssuesListModal(false)}
         searchParams={{ module: true }}

--- a/web/components/issues/issue-layouts/kanban/headers/group-by-card.tsx
+++ b/web/components/issues/issue-layouts/kanban/headers/group-by-card.tsx
@@ -93,6 +93,8 @@ export const HeaderGroupByCard: FC<IHeaderGroupByCard> = observer((props) => {
       )}
       {renderExistingIssueModal && (
         <ExistingIssuesListModal
+          workspaceSlug={workspaceSlug?.toString()}
+          projectId={projectId?.toString()}
           isOpen={openExistingIssueListModal}
           handleClose={() => setOpenExistingIssueListModal(false)}
           searchParams={ExistingIssuesListModalPayload}

--- a/web/components/issues/issue-layouts/list/headers/group-by-card.tsx
+++ b/web/components/issues/issue-layouts/list/headers/group-by-card.tsx
@@ -110,6 +110,8 @@ export const HeaderGroupByCard = observer(
 
           {renderExistingIssueModal && (
             <ExistingIssuesListModal
+              workspaceSlug={workspaceSlug?.toString()}
+              projectId={projectId?.toString()}
               isOpen={openExistingIssueListModal}
               handleClose={() => setOpenExistingIssueListModal(false)}
               searchParams={ExistingIssuesListModalPayload}

--- a/web/components/issues/peek-overview/root.tsx
+++ b/web/components/issues/peek-overview/root.tsx
@@ -114,9 +114,11 @@ export const IssuePeekOverview: FC<IIssuePeekOverview> = observer((props) => {
       addIssueToCycle: async (workspaceSlug: string, projectId: string, cycleId: string, issueIds: string[]) => {
         try {
           await addIssueToCycle(workspaceSlug, projectId, cycleId, issueIds)
-            .then((res) => {
-              updateIssue(workspaceSlug, projectId, res.id, res);
-              fetchIssue(workspaceSlug, projectId, res.id);
+            .then(() => {
+              issueIds.map((issueId) => {
+                updateIssue(workspaceSlug, projectId, issueId, { cycle_id: cycleId });
+                fetchIssue(workspaceSlug, projectId, issueId, is_archived);
+              });
               setToastAlert({
                 title: "Cycle added to issue successfully",
                 type: "success",
@@ -157,9 +159,11 @@ export const IssuePeekOverview: FC<IIssuePeekOverview> = observer((props) => {
       addIssueToModule: async (workspaceSlug: string, projectId: string, moduleId: string, issueIds: string[]) => {
         try {
           await addIssueToModule(workspaceSlug, projectId, moduleId, issueIds)
-            .then((res) => {
-              updateIssue(workspaceSlug, projectId, res.id, res);
-              fetchIssue(workspaceSlug, projectId, res.id);
+            .then(() => {
+              issueIds.map((issueId) => {
+                updateIssue(workspaceSlug, projectId, issueId, { module_id: moduleId });
+                fetchIssue(workspaceSlug, projectId, issueId, is_archived);
+              });
               setToastAlert({
                 title: "Module added to issue successfully",
                 type: "success",

--- a/web/components/issues/peek-overview/root.tsx
+++ b/web/components/issues/peek-overview/root.tsx
@@ -113,25 +113,12 @@ export const IssuePeekOverview: FC<IIssuePeekOverview> = observer((props) => {
       },
       addIssueToCycle: async (workspaceSlug: string, projectId: string, cycleId: string, issueIds: string[]) => {
         try {
-          await addIssueToCycle(workspaceSlug, projectId, cycleId, issueIds)
-            .then(() => {
-              issueIds.map((issueId) => {
-                updateIssue(workspaceSlug, projectId, issueId, { cycle_id: cycleId });
-                fetchIssue(workspaceSlug, projectId, issueId, is_archived);
-              });
-              setToastAlert({
-                title: "Cycle added to issue successfully",
-                type: "success",
-                message: "Issue added to issue successfully",
-              });
-            })
-            .catch(() => {
-              setToastAlert({
-                type: "error",
-                title: "Error!",
-                message: "Selected issues could not be added to the cycle. Please try again.",
-              });
-            });
+          await addIssueToCycle(workspaceSlug, projectId, cycleId, issueIds);
+          setToastAlert({
+            title: "Cycle added to issue successfully",
+            type: "success",
+            message: "Issue added to issue successfully",
+          });
         } catch (error) {
           setToastAlert({
             title: "Cycle add to issue failed",
@@ -158,25 +145,12 @@ export const IssuePeekOverview: FC<IIssuePeekOverview> = observer((props) => {
       },
       addIssueToModule: async (workspaceSlug: string, projectId: string, moduleId: string, issueIds: string[]) => {
         try {
-          await addIssueToModule(workspaceSlug, projectId, moduleId, issueIds)
-            .then(() => {
-              issueIds.map((issueId) => {
-                updateIssue(workspaceSlug, projectId, issueId, { module_id: moduleId });
-                fetchIssue(workspaceSlug, projectId, issueId, is_archived);
-              });
-              setToastAlert({
-                title: "Module added to issue successfully",
-                type: "success",
-                message: "Module added to issue successfully",
-              });
-            })
-            .catch(() =>
-              setToastAlert({
-                type: "error",
-                title: "Error!",
-                message: "Selected issues could not be added to the module. Please try again.",
-              })
-            );
+          await addIssueToModule(workspaceSlug, projectId, moduleId, issueIds);
+          setToastAlert({
+            title: "Module added to issue successfully",
+            type: "success",
+            message: "Module added to issue successfully",
+          });
         } catch (error) {
           setToastAlert({
             title: "Module add to issue failed",

--- a/web/components/issues/sub-issues/root.tsx
+++ b/web/components/issues/sub-issues/root.tsx
@@ -369,6 +369,8 @@ export const SubIssuesRoot: FC<ISubIssuesRoot> = observer((props) => {
 
           {issueCrudState?.existing?.toggle && issueCrudState?.existing?.parentIssueId && (
             <ExistingIssuesListModal
+              workspaceSlug={workspaceSlug}
+              projectId={projectId}
               isOpen={issueCrudState?.existing?.toggle}
               handleClose={() => handleIssueCrudState("existing", null, null)}
               searchParams={{ sub_issue: true, issue_id: issueCrudState?.existing?.parentIssueId }}

--- a/web/store/issue/cycle/issue.store.ts
+++ b/web/store/issue/cycle/issue.store.ts
@@ -3,6 +3,7 @@ import set from "lodash/set";
 import update from "lodash/update";
 import concat from "lodash/concat";
 import pull from "lodash/pull";
+import uniq from "lodash/uniq";
 // base class
 import { IssueHelperStore } from "../helpers/issue-helper.store";
 // services
@@ -165,7 +166,6 @@ export class CycleIssues extends IssueHelperStore implements ICycleIssues {
 
       return response;
     } catch (error) {
-      console.log(error);
       this.loader = undefined;
       throw error;
     }
@@ -267,10 +267,12 @@ export class CycleIssues extends IssueHelperStore implements ICycleIssues {
       });
 
       runInAction(() => {
-        update(this.issues, cycleId, (cycleIssueIds) => {
-          if (!cycleIssueIds) return [...issueIds];
-          else return concat(cycleIssueIds, [...issueIds]);
+        update(this.issues, cycleId, (cycleIssueIds = []) => {
+          uniq(concat(cycleIssueIds, issueIds));
         });
+      });
+      issueIds.forEach((issueId) => {
+        this.rootStore.issues.updateIssue(issueId, { cycle_id: cycleId });
       });
 
       return issueToCycle;
@@ -332,7 +334,6 @@ export class CycleIssues extends IssueHelperStore implements ICycleIssues {
 
       return response;
     } catch (error) {
-      console.log(error);
       this.loader = undefined;
       throw error;
     }

--- a/web/store/issue/module/issue.store.ts
+++ b/web/store/issue/module/issue.store.ts
@@ -3,6 +3,7 @@ import set from "lodash/set";
 import update from "lodash/update";
 import concat from "lodash/concat";
 import pull from "lodash/pull";
+import uniq from "lodash/uniq";
 // base class
 import { IssueHelperStore } from "../helpers/issue-helper.store";
 // services
@@ -263,6 +264,15 @@ export class ModuleIssues extends IssueHelperStore implements IModuleIssues {
           if (!moduleIssueIds) return [...issueIds];
           else return concat(moduleIssueIds, [...issueIds]);
         });
+      });
+
+      runInAction(() => {
+        update(this.issues, moduleId, (moduleIssueIds = []) => {
+          uniq(concat(moduleIssueIds, issueIds));
+        });
+      });
+      issueIds.forEach((issueId) => {
+        this.rootStore.issues.updateIssue(issueId, { cycle_id: moduleId });
       });
 
       return issueToModule;

--- a/web/store/issue/module/issue.store.ts
+++ b/web/store/issue/module/issue.store.ts
@@ -260,19 +260,12 @@ export class ModuleIssues extends IssueHelperStore implements IModuleIssues {
       });
 
       runInAction(() => {
-        update(this.issues, moduleId, (moduleIssueIds) => {
-          if (!moduleIssueIds) return [...issueIds];
-          else return concat(moduleIssueIds, [...issueIds]);
-        });
-      });
-
-      runInAction(() => {
         update(this.issues, moduleId, (moduleIssueIds = []) => {
           uniq(concat(moduleIssueIds, issueIds));
         });
       });
       issueIds.forEach((issueId) => {
-        this.rootStore.issues.updateIssue(issueId, { cycle_id: moduleId });
+        this.rootStore.issues.updateIssue(issueId, { module_id: moduleId });
       });
 
       return issueToModule;


### PR DESCRIPTION
### Problem
- The "Add to cycle" and "Add to module" mutations were not working in the Issue Peek Overview and Issue Sidebar.
- The Issue Relation modal failed to render any issues within the workspace in the Issue Peek Overview.
### Resolution
- Rectified the issue by fixing the logic for mutating issues related to "Add to cycle" and "Add to module" functionalities in both Peek Overview and Issue Sidebar.
- Previously, the workspace slug and project ID were obtained from the router. This has been resolved by now passing the workspace slug and project ID as props.