### PR TITLE
[WEB-491] chore: project filter updated

### DIFF
--- a/apiserver/plane/app/views/workspace.py
+++ b/apiserver/plane/app/views/workspace.py
@@ -1248,6 +1248,7 @@ class WorkspaceUserProfileEndpoint(BaseAPIView):
                 Project.objects.filter(
                     workspace__slug=slug,
                     project_projectmember__member=request.user,
+                    project_projectmember__is_active=True,
                 )
                 .annotate(
                     created_issues=Count(


### PR DESCRIPTION
#### Problem:

- In the user profile page, a few projects are displayed that the user has already exited from.

#### Solution:
- Resolved the bug by filtering the project member active filter


#### Issue link: [[WEB-491](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/b9759550-c2c7-4d6c-a3f9-f5f9a1c81d36)]