### PR TITLE
[WEB-516] fix: workspace dropdown overlapping fix

### DIFF
--- a/web/components/workspace/sidebar-dropdown.tsx
+++ b/web/components/workspace/sidebar-dropdown.tsx
@@ -157,7 +157,7 @@ export const WorkspaceSidebarDropdown = observer(() => {
               <Menu.Items as={Fragment}>
                 <div className="fixed left-4 z-20 mt-1 flex w-full max-w-[19rem] origin-top-left flex-col rounded-md border-[0.5px] border-custom-sidebar-border-300 bg-custom-sidebar-background-100 shadow-custom-shadow-rg divide-y divide-custom-border-100 outline-none">
                   <div className="flex max-h-96 flex-col items-start justify-start gap-2 overflow-y-scroll mb-2 px-4 vertical-scrollbar scrollbar-sm">
-                    <h6 className="sticky top-0 z-10 h-full w-full pt-3 text-sm font-medium text-custom-sidebar-text-400">
+                    <h6 className="sticky top-0 z-10 h-full w-full pt-3 pb-1 text-sm font-medium text-custom-sidebar-text-400 bg-custom-background-100">
                       {currentUser?.email}
                     </h6>
                     {workspacesList ? (


### PR DESCRIPTION
#### Problem:
1. The email ID in the App sidebar workspace dropdown is overlapping with the workspace name.
#### Solution:
1. Implement necessary adjustments to ensure proper display and functionality as intended.

#### Media:
| Before | After |
|--------|--------|
| ![8dfcfddd-69ce-46dd-9487-f8b578251b7f](https://github.com/makeplane/plane/assets/121005188/22fae7ea-b196-44d1-8607-5d683931fc88) | ![46dff735-4508-4f7b-a908-37491a1e1e51](https://github.com/makeplane/plane/assets/121005188/c817b697-b94d-4fae-ae8c-355004083586) |

#### Issue link: [[WEB-516]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/5d9cc369-3eb8-428f-8b70-4ad1f4ca519f)