### PR TITLE
Removed redundant cache from `build-test-pull-request` action for more efficient builds

### DIFF
--- a/.github/workflows/build-test-pull-request.yml
+++ b/.github/workflows/build-test-pull-request.yml
@@ -21,7 +21,6 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 18.x
-          cache: "yarn"
 
       - name: Get changed files
         id: changed-files


### PR DESCRIPTION
## Description
- The Pull Request removes redundant node cache responsible for taking significant time in `post-node-setup`, the cache will be handled by means of Artifacts in next Pull Request.