### PR TITLE
fix: peek overview issue description initial load bug

### DIFF
--- a/web/components/issues/description-form.tsx
+++ b/web/components/issues/description-form.tsx
@@ -41,10 +41,9 @@ export const IssueDescriptionForm: FC<IssueDetailsProps> = observer((props) => {
   const { workspaceSlug, projectId, issueId, issue, issueOperations, disabled, isSubmitting, setIsSubmitting } = props;
   const workspaceStore = useWorkspace();
   const workspaceId = workspaceStore.getWorkspaceBySlug(workspaceSlug)?.id as string;
-
   // states
   const [characterLimit, setCharacterLimit] = useState(false);
-
+  // hooks
   const { setShowAlert } = useReloadConfirmations();
   // store hooks
   const { mentionHighlights, mentionSuggestions } = useMention();
@@ -57,8 +56,8 @@ export const IssueDescriptionForm: FC<IssueDetailsProps> = observer((props) => {
     formState: { errors },
   } = useForm<TIssue>({
     defaultValues: {
-      name: "",
-      description_html: "",
+      name: issue?.name,
+      description_html: issue?.description_html,
     },
   });
 
@@ -67,24 +66,6 @@ export const IssueDescriptionForm: FC<IssueDetailsProps> = observer((props) => {
     id: issue.id,
     description_html: issue.description_html,
   });
-
-  // adding issue.description_html or issue.name to dependency array causes
-  // editor rerendering on every save
-  useEffect(() => {
-    if (issue.id) {
-      setLocalTitleValue(issue.name);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [issue.id]); // TODO: verify the exhaustive-deps warning
-
-  useEffect(() => {
-    if (["", "<p></p>", undefined, null].includes(localIssueDescription.description_html)) {
-      setLocalIssueDescription((state) => {
-        if (!["", "<p></p>", undefined, null].includes(state.description_html)) return state;
-        return { id: issue.id, description_html: issue.description_html || "<p></p>" };
-      });
-    }
-  }, [issue.description_html, localIssueDescription.description_html, issue.id]);
 
   const handleDescriptionFormSubmit = useCallback(
     async (formData: Partial<TIssue>) => {
@@ -122,6 +103,11 @@ export const IssueDescriptionForm: FC<IssueDetailsProps> = observer((props) => {
     reset({
       ...issue,
     });
+    setLocalIssueDescription({
+      id: issue.id,
+      description_html: issue.description_html === "" ? "<p></p>" : issue.description_html,
+    });
+    setLocalTitleValue(issue.name);
   }, [issue, reset]);
 
   // ADDING handleDescriptionFormSubmit TO DEPENDENCY ARRAY PRODUCES ADVERSE EFFECTS

--- a/web/components/issues/description-form.tsx
+++ b/web/components/issues/description-form.tsx
@@ -78,9 +78,9 @@ export const IssueDescriptionForm: FC<IssueDetailsProps> = observer((props) => {
   }, [issue.id]); // TODO: verify the exhaustive-deps warning
 
   useEffect(() => {
-    if (["", undefined, null].includes(localIssueDescription.description_html)) {
+    if (["", "<p></p>", undefined, null].includes(localIssueDescription.description_html)) {
       setLocalIssueDescription((state) => {
-        if (!["", undefined, null].includes(state.description_html)) return state;
+        if (!["", "<p></p>", undefined, null].includes(state.description_html)) return state;
         return { id: issue.id, description_html: issue.description_html || "<p></p>" };
       });
     }


### PR DESCRIPTION
This PR resolves the initial loading bug in the peek overview issue description. Previously, the issue description failed to load initially due to overlooked edge cases. I have addressed and made necessary changes to ensure it now functions as expected.