### PR TITLE
[WEB-472] fix: Page title for global view

### DIFF
--- a/web/pages/[workspaceSlug]/workspace-views/[globalViewId].tsx
+++ b/web/pages/[workspaceSlug]/workspace-views/[globalViewId].tsx
@@ -1,20 +1,37 @@
 import { ReactElement } from "react";
+import { useRouter } from "next/router";
+import { observer } from "mobx-react";
 // layouts
 import { AppLayout } from "layouts/app-layout";
+// hooks
+import { useGlobalView, useWorkspace } from "hooks/store";
 // components
 import { GlobalViewsHeader } from "components/workspace";
 import { AllIssueLayoutRoot } from "components/issues";
 import { GlobalIssuesHeader } from "components/headers";
+import { PageHead } from "components/core";
 // types
 import { NextPageWithLayout } from "lib/types";
-import { observer } from "mobx-react";
-import { useWorkspace } from "hooks/store";
-import { PageHead } from "components/core";
+// constants
+import { DEFAULT_GLOBAL_VIEWS_LIST } from "constants/workspace";
 
 const GlobalViewIssuesPage: NextPageWithLayout = observer(() => {
+  // router
+  const router = useRouter();
+  const { globalViewId } = router.query;
+  // store hooks
   const { currentWorkspace } = useWorkspace();
+  const { getViewDetailsById } = useGlobalView();
   // derived values
-  const pageTitle = currentWorkspace?.name ? `${currentWorkspace?.name} - Views` : undefined;
+  const globalViewDetails = globalViewId ? getViewDetailsById(globalViewId as string) : undefined;
+  const defaultView = DEFAULT_GLOBAL_VIEWS_LIST.find((view) => view.key === globalViewId);
+  const pageTitle =
+    currentWorkspace?.name && defaultView?.label
+      ? `${currentWorkspace?.name} - ${defaultView?.label}`
+      : currentWorkspace?.name && globalViewDetails?.name
+      ? `${currentWorkspace?.name} - ${globalViewDetails?.name}`
+      : undefined;
+
   return (
     <>
       <PageHead title={pageTitle} />

--- a/web/pages/[workspaceSlug]/workspace-views/[globalViewId].tsx
+++ b/web/pages/[workspaceSlug]/workspace-views/[globalViewId].tsx
@@ -23,7 +23,7 @@ const GlobalViewIssuesPage: NextPageWithLayout = observer(() => {
   const { currentWorkspace } = useWorkspace();
   const { getViewDetailsById } = useGlobalView();
   // derived values
-  const globalViewDetails = globalViewId ? getViewDetailsById(globalViewId as string) : undefined;
+  const globalViewDetails = globalViewId ? getViewDetailsById(globalViewId.toString()) : undefined;
   const defaultView = DEFAULT_GLOBAL_VIEWS_LIST.find((view) => view.key === globalViewId);
   const pageTitle =
     currentWorkspace?.name && defaultView?.label


### PR DESCRIPTION
### This PR improves the title for the global view detail page:

**Problem:**
The tab title is coming as  `<Workspace Name> - Views` for the global view detail page.

**Improvement:**
A specific active view name should be there: `<Workspace Name> - <View Name>`

**Before:**

![image](https://github.com/makeplane/plane/assets/94619783/cd744c6e-83cd-42e1-be72-717da88d05d9)

**After:**

https://github.com/makeplane/plane/assets/94619783/5f30eddc-8bf3-4adc-b54f-b2712b5bc5d0

This PR is attached to [WEB-472](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/e27fa535-b873-4441-bb26-b683236ee5ab)
