### PR TITLE
fix: issue description empty state initial load in inbox and issue detail page

### DIFF
--- a/packages/editor/rich-text-editor/src/ui/index.tsx
+++ b/packages/editor/rich-text-editor/src/ui/index.tsx
@@ -100,7 +100,7 @@ const RichTextEditor = ({
   });
 
   React.useEffect(() => {
-    if (editor && initialValue) editor.commands.setContent(initialValue);
+    if (editor && initialValue && editor.getHTML() != initialValue) editor.commands.setContent(initialValue);
   }, [editor, initialValue]);
 
   if (!editor) return null;

--- a/web/components/issues/description-input.tsx
+++ b/web/components/issues/description-input.tsx
@@ -20,7 +20,6 @@ export type IssueDescriptionInputProps = {
   initialValue: string | undefined;
   disabled?: boolean;
   issueOperations: TIssueOperations;
-  isSubmitting: "submitting" | "submitted" | "saved";
   setIsSubmitting: (value: "submitting" | "submitted" | "saved") => void;
 };
 

--- a/web/components/issues/description-input.tsx
+++ b/web/components/issues/description-input.tsx
@@ -1,5 +1,4 @@
 import { FC, useState, useEffect } from "react";
-import { observer } from "mobx-react";
 // components
 import { Loader } from "@plane/ui";
 import { RichReadOnlyEditor, RichTextEditor } from "@plane/rich-text-editor";
@@ -14,19 +13,19 @@ import { TIssueOperations } from "./issue-detail";
 import useDebounce from "hooks/use-debounce";
 
 export type IssueDescriptionInputProps = {
-  disabled?: boolean;
-  value: string | undefined | null;
   workspaceSlug: string;
-  isSubmitting: "submitting" | "submitted" | "saved";
-  setIsSubmitting: (value: "submitting" | "submitted" | "saved") => void;
-  issueOperations: TIssueOperations;
   projectId: string;
   issueId: string;
-  initialValue?: string;
+  value: string | undefined;
+  initialValue: string | undefined;
+  disabled?: boolean;
+  issueOperations: TIssueOperations;
+  isSubmitting: "submitting" | "submitted" | "saved";
+  setIsSubmitting: (value: "submitting" | "submitted" | "saved") => void;
 };
 
