### PR TITLE
[WEB-456] chore: display sub issues option added in global view issues

### DIFF
--- a/web/constants/issue.ts
+++ b/web/constants/issue.ts
@@ -320,8 +320,8 @@ export const ISSUE_DISPLAY_FILTERS_BY_LAYOUT: {
         type: [null, "active", "backlog"],
       },
       extra_options: {
-        access: false,
-        values: [],
+        access: true,
+        values: ["sub_issue"],
       },
     },
     list: {

--- a/web/store/issue/workspace/filter.store.ts
+++ b/web/store/issue/workspace/filter.store.ts
@@ -99,8 +99,6 @@ export class WorkspaceIssuesFilter extends IssueFilterHelperStore implements IWo
       filteredParams
     );
 
-    if (userFilters?.displayFilters?.layout === "spreadsheet") filteredRouteParams.sub_issue = true;
-
     return filteredRouteParams;
   };
 
@@ -212,11 +210,6 @@ export class WorkspaceIssuesFilter extends IssueFilterHelperStore implements IWo
           if (_filters.displayFilters.layout === "kanban" && _filters.displayFilters.group_by === null) {
             _filters.displayFilters.group_by = "state";
             updatedDisplayFilters.group_by = "state";
-          }
-          // set sub_issue to false if layout is switched to spreadsheet and sub_issue is true
-          if (_filters.displayFilters.layout === "spreadsheet" && _filters.displayFilters.sub_issue === true) {
-            _filters.displayFilters.sub_issue = false;
-            updatedDisplayFilters.sub_issue = false;
           }
 
           runInAction(() => {

--- a/web/store/issue/workspace/filter.store.ts
+++ b/web/store/issue/workspace/filter.store.ts
@@ -99,7 +99,7 @@ export class WorkspaceIssuesFilter extends IssueFilterHelperStore implements IWo
       filteredParams
     );
 
-    if (userFilters?.displayFilters?.layout === "spreadsheet") filteredRouteParams.sub_issue = false;
+    if (userFilters?.displayFilters?.layout === "spreadsheet") filteredRouteParams.sub_issue = true;
 
     return filteredRouteParams;
   };


### PR DESCRIPTION
### Problem
- Users are unable to view sub-issues in the global view of issues.
### Resolution
- To resolve this issue, I have implemented a toggle option to display sub-issues in the filter menu.

 ---
 
This PR is linked to [[WEB-456]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/5a443a21-5f92-4aa9-8194-70ae511f0320).

---
### Media
![1dafe5c5-5b93-49a6-8ff5-a23b6ae9b3db](https://github.com/makeplane/plane/assets/121005188/8c1ed449-8278-44d6-a3be-57084848b761)

