### PR TITLE
fix: Add missing project and subscriber filters to the list of filter params

### DIFF
--- a/web/components/notifications/notification-header.tsx
+++ b/web/components/notifications/notification-header.tsx
@@ -95,6 +95,7 @@ export const NotificationHeader: React.FC<NotificationHeaderProps> = (props) => 
                 <MoreVertical className="h-3.5 w-3.5" />
               </div>
             }
+            closeOnSelect
           >
             <CustomMenu.MenuItem onClick={markAllNotificationsAsRead}>
               <div className="flex items-center gap-2">

--- a/web/constants/issue.ts
+++ b/web/constants/issue.ts
@@ -304,7 +304,17 @@ export const ISSUE_DISPLAY_FILTERS_BY_LAYOUT: {
   },
   my_issues: {
     spreadsheet: {
-      filters: ["priority", "state_group", "labels", "assignees", "created_by", "project", "start_date", "target_date"],
+      filters: [
+        "priority",
+        "state_group",
+        "labels",
+        "assignees",
+        "created_by",
+        "subscriber",
+        "project",
+        "start_date",
+        "target_date",
+      ],
       display_properties: true,
       display_filters: {
         type: [null, "active", "backlog"],

--- a/web/hooks/use-user-notifications.tsx
+++ b/web/hooks/use-user-notifications.tsx
@@ -264,6 +264,13 @@ const useUserNotification = () => {
 
     await userNotificationServices
       .markAllNotificationsAsRead(workspaceSlug.toString(), markAsReadParams)
+      .then(() => {
+        setToastAlert({
+          type: "success",
+          title: "Success!",
+          message: "All Notifications marked as read.",
+        });
+      })
       .catch(() => {
         setToastAlert({
           type: "error",

--- a/web/store/issue/helpers/issue-filter-helper.store.ts
+++ b/web/store/issue/helpers/issue-filter-helper.store.ts
@@ -73,6 +73,8 @@ export class IssueFilterHelperStore implements IIssueFilterHelperStore {
       labels: filters?.labels || undefined,
       start_date: filters?.start_date || undefined,
       target_date: filters?.target_date || undefined,
+      project: filters.project || undefined,
+      subscriber: filters.subscriber || undefined,
       // display filters
       type: displayFilters?.type || undefined,
       sub_issue: displayFilters?.sub_issue ?? true,


### PR DESCRIPTION
This PR fixes the missing project and subscriber filter params for the issue filter params and also adds a toast message for marking all notifications as read.