### PR TITLE
[WEB-470] fix: module select fix

### DIFF
--- a/web/components/issues/issue-detail/module-select.tsx
+++ b/web/components/issues/issue-detail/module-select.tsx
@@ -10,6 +10,7 @@ import { Spinner } from "@plane/ui";
 import { cn } from "helpers/common.helper";
 // types
 import type { TIssueOperations } from "./root";
+import { xor } from "lodash";
 
 type TIssueModuleSelect = {
   className?: string;
@@ -34,19 +35,15 @@ export const IssueModuleSelect: React.FC<TIssueModuleSelect> = observer((props) 
 
   const handleIssueModuleChange = async (moduleIds: string[]) => {
     if (!issue || !issue.module_ids) return;
-
     setIsUpdating(true);
-
-    if (moduleIds.length === 0)
-      await issueOperations.removeModulesFromIssue?.(workspaceSlug, projectId, issueId, issue.module_ids);
-    else if (moduleIds.length > issue.module_ids.length) {
-      const newModuleIds = moduleIds.filter((m) => !issue.module_ids?.includes(m));
-      await issueOperations.addModulesToIssue?.(workspaceSlug, projectId, issueId, newModuleIds);
-    } else if (moduleIds.length < issue.module_ids.length) {
-      const removedModuleIds = issue.module_ids.filter((m) => !moduleIds.includes(m));
-      await issueOperations.removeModulesFromIssue?.(workspaceSlug, projectId, issueId, removedModuleIds);
+    const updatedModuleId = xor(issue.module_ids, moduleIds)[0];
+    if (updatedModuleId !== undefined) {
+      if (issue.module_ids.includes(updatedModuleId)) {
+        await issueOperations.removeModulesFromIssue?.(workspaceSlug, projectId, issueId, [updatedModuleId]);
+      } else {
+        await issueOperations.addModulesToIssue?.(workspaceSlug, projectId, issueId, [updatedModuleId]);
+      }
     }
-
     setIsUpdating(false);
   };
 

--- a/web/components/issues/issue-detail/module-select.tsx
+++ b/web/components/issues/issue-detail/module-select.tsx
@@ -36,8 +36,8 @@ export const IssueModuleSelect: React.FC<TIssueModuleSelect> = observer((props) 
   const handleIssueModuleChange = async (moduleIds: string[]) => {
     if (!issue || !issue.module_ids) return;
     setIsUpdating(true);
-    const updatedModuleId = xor(issue.module_ids, moduleIds)[0];
-    if (updatedModuleId !== undefined) {
+    const updatedModuleIds = xor(issue.module_ids, moduleIds);
+    for (const updatedModuleId of updatedModuleIds) {
       if (issue.module_ids.includes(updatedModuleId)) {
         await issueOperations.removeModulesFromIssue?.(workspaceSlug, projectId, issueId, [updatedModuleId]);
       } else {

--- a/web/components/issues/issue-detail/module-select.tsx
+++ b/web/components/issues/issue-detail/module-select.tsx
@@ -37,13 +37,22 @@ export const IssueModuleSelect: React.FC<TIssueModuleSelect> = observer((props) 
     if (!issue || !issue.module_ids) return;
     setIsUpdating(true);
     const updatedModuleIds = xor(issue.module_ids, moduleIds);
-    for (const updatedModuleId of updatedModuleIds) {
-      if (issue.module_ids.includes(updatedModuleId)) {
-        await issueOperations.removeModulesFromIssue?.(workspaceSlug, projectId, issueId, [updatedModuleId]);
+    const modulesToAdd: string[] = [];
+    const modulesToRemove: string[] = [];
+
+    for (const moduleId of updatedModuleIds) {
+      if (issue.module_ids.includes(moduleId)) {
+        modulesToRemove.push(moduleId);
       } else {
-        await issueOperations.addModulesToIssue?.(workspaceSlug, projectId, issueId, [updatedModuleId]);
+        modulesToAdd.push(moduleId);
       }
     }
+    if (modulesToRemove.length > 0)
+      await issueOperations.removeModulesFromIssue?.(workspaceSlug, projectId, issueId, modulesToRemove);
+
+    if (modulesToAdd.length > 0)
+      await issueOperations.addModulesToIssue?.(workspaceSlug, projectId, issueId, modulesToAdd);
+
     setIsUpdating(false);
   };
 

--- a/web/components/issues/issue-detail/module-select.tsx
+++ b/web/components/issues/issue-detail/module-select.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { observer } from "mobx-react-lite";
+import xor from "lodash/xor";
 // hooks
 import { useIssueDetail } from "hooks/store";
 // components
@@ -10,7 +11,6 @@ import { Spinner } from "@plane/ui";
 import { cn } from "helpers/common.helper";
 // types
 import type { TIssueOperations } from "./root";
-import { xor } from "lodash";
 
 type TIssueModuleSelect = {
   className?: string;

--- a/web/store/issue/module/issue.store.ts
+++ b/web/store/issue/module/issue.store.ts
@@ -356,7 +356,7 @@ export class ModuleIssues extends IssueHelperStore implements IModuleIssues {
       runInAction(() => {
         moduleIds.forEach((moduleId) => {
           update(this.issues, moduleId, (moduleIssueIds = []) => {
-            if (moduleIssueIds.includes(issueId)) return moduleIssueIds;
+            if (moduleIssueIds.includes(issueId)) return pull(moduleIssueIds, issueId);
             else return uniq(concat(moduleIssueIds, [issueId]));
           });
           update(this.rootStore.issues.issuesMap, [issueId, "module_ids"], (issueModuleIds = []) =>


### PR DESCRIPTION
#### Problem:
1. Upon removing the last module from the module select dropdown, an initial success alert is displayed. However, upon refreshing the page, the previous state is restored.

#### Solution:
1. Identified a logic issue in update handling. Adjusted the logic to ensure proper functionality and addressed the issue accordingly.

#### Issue link: [[WEB-470]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/061455ad-0b8a-4eef-a0c8-7aa350ecc687)