### PR TITLE
[WEB-536] fix: analytics highlight while switching between `scope_and_demand` and `custom` tab.

### DIFF
--- a/web/constants/dashboard.ts
+++ b/web/constants/dashboard.ts
@@ -256,7 +256,7 @@ export const SIDEBAR_MENU_ITEMS: {
     label: "Analytics",
     href: `/analytics`,
     access: EUserWorkspaceRoles.MEMBER,
-    highlight: (pathname: string, baseUrl: string) => pathname === `${baseUrl}/analytics`,
+    highlight: (pathname: string, baseUrl: string) => pathname.includes(`${baseUrl}/analytics`),
     Icon: BarChart2,
   },
   {


### PR DESCRIPTION
#### Problem
The Analytics tab highlight was not being shown when we switch between scope_and_demand` and `custom` tabs inside the page. This was due to the changes in the URL while switching between tabs as the highlight logic was checking for an exact match in the URL.

#### Solution
Updated the highlight logic to check if the URL includes `analytics` in it. 
![image](https://github.com/makeplane/plane/assets/33979846/81506dec-ac1b-4e3c-b29a-0dab0d647cf4)


This PR is linked to [WEB-536](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/1ed3978e-e5e4-4a6a-978b-7204b6dc747a)