### PR TITLE
fix: members dropdown avatar shrinking

### DIFF
--- a/web/components/project/send-project-invitation-modal.tsx
+++ b/web/components/project/send-project-invitation-modal.tsx
@@ -5,12 +5,10 @@ import { useForm, Controller, useFieldArray } from "react-hook-form";
 import { Dialog, Transition } from "@headlessui/react";
 import { ChevronDown, Plus, X } from "lucide-react";
 // hooks
-import { useEventTracker, useMember, useUser, useWorkspace } from "hooks/store";
+import { useEventTracker, useMember, useUser } from "hooks/store";
 import useToast from "hooks/use-toast";
 // ui
 import { Avatar, Button, CustomSelect, CustomSearchSelect } from "@plane/ui";
-// helpers
-import { getUserRole } from "helpers/user.helper";
 // constants
 import { ROLE } from "constants/workspace";
 import { EUserProjectRoles } from "constants/project";
@@ -149,9 +147,13 @@ export const SendProjectInvitationModal: React.FC<Props> = observer((props) => {
       } ${memberDetails?.member.display_name.toLowerCase()}`,
       content: (
         <div className="flex items-center gap-2">
-          <Avatar name={memberDetails?.member.display_name} src={memberDetails?.member.avatar} />
-          {memberDetails?.member.display_name} (
-          {memberDetails?.member.first_name + " " + memberDetails?.member.last_name})
+          <div className="grid place-items-center flex-shrink-0">
+            <Avatar name={memberDetails?.member.display_name} src={memberDetails?.member.avatar} />
+          </div>
+          <span className="truncate">
+            {memberDetails?.member.display_name} (
+            {memberDetails?.member.first_name + " " + memberDetails?.member.last_name})
+          </span>
         </div>
       ),
     };


### PR DESCRIPTION
#### Problem:

1. In the add members to project modal, if the display name of a member is too long, their avatar shrinks.

#### Solution:

1. Added `flex-shrink-0` to the avatar to handle shrinking.

#### Other improvements:

1. Show an ellipsis if the display name is too long.

#### Media:

| Before | After |
|--------|--------|
| <img width="339" alt="image" src="https://github.com/makeplane/plane/assets/65252264/84da5768-0506-463c-8f55-669702b1de75"> | <img width="339" alt="image" src="https://github.com/makeplane/plane/assets/65252264/edc76b7d-17d1-493e-b084-c61c8dc5e601"> | 