### PR TITLE
[WEB-538] style: fix invite member icons in dropdown shrink when name is too large.

### DIFF
--- a/web/components/project/send-project-invitation-modal.tsx
+++ b/web/components/project/send-project-invitation-modal.tsx
@@ -148,10 +148,14 @@ export const SendProjectInvitationModal: React.FC<Props> = observer((props) => {
         memberDetails?.member.last_name
       } ${memberDetails?.member.display_name.toLowerCase()}`,
       content: (
-        <div className="flex items-center gap-2">
-          <Avatar name={memberDetails?.member.display_name} src={memberDetails?.member.avatar} />
-          {memberDetails?.member.display_name} (
-          {memberDetails?.member.first_name + " " + memberDetails?.member.last_name})
+        <div className="flex w-full items-center gap-2">
+          <div className="flex-shrink-0 pt-0.5">
+            <Avatar name={memberDetails?.member.display_name} src={memberDetails?.member.avatar} />
+          </div>
+          <div className="truncate">
+            {memberDetails?.member.display_name} (
+            {memberDetails?.member.first_name + " " + memberDetails?.member.last_name})
+          </div>
         </div>
       ),
     };


### PR DESCRIPTION
#### Problem:
The invite members icon in dropdown is getting shrink when the name is too large.
#### Solution:
Added the proper style with truncate to avoid this issue.

#### Media:
| Before | After |
|--------|--------|
| ![image](https://github.com/makeplane/plane/assets/33979846/c8df51fe-0bac-414b-80df-c0a68cb5629a) | ![image](https://github.com/makeplane/plane/assets/33979846/0a25d1b5-fc3c-48ce-9f3d-358643b718ca) |