### PR TITLE
[WEB-496] improvement: disable submit `on enter` when there is no text in comment box.

### DIFF
--- a/web/components/issues/issue-detail/issue-activity/comments/comment-create.tsx
+++ b/web/components/issues/issue-detail/issue-activity/comments/comment-create.tsx
@@ -82,7 +82,7 @@ export const IssueCommentCreate: FC<TIssueCommentCreate> = (props) => {
             render={({ field: { value, onChange } }) => (
               <LiteTextEditorWithRef
                 onEnterKeyPress={(e) => {
-                  handleSubmit(onSubmit)(e);
+                  !(watch("comment_html") === "") && handleSubmit(onSubmit)(e);
                 }}
                 cancelUploadImage={fileService.cancelUpload}
                 uploadFile={fileService.getUploadFileFunction(workspaceSlug as string)}


### PR DESCRIPTION

This PR provides additional fix to PR #3754 by disabling enter key submit as well.  

---
This PR is linked to [WEB-496](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/4346614a-d52f-418b-8a40-b929d10079c5)