### PR TITLE
fix: all issues custom views by defining list layout for my-issue

### DIFF
--- a/web/constants/issue.ts
+++ b/web/constants/issue.ts
@@ -324,6 +324,27 @@ export const ISSUE_DISPLAY_FILTERS_BY_LAYOUT: {
         values: [],
       },
     },
+    list: {
+      filters: [
+        "priority",
+        "state_group",
+        "labels",
+        "assignees",
+        "created_by",
+        "subscriber",
+        "project",
+        "start_date",
+        "target_date",
+      ],
+      display_properties: true,
+      display_filters: {
+        type: [null, "active", "backlog"],
+      },
+      extra_options: {
+        access: false,
+        values: [],
+      },
+    },
   },
   issues: {
     list: {


### PR DESCRIPTION
This PR fixes the custom views by defining issue filters for list in global issues. 

This had to be done because, the data of the custom views seems to be corrupted to show issue layout for some views as "list" instead of "spreadsheet". Adding this to fix it for now. 
By default when creating a new view it adds "spreadsheet" as issue layout as it should.