### PR TITLE
[WEB-552] fix: Gantt chart unnecessary overflow

### DIFF
--- a/web/components/gantt-chart/chart/views/month.tsx
+++ b/web/components/gantt-chart/chart/views/month.tsx
@@ -15,9 +15,9 @@ export const MonthChartView: FC<any> = observer(() => {
   const monthBlocks: IMonthBlock[] = renderView;
 
   return (
-    <div className="absolute top-0 left-0 h-full w-max flex divide-x divide-custom-border-100/50">
+    <div className="absolute top-0 left-0 min-h-full h-max w-max flex divide-x divide-custom-border-100/50">
       {monthBlocks?.map((block, rootIndex) => (
-        <div key={`month-${block?.month}-${block?.year}`} className="relative">
+        <div key={`month-${block?.month}-${block?.year}`} className="relative flex flex-col">
           <div
             className="w-full sticky top-0 z-[5] bg-custom-background-100"
             style={{

--- a/yarn.lock
+++ b/yarn.lock
@@ -2812,7 +2812,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^18.2.42":
+"@types/react@*", "@types/react@18.2.42", "@types/react@^18.2.42":
   version "18.2.42"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.42.tgz#6f6b11a904f6d96dda3c2920328a97011a00aba7"
   integrity sha512-c1zEr96MjakLYus/wPnuWDo1/zErfdU9rNsIGmE+NV71nx88FG9Ttgo5dqorXTu/LImX2f63WBP986gJkMPNbA==


### PR DESCRIPTION
#### Problem:

1. Even if there are a very few number of blocks in the Gantt chart, it was scrollable.

#### Solution:

1. Updated the height of the background timeline.

#### Media:

Before fix-

https://github.com/makeplane/plane/assets/65252264/a1a32e03-25e2-4f5f-9ca4-9b4fa19b1ba8

After fix-

https://github.com/makeplane/plane/assets/65252264/884bfcd4-2d4f-441a-9eea-eba240307b6f

#### Issue: [WEB-552](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/9d8ef9da-3f79-49c8-a19a-35831eb76b73)