### PR TITLE
fix: scroll sync for the sidebar and blocks

### DIFF
--- a/web/components/gantt-chart/blocks/blocks-list.tsx
+++ b/web/components/gantt-chart/blocks/blocks-list.tsx
@@ -86,7 +86,7 @@ export const GanttChartBlocksList: FC<GanttChartBlocksProps> = observer((props) 
       className="h-full"
       style={{
         width: `${itemsContainerWidth}px`,
-        marginTop: `${HEADER_HEIGHT}px`,
+        transform: `translateY(${HEADER_HEIGHT}px)`,
       }}
     >
       {blocks?.map((block) => {


### PR DESCRIPTION
#### Bugs:

1. Scroll difference between the sidebar and the blocks container

| Before | After |
|--------|--------|
| <video src="https://github.com/makeplane/plane/assets/65252264/3e933b5d-a941-4f96-9307-ec2cd009b40e" /> | <video src="https://github.com/makeplane/plane/assets/65252264/0dd5b890-8c8f-4e52-ba1c-d118d9e3d5b1" /> | 