### PR TITLE
[WEB-518] chore: cycle issue transfer button validation

### DIFF
--- a/web/components/cycles/transfer-issues.tsx
+++ b/web/components/cycles/transfer-issues.tsx
@@ -16,12 +16,13 @@ import { CYCLE_DETAILS } from "constants/fetch-keys";
 
 type Props = {
   handleClick: () => void;
+  disabled?: boolean;
 };
 
 const cycleService = new CycleService();
 
 export const TransferIssues: React.FC<Props> = (props) => {
-  const { handleClick } = props;
+  const { handleClick, disabled = false } = props;
 
   const router = useRouter();
   const { workspaceSlug, projectId, cycleId } = router.query;
@@ -46,7 +47,12 @@ export const TransferIssues: React.FC<Props> = (props) => {
 
       {isEmpty(cycleDetails?.progress_snapshot) && transferableIssuesCount > 0 && (
         <div>
-          <Button variant="primary" prependIcon={<TransferIcon color="white" />} onClick={handleClick}>
+          <Button
+            variant="primary"
+            prependIcon={<TransferIcon color="white" />}
+            onClick={handleClick}
+            disabled={disabled}
+          >
             Transfer Issues
           </Button>
         </div>

--- a/web/components/issues/issue-layouts/roots/cycle-layout-root.tsx
+++ b/web/components/issues/issue-layouts/roots/cycle-layout-root.tsx
@@ -3,6 +3,7 @@ import { useRouter } from "next/router";
 import { observer } from "mobx-react-lite";
 import useSWR from "swr";
 import size from "lodash/size";
+import isEmpty from "lodash/isEmpty";
 // hooks
 import { useCycle, useIssues } from "hooks/store";
 // components
@@ -89,7 +90,12 @@ export const CycleLayoutRoot: React.FC = observer(() => {
     <>
       <TransferIssuesModal handleClose={() => setTransferIssuesModal(false)} isOpen={transferIssuesModal} />
       <div className="relative flex h-full w-full flex-col overflow-hidden">
-        {cycleStatus === "completed" && <TransferIssues handleClick={() => setTransferIssuesModal(true)} />}
+        {cycleStatus === "completed" && (
+          <TransferIssues
+            handleClick={() => setTransferIssuesModal(true)}
+            disabled={!isEmpty(cycleDetails?.progress_snapshot) ?? false}
+          />
+        )}
         <CycleAppliedFiltersRoot />
 
         {issues?.groupedIssueIds?.length === 0 ? (


### PR DESCRIPTION
#### Problem:
1. Once completed cycle issue is transferred, the problem arises where the user can reopen the transfer issue modal, which is not the intended behavior.
#### Solution:
2. A validation has been implemented to disable the button once the issue has been transferred.

#### Issue link: [[WEB-518]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/06c77639-3cb9-4b75-a5e5-e9cedf8c6b28)