### PR TITLE
[WEB-553] fix: cycle select dropdown issue layout overflow

### DIFF
--- a/web/components/dropdowns/cycle.tsx
+++ b/web/components/dropdowns/cycle.tsx
@@ -204,7 +204,7 @@ export const CycleDropdown: React.FC<Props> = observer((props) => {
             >
               {!hideIcon && <ContrastIcon className="h-3 w-3 flex-shrink-0" />}
               {BUTTON_VARIANTS_WITH_TEXT.includes(buttonVariant) && (
-                <span className="flex-grow truncate">{selectedCycle?.name ?? placeholder}</span>
+                <span className="flex-grow truncate max-w-40">{selectedCycle?.name ?? placeholder}</span>
               )}
               {dropdownArrow && (
                 <ChevronDown className={cn("h-2.5 w-2.5 flex-shrink-0", dropdownArrowClassName)} aria-hidden="true" />

--- a/web/components/issues/issue-layouts/properties/all-properties.tsx
+++ b/web/components/issues/issue-layouts/properties/all-properties.tsx
@@ -346,7 +346,7 @@ export const IssueProperties: React.FC<IIssueProperties> = observer((props) => {
       {/* cycles */}
       {cycleId === undefined && (
         <WithDisplayPropertiesHOC displayProperties={displayProperties} displayPropertyKey="cycle">
-          <div className="h-5">
+          <div className="h-5 truncate">
             <CycleDropdown
               projectId={issue?.project_id}
               value={issue?.cycle_id}


### PR DESCRIPTION
#### Problem:
1. In the issue layout, selecting a module with a longer title causes the UI to break and overflow.
#### Solution:
1. This issue has been resolved by implementing a maximum width and truncte.

#### Media:
| Before | After |
|--------|--------|
| ![2d596ef6-ac07-48c8-aa61-5367edbce9ff](https://github.com/makeplane/plane/assets/121005188/859cdc33-0199-46cf-8b58-e1acb0b06e61) | ![6aab0c4b-6ce8-41f2-914d-29c322cfa29d](https://github.com/makeplane/plane/assets/121005188/3d325b22-c46c-46e9-bbb9-ef54174710bb) | 

#### Issue link: [[WEB-553]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/f2ea9a87-afc2-406a-b889-9a8eb47b32aa)