### PR TITLE
[WEB-464] improvement: remove `add sub-issues` button from the bottom if sub-issues are available.

### DIFF
--- a/web/components/issues/sub-issues/root.tsx
+++ b/web/components/issues/sub-issues/root.tsx
@@ -341,38 +341,6 @@ export const SubIssuesRoot: FC<ISubIssuesRoot> = observer((props) => {
                   />
                 </div>
               )}
-
-              <div>
-                <CustomMenu
-                  label={
-                    <div className="flex items-center gap-1">
-                      <Plus className="h-3 w-3" />
-                      Add sub-issue
-                    </div>
-                  }
-                  buttonClassName="whitespace-nowrap"
-                  placement="bottom-end"
-                  noBorder
-                  noChevron
-                >
-                  <CustomMenu.MenuItem
-                    onClick={() => {
-                      setTrackElement("Issue detail add sub-issue");
-                      handleIssueCrudState("create", parentIssueId, null);
-                    }}
-                  >
-                    Create new
-                  </CustomMenu.MenuItem>
-                  <CustomMenu.MenuItem
-                    onClick={() => {
-                      setTrackElement("Issue detail add sub-issue");
-                      handleIssueCrudState("existing", parentIssueId, null);
-                    }}
-                  >
-                    Add an existing issue
-                  </CustomMenu.MenuItem>
-                </CustomMenu>
-              </div>
             </>
           ) : (
             !disabled && (


### PR DESCRIPTION
This PR addresses the requirement to remove `Add sub-issues` button from the bottom part when sub-issues are available as we already have the same buttons on top.

#### Reference:
![image](https://github.com/makeplane/plane/assets/33979846/1eec7290-0e17-44db-90da-6b78a34a7d4d)

This PR is linked to [WEB-464](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/7ed71e98-02c0-4c4d-8e7f-5df7d2dfbf22)