### PR TITLE
[WEB-609] fix: header text overflow issue in kanban layout

### DIFF
--- a/web/components/issues/issue-layouts/kanban/default.tsx
+++ b/web/components/issues/issue-layouts/kanban/default.tsx
@@ -101,14 +101,15 @@ const GroupByKanBan: React.FC<IGroupByKanBan> = observer((props) => {
 
   const groupList = showEmptyGroup ? list : groupWithIssues;
 
-  const visibilityGroupBy = (_list: IGroupByColumn) =>
-    sub_group_by
-      ? kanbanFilters?.sub_group_by.includes(_list.id)
-        ? true
-        : false
-      : kanbanFilters?.group_by.includes(_list.id)
-      ? true
-      : false;
+  const visibilityGroupBy = (_list: IGroupByColumn) => {
+    if (sub_group_by) {
+      if (kanbanFilters?.sub_group_by.includes(_list.id)) return true;
+      return false;
+    } else {
+      if (kanbanFilters?.group_by.includes(_list.id)) return true;
+      return false;
+    }
+  };
 
   const isGroupByCreatedBy = group_by === "created_by";
 

--- a/web/components/issues/issue-layouts/kanban/default.tsx
+++ b/web/components/issues/issue-layouts/kanban/default.tsx
@@ -102,7 +102,13 @@ const GroupByKanBan: React.FC<IGroupByKanBan> = observer((props) => {
   const groupList = showEmptyGroup ? list : groupWithIssues;
 
   const visibilityGroupBy = (_list: IGroupByColumn) =>
-    sub_group_by ? false : kanbanFilters?.group_by.includes(_list.id) ? true : false;
+    sub_group_by
+      ? kanbanFilters?.sub_group_by.includes(_list.id)
+        ? true
+        : false
+      : kanbanFilters?.group_by.includes(_list.id)
+      ? true
+      : false;
 
   const isGroupByCreatedBy = group_by === "created_by";
 

--- a/web/components/issues/issue-layouts/kanban/headers/group-by-card.tsx
+++ b/web/components/issues/issue-layouts/kanban/headers/group-by-card.tsx
@@ -106,13 +106,21 @@ export const HeaderGroupByCard: FC<IHeaderGroupByCard> = observer((props) => {
           {icon ? icon : <Circle width={14} strokeWidth={2} />}
         </div>
 
-        <div className={`flex items-center gap-1 ${verticalAlignPosition ? `flex-col` : `w-full flex-row`}`}>
+        <div
+          className={`relative overflow-hidden flex items-center gap-1 ${
+            verticalAlignPosition ? `flex-col` : `w-full flex-row`
+          }`}
+        >
           <div
-            className={`line-clamp-1 font-medium text-custom-text-100 ${verticalAlignPosition ? `vertical-lr` : ``}`}
+            className={`inline-block truncate line-clamp-1 font-medium text-custom-text-100 overflow-hidden ${
+              verticalAlignPosition ? `vertical-lr max-h-[400px]` : ``
+            }`}
           >
             {title}
           </div>
-          <div className={`text-sm font-medium text-custom-text-300 ${verticalAlignPosition ? `` : `pl-2`}`}>
+          <div
+            className={`flex-shrink-0 text-sm font-medium text-custom-text-300 ${verticalAlignPosition ? `` : `pl-2`}`}
+          >
             {count || 0}
           </div>
         </div>


### PR DESCRIPTION
This PR addresses a problem with text overflow in the header of the Kanban layout, which resulted in truncated or poorly displayed header text.

Media:
| Before | After |
|--------|--------|
| ![image](https://github.com/makeplane/plane/assets/28592219/77e7c267-1cca-4bbb-88c1-c58efe90415e) | <img width="722" alt="Screenshot 2024-02-29 at 8 19 02 PM" src="https://github.com/makeplane/plane/assets/28592219/181445b7-2dce-4a74-8ddf-5e78aaa4bfaa"> | 



