### PR TITLE
[WEB-556] fix: cycle store get completed cycle function updated

### DIFF
--- a/web/store/cycle.store.ts
+++ b/web/store/cycle.store.ts
@@ -1,6 +1,6 @@
 import { action, computed, observable, makeObservable, runInAction } from "mobx";
 import { computedFn } from "mobx-utils";
-import { isFuture, isPast } from "date-fns";
+import { isFuture, isPast, isToday } from "date-fns";
 import set from "lodash/set";
 import sortBy from "lodash/sortBy";
 // types
@@ -118,7 +118,8 @@ export class CycleStore implements ICycleStore {
     if (!projectId || !this.fetchedMap[projectId]) return null;
     let completedCycles = Object.values(this.cycleMap ?? {}).filter((c) => {
       const hasEndDatePassed = isPast(new Date(c.end_date ?? ""));
-      return c.project_id === projectId && hasEndDatePassed;
+      const isEndDateToday = isToday(new Date(c.end_date ?? ""));
+      return c.project_id === projectId && hasEndDatePassed && !isEndDateToday;
     });
     completedCycles = sortBy(completedCycles, [(c) => c.sort_order]);
     const completedCycleIds = completedCycles.map((c) => c.id);


### PR DESCRIPTION
#### Problem:
1. Active cycles with today's end date were not displaying some actionable items in the issue layout.
#### Solution:
1. After investigating, I found a problem with the cycle store regarding the filtering of completed cycles from the cycle map. Cycles that end today were not being taken into account. I've made the required adjustments to ensure it now operates as expected.

#### Issue link: [[WEB-556]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/81ecc670-b512-4067-8a00-6074f8e20aca)