### PR TITLE
fix: project description

### DIFF
--- a/web/components/project/form.tsx
+++ b/web/components/project/form.tsx
@@ -1,7 +1,7 @@
-import { FC, useEffect, useState } from "react";
+import { FC, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 // hooks
-import { useEventTracker, useProject, useWorkspace } from "hooks/store";
+import { useEventTracker, useProject } from "hooks/store";
 import useToast from "hooks/use-toast";
 // components
 import EmojiIconPicker from "components/emoji-icon-picker";
@@ -34,7 +34,6 @@ export const ProjectDetailsForm: FC<IProjectDetailsForm> = (props) => {
   const [isLoading, setIsLoading] = useState(false);
   // store hooks
   const { captureProjectEvent } = useEventTracker();
-  const { currentWorkspace } = useWorkspace();
   const { updateProject } = useProject();
   // toast alert
   const { setToastAlert } = useToast();
@@ -45,7 +44,6 @@ export const ProjectDetailsForm: FC<IProjectDetailsForm> = (props) => {
     control,
     setValue,
     setError,
-    reset,
     formState: { errors, dirtyFields },
   } = useForm<IProject>({
     defaultValues: {
@@ -54,15 +52,6 @@ export const ProjectDetailsForm: FC<IProjectDetailsForm> = (props) => {
       workspace: (project.workspace as IWorkspace).id,
     },
   });
-
-  useEffect(() => {
-    if (!project) return;
-    reset({
-      ...project,
-      emoji_and_icon: project.emoji ?? project.icon_prop,
-      workspace: (project.workspace as IWorkspace).id,
-    });
-  }, [project, reset]);
 
   const handleIdentifierChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { value } = event.target;

--- a/web/components/project/form.tsx
+++ b/web/components/project/form.tsx
@@ -22,11 +22,12 @@ import { PROJECT_UPDATED } from "constants/event-tracker";
 export interface IProjectDetailsForm {
   project: IProject;
   workspaceSlug: string;
+  projectId: string;
   isAdmin: boolean;
 }
 const projectService = new ProjectService();
 export const ProjectDetailsForm: FC<IProjectDetailsForm> = (props) => {
-  const { project, workspaceSlug, isAdmin } = props;
+  const { project, workspaceSlug, projectId, isAdmin } = props;
   // states
   const [isLoading, setIsLoading] = useState(false);
   // store hooks
@@ -43,6 +44,7 @@ export const ProjectDetailsForm: FC<IProjectDetailsForm> = (props) => {
     setError,
     reset,
     formState: { errors, dirtyFields },
+    getValues,
   } = useForm<IProject>({
     defaultValues: {
       ...project,
@@ -50,14 +52,17 @@ export const ProjectDetailsForm: FC<IProjectDetailsForm> = (props) => {
       workspace: (project.workspace as IWorkspace).id,
     },
   });
+
   useEffect(() => {
-    if (!project || !reset) return;
-    reset({
-      ...project,
-      emoji_and_icon: project.emoji ?? project.icon_prop,
-      workspace: (project.workspace as IWorkspace).id,
-    });
-  }, [project, reset]);
+    if (project && projectId !== getValues("id")) {
+      reset({
+        ...project,
+        emoji_and_icon: project.emoji ?? project.icon_prop,
+        workspace: (project.workspace as IWorkspace).id,
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [project, projectId]);
   const handleIdentifierChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { value } = event.target;
     const alphanumericValue = value.replace(/[^a-zA-Z0-9]/g, "");

--- a/web/layouts/settings-layout/project/layout.tsx
+++ b/web/layouts/settings-layout/project/layout.tsx
@@ -8,7 +8,7 @@ import { useUser } from "hooks/store";
 import { ProjectSettingsSidebar } from "./sidebar";
 import { NotAuthorizedView } from "components/auth-screens";
 // ui
-import { Button, LayersIcon } from "@plane/ui";
+import { Button, LayersIcon, Loader } from "@plane/ui";
 // constants
 import { EUserProjectRoles } from "constants/project";
 
@@ -28,6 +28,36 @@ export const ProjectSettingLayout: FC<IProjectSettingLayout> = observer((props) 
 
   const restrictViewSettings = currentProjectRole && currentProjectRole <= EUserProjectRoles.VIEWER;
 
+  if (!currentProjectRole) {
+    return (
+      <div className="inset-y-0 z-20 flex flex-grow-0 h-full w-full gap-2 overflow-x-hidden overflow-y-scroll">
+        <div className="w-80 flex-shrink-0 overflow-y-hidden pt-8 sm:hidden hidden md:block lg:block">
+          <div className="flex w-80 flex-col gap-6 px-5">
+            <div className="flex flex-col gap-2">
+              <span className="text-xs font-semibold text-custom-sidebar-text-400">SETTINGS</span>
+              <Loader className="flex w-full flex-col gap-2">
+                {[...Array(4)].map(() => (
+                  <Loader.Item height="34px" />
+                ))}
+              </Loader>
+            </div>
+          </div>
+        </div>
+        <div className="w-full pt-14 px-9 sm:pl-10 md:pl-0 lg:pl-0">
+          <Loader className="flex w-full flex-col gap-2 px-5">
+            <div className="pb-4">
+              <Loader.Item height="34px" width="150px" />
+            </div>
+
+            {[...Array(8)].map(() => (
+              <Loader.Item height="34px" />
+            ))}
+          </Loader>
+        </div>
+      </div>
+    );
+  }
+
   return restrictViewSettings ? (
     <NotAuthorizedView
       type="project"
@@ -45,9 +75,7 @@ export const ProjectSettingLayout: FC<IProjectSettingLayout> = observer((props) 
       <div className="w-80 flex-shrink-0 overflow-y-hidden pt-8 sm:hidden hidden md:block lg:block">
         <ProjectSettingsSidebar />
       </div>
-      <div className="w-full pl-10 sm:pl-10 md:pl-0 lg:pl-0">
-        {children}
-      </div>
+      <div className="w-full pl-10 sm:pl-10 md:pl-0 lg:pl-0">{children}</div>
     </div>
   );
 });

--- a/web/layouts/settings-layout/project/layout.tsx
+++ b/web/layouts/settings-layout/project/layout.tsx
@@ -8,7 +8,7 @@ import { useUser } from "hooks/store";
 import { ProjectSettingsSidebar } from "./sidebar";
 import { NotAuthorizedView } from "components/auth-screens";
 // ui
-import { Button, LayersIcon, Loader } from "@plane/ui";
+import { Button, LayersIcon } from "@plane/ui";
 // constants
 import { EUserProjectRoles } from "constants/project";
 
@@ -28,36 +28,6 @@ export const ProjectSettingLayout: FC<IProjectSettingLayout> = observer((props) 
 
   const restrictViewSettings = currentProjectRole && currentProjectRole <= EUserProjectRoles.VIEWER;
 
-  if (!currentProjectRole) {
-    return (
-      <div className="inset-y-0 z-20 flex flex-grow-0 h-full w-full gap-2 overflow-x-hidden overflow-y-scroll">
-        <div className="w-80 flex-shrink-0 overflow-y-hidden pt-8 sm:hidden hidden md:block lg:block">
-          <div className="flex w-80 flex-col gap-6 px-5">
-            <div className="flex flex-col gap-2">
-              <span className="text-xs font-semibold text-custom-sidebar-text-400">SETTINGS</span>
-              <Loader className="flex w-full flex-col gap-2">
-                {[...Array(4)].map(() => (
-                  <Loader.Item height="34px" />
-                ))}
-              </Loader>
-            </div>
-          </div>
-        </div>
-        <div className="w-full pt-14 px-9 sm:pl-10 md:pl-0 lg:pl-0">
-          <Loader className="flex w-full flex-col gap-2 px-5">
-            <div className="pb-4">
-              <Loader.Item height="34px" width="150px" />
-            </div>
-
-            {[...Array(8)].map(() => (
-              <Loader.Item height="34px" />
-            ))}
-          </Loader>
-        </div>
-      </div>
-    );
-  }
-
   return restrictViewSettings ? (
     <NotAuthorizedView
       type="project"
@@ -71,11 +41,11 @@ export const ProjectSettingLayout: FC<IProjectSettingLayout> = observer((props) 
       }
     />
   ) : (
-    <div className="inset-y-0 z-20 flex flex-grow-0 h-full w-full gap-2 overflow-x-hidden overflow-y-scroll">
+    <div className="inset-y-0 z-20 flex flex-grow-0 h-full w-full">
       <div className="w-80 flex-shrink-0 overflow-y-hidden pt-8 sm:hidden hidden md:block lg:block">
         <ProjectSettingsSidebar />
       </div>
-      <div className="w-full pl-10 sm:pl-10 md:pl-0 lg:pl-0">{children}</div>
+      <div className="w-full pl-10 sm:pl-10 md:pl-0 lg:pl-0 overflow-x-hidden overflow-y-scroll">{children}</div>
     </div>
   );
 });

--- a/web/layouts/settings-layout/project/sidebar.tsx
+++ b/web/layouts/settings-layout/project/sidebar.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import { useRouter } from "next/router";
 import Link from "next/link";
+// ui
+import { Loader } from "@plane/ui";
 // hooks
 import { useUser } from "hooks/store";
 // constants
@@ -15,6 +17,21 @@ export const ProjectSettingsSidebar = () => {
   } = useUser();
 
   const projectMemberInfo = currentProjectRole || EUserProjectRoles.GUEST;
+
+  if (!currentProjectRole) {
+    return (
+      <div className="flex w-80 flex-col gap-6 px-5">
+        <div className="flex flex-col gap-2">
+          <span className="text-xs font-semibold text-custom-sidebar-text-400">SETTINGS</span>
+          <Loader className="flex w-full flex-col gap-2">
+            {[...Array(8)].map(() => (
+              <Loader.Item height="34px" />
+            ))}
+          </Loader>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="flex w-80 flex-col gap-6 px-5">

--- a/web/pages/[workspaceSlug]/projects/[projectId]/settings/index.tsx
+++ b/web/pages/[workspaceSlug]/projects/[projectId]/settings/index.tsx
@@ -49,10 +49,11 @@ const GeneralSettingsPage: NextPageWithLayout = observer(() => {
       )}
 
       <div className={`w-full overflow-y-auto py-8 pr-9 ${isAdmin ? "" : "opacity-60"}`}>
-        {currentProjectDetails && workspaceSlug && !isLoading ? (
+        {currentProjectDetails && workspaceSlug && projectId && !isLoading ? (
           <ProjectDetailsForm
             project={currentProjectDetails}
             workspaceSlug={workspaceSlug.toString()}
+            projectId={projectId.toString()}
             isAdmin={isAdmin}
           />
         ) : (

--- a/web/pages/[workspaceSlug]/projects/[projectId]/settings/index.tsx
+++ b/web/pages/[workspaceSlug]/projects/[projectId]/settings/index.tsx
@@ -28,7 +28,7 @@ const GeneralSettingsPage: NextPageWithLayout = observer(() => {
   const { currentProjectDetails, fetchProjectDetails } = useProject();
   // api call to fetch project details
   // TODO: removed this API if not necessary
-  useSWR(
+  const { isLoading } = useSWR(
     workspaceSlug && projectId ? `PROJECT_DETAILS_${projectId}` : null,
     workspaceSlug && projectId ? () => fetchProjectDetails(workspaceSlug.toString(), projectId.toString()) : null
   );
@@ -49,7 +49,7 @@ const GeneralSettingsPage: NextPageWithLayout = observer(() => {
       )}
 
       <div className={`w-full overflow-y-auto py-8 pr-9 ${isAdmin ? "" : "opacity-60"}`}>
-        {currentProjectDetails && workspaceSlug ? (
+        {currentProjectDetails && workspaceSlug && !isLoading ? (
           <ProjectDetailsForm
             project={currentProjectDetails}
             workspaceSlug={workspaceSlug.toString()}


### PR DESCRIPTION
### Problem 
1. Upon loading the general settings page of the project, if a user enters information into the description field immediately after the page loads, the description is being reset to its initial state.
### Resolution
1. A useEffect hook was causing this undesired reset behavior. As this useEffect was unnecessary, I made the necessary modifications to rectify the issue.

Additionally, project settings sidebar loader added. 