### PR TITLE
dev: validation for external id and external source

### DIFF
--- a/apiserver/plane/api/views/cycle.py
+++ b/apiserver/plane/api/views/cycle.py
@@ -253,9 +253,16 @@ class CycleAPIEndpoint(WebhookMixin, BaseAPIView):
                         external_id=request.data.get("external_id"),
                     ).exists()
                 ):
+                    cycle = Cycle.objects.filter(
+                        workspace__slug=slug,
+                        project_id=project_id,
+                        external_source=request.data.get("external_source"),
+                        external_id=request.data.get("external_id"),
+                    ).first()
                     return Response(
                         {
-                            "error": "Cycle with the same external id and external source already exists"
+                            "error": "Cycle with the same external id and external source already exists",
+                            "cycle": str(cycle.id),
                         },
                         status=status.HTTP_410_GONE,
                     )
@@ -322,7 +329,8 @@ class CycleAPIEndpoint(WebhookMixin, BaseAPIView):
             ):
                 return Response(
                     {
-                        "error": "Cycle with the same external id and external source already exists"
+                        "error": "Cycle with the same external id and external source already exists",
+                        "cycle_id": str(cycle.id),
                     },
                     status=status.HTTP_410_GONE,
                 )

--- a/apiserver/plane/api/views/cycle.py
+++ b/apiserver/plane/api/views/cycle.py
@@ -264,7 +264,7 @@ class CycleAPIEndpoint(WebhookMixin, BaseAPIView):
                             "error": "Cycle with the same external id and external source already exists",
                             "cycle": str(cycle.id),
                         },
-                        status=status.HTTP_410_GONE,
+                        status=status.HTTP_409_CONFLICT,
                     )
                 serializer.save(
                     project_id=project_id,
@@ -315,15 +315,10 @@ class CycleAPIEndpoint(WebhookMixin, BaseAPIView):
             if (
                 request.data.get("external_id")
                 and (cycle.external_id != request.data.get("external_id"))
-                and request.data.get("external_source")
-                and (
-                    cycle.external_source
-                    != request.data.get("external_source")
-                )
                 and Cycle.objects.filter(
                     project_id=project_id,
                     workspace__slug=slug,
-                    external_source=request.data.get("external_source"),
+                    external_source=request.data.get("external_source", cycle.external_source),
                     external_id=request.data.get("external_id"),
                 ).exists()
             ):
@@ -332,7 +327,7 @@ class CycleAPIEndpoint(WebhookMixin, BaseAPIView):
                         "error": "Cycle with the same external id and external source already exists",
                         "cycle_id": str(cycle.id),
                     },
-                    status=status.HTTP_410_GONE,
+                    status=status.HTTP_409_CONFLICT,
                 )
             serializer.save()
             return Response(serializer.data, status=status.HTTP_200_OK)

--- a/apiserver/plane/api/views/issue.py
+++ b/apiserver/plane/api/views/issue.py
@@ -230,9 +230,16 @@ class IssueAPIEndpoint(WebhookMixin, BaseAPIView):
                     external_id=request.data.get("external_id"),
                 ).exists()
             ):
+                issue = Issue.objects.filter(
+                    workspace__slug=slug,
+                    project_id=project_id,
+                    external_id=request.data.get("external_id"),
+                    external_source=request.data.get("external_source"),
+                ).first()
                 return Response(
                     {
-                        "error": "Issue with the same external id and external source already exists"
+                        "error": "Issue with the same external id and external source already exists",
+                        "issue_id": str(issue.id),
                     },
                     status=status.HTTP_410_GONE,
                 )
@@ -290,7 +297,8 @@ class IssueAPIEndpoint(WebhookMixin, BaseAPIView):
             ):
                 return Response(
                     {
-                        "error": "Issue with the same external id and external source already exists"
+                        "error": "Issue with the same external id and external source already exists",
+                        "issue_id": str(issue.id)
                     },
                     status=status.HTTP_410_GONE,
                 )

