### PR TITLE
[WEB-607] fix: module sidebar description duplicacy

### DIFF
--- a/web/components/modules/sidebar.tsx
+++ b/web/components/modules/sidebar.tsx
@@ -368,12 +368,6 @@ export const ModuleDetailsSidebar: React.FC<Props> = observer((props) => {
           </div>
         </div>
 
-        {moduleDetails.description && (
-          <span className="w-full whitespace-normal break-words py-2.5 text-sm leading-5 text-custom-text-200">
-            {moduleDetails.description}
-          </span>
-        )}
-
         <div className="flex flex-col gap-5 pb-6 pt-2.5">
           <div className="flex items-center justify-start gap-1">
             <div className="flex w-2/5 items-center justify-start gap-2 text-custom-text-300">


### PR DESCRIPTION
#### Improvement:
This PR addresses a bug in the module sidebar where the description was rendered twice, which was not the intended behavior. I have resolved this issue and made the necessary changes to ensure it appears as intended.

#### Issue link: [[WEB-607]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/491d6a89-daf8-4680-a58d-b2056a07ec81)