### PR TITLE
[WEB-541] fix: calendar misalignment because of scrollbar

### DIFF
--- a/web/components/issues/issue-layouts/calendar/calendar.tsx
+++ b/web/components/issues/issue-layouts/calendar/calendar.tsx
@@ -73,42 +73,44 @@ export const CalendarChart: React.FC<Props> = observer((props) => {
     <>
       <div className="flex h-full w-full flex-col overflow-hidden">
         <CalendarHeader issuesFilterStore={issuesFilterStore} viewId={viewId} />
-        <CalendarWeekHeader isLoading={!issues} showWeekends={showWeekends} />
-        <div className="h-full w-full overflow-y-auto vertical-scrollbar scrollbar-lg">
-          {layout === "month" && (
-            <div className="grid h-full w-full grid-cols-1 divide-y-[0.5px] divide-custom-border-200">
-              {allWeeksOfActiveMonth &&
-                Object.values(allWeeksOfActiveMonth).map((week: ICalendarWeek, weekIndex) => (
-                  <CalendarWeekDays
-                    issuesFilterStore={issuesFilterStore}
-                    key={weekIndex}
-                    week={week}
-                    issues={issues}
-                    groupedIssueIds={groupedIssueIds}
-                    enableQuickIssueCreate
-                    disableIssueCreation={!enableIssueCreation || !isEditingAllowed}
-                    quickActions={quickActions}
-                    quickAddCallback={quickAddCallback}
-                    viewId={viewId}
-                    readOnly={readOnly}
-                  />
-                ))}
-            </div>
-          )}
-          {layout === "week" && (
-            <CalendarWeekDays
-              issuesFilterStore={issuesFilterStore}
-              week={issueCalendarView.allDaysOfActiveWeek}
-              issues={issues}
-              groupedIssueIds={groupedIssueIds}
-              enableQuickIssueCreate
-              disableIssueCreation={!enableIssueCreation || !isEditingAllowed}
-              quickActions={quickActions}
-              quickAddCallback={quickAddCallback}
-              viewId={viewId}
-              readOnly={readOnly}
-            />
-          )}
+        <div className="flex h-full w-full vertical-scrollbar scrollbar-lg flex-col">
+          <CalendarWeekHeader isLoading={!issues} showWeekends={showWeekends} />
+          <div className="h-full w-full">
+            {layout === "month" && (
+              <div className="grid h-full w-full grid-cols-1 divide-y-[0.5px] divide-custom-border-200">
+                {allWeeksOfActiveMonth &&
+                  Object.values(allWeeksOfActiveMonth).map((week: ICalendarWeek, weekIndex) => (
+                    <CalendarWeekDays
+                      issuesFilterStore={issuesFilterStore}
+                      key={weekIndex}
+                      week={week}
+                      issues={issues}
+                      groupedIssueIds={groupedIssueIds}
+                      enableQuickIssueCreate
+                      disableIssueCreation={!enableIssueCreation || !isEditingAllowed}
+                      quickActions={quickActions}
+                      quickAddCallback={quickAddCallback}
+                      viewId={viewId}
+                      readOnly={readOnly}
+                    />
+                  ))}
+              </div>
+            )}
+            {layout === "week" && (
+              <CalendarWeekDays
+                issuesFilterStore={issuesFilterStore}
+                week={issueCalendarView.allDaysOfActiveWeek}
+                issues={issues}
+                groupedIssueIds={groupedIssueIds}
+                enableQuickIssueCreate
+                disableIssueCreation={!enableIssueCreation || !isEditingAllowed}
+                quickActions={quickActions}
+                quickAddCallback={quickAddCallback}
+                viewId={viewId}
+                readOnly={readOnly}
+              />
+            )}
+          </div>
         </div>
       </div>
     </>

--- a/web/components/issues/issue-layouts/calendar/day-tile.tsx
+++ b/web/components/issues/issue-layouts/calendar/day-tile.tsx
@@ -91,7 +91,7 @@ export const CalendarDayTile: React.FC<Props> = observer((props) => {
                   snapshot.isDraggingOver || date.date.getDay() === 0 || date.date.getDay() === 6
                     ? "bg-custom-background-90"
                     : "bg-custom-background-100"
-                } ${calendarLayout === "month" ? "min-h-[9rem]" : ""}`}
+                } ${calendarLayout === "month" ? "min-h-[5rem]" : ""}`}
                 {...provided.droppableProps}
                 ref={provided.innerRef}
               >

--- a/web/components/issues/issue-layouts/calendar/week-header.tsx
+++ b/web/components/issues/issue-layouts/calendar/week-header.tsx
@@ -13,7 +13,7 @@ export const CalendarWeekHeader: React.FC<Props> = observer((props) => {
 
   return (
     <div
-      className={`relative grid divide-x-[0.5px] divide-custom-border-200 text-sm font-medium ${
+      className={`relative sticky top-0 z-[1] grid divide-x-[0.5px] divide-custom-border-200 text-sm font-medium ${
         showWeekends ? "grid-cols-7" : "grid-cols-5"
       }`}
     >


### PR DESCRIPTION
[WEB-541](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/258a1776-6ac0-4b7b-92eb-83dd2bb78672)

fix:
- make the entire calendar scrollable along with header and make the header sticky to the top
- reduce min height of the day tile to not have scrollbar in the first place because without any issues

before with issues: 
![image](https://github.com/makeplane/plane/assets/71900764/87a67b9f-4f3e-411a-af61-9397f2f6a0c9)

after with issues:
![image](https://github.com/makeplane/plane/assets/71900764/2d192a78-1521-4198-9199-d1f8aee420d5)

before without issues: 
![image](https://github.com/makeplane/plane/assets/71900764/750dbf6d-680f-459f-b094-9527be1e334d)

after without issues: 
![image](https://github.com/makeplane/plane/assets/71900764/2bcf63f7-ffa2-4a7e-9953-7bf3bf76d47c)
