### PR TITLE
fix local development setup issue makeplane/plane#3641

### DIFF
--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -137,7 +137,7 @@ services:
       dockerfile: Dockerfile.dev
       args:
         DOCKER_BUILDKIT: 1
-    restart: no
+    restart: "no"
     networks:
       - dev_env
     volumes:


### PR DESCRIPTION
"The reason is values yes and no are evaluated as true or false. That is why you need to use double quotes so that it is interpreted as string."

Ref: [Stackoverflow answer](https://stackoverflow.com/a/46233453/5081894)