### PR TITLE
[WEB-394]: Added a description to project network options

### DIFF
--- a/packages/ui/src/dropdowns/custom-select.tsx
+++ b/packages/ui/src/dropdowns/custom-select.tsx
@@ -122,7 +122,7 @@ const Option = (props: ICustomSelectItemProps) => {
       value={value}
       className={({ active }) =>
         cn(
-          "cursor-pointer select-none truncate rounded px-1 py-1.5 text-custom-text-200",
+          "cursor-pointer select-none truncate rounded px-1 py-1.5 text-custom-text-200 flex items-center justify-between gap-2",
           {
             "bg-custom-background-80": active,
           },
@@ -131,10 +131,10 @@ const Option = (props: ICustomSelectItemProps) => {
       }
     >
       {({ selected }) => (
-        <div className="flex items-center justify-between gap-2">
-          <div className="flex items-center gap-2">{children}</div>
+        <>
+          {children}
           {selected && <Check className="h-3.5 w-3.5 flex-shrink-0" />}
-        </div>
+        </>
       )}
     </Listbox.Option>
   );

--- a/web/components/core/filters/date-filter-select.tsx
+++ b/web/components/core/filters/date-filter-select.tsx
@@ -51,10 +51,10 @@ export const DateFilterSelect: React.FC<Props> = ({ title, value, onChange }) =>
   >
     {dueDateRange.map((option, index) => (
       <CustomSelect.Option key={index} value={option.value}>
-        <>
+        <div className="flex items-center gap-2">
           <span>{option.icon}</span>
           {title} {option.name}
-        </>
+        </div>
       </CustomSelect.Option>
     ))}
   </CustomSelect>

--- a/web/components/modules/sidebar-select/select-status.tsx
+++ b/web/components/modules/sidebar-select/select-status.tsx
@@ -46,10 +46,10 @@ export const SidebarStatusSelect: React.FC<Props> = ({ control, submitChanges, w
           >
             {MODULE_STATUS.map((option) => (
               <CustomSelect.Option key={option.value} value={option.value}>
-                <>
+                <div className="flex items-center gap-2">
                   <span className="h-2 w-2 flex-shrink-0 rounded-full" style={{ backgroundColor: option.color }} />
                   {option.label}
-                </>
+                </div>
               </CustomSelect.Option>
             ))}
           </CustomSelect>

--- a/web/components/project/create-project-modal.tsx
+++ b/web/components/project/create-project-modal.tsx
@@ -160,7 +160,7 @@ export const CreateProjectModal: FC<Props> = observer((props) => {
             payload: {
               ...payload,
               state: "FAILED",
-            }
+            },
           });
         });
       });
