### PR TITLE
[WEB-580] chore: issue peek overview improvement

### DIFF
--- a/web/components/issues/peek-overview/view.tsx
+++ b/web/components/issues/peek-overview/view.tsx
@@ -5,6 +5,7 @@ import { observer } from "mobx-react-lite";
 // hooks
 import useOutsideClickDetector from "hooks/use-outside-click-detector";
 import useKeypress from "hooks/use-keypress";
+import useToast from "hooks/use-toast";
 // store hooks
 import { useIssueDetail } from "hooks/store";
 // components
@@ -47,12 +48,18 @@ export const IssueView: FC<IIssueView> = observer((props) => {
     issue: { getIssueById },
   } = useIssueDetail();
   const issue = getIssueById(issueId);
+  // hooks
+  const { alerts } = useToast();
   // remove peek id
   const removeRoutePeekId = () => {
     setPeekIssue(undefined);
   };
-  // hooks
-  useOutsideClickDetector(issuePeekOverviewRef, () => !isAnyModalOpen && removeRoutePeekId());
+
+  useOutsideClickDetector(issuePeekOverviewRef, () => {
+    if (!isAnyModalOpen && (!alerts || alerts.length === 0)) {
+      removeRoutePeekId();
+    }
+  });
   const handleKeyDown = () => !isAnyModalOpen && removeRoutePeekId();
   useKeypress("Escape", handleKeyDown);
 


### PR DESCRIPTION
#### Improvement:
This PR implements an enhancement for the issue peek overview. Previously, when the peek overview was open and a user attempted to close a toast alert, it inadvertently closed the peek overview, which was not the intended behavior. I have addressed this issue and made the necessary adjustments to ensure that it now functions as expected.

#### Issue link: [[WEB-580]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/3f51d05a-f0a0-4eb9-8da6-d3222d42b820)