### PR TITLE
[CHANG-8] chore: Upgraded Build Pull Request CI for Faster Parallel Build with Linting Capabilities

### DIFF
--- a/.github/workflows/build-test-pull-request.yml
+++ b/.github/workflows/build-test-pull-request.yml
@@ -5,23 +5,14 @@ on:
     types: ["opened", "synchronize"]
 
 jobs:
-  build-pull-request-contents:
-    name: Build Pull Request Contents
-    runs-on: ubuntu-20.04
-    permissions:
-      pull-requests: read
-
+  get-changed-files:
+    runs-on: ubuntu-latest
+    outputs:
+      apiserver_changed: ${{ steps.changed-files.outputs.apiserver_any_changed }}
+      web_changed: ${{ steps.changed-files.outputs.web_any_changed }}
+      space_changed: ${{ steps.changed-files.outputs.deploy_any_changed }}
     steps:
-      - name: Checkout Repository to Actions
-        uses: actions/checkout@v3.3.0
-        with:
-          token: ${{ secrets.ACCESS_TOKEN }}
-
-      - name: Setup Node.js 18.x
-        uses: actions/setup-node@v2
-        with:
-          node-version: 18.x
-
+      - uses: actions/checkout@v3
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@v41
@@ -33,15 +24,72 @@ jobs:
               - web/**
             deploy:
               - space/**
+              
+  lint-apiserver:
+    needs: get-changed-files
+    runs-on: ubuntu-latest
+    if: needs.get-changed-files.outputs.apiserver_changed == 'true'
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x' # Specify the Python version you need
+      - name: Install Pylint
+        run: python -m pip install ruff
+      - name: Install Apiserver Dependencies
+        run: cd apiserver && pip install -r requirements.txt
+      - name: Lint apiserver
+        run: ruff check --fix apiserver
 
-      - name: Build Plane's Main App
-        if: steps.changed-files.outputs.web_any_changed == 'true'
-        run: |
-          yarn
-          yarn build --filter=web
+  lint-web:
+    needs: get-changed-files
+    if: needs.get-changed-files.outputs.web_changed == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 18.x
+      - run: yarn install
+      - run: yarn lint --filter=web
 
-      - name: Build Plane's Deploy App
-        if: steps.changed-files.outputs.deploy_any_changed == 'true'
-        run: |
-          yarn 
-          yarn build --filter=space
+  lint-space:
+    needs: get-changed-files
+    if: needs.get-changed-files.outputs.space_changed == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 18.x
+      - run: yarn install
+      - run: yarn lint --filter=space
+
+  build-web:
+    needs: [get-changed-files, lint-web]
+    if: needs.get-changed-files.outputs.web_changed == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 18.x
+      - run: yarn install
+      - run: yarn build --filter=web
+
+  build-space:
+    needs: [get-changed-files, lint-space]
+    if: needs.get-changed-files.outputs.space_changed == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 18.x
+      - run: yarn install
+      - run: yarn build --filter=space


### PR DESCRIPTION
<img width="935" alt="image" src="https://github.com/makeplane/plane/assets/72302948/394f424c-8fd0-43ce-8167-b08f7ff60c45">

## Description
The pull request upgrades the Pull Request Build CI in order to facilitate parallel builds and along side linting for the packages that are changes. 
There are several jobs which can be divided into three categories
- **Get Changed Files** -> The job outputs 3 booleans, which indicates whether a project out of `apiserver` / `web` / `space` has been changed or not, these are used by other jobs to decide whether a job should run or not 
- **Linting Jobs**  -> Linting jobs are defined for `web` / `space` / `apiserver` if a linting job failes the corresponding build won't be triggered and eventually the CI would fail. 
- **Build Jobs** -> There are two build jobs, that builds web and space projects in parallel