### PR TITLE
[WEB-474]: Layout change not working in cycles and modules

### DIFF
--- a/web/components/issues/issue-layouts/calendar/calendar.tsx
+++ b/web/components/issues/issue-layouts/calendar/calendar.tsx
@@ -76,7 +76,7 @@ export const CalendarChart: React.FC<Props> = observer((props) => {
         <CalendarWeekHeader isLoading={!issues} showWeekends={showWeekends} />
         <div className="h-full w-full overflow-y-auto">
           {layout === "month" && (
-            <div className="grid h-full w-full grid-cols-1 divide-y-[0.5px] divide-custom-border-400">
+            <div className="grid h-full w-full grid-cols-1 divide-y-[0.5px] divide-custom-border-200">
               {allWeeksOfActiveMonth &&
                 Object.values(allWeeksOfActiveMonth).map((week: ICalendarWeek, weekIndex) => (
                   <CalendarWeekDays

--- a/web/components/issues/issue-layouts/calendar/dropdowns/options-dropdown.tsx
+++ b/web/components/issues/issue-layouts/calendar/dropdowns/options-dropdown.tsx
@@ -53,12 +53,18 @@ export const CalendarOptionsDropdown: React.FC<ICalendarHeader> = observer((prop
   const handleLayoutChange = (layout: TCalendarLayouts) => {
     if (!workspaceSlug || !projectId) return;
 
-    issuesFilterStore.updateFilters(workspaceSlug.toString(), projectId.toString(), EIssueFilterType.DISPLAY_FILTERS, {
-      calendar: {
-        ...issuesFilterStore.issueFilters?.displayFilters?.calendar,
-        layout,
+    issuesFilterStore.updateFilters(
+      workspaceSlug.toString(),
+      projectId.toString(),
+      EIssueFilterType.DISPLAY_FILTERS,
+      {
+        calendar: {
+          ...issuesFilterStore.issueFilters?.displayFilters?.calendar,
+          layout,
+        },
       },
-    });
+      viewId
+    );
 
     issueCalendarView.updateCalendarPayload(
       layout === "month"

--- a/web/components/issues/issue-layouts/calendar/week-days.tsx
+++ b/web/components/issues/issue-layouts/calendar/week-days.tsx
@@ -50,7 +50,7 @@ export const CalendarWeekDays: React.FC<Props> = observer((props) => {
 
   return (
     <div
-      className={`grid divide-x-[0.5px] divide-custom-border-400 ${showWeekends ? "grid-cols-7" : "grid-cols-5"} ${
+      className={`grid divide-x-[0.5px] divide-custom-border-200 ${showWeekends ? "grid-cols-7" : "grid-cols-5"} ${
         calendarLayout === "month" ? "" : "h-full"
       }`}
     >

--- a/web/components/issues/issue-layouts/calendar/week-header.tsx
+++ b/web/components/issues/issue-layouts/calendar/week-header.tsx
@@ -13,7 +13,7 @@ export const CalendarWeekHeader: React.FC<Props> = observer((props) => {
 
   return (
     <div
-      className={`relative grid divide-x-[0.5px] divide-custom-border-400 text-sm font-medium ${
+      className={`relative grid divide-x-[0.5px] divide-custom-border-200 text-sm font-medium ${
         showWeekends ? "grid-cols-7" : "grid-cols-5"
       }`}
     >

--- a/web/store/issue/issue_calendar_view.store.ts
+++ b/web/store/issue/issue_calendar_view.store.ts
@@ -78,7 +78,7 @@ export class CalendarStore implements ICalendarStore {
     const { activeWeekDate } = this.calendarFilters;
 
     return this.calendarPayload[`y-${activeWeekDate.getFullYear()}`][`m-${activeWeekDate.getMonth()}`][
-      `w-${this.activeWeekNumber}`
+      `w-${this.activeWeekNumber - 1}`
     ];
   }
 


### PR DESCRIPTION
#### Problem:

1. Layout change is not working in the calendar layout inside cycles and modules.
2. When clicking on the `Today` button in the week layout, a week ahead of the current week is being displayed.

#### Solution:

1. Fixed update layout handler, the function required `cycleId`/`moduleId` as a param which was missing.
2. Fixed the logic to display all days of the current week, which was always rendering a week ahead of the desired week.

#### Media:

https://github.com/makeplane/plane/assets/65252264/a9de4468-3803-4fe6-b798-5967c3f6cd26

#### Issues: [WEB-473](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/c46da154-873b-4f64-90a8-efaf0cd339c8), [WEB-474](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/3dabec61-f15f-491c-8d07-21c30a4bdcc7)