@@ -365,13 +365,14 @@ export const CreateProjectModal: FC<Props> = observer((props) => {
                               tabIndex={4}
                             >
                               {NETWORK_CHOICES.map((network) => (
-                                <CustomSelect.Option
-                                  key={network.key}
-                                  value={network.key}
-                                  className="flex items-center gap-1"
-                                >
-                                  <network.icon className="h-4 w-4" />
-                                  {network.label}
+                                <CustomSelect.Option key={network.key} value={network.key}>
+                                  <div className="flex items-start gap-2">
+                                    <network.icon className="h-3.5 w-3.5" />
+                                    <div className="-mt-1">
+                                      <p>{network.label}</p>
+                                      <p className="text-xs text-custom-text-400">{network.description}.</p>
+                                    </div>
+                                  </div>
                                 </CustomSelect.Option>
                               ))}
                             </CustomSelect>

--- a/web/components/project/create-project-modal.tsx
+++ b/web/components/project/create-project-modal.tsx
@@ -369,7 +369,7 @@ export const CreateProjectModal: FC<Props> = observer((props) => {
                                     <network.icon className="h-3.5 w-3.5" />
                                     <div className="-mt-1">
                                       <p>{network.label}</p>
-                                      <p className="text-xs text-custom-text-400">{network.description}.</p>
+                                      <p className="text-xs text-custom-text-400">{network.description}</p>
                                     </div>
                                   </div>
                                 </CustomSelect.Option>

--- a/web/components/project/create-project-modal.tsx
+++ b/web/components/project/create-project-modal.tsx
@@ -4,7 +4,7 @@ import { Dialog, Transition } from "@headlessui/react";
 import { observer } from "mobx-react-lite";
 import { X } from "lucide-react";
 // hooks
-import { useEventTracker, useProject, useUser, useWorkspace } from "hooks/store";
+import { useEventTracker, useProject, useUser } from "hooks/store";
 import useToast from "hooks/use-toast";
 // ui
 import { Button, CustomSelect, Input, TextArea } from "@plane/ui";
@@ -66,7 +66,6 @@ export const CreateProjectModal: FC<Props> = observer((props) => {
   const {
     membership: { currentWorkspaceRole },
   } = useUser();
-  const { currentWorkspace } = useWorkspace();
   const { addProjectToFavorites, createProject } = useProject();
   // states
   const [isChangeInIdentifierRequired, setIsChangeInIdentifierRequired] = useState(true);

--- a/web/components/project/form.tsx
+++ b/web/components/project/form.tsx
@@ -299,7 +299,7 @@ export const ProjectDetailsForm: FC<IProjectDetailsForm> = (props) => {
                           <network.icon className="h-3.5 w-3.5" />
                           <div className="-mt-1">
                             <p>{network.label}</p>
-                            <p className="text-xs text-custom-text-400">{network.description}.</p>
+                            <p className="text-xs text-custom-text-400">{network.description}</p>
                           </div>
                         </div>
                       </CustomSelect.Option>

--- a/web/components/project/form.tsx
+++ b/web/components/project/form.tsx
@@ -291,7 +291,7 @@ export const ProjectDetailsForm: FC<IProjectDetailsForm> = (props) => {
                     buttonClassName="!border-custom-border-200 !shadow-none font-medium rounded-md"
                     input
                     disabled={!isAdmin}
-                    optionsClassName="w-full"
+                    // optionsClassName="w-full"
                   >
                     {NETWORK_CHOICES.map((network) => (
                       <CustomSelect.Option key={network.key} value={network.key}>

--- a/web/components/project/form.tsx
+++ b/web/components/project/form.tsx
@@ -132,7 +132,7 @@ export const ProjectDetailsForm: FC<IProjectDetailsForm> = (props) => {
     }, 300);
   };
   const currentNetwork = NETWORK_CHOICES.find((n) => n.key === project?.network);
-  const selectedNetwork = NETWORK_CHOICES.find((n) => n.key === watch("network"));
+
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
       <div className="relative mt-6 h-44 w-full">
@@ -269,23 +269,44 @@ export const ProjectDetailsForm: FC<IProjectDetailsForm> = (props) => {
             <Controller
               name="network"
               control={control}
-              render={({ field: { value, onChange } }) => (
-                <CustomSelect
-                  value={value}
-                  onChange={onChange}
-                  label={selectedNetwork?.label ?? "Select network"}
-                  buttonClassName="!border-custom-border-200 !shadow-none font-medium rounded-md"
-                  input
-                  disabled={!isAdmin}
-                  optionsClassName="w-full"
-                >
-                  {NETWORK_CHOICES.map((network) => (
-                    <CustomSelect.Option key={network.key} value={network.key}>
-                      {network.label}
-                    </CustomSelect.Option>
-                  ))}
-                </CustomSelect>
-              )}
+              render={({ field: { value, onChange } }) => {
+                const selectedNetwork = NETWORK_CHOICES.find((n) => n.key === value);
+
+                return (
+                  <CustomSelect
+                    value={value}
+                    onChange={onChange}
+                    label={
+                      <div className="flex items-center gap-1">
+                        {selectedNetwork ? (
+                          <>
+                            <selectedNetwork.icon className="h-3.5 w-3.5" />
+                            {selectedNetwork.label}
+                          </>
+                        ) : (
+                          <span className="text-custom-text-400">Select network</span>
+                        )}
+                      </div>
+                    }
+                    buttonClassName="!border-custom-border-200 !shadow-none font-medium rounded-md"
+                    input
+                    disabled={!isAdmin}
+                    optionsClassName="w-full"
+                  >
+                    {NETWORK_CHOICES.map((network) => (
+                      <CustomSelect.Option key={network.key} value={network.key}>
+                        <div className="flex items-start gap-2">
+                          <network.icon className="h-3.5 w-3.5" />
+                          <div className="-mt-1">
+                            <p>{network.label}</p>
+                            <p className="text-xs text-custom-text-400">{network.description}.</p>
+                          </div>
+                        </div>
+                      </CustomSelect.Option>
+                    ))}
+                  </CustomSelect>
+                );
+              }}
             />
           </div>
         </div>

--- a/web/constants/project.ts
+++ b/web/constants/project.ts
@@ -11,15 +11,22 @@ export enum EUserProjectRoles {
   ADMIN = 20,
 }
 
-export const NETWORK_CHOICES: { key: 0 | 2; label: string; icon: LucideIcon }[] = [
+export const NETWORK_CHOICES: {
+  key: 0 | 2;
+  label: string;
+  description: string;
+  icon: LucideIcon;
+}[] = [
   {
     key: 0,
     label: "Private",
+    description: "Accessible only by invite",
     icon: Lock,
   },
   {
     key: 2,
     label: "Public",
+    description: "Anyone in the workspace can join",
     icon: Globe2,
   },
 ];


### PR DESCRIPTION
#### Problem:

1. Project network title isn't descriptive enough, making it hard for the new users to differentiate between `Public` and `Private` projects.

#### Solution:

1. Added a description alongside the network title.

#### Media:

1. Create project modal
<img width="501" alt="image" src="https://github.com/makeplane/plane/assets/65252264/015a0efc-285a-4cf9-a4bd-839d6c4bb7b0">

****

2. Project general settings
<img width="520" alt="image" src="https://github.com/makeplane/plane/assets/65252264/4662874f-efc0-4550-a5d4-a8c43bbd8882">

#### Issue link: [WEB-394](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/631e6e5f-e6b7-468b-a5ea-34eea0a10f26)