### PR TITLE
[WEB-494] fix: selected label indicator are not showing up on the issue create modal.

### DIFF
--- a/web/components/issues/select/label.tsx
+++ b/web/components/issues/select/label.tsx
@@ -154,22 +154,22 @@ export const IssueLabelSelect: React.FC<Props> = observer((props) => {
                             className={({ active }) =>
                               `${
                                 active ? "bg-custom-background-80" : ""
-                              } group flex min-w-[14rem] cursor-pointer select-none items-center gap-2 truncate rounded px-1 py-1.5 text-custom-text-200`
+                              } group flex w-full cursor-pointer select-none items-center gap-2 truncate rounded px-1 py-1.5 text-custom-text-200`
                             }
                             value={label.id}
                           >
                             {({ selected }) => (
                               <div className="flex w-full justify-between gap-2 rounded">
-                                <div className="flex items-center justify-start gap-2">
+                                <div className="flex items-center justify-start gap-2 truncate">
                                   <span
                                     className="h-2.5 w-2.5 flex-shrink-0 rounded-full"
                                     style={{
                                       backgroundColor: label.color,
                                     }}
                                   />
-                                  <span>{label.name}</span>
+                                  <span className="truncate">{label.name}</span>
                                 </div>
-                                <div className="flex items-center justify-center rounded p-1">
+                                <div className="flex shrink-0 items-center justify-center rounded p-1">
                                   <Check className={`h-3 w-3 ${selected ? "opacity-100" : "opacity-0"}`} />
                                 </div>
                               </div>


### PR DESCRIPTION
#### Problem
Selected label indicator are not showing up on the issue create modal.
![image](https://github.com/makeplane/plane/assets/33979846/5acd1ccd-fd71-4197-a19f-4f75c6961ec8)

#### Solution
The indicator was already there but there was an overflow issues in the labels select component. Fixed it by changing the CSS.
![image](https://github.com/makeplane/plane/assets/33979846/98108930-1007-4096-9fdd-d40d661c78c4)

This PR is linked to [WEB-494](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/50b7de51-33a2-4e33-ba94-42bd0143ce4e)