### PR TITLE
[WEB-600] fix: fixed sub-group-by issue count display in kanban layout header

### DIFF
--- a/web/components/issues/issue-layouts/kanban/swimlanes.tsx
+++ b/web/components/issues/issue-layouts/kanban/swimlanes.tsx
@@ -30,6 +30,15 @@ interface ISubGroupSwimlaneHeader {
   kanbanFilters: TIssueKanbanFilters;
   handleKanbanFilters: (toggle: "group_by" | "sub_group_by", value: string) => void;
 }
+
+const getSubGroupHeaderIssuesCount = (issueIds: TSubGroupedIssues, groupById: string) => {
+  let headerCount = 0;
+  Object.keys(issueIds).map((groupState) => {
+    headerCount = headerCount + (issueIds?.[groupState]?.[groupById]?.length || 0);
+  });
+  return headerCount;
+};
+
 const SubGroupSwimlaneHeader: React.FC<ISubGroupSwimlaneHeader> = ({
   issueIds,
   sub_group_by,
@@ -41,27 +50,21 @@ const SubGroupSwimlaneHeader: React.FC<ISubGroupSwimlaneHeader> = ({
   <div className="relative flex h-max min-h-full w-full items-center">
     {list &&
       list.length > 0 &&
-      list.map((_list: IGroupByColumn) => {
-        let headerCount = 0;
-        Object.keys(issueIds).map((groupState) => {
-          headerCount = headerCount + ((issueIds as TSubGroupedIssues)?.[groupState]?.[_list?.id]?.length || 0);
-        });
-        return (
-          <div key={`${sub_group_by}_${_list.id}`} className="flex w-[340px] flex-shrink-0 flex-col">
-            <HeaderGroupByCard
-              sub_group_by={sub_group_by}
-              group_by={group_by}
-              column_id={_list.id}
-              icon={_list.icon}
-              title={_list.name}
-              count={headerCount}
-              kanbanFilters={kanbanFilters}
-              handleKanbanFilters={handleKanbanFilters}
-              issuePayload={_list.payload}
-            />
-          </div>
-        );
-      })}
+      list.map((_list: IGroupByColumn) => (
+        <div key={`${sub_group_by}_${_list.id}`} className="flex w-[340px] flex-shrink-0 flex-col">
+          <HeaderGroupByCard
+            sub_group_by={sub_group_by}
+            group_by={group_by}
+            column_id={_list.id}
+            icon={_list.icon}
+            title={_list.name}
+            count={getSubGroupHeaderIssuesCount(issueIds as TSubGroupedIssues, _list?.id)}
+            kanbanFilters={kanbanFilters}
+            handleKanbanFilters={handleKanbanFilters}
+            issuePayload={_list.payload}
+          />
+        </div>
+      ))}
   </div>
 );
 

--- a/web/components/issues/issue-layouts/kanban/swimlanes.tsx
+++ b/web/components/issues/issue-layouts/kanban/swimlanes.tsx
@@ -41,21 +41,27 @@ const SubGroupSwimlaneHeader: React.FC<ISubGroupSwimlaneHeader> = ({
   <div className="relative flex h-max min-h-full w-full items-center">
     {list &&
       list.length > 0 &&
-      list.map((_list: IGroupByColumn) => (
-        <div key={`${sub_group_by}_${_list.id}`} className="flex w-[340px] flex-shrink-0 flex-col">
-          <HeaderGroupByCard
-            sub_group_by={sub_group_by}
-            group_by={group_by}
-            column_id={_list.id}
-            icon={_list.icon}
-            title={_list.name}
-            count={(issueIds as TGroupedIssues)?.[_list.id]?.length || 0}
-            kanbanFilters={kanbanFilters}
-            handleKanbanFilters={handleKanbanFilters}
-            issuePayload={_list.payload}
-          />
-        </div>
-      ))}
+      list.map((_list: IGroupByColumn) => {
+        let headerCount = 0;
+        Object.keys(issueIds).map((groupState) => {
+          headerCount = headerCount + ((issueIds as TSubGroupedIssues)?.[groupState]?.[_list?.id]?.length || 0);
+        });
+        return (
+          <div key={`${sub_group_by}_${_list.id}`} className="flex w-[340px] flex-shrink-0 flex-col">
+            <HeaderGroupByCard
+              sub_group_by={sub_group_by}
+              group_by={group_by}
+              column_id={_list.id}
+              icon={_list.icon}
+              title={_list.name}
+              count={headerCount}
+              kanbanFilters={kanbanFilters}
+              handleKanbanFilters={handleKanbanFilters}
+              issuePayload={_list.payload}
+            />
+          </div>
+        );
+      })}
   </div>
 );
 


### PR DESCRIPTION
This PR contains a fix aimed at resolving an issue with the display of sub-group-by issue counts in the header of the Kanban layout within project issues.

Media:
| Before | After |
|--------|--------|
| <img width="352" alt="Screenshot 2024-02-29 at 5 00 34 PM" src="https://github.com/makeplane/plane/assets/28592219/ea74f15a-2359-42a8-9581-f48bb85f47e5"> | <img width="354" alt="Screenshot 2024-02-29 at 5 00 44 PM" src="https://github.com/makeplane/plane/assets/28592219/ee725210-73a2-4ce4-81fc-e9167ea3be0c"> | 

