### PR TITLE
[WEB-552] fix: Gantt chart scroll container height

### DIFF
--- a/web/components/gantt-chart/chart/main-content.tsx
+++ b/web/components/gantt-chart/chart/main-content.tsx
@@ -111,7 +111,7 @@ export const GanttChartMainContent: React.FC<Props> = observer((props) => {
         title={title}
         quickAdd={quickAdd}
       />
-      <div className="relative h-full flex-shrink-0 flex-grow">
+      <div className="relative min-h-full h-max flex-shrink-0 flex-grow">
         <ActiveChartView />
         {currentViewData && (
           <GanttChartBlocksList


### PR DESCRIPTION
#### Problem:

1. Gantt chart timeline is not occupying the complete available height.

#### Solution:

1. Added `h-max` class to the scroll container.