### PR TITLE
[WEB-461] chore: issue transfer validation added for completed cycle

### DIFF
--- a/web/components/cycles/transfer-issues.tsx
+++ b/web/components/cycles/transfer-issues.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/router";
 
 import useSWR from "swr";
 
+import isEmpty from "lodash/isEmpty";
 // component
 import { Button, TransferIcon } from "@plane/ui";
 // icon
@@ -43,7 +44,7 @@ export const TransferIssues: React.FC<Props> = (props) => {
         <span>Completed cycles are not editable.</span>
       </div>
 
-      {transferableIssuesCount > 0 && (
+      {isEmpty(cycleDetails?.progress_snapshot) && transferableIssuesCount > 0 && (
         <div>
           <Button variant="primary" prependIcon={<TransferIcon color="white" />} onClick={handleClick}>
             Transfer Issues


### PR DESCRIPTION
In this PR, I've implemented validation for the transfer issue button when the cycle is completed. If an issue from a completed cycle has already been transferred with a captured snapshot, the user is now prevented from transferring it again.

This PR is linked to [[WEB-461]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/81392d2d-59ef-4b56-8e3d-c5088d695cbe).