### PR TITLE
Please finally update the used version of Node in Docker containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine AS builder
+FROM node:18.19-alpine AS builder
 RUN apk add --no-cache libc6-compat
 # Set working directory
 WORKDIR /app
@@ -12,7 +12,7 @@ RUN turbo prune --scope=app --scope=plane-deploy --docker
 CMD tree -I node_modules/
 
 # Add lockfile and package.json's of isolated subworkspace
-FROM node:18-alpine AS installer
+FROM node:18.19-alpine AS installer
 
 RUN apk add --no-cache libc6-compat
 WORKDIR /app

--- a/space/Dockerfile.dev
+++ b/space/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM node:18-alpine
+FROM node:18.19-alpine
 RUN apk add --no-cache libc6-compat
 # Set working directory
 WORKDIR /app

--- a/space/Dockerfile.space
+++ b/space/Dockerfile.space
@@ -1,4 +1,4 @@
-FROM node:18-alpine AS builder
+FROM node:18.19-alpine AS builder
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
@@ -7,7 +7,7 @@ COPY . .
 
 RUN turbo prune --scope=space --docker
 
-FROM node:18-alpine AS installer
+FROM node:18.19-alpine AS installer
 
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
@@ -29,7 +29,7 @@ ENV NEXT_PUBLIC_DEPLOY_WITH_NGINX=$NEXT_PUBLIC_DEPLOY_WITH_NGINX
 
 RUN yarn turbo run build --filter=space
 
-FROM node:18-alpine AS runner
+FROM node:18.19-alpine AS runner
 WORKDIR /app
 
 RUN addgroup --system --gid 1001 plane

--- a/web/Dockerfile.dev
+++ b/web/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM node:18-alpine
+FROM node:18.19-alpine
 RUN apk add --no-cache libc6-compat
 # Set working directory
 WORKDIR /app

--- a/web/Dockerfile.web
+++ b/web/Dockerfile.web
@@ -1,7 +1,7 @@
 # ******************************************
 # STAGE 1: Build the project
 # ******************************************
-FROM node:18-alpine AS builder
+FROM node:18.19-alpine AS builder
 RUN apk add --no-cache libc6-compat
 # Set working directory
 WORKDIR /app
@@ -16,7 +16,7 @@ RUN turbo prune --scope=web --docker
 # STAGE 2: Install dependencies & build the project
 # ******************************************
 # Add lockfile and package.json's of isolated subworkspace
-FROM node:18-alpine AS installer
+FROM node:18.19-alpine AS installer
 
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
@@ -43,7 +43,7 @@ RUN yarn turbo run build --filter=web
 # STAGE 3: Copy the project and start it
 # ******************************************
 
-FROM node:18-alpine AS runner
+FROM node:18.19-alpine AS runner
 WORKDIR /app
 
 # Don't run production as root


### PR DESCRIPTION
`node:18-alpine` is no longer a good version for building Plane docker containers, already since `0.14-dev`. Many packages do require newer version. Therefore, this PR is bumping the used version of Node by changing the version signature of the base container:

```
find . -name "Dockerfile*" -exec sed -i "s/18-alpine/18.19-alpine/g" {} \;
```

Please share the detail explaining how the new prebuilt Plane containers are being successfully built, despite this issue. 

Please stop using any alternative ways of building the Docker containers (if they exist), because this breaks the chain of trust. If we are not able to reproduce the containers using the public Dockerfile, then one can assume the prebuilt images may contain extra features, such as malware.