### PR TITLE
fix: color pick background color on change effecting other input fields

### DIFF
--- a/web/components/core/theme/custom-theme-selector.tsx
+++ b/web/components/core/theme/custom-theme-selector.tsx
@@ -66,7 +66,6 @@ export const CustomThemeSelector: React.FC = observer(() => {
 
   const handleValueChange = (val: string | undefined, onChange: any) => {
     let hex = val;
-
     // prepend a hashtag if it doesn't exist
     if (val && val[0] !== "#") hex = `#${val}`;
 
@@ -94,7 +93,7 @@ export const CustomThemeSelector: React.FC = observer(() => {
                       placeholder="#0d101b"
                       className="w-full"
                       style={{
-                        backgroundColor: value,
+                        backgroundColor: watch("background"),
                         color: watch("text"),
                       }}
                       hasError={Boolean(errors?.background)}
@@ -120,8 +119,8 @@ export const CustomThemeSelector: React.FC = observer(() => {
                       placeholder="#c5c5c5"
                       className="w-full"
                       style={{
-                        backgroundColor: watch("background"),
-                        color: value,
+                        backgroundColor: watch("text"),
+                        color: watch("background"),
                       }}
                       hasError={Boolean(errors?.text)}
                     />
@@ -146,7 +145,7 @@ export const CustomThemeSelector: React.FC = observer(() => {
                       placeholder="#3f76ff"
                       className="w-full"
                       style={{
-                        backgroundColor: value,
+                        backgroundColor: watch("primary"),
                         color: watch("text"),
                       }}
                       hasError={Boolean(errors?.primary)}
@@ -172,7 +171,7 @@ export const CustomThemeSelector: React.FC = observer(() => {
                       placeholder="#0d101b"
                       className="w-full"
                       style={{
-                        backgroundColor: value,
+                        backgroundColor: watch("sidebarBackground"),
                         color: watch("sidebarText"),
                       }}
                       hasError={Boolean(errors?.sidebarBackground)}
@@ -200,8 +199,8 @@ export const CustomThemeSelector: React.FC = observer(() => {
                       placeholder="#c5c5c5"
                       className="w-full"
                       style={{
-                        backgroundColor: watch("sidebarBackground"),
-                        color: value,
+                        backgroundColor: watch("sidebarText"),
+                        color: watch("sidebarBackground"),
                       }}
                       hasError={Boolean(errors?.sidebarText)}
                     />


### PR DESCRIPTION
### Problem:
When users attempt to select a color in the profile theme settings, the color picker unintentionally modifies the background color of nearby input fields, causing confusion and potential interference with the intended customization process.

<img width="895" alt="Screenshot 2024-02-18 at 2 57 42 PM" src="https://github.com/makeplane/plane/assets/9498163/88f38608-90ca-4b0e-b56b-5138afb71a80">


### Resolution: 

To address the issue of unintended style changes to input fields based on selected background and text colors in the theme settings, we propose implementing a more precise and controlled application of styles. This entails refining the styling mechanism to specifically target the desired elements without affecting adjacent input fields.

<img width="885" alt="Screenshot 2024-02-18 at 3 09 28 PM" src="https://github.com/makeplane/plane/assets/9498163/d437350e-4678-422f-aa91-0e8f0dacf5cf">


#### Affected Screens by the changes made in this PR:
- Profile Theme Prefrences