### PR TITLE
[WEB-539] style: add background to user email in dashboard dropdown for better UX on workspace list scroll.

### DIFF
--- a/web/components/workspace/sidebar-dropdown.tsx
+++ b/web/components/workspace/sidebar-dropdown.tsx
@@ -157,7 +157,7 @@ export const WorkspaceSidebarDropdown = observer(() => {
               <Menu.Items as={Fragment}>
                 <div className="fixed left-4 z-20 mt-1 flex w-full max-w-[19rem] origin-top-left flex-col rounded-md border-[0.5px] border-custom-sidebar-border-300 bg-custom-sidebar-background-100 shadow-custom-shadow-rg divide-y divide-custom-border-100 outline-none">
                   <div className="flex max-h-96 flex-col items-start justify-start gap-2 overflow-y-scroll mb-2 px-4 vertical-scrollbar scrollbar-sm">
-                    <h6 className="sticky top-0 z-10 h-full w-full pt-3 text-sm font-medium text-custom-sidebar-text-400">
+                    <h6 className="sticky top-0 z-10 h-full w-full pt-3 pb-1 text-sm font-medium text-custom-sidebar-text-400 bg-custom-sidebar-background-100">
                       {currentUser?.email}
                     </h6>
                     {workspacesList ? (


### PR DESCRIPTION
#### Before
![image](https://github.com/makeplane/plane/assets/33979846/96d68efb-4340-4120-93a0-06701f91a86b)

#### After
![image](https://github.com/makeplane/plane/assets/33979846/c3613398-89b1-4828-868d-dab0dc3317b5)

This PR is linked to [WEB-539](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/95ec7b16-c796-4f7b-824e-c6ae37768820)