### PR TITLE
[WEB-479]: rendering issue title without overflow problem in issue peekoverview

### DIFF
--- a/web/components/issues/title-input.tsx
+++ b/web/components/issues/title-input.tsx
@@ -48,7 +48,7 @@ export const IssueTitleInput: FC<IssueTitleInputProps> = observer((props) => {
     [setIsSubmitting]
   );
 
-  if (disabled) <div className="text-2xl font-medium">{title}</div>;
+  if (disabled) return <div className="text-2xl font-medium">{title}</div>;
 
   return (
     <div className="relative">

--- a/web/components/issues/title-input.tsx
+++ b/web/components/issues/title-input.tsx
@@ -48,6 +48,14 @@ export const IssueTitleInput: FC<IssueTitleInputProps> = observer((props) => {
     [setIsSubmitting]
   );
 
+  if (disabled) {
+    return (
+      <div className="min-h-min block w-full resize-none overflow-hidden rounded border-none bg-transparent text-2xl font-medium outline-none ring-0 focus:ring-1 focus:ring-custom-primary">
+        {title}
+      </div>
+    );
+  }
+
   return (
     <div className="relative">
       <TextArea

--- a/web/components/issues/title-input.tsx
+++ b/web/components/issues/title-input.tsx
@@ -48,13 +48,7 @@ export const IssueTitleInput: FC<IssueTitleInputProps> = observer((props) => {
     [setIsSubmitting]
   );
 
-  if (disabled) {
-    return (
-      <div className="min-h-min block w-full resize-none overflow-hidden rounded border-none bg-transparent text-2xl font-medium outline-none ring-0 focus:ring-1 focus:ring-custom-primary">
-        {title}
-      </div>
-    );
-  }
+  if (disabled) <div className="text-2xl font-medium">{title}</div>;
 
   return (
     <div className="relative">


### PR DESCRIPTION
This PR addresses and resolves the overflow issue encountered in the titles of issues displayed in the issue peek overview and the issue detail page. The fix ensures that long-issue titles are properly handled, preventing text overflow and ensuring that titles are displayed cleanly and consistently across the platform.