### PR TITLE
[WEB-496] improvement: disable submit button when there is no text in comment box.

### DIFF
--- a/web/components/issues/issue-detail/issue-activity/comments/comment-create.tsx
+++ b/web/components/issues/issue-detail/issue-activity/comments/comment-create.tsx
@@ -53,7 +53,8 @@ export const IssueCommentCreate: FC<TIssueCommentCreate> = (props) => {
     control,
     formState: { isSubmitting },
     reset,
-  } = useForm<Partial<TIssueComment>>({ defaultValues: { comment_html: "<p></p>" } });
+    watch,
+  } = useForm<Partial<TIssueComment>>({ defaultValues: { comment_html: "" } });
 
   const onSubmit = async (formData: Partial<TIssueComment>) => {
     await activityOperations.createComment(formData).finally(() => {
@@ -88,7 +89,7 @@ export const IssueCommentCreate: FC<TIssueCommentCreate> = (props) => {
                 deleteFile={fileService.getDeleteImageFunction(workspaceId)}
                 restoreFile={fileService.getRestoreImageFunction(workspaceId)}
                 ref={editorRef}
-                value={!value ? "<p></p>" : value}
+                value={value ?? ""}
                 customClassName="p-2"
                 editorContentCustomClassNames="min-h-[35px]"
                 debouncedUpdatesEnabled={false}
@@ -104,7 +105,7 @@ export const IssueCommentCreate: FC<TIssueCommentCreate> = (props) => {
                 }
                 submitButton={
                   <Button
-                    disabled={isSubmitting}
+                    disabled={isSubmitting || watch("comment_html") === ""}
                     variant="primary"
                     type="submit"
                     className="!px-2.5 !py-1.5 !text-xs"


### PR DESCRIPTION
This PR addresses the requirement to disable submit button when there is no text in comment box.

#### Demo
[scrnli_2_22_2024_6-36-35 PM.webm](https://github.com/makeplane/plane/assets/33979846/9cb65df8-0fc4-4fb5-9a57-354244f15b01)


This PR is linked to [WEB-496](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/4346614a-d52f-418b-8a40-b929d10079c5)