--- a/apiserver/plane/api/views/module.py
+++ b/apiserver/plane/api/views/module.py
@@ -153,7 +153,7 @@ class ModuleAPIEndpoint(WebhookMixin, BaseAPIView):
                         "error": "Module with the same external id and external source already exists",
                         "module_id": str(module.id),
                     },
-                    status=status.HTTP_410_GONE,
+                    status=status.HTTP_409_CONFLICT,
                 )
             serializer.save()
             module = Module.objects.get(pk=serializer.data["id"])
@@ -175,15 +175,10 @@ class ModuleAPIEndpoint(WebhookMixin, BaseAPIView):
             if (
                 request.data.get("external_id")
                 and (module.external_id != request.data.get("external_id"))
-                and request.data.get("external_source")
-                and (
-                    module.external_source
-                    != request.data.get("external_source")
-                )
                 and Module.objects.filter(
                     project_id=project_id,
                     workspace__slug=slug,
-                    external_source=request.data.get("external_source"),
+                    external_source=request.data.get("external_source", module.external_source),
                     external_id=request.data.get("external_id"),
                 ).exists()
             ):
@@ -192,10 +187,10 @@ class ModuleAPIEndpoint(WebhookMixin, BaseAPIView):
                         "error": "Module with the same external id and external source already exists",
                         "module_id": str(module.id),
                     },
-                    status=status.HTTP_410_GONE,
+                    status=status.HTTP_409_CONFLICT,
                 )
             serializer.save()
-            return Response(serializer.data, status=status.HTTP_201_CREATED)
+            return Response(serializer.data, status=status.HTTP_200_OK)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
     def get(self, request, slug, project_id, pk=None):

--- a/apiserver/plane/api/views/module.py
+++ b/apiserver/plane/api/views/module.py
@@ -142,9 +142,16 @@ class ModuleAPIEndpoint(WebhookMixin, BaseAPIView):
                     external_id=request.data.get("external_id"),
                 ).exists()
             ):
+                module = Module.objects.filter(
+                    project_id=project_id,
+                    workspace__slug=slug,
+                    external_source=request.data.get("external_source"),
+                    external_id=request.data.get("external_id"),
+                ).first()
                 return Response(
                     {
-                        "error": "Module with the same external id and external source already exists"
+                        "error": "Module with the same external id and external source already exists",
+                        "module_id": str(module.id),
                     },
                     status=status.HTTP_410_GONE,
                 )
@@ -182,7 +189,8 @@ class ModuleAPIEndpoint(WebhookMixin, BaseAPIView):
             ):
                 return Response(
                     {
-                        "error": "Module with the same external id and external source already exists"
+                        "error": "Module with the same external id and external source already exists",
+                        "module_id": str(module.id),
                     },
                     status=status.HTTP_410_GONE,
                 )

--- a/apiserver/plane/api/views/module.py
+++ b/apiserver/plane/api/views/module.py
@@ -132,6 +132,22 @@ class ModuleAPIEndpoint(WebhookMixin, BaseAPIView):
             },
         )
         if serializer.is_valid():
+            if (
+                request.data.get("external_id")
+                and request.data.get("external_source")
+                and Module.objects.filter(
+                    project_id=project_id,
+                    workspace__slug=slug,
+                    external_source=request.data.get("external_source"),
+                    external_id=request.data.get("external_id"),
+                ).exists()
+            ):
+                return Response(
+                    {
+                        "error": "Module with the same external id and external source already exists"
+                    },
+                    status=status.HTTP_410_GONE,
+                )
             serializer.save()
             module = Module.objects.get(pk=serializer.data["id"])
             serializer = ModuleSerializer(module)
@@ -149,6 +165,27 @@ class ModuleAPIEndpoint(WebhookMixin, BaseAPIView):
             partial=True,
         )
         if serializer.is_valid():
+            if (
+                request.data.get("external_id")
+                and (module.external_id != request.data.get("external_id"))
+                and request.data.get("external_source")
+                and (
+                    module.external_source
+                    != request.data.get("external_source")
+                )
+                and Module.objects.filter(
+                    project_id=project_id,
+                    workspace__slug=slug,
+                    external_source=request.data.get("external_source"),
+                    external_id=request.data.get("external_id"),
+                ).exists()
+            ):
+                return Response(
+                    {
+                        "error": "Module with the same external id and external source already exists"
+                    },
+                    status=status.HTTP_410_GONE,
+                )
             serializer.save()
             return Response(serializer.data, status=status.HTTP_201_CREATED)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/apiserver/plane/api/views/state.py
