### PR TITLE
fix: resolved issue with resetting the draft issue form

### DIFF
--- a/web/components/issues/draft-issue-form.tsx
+++ b/web/components/issues/draft-issue-form.tsx
@@ -170,17 +170,6 @@ export const DraftIssueForm: FC<IssueFormProps> = observer((props) => {
   //   handleClose();
   // };
 
-  useEffect(() => {
-    if (!isOpen || data) return;
-
-    setLocalStorageValue(
-      JSON.stringify({
-        ...payload,
-      })
-    );
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [JSON.stringify(payload), isOpen, data]);
-
   // const onClose = () => {
   //   handleClose();
   // };
@@ -255,14 +244,6 @@ export const DraftIssueForm: FC<IssueFormProps> = observer((props) => {
       })
       .finally(() => setIAmFeelingLucky(false));
   };
-
-  useEffect(() => {
-    reset({
-      ...defaultValues,
-      ...(prePopulatedData ?? {}),
-      ...(data ?? {}),
-    });
-  }, [prePopulatedData, reset, data]);
 
   useEffect(() => {
     setFocus("name");


### PR DESCRIPTION
Problem
- When the "Create more" toggle is enabled and an issue is created, the draft issue form resets, resulting in the loss of project data.
Solution
- This PR resolves the issue by implementing a fix that ensures the accurate resetting of data in the draft issue form.