### PR TITLE
Fix: Updated Self install script to point towards the correct release.

### DIFF
--- a/deploy/selfhost/install.sh
+++ b/deploy/selfhost/install.sh
@@ -3,7 +3,7 @@
 BRANCH=master
 SCRIPT_DIR=$PWD
 PLANE_INSTALL_DIR=$PWD/plane-app
-export APP_RELEASE=$BRANCH
+export APP_RELEASE=stable
 export DOCKERHUB_USER=makeplane
 export PULL_POLICY=always
 USE_GLOBAL_IMAGES=1


### PR DESCRIPTION
The issue currently is that Plane tries to install from the Master Branch which causes the API server to not launch properly due to migration issues.

Simply changing to the stable release of plane fixes this.