### PR TITLE
[WEB-483] chore: issue embed suggestion dropdown improvement

### DIFF
--- a/packages/editor/document-editor/src/ui/extensions/widgets/issue-embed-suggestion-list/issue-suggestion-renderer.tsx
+++ b/packages/editor/document-editor/src/ui/extensions/widgets/issue-embed-suggestion-list/issue-suggestion-renderer.tsx
@@ -145,7 +145,7 @@ const IssueSuggestionList = ({
     <div
       id="issue-list-container"
       ref={commandListContainer}
-      className=" fixed z-[10] max-h-80 w-60 overflow-y-auto overflow-x-hidden rounded-md border border-custom-border-100 bg-custom-background-100 px-1 shadow-custom-shadow-xs transition-all"
+      className=" fixed z-[10] max-h-80 w-96 overflow-y-auto overflow-x-hidden rounded-md border border-custom-border-100 bg-custom-background-100 px-1 shadow-custom-shadow-xs transition-all"
     >
       {sections.map((section) => {
         const sectionItems = displayedItems[section];
@@ -175,8 +175,8 @@ const IssueSuggestionList = ({
                   >
                     <h5 className="whitespace-nowrap text-xs text-custom-text-300">{item.identifier}</h5>
                     <PriorityIcon priority={item.priority} />
-                    <div>
-                      <p className="flex-grow truncate text-xs">{item.title}</p>
+                    <div className="w-full truncate">
+                      <p className="flex-grow w-full truncate text-xs">{item.title}</p>
                     </div>
                   </button>
                 ))}


### PR DESCRIPTION
#### Problem:
- When the length of the issue is too long, the issue title gets cut off in the issue suggestion dropdown within the issue embed on Page.

#### Solution:
- I have addressed this issue and made necessary adjustments to improve its appearance.

#### Issue link: [[WEB-483]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/92ea5b45-18d5-4984-808e-677f174e56c6)

#### Media:
| Before | After |
|--------|--------|
| ![isssue-suggestion-before](https://github.com/makeplane/plane/assets/121005188/28e34a9f-2984-4ebb-8d6f-5230a850adf0) |  ![isssue-suggestion-after](https://github.com/makeplane/plane/assets/121005188/f6b33f6e-7e63-4066-9dc9-92d68aea32e3) | 