-export const IssueDescriptionInput: FC<IssueDescriptionInputProps> = observer((props) => {
-  const { disabled, value, workspaceSlug, setIsSubmitting, issueId, issueOperations, projectId, initialValue } = props;
+export const IssueDescriptionInput: FC<IssueDescriptionInputProps> = (props) => {
+  const { workspaceSlug, projectId, issueId, value, initialValue, disabled, issueOperations, setIsSubmitting } = props;
   // states
   const [descriptionHTML, setDescriptionHTML] = useState(value);
   // store hooks
@@ -78,7 +77,7 @@ export const IssueDescriptionInput: FC<IssueDescriptionInputProps> = observer((p
       uploadFile={fileService.getUploadFileFunction(workspaceSlug)}
       deleteFile={fileService.getDeleteImageFunction(workspaceId)}
       restoreFile={fileService.getRestoreImageFunction(workspaceId)}
-      value={descriptionHTML === "" ? "<p></p>" : descriptionHTML}
+      value={descriptionHTML}
       initialValue={initialValue}
       dragDropEnabled
       customClassName="min-h-[150px] shadow-sm"
@@ -90,4 +89,4 @@ export const IssueDescriptionInput: FC<IssueDescriptionInputProps> = observer((p
       mentionHighlights={mentionHighlights}
     />
   );
-});
+};

--- a/web/components/issues/issue-detail/inbox/main-content.tsx
+++ b/web/components/issues/issue-detail/inbox/main-content.tsx
@@ -98,7 +98,6 @@ export const InboxIssueMainContent: React.FC<Props> = observer((props) => {
           initialValue={issueDescription}
           disabled={!is_editable}
           issueOperations={issueOperations}
-          isSubmitting={isSubmitting}
           setIsSubmitting={(value) => setIsSubmitting(value)}
         />
 

--- a/web/components/issues/issue-detail/inbox/main-content.tsx
+++ b/web/components/issues/issue-detail/inbox/main-content.tsx
@@ -1,7 +1,8 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { observer } from "mobx-react-lite";
 // hooks
 import { useIssueDetail, useProjectState, useUser } from "hooks/store";
+import useReloadConfirmations from "hooks/use-reload-confirmation";
 // components
 import { IssueUpdateStatus, TIssueOperations } from "components/issues";
 import { IssueTitleInput } from "../../title-input";
@@ -31,11 +32,30 @@ export const InboxIssueMainContent: React.FC<Props> = observer((props) => {
   const {
     issue: { getIssueById },
   } = useIssueDetail();
+  const { setShowAlert } = useReloadConfirmations(isSubmitting === "submitting");
 
-  const issue = getIssueById(issueId);
+  useEffect(() => {
+    if (isSubmitting === "submitted") {
+      setShowAlert(false);
+      setTimeout(async () => {
+        setIsSubmitting("saved");
+      }, 3000);
+    } else if (isSubmitting === "submitting") {
+      setShowAlert(true);
+    }
+  }, [isSubmitting, setShowAlert, setIsSubmitting]);
+
+  const issue = issueId ? getIssueById(issueId) : undefined;
   if (!issue) return <></>;
 
   const currentIssueState = projectStates?.find((s) => s.id === issue.state_id);
+
+  const issueDescription =
+    issue.description_html !== undefined || issue.description_html !== null
+      ? issue.description_html != ""
+        ? issue.description_html
+        : "<p></p>"
+      : undefined;
 
   return (
     <>
@@ -74,12 +94,12 @@ export const InboxIssueMainContent: React.FC<Props> = observer((props) => {
           workspaceSlug={workspaceSlug}
           projectId={issue.project_id}
           issueId={issue.id}
+          value={issueDescription}
+          initialValue={issueDescription}
+          disabled={!is_editable}
+          issueOperations={issueOperations}
           isSubmitting={isSubmitting}
           setIsSubmitting={(value) => setIsSubmitting(value)}
-          issueOperations={issueOperations}
-          disabled={!is_editable}
-          value={issue.description_html}
-          initialValue={issue.description_html}
         />
 
         {currentUser && (

--- a/web/components/issues/issue-detail/main-content.tsx
+++ b/web/components/issues/issue-detail/main-content.tsx
@@ -102,7 +102,6 @@ export const IssueMainContent: React.FC<Props> = observer((props) => {
           initialValue={issueDescription}
           disabled={!is_editable}
           issueOperations={issueOperations}
-          isSubmitting={isSubmitting}
           setIsSubmitting={(value) => setIsSubmitting(value)}
         />
 

--- a/web/components/issues/issue-detail/main-content.tsx
+++ b/web/components/issues/issue-detail/main-content.tsx
@@ -1,7 +1,8 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { observer } from "mobx-react-lite";
 // hooks
 import { useIssueDetail, useProjectState, useUser } from "hooks/store";
+import useReloadConfirmations from "hooks/use-reload-confirmation";
 // components
 import { IssueAttachmentRoot, IssueUpdateStatus } from "components/issues";
 import { IssueTitleInput } from "../title-input";
@@ -33,11 +34,30 @@ export const IssueMainContent: React.FC<Props> = observer((props) => {
   const {
     issue: { getIssueById },
   } = useIssueDetail();
+  const { setShowAlert } = useReloadConfirmations(isSubmitting === "submitting");
 
-  const issue = getIssueById(issueId);
+  useEffect(() => {
+    if (isSubmitting === "submitted") {
+      setShowAlert(false);
+      setTimeout(async () => {
+        setIsSubmitting("saved");
+      }, 2000);
+    } else if (isSubmitting === "submitting") {
+      setShowAlert(true);
+    }
+  }, [isSubmitting, setShowAlert, setIsSubmitting]);
+
+  const issue = issueId ? getIssueById(issueId) : undefined;
   if (!issue) return <></>;
 
   const currentIssueState = projectStates?.find((s) => s.id === issue.state_id);
+
+  const issueDescription =
+    issue.description_html !== undefined || issue.description_html !== null
+      ? issue.description_html != ""
+        ? issue.description_html
+        : "<p></p>"
+      : undefined;
 
   return (
     <>
@@ -78,11 +98,12 @@ export const IssueMainContent: React.FC<Props> = observer((props) => {
           workspaceSlug={workspaceSlug}
           projectId={issue.project_id}
           issueId={issue.id}
+          value={issueDescription}
+          initialValue={issueDescription}
+          disabled={!is_editable}
+          issueOperations={issueOperations}
           isSubmitting={isSubmitting}
           setIsSubmitting={(value) => setIsSubmitting(value)}
-          issueOperations={issueOperations}
-          disabled={!is_editable}
-          value={issue.description_html}
         />
 
         {currentUser && (

--- a/web/components/issues/peek-overview/issue-detail.tsx
+++ b/web/components/issues/peek-overview/issue-detail.tsx
@@ -78,7 +78,6 @@ export const PeekOverviewIssueDetails: FC<IPeekOverviewIssueDetails> = observer(
         initialValue={issueDescription}
         disabled={disabled}
         issueOperations={issueOperations}
-        isSubmitting={isSubmitting}
         setIsSubmitting={(value) => setIsSubmitting(value)}
       />
 

--- a/web/components/issues/peek-overview/issue-detail.tsx
+++ b/web/components/issues/peek-overview/issue-detail.tsx
@@ -30,12 +30,6 @@ export const PeekOverviewIssueDetails: FC<IPeekOverviewIssueDetails> = observer(
   } = useIssueDetail();
   // hooks
   const { setShowAlert } = useReloadConfirmations(isSubmitting === "submitting");
-  // derived values
-  const issue = getIssueById(issueId);
-
-  if (!issue) return <></>;
-
-  const projectDetails = getProjectById(issue?.project_id);
 
   useEffect(() => {
     if (isSubmitting === "submitted") {
@@ -47,6 +41,18 @@ export const PeekOverviewIssueDetails: FC<IPeekOverviewIssueDetails> = observer(
       setShowAlert(true);
     }
   }, [isSubmitting, setShowAlert, setIsSubmitting]);
+
+  const issue = issueId ? getIssueById(issueId) : undefined;
+  if (!issue) return <></>;
+
+  const projectDetails = getProjectById(issue?.project_id);
+
+  const issueDescription =
+    issue.description_html !== undefined || issue.description_html !== null
+      ? issue.description_html != ""
+        ? issue.description_html
+        : "<p></p>"
+      : undefined;
 
   return (
     <>
@@ -63,16 +69,19 @@ export const PeekOverviewIssueDetails: FC<IPeekOverviewIssueDetails> = observer(
         disabled={disabled}
         value={issue.name}
       />
+
       <IssueDescriptionInput
         workspaceSlug={workspaceSlug}
         projectId={issue.project_id}
         issueId={issue.id}
+        value={issueDescription}
+        initialValue={issueDescription}
+        disabled={disabled}
+        issueOperations={issueOperations}
         isSubmitting={isSubmitting}
         setIsSubmitting={(value) => setIsSubmitting(value)}
-        issueOperations={issueOperations}
-        disabled={disabled}
-        value={issue.description_html}
       />
+
       {currentUser && (
         <IssueReaction
           workspaceSlug={workspaceSlug}


### PR DESCRIPTION
This update addresses a critical issue affecting the rendering of content within the Issue Description Editor when the description is empty.

Affected places:
1. Issue peek overview
2. issue detail
3. project inbox

