### PR TITLE
fix: draft issue modal

### DIFF
--- a/web/components/issues/draft-issue-form.tsx
+++ b/web/components/issues/draft-issue-form.tsx
@@ -257,14 +257,16 @@ export const DraftIssueForm: FC<IssueFormProps> = observer((props) => {
   };
 
   useEffect(() => {
-    setFocus("name");
-
     reset({
       ...defaultValues,
       ...(prePopulatedData ?? {}),
       ...(data ?? {}),
     });
-  }, [setFocus, prePopulatedData, reset, data]);
+  }, [prePopulatedData, reset, data]);
+
+  useEffect(() => {
+    setFocus("name");
+  }, [setFocus]);
 
   // update projectId in form when projectId changes
   useEffect(() => {


### PR DESCRIPTION
This PR addresses the focus issue in the draft issue modal, which was causing problems with the issue description. Now, when a user attempts to type the description, the focus no longer shifts to the title. This has been resolved by separating the focus and preload functionalities in the useEffect.