### PR TITLE
[CHANG-6] Added Workflow for comparing version between Master & Head before Release

### DIFF
--- a/.github/workflows/check-version.yml
+++ b/.github/workflows/check-version.yml
@@ -1,0 +1,45 @@
+name: Version Change Before Release
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  check-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Get PR Branch version
+        run: echo "PR_VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_ENV
+
+      - name: Fetch base branch
+        run: git fetch origin master:master
+
+      - name: Get Master Branch version
+        run: |
+          git checkout master
+          echo "MASTER_VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_ENV
+
+      - name: Get master branch version and compare
+        run: |
+          echo "Comparing versions: PR version is $PR_VERSION, Master version is $MASTER_VERSION"
+          if [ "$PR_VERSION" == "$MASTER_VERSION" ]; then
+            echo "Version in PR branch is the same as in master. Failing the CI."
+            exit 1
+          else
+            echo "Version check passed. Versions are different."
+          fi
+        env:
+          PR_VERSION: ${{ env.PR_VERSION }}
+          MASTER_VERSION: ${{ env.MASTER_VERSION }}


### PR DESCRIPTION
## Description
The Pull Request adds a new workflow, that runs when a pull request is raised to `master` branch, which withstands the below two cases, 
- If the package.json version of the `master` branch and `head` branch is same, this means that the version has not been changed and the job will fail.
- If the package.json version of `master` and `head` are different, this implies that the version has been successfully changed, resulting in the job to pass.