### PR TITLE
[WEB-396] fix: removed view icons from workspace and project views list

### DIFF
--- a/web/components/views/view-list-item.tsx
+++ b/web/components/views/view-list-item.tsx
@@ -9,7 +9,7 @@ import useToast from "hooks/use-toast";
 // components
 import { CreateUpdateProjectViewModal, DeleteProjectViewModal } from "components/views";
 // ui
-import { CustomMenu, PhotoFilterIcon } from "@plane/ui";
+import { CustomMenu } from "@plane/ui";
 // helpers
 import { calculateTotalFilters } from "helpers/filter.helper";
 import { copyUrlToClipboard } from "helpers/string.helper";

--- a/web/components/views/view-list-item.tsx
+++ b/web/components/views/view-list-item.tsx
@@ -83,9 +83,6 @@ export const ProjectViewListItem: React.FC<Props> = observer((props) => {
           <div className="relative flex w-full items-center justify-between rounded p-4">
             <div className="flex w-full items-center justify-between">
               <div className="flex items-center gap-4 overflow-hidden">
-                <div className="grid h-10 w-10 flex-shrink-0 place-items-center rounded bg-custom-background-90 group-hover:bg-custom-background-100">
-                  <PhotoFilterIcon className="h-3.5 w-3.5" />
-                </div>
                 <div className="flex flex-col overflow-hidden ">
                   <p className="truncate break-all text-sm font-medium  leading-4">{view.name}</p>
                   {view?.description && <p className="break-all text-xs text-custom-text-200">{view.description}</p>}

--- a/web/components/workspace/views/default-view-list-item.tsx
+++ b/web/components/workspace/views/default-view-list-item.tsx
@@ -20,9 +20,6 @@ export const GlobalDefaultViewListItem: React.FC<Props> = observer((props) => {
         <div className="relative flex w-full items-center justify-between rounded px-5 py-4">
           <div className="flex w-full items-center justify-between">
             <div className="flex items-center gap-4">
-              <div className="grid h-10 w-10 place-items-center rounded bg-custom-background-90 group-hover:bg-custom-background-100">
-                <PhotoFilterIcon className="h-3.5 w-3.5" />
-              </div>
               <div className="flex flex-col">
                 <p className="truncate text-sm font-medium leading-4">{truncateText(view.label, 75)}</p>
               </div>

--- a/web/components/workspace/views/default-view-list-item.tsx
+++ b/web/components/workspace/views/default-view-list-item.tsx
@@ -1,8 +1,6 @@
 import { useRouter } from "next/router";
 import Link from "next/link";
 import { observer } from "mobx-react-lite";
-// icons
-import { PhotoFilterIcon } from "@plane/ui";
 // helpers
 import { truncateText } from "helpers/string.helper";
 

--- a/web/components/workspace/views/view-list-item.tsx
+++ b/web/components/workspace/views/view-list-item.tsx
@@ -25,7 +25,7 @@ export const GlobalViewListItem: React.FC<Props> = observer((props) => {
   const { workspaceSlug } = router.query;
   // store hooks
   const { getViewDetailsById } = useGlobalView();
-  const {setTrackElement} = useEventTracker();
+  const { setTrackElement } = useEventTracker();
   // derived data
   const view = getViewDetailsById(viewId);
 
@@ -42,9 +42,6 @@ export const GlobalViewListItem: React.FC<Props> = observer((props) => {
           <div className="relative flex w-full items-center justify-between rounded p-4">
             <div className="flex w-full items-center justify-between">
               <div className="flex items-center gap-4">
-                <div className="grid h-10 w-10 place-items-center rounded bg-custom-background-90 group-hover:bg-custom-background-100">
-                  <PhotoFilterIcon className="h-3.5 w-3.5" />
-                </div>
                 <div className="flex flex-col">
                   <p className="truncate text-sm font-medium leading-4">{truncateText(view.name, 75)}</p>
                   {view?.description && <p className="text-xs text-custom-text-200">{view.description}</p>}

--- a/web/components/workspace/views/view-list-item.tsx
+++ b/web/components/workspace/views/view-list-item.tsx
@@ -8,7 +8,7 @@ import { useEventTracker, useGlobalView } from "hooks/store";
 // components
 import { CreateUpdateWorkspaceViewModal, DeleteGlobalViewModal } from "components/workspace";
 // ui
-import { CustomMenu, PhotoFilterIcon } from "@plane/ui";
+import { CustomMenu } from "@plane/ui";
 // helpers
 import { truncateText } from "helpers/string.helper";
 import { calculateTotalFilters } from "helpers/filter.helper";


### PR DESCRIPTION
This PR simplifies the UI by removing icons from the views at both the workspace and project levels. 

The primary goal is to increase the number of list items visible on the screen, thereby improving user experience by enabling users to view more of their projects or workspaces at a glance. This change is aimed at streamlining navigation and making the interface more efficient for users.

Screenshots:
| Old screenshot | New Screenshot |
|--------|--------|
| <img width="2282" alt="Screenshot 2024-02-21 at 1 15 27 PM" src="https://github.com/makeplane/plane/assets/28592219/569f5d49-bfc4-44a5-af81-bfc7769ecab1"> | <img width="2282" alt="Screenshot 2024-02-21 at 1 15 38 PM" src="https://github.com/makeplane/plane/assets/28592219/c1584de4-029c-49e1-a463-89b6a1bf138a"> |


