### PR TITLE
[WEB-531] fix: added default priority state in quick-add in issues layouts

### DIFF
--- a/web/helpers/issue.helper.ts
+++ b/web/helpers/issue.helper.ts
@@ -123,6 +123,7 @@ export const createIssuePayload: (projectId: string, formData: Partial<TIssue>) 
   const payload: TIssue = {
     id: uuidv4(),
     project_id: projectId,
+    priority: "none",
     // tempId is used for optimistic updates. It is not a part of the API response.
     tempId: uuidv4(),
     // to be overridden by the form data


### PR DESCRIPTION
This PR contains a fix for the default priority state when we are creating an issue via quick-add in all layouts.