### PR TITLE
[WEB-605] fix: project sidebar favorite list logic updated

### DIFF
--- a/web/store/project/project.store.ts
+++ b/web/store/project/project.store.ts
@@ -148,7 +148,7 @@ export class ProjectStore implements IProjectStore {
     projects = sortBy(projects, "created_at");
 
     const projectIds = projects
-      .filter((project) => project.workspace === currentWorkspace.id && project.is_favorite)
+      .filter((project) => project.workspace === currentWorkspace.id && project.is_member && project.is_favorite)
       .map((project) => project.id);
     return projectIds;
   }


### PR DESCRIPTION
#### Improvement:
This PR resolves an issue with the project sidebar favorite list. Previously, when a user favorited project XYZ and then left it, the project would still appear under the favorite section, which was not the intended behavior. I have addressed this issue and made the necessary changes to ensure it functions as intended.

#### Issue link: [[WEB-605]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/1462120f-ccec-4dd5-8ff4-75d3bb8ad14b)