### PR TITLE
[WEB-597] chore: dashboard overdue issues

### DIFF
--- a/apiserver/plane/app/views/dashboard.py
+++ b/apiserver/plane/app/views/dashboard.py
@@ -56,10 +56,9 @@ def dashboard_overview_stats(self, request, slug):
         assignees__in=[request.user],
     ).count()
 
-    today = timezone.now().date()
     pending_issues_count = Issue.issue_objects.filter(
         ~Q(state__group__in=["completed", "cancelled"]),
-        Q(target_date__isnull=True) | Q(target_date__lt=today),
+        Q(target_date__lt=timezone.now().date()),
         project__project_projectmember__is_active=True,
         project__project_projectmember__member=request.user,
         workspace__slug=slug,

--- a/apiserver/plane/app/views/dashboard.py
+++ b/apiserver/plane/app/views/dashboard.py
@@ -58,7 +58,7 @@ def dashboard_overview_stats(self, request, slug):
 
     pending_issues_count = Issue.issue_objects.filter(
         ~Q(state__group__in=["completed", "cancelled"]),
-        Q(target_date__lt=timezone.now().date()),
+        target_date__lt=timezone.now().date(),
         project__project_projectmember__is_active=True,
         project__project_projectmember__member=request.user,
         workspace__slug=slug,

--- a/apiserver/plane/app/views/dashboard.py
+++ b/apiserver/plane/app/views/dashboard.py
@@ -56,8 +56,10 @@ def dashboard_overview_stats(self, request, slug):
         assignees__in=[request.user],
     ).count()
 
+    today = timezone.now().date()
     pending_issues_count = Issue.issue_objects.filter(
         ~Q(state__group__in=["completed", "cancelled"]),
+        Q(target_date__isnull=True) | Q(target_date__lt=today),
         project__project_projectmember__is_active=True,
         project__project_projectmember__member=request.user,
         workspace__slug=slug,

--- a/web/components/dashboard/widgets/overview-stats.tsx
+++ b/web/components/dashboard/widgets/overview-stats.tsx
@@ -37,7 +37,7 @@ export const OverviewStatsWidget: React.FC<WidgetProps> = observer((props) => {
       key: "overdue",
       title: "Issues overdue",
       count: widgetStats?.pending_issues_count,
-      link: `/${workspaceSlug}/workspace-views/assigned/?target_date=${today};before`,
+      link: `/${workspaceSlug}/workspace-views/assigned/?state_group=backlog,unstarted,started&target_date=${today};before`,
     },
     {
       key: "created",


### PR DESCRIPTION
#### Problem:
The dashboard for overdue issues previously had a filter that displayed all the issues with target dates that had passed.
#### Solution:
The filter has been updated to display issues assigned to the user with target dates before today's date, and with the state groups `backlog`, `started`, and `in progress`.
#### Media:

| Before | After |
|--------|--------|
| <img width="501" alt="image" src="https://github.com/makeplane/plane/assets/72156168/ebe7590b-bc2a-4bc4-8059-5149a0189c82"> | <img width="501" alt="image" src="https://github.com/makeplane/plane/assets/72156168/c01d9136-4769-454d-b20e-124abff4ccd4"> | 

#### Issue link: [[WEB-597](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/78ad3060-ff63-4c0e-b9ba-af16472b55e4)]