+++ b/apiserver/plane/api/views/state.py
@@ -38,6 +38,30 @@ class StateAPIEndpoint(BaseAPIView):
             data=request.data, context={"project_id": project_id}
         )
         if serializer.is_valid():
+            if (
+                request.data.get("external_id")
+                and request.data.get("external_source")
+                and State.objects.filter(
+                    project_id=project_id,
+                    workspace__slug=slug,
+                    external_source=request.data.get("external_source"),
+                    external_id=request.data.get("external_id"),
+                ).exists()
+            ):
+                state = State.objects.filter(
+                    workspace__slug=slug,
+                    project_id=project_id,
+                    external_id=request.data.get("external_id"),
+                    external_source=request.data.get("external_source"),
+                ).first()
+                return Response(
+                    {
+                        "error": "State with the same external id and external source already exists",
+                        "state_id": str(state.id),
+                    },
+                    status=status.HTTP_410_GONE,
+                )
+
             serializer.save(project_id=project_id)
             return Response(serializer.data, status=status.HTTP_200_OK)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
@@ -91,6 +115,28 @@ class StateAPIEndpoint(BaseAPIView):
         )
         serializer = StateSerializer(state, data=request.data, partial=True)
         if serializer.is_valid():
+            if (
+                str(request.data.get("external_id"))
+                and (state.external_id != str(request.data.get("external_id")))
+                and request.data.get("external_source")
+                and (
+                    state.external_source
+                    != request.data.get("external_source")
+                )
+                and Issue.objects.filter(
+                    project_id=project_id,
+                    workspace__slug=slug,
+                    external_source=request.data.get("external_source"),
+                    external_id=request.data.get("external_id"),
+                ).exists()
+            ):
+                return Response(
+                    {
+                        "error": "Issue with the same external id and external source already exists",
+                        "state_id": str(state.id),
+                    },
+                    status=status.HTTP_410_GONE,
+                )
             serializer.save()
             return Response(serializer.data, status=status.HTTP_200_OK)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/apiserver/plane/api/views/state.py
+++ b/apiserver/plane/api/views/state.py
@@ -59,7 +59,7 @@ class StateAPIEndpoint(BaseAPIView):
                         "error": "State with the same external id and external source already exists",
                         "state_id": str(state.id),
                     },
-                    status=status.HTTP_410_GONE,
+                    status=status.HTTP_409_CONFLICT,
                 )
 
             serializer.save(project_id=project_id)
@@ -118,24 +118,19 @@ class StateAPIEndpoint(BaseAPIView):
             if (
                 str(request.data.get("external_id"))
                 and (state.external_id != str(request.data.get("external_id")))
-                and request.data.get("external_source")
-                and (
-                    state.external_source
-                    != request.data.get("external_source")
-                )
-                and Issue.objects.filter(
+                and State.objects.filter(
                     project_id=project_id,
                     workspace__slug=slug,
-                    external_source=request.data.get("external_source"),
+                    external_source=request.data.get("external_source", state.external_source),
                     external_id=request.data.get("external_id"),
                 ).exists()
             ):
                 return Response(
                     {
-                        "error": "Issue with the same external id and external source already exists",
+                        "error": "State with the same external id and external source already exists",
                         "state_id": str(state.id),
                     },
-                    status=status.HTTP_410_GONE,
+                    status=status.HTTP_409_CONFLICT,
                 )
             serializer.save()
             return Response(serializer.data, status=status.HTTP_200_OK)


### PR DESCRIPTION
- Added validation for external source and external id in issue, cycle, module and states which will cause a validation error if the same external source and external id is already created with a status of `409 Conflict`.
![image](https://github.com/makeplane/plane/assets/118773738/84d2ebad-9278-46e2-a9c5-d5524a881618)
