### PR TITLE
[WEB-616] fix: inbox issue navigation issue title and description event propagation

### DIFF
--- a/web/components/inbox/inbox-issue-actions.tsx
+++ b/web/components/inbox/inbox-issue-actions.tsx
@@ -131,6 +131,8 @@ export const InboxIssueActionsHeader: FC<TInboxIssueActionsHeader> = observer((p
   const handleInboxIssueNavigation = useCallback(
     (direction: "next" | "prev") => {
       if (!inboxIssues || !inboxIssueId) return;
+      const activeElement = document.activeElement as HTMLElement;
+      if ((activeElement && activeElement.classList.contains("tiptap")) || activeElement.id === "title-input") return;
       const nextIssueIndex =
         direction === "next"
           ? (currentIssueIndex + 1) % inboxIssues.length

--- a/web/components/inbox/inbox-issue-actions.tsx
+++ b/web/components/inbox/inbox-issue-actions.tsx
@@ -132,7 +132,7 @@ export const InboxIssueActionsHeader: FC<TInboxIssueActionsHeader> = observer((p
     (direction: "next" | "prev") => {
       if (!inboxIssues || !inboxIssueId) return;
       const activeElement = document.activeElement as HTMLElement;
-      if ((activeElement && activeElement.classList.contains("tiptap")) || activeElement.id === "title-input") return;
+      if (activeElement && (activeElement.classList.contains("tiptap") || activeElement.id === "title-input")) return;
       const nextIssueIndex =
         direction === "next"
           ? (currentIssueIndex + 1) % inboxIssues.length


### PR DESCRIPTION
#### Problem:
1. In the project inbox, when the focus is on any input or description, pressing the down or up arrow key triggers navigation issues within the inbox.

#### Solution:
1. I have identified the problem and implemented necessary changes to ensure it functions as intended.

#### Issue link: [[WEB-616]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/9f5fc2ce-46ad-4e1f-9bf1-6484b0bcea32)

#### Media:
| Before | After |
|--------|--------|
| ![90de96b0-6a27-405e-a999-3965ee1b3df6](https://github.com/makeplane/plane/assets/121005188/41360d84-4377-4f23-87fc-9f0f0a2165d7) | ![1c9098ca-ba11-4b18-a885-782d8a2bbee1](https://github.com/makeplane/plane/assets/121005188/1dcc3fb2-0a3d-4515-aba0-e1a5e01076d7) | 


