### PR TITLE
[WEB-591] fix: navigating to a page through Cmd K throws error

### DIFF
--- a/web/hooks/store/use-page.ts
+++ b/web/hooks/store/use-page.ts
@@ -9,13 +9,13 @@ export const usePage = (pageId: string) => {
   const { projectPageMap, projectArchivedPageMap } = context.projectPages;
 
   const { projectId, workspaceSlug } = context.app.router;
-  if (!projectId || !workspaceSlug) throw new Error("usePage must be used within ProjectProvider");
-
-  if (projectPageMap[projectId] && projectPageMap[projectId][pageId]) {
-    return projectPageMap[projectId][pageId];
-  } else if (projectArchivedPageMap[projectId] && projectArchivedPageMap[projectId][pageId]) {
-    return projectArchivedPageMap[projectId][pageId];
-  } else {
+  if (!projectId || !workspaceSlug) {
+    console.log("usePage must be used within ProjectProvider");
     return;
   }
+
+  if (projectPageMap[projectId] && projectPageMap[projectId][pageId]) return projectPageMap[projectId][pageId];
+  else if (projectArchivedPageMap[projectId] && projectArchivedPageMap[projectId][pageId])
+    return projectArchivedPageMap[projectId][pageId];
+  else return;
 };


### PR DESCRIPTION
#### Problem:

1. When navigating to a page from the `Cmd K` modal in the dashboard, the application crashes.

#### Solution:

1. When the `projectId` is not present in the route, the `usePage` hook throws an error, but now it simply returns undefined which is handled in the component level.

#### Plane issue: [WEB-591](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/46fbfd26-9a67-4184-926f-b41ccb758746)