### PR TITLE
chore: fix assignee tooltip logic in list and Kanban layout for consistency.

### DIFF
--- a/web/components/issues/issue-layouts/properties/all-properties.tsx
+++ b/web/components/issues/issue-layouts/properties/all-properties.tsx
@@ -155,7 +155,6 @@ export const IssueProperties: React.FC<IIssueProperties> = observer((props) => {
             multiple
             buttonVariant={issue.assignee_ids?.length > 0 ? "transparent-without-text" : "border-without-text"}
             buttonClassName={issue.assignee_ids?.length > 0 ? "hover:bg-transparent px-0" : ""}
-            tooltip
           />
         </div>
       </WithDisplayPropertiesHOC>


### PR DESCRIPTION
#### Problem
Assignee tooltip logic was inconsistent in list and Kanban layouts resulting in different kind of tooltip content being shown.

#### Solution
Removed the `tooltip` prop, which was responsible for showing combined tooltip with just total count instead of names of individual assignees. 

