### PR TITLE
[WEB-618] fix: remove member button alignment in the workspace invite modal

### DIFF
--- a/web/components/workspace/send-workspace-invitation-modal.tsx
+++ b/web/components/workspace/send-workspace-invitation-modal.tsx
@@ -121,7 +121,7 @@ export const SendWorkspaceInvitationModal: React.FC<Props> = observer((props) =>
 
                     <div className="mb-3 space-y-4">
                       {fields.map((field, index) => (
-                        <div key={field.id} className="group relative grid grid-cols-11 gap-4">
+                        <div key={field.id} className="group relative grid grid-cols-11 items-start gap-4">
                           <div className="col-span-7">
                             <Controller
                               control={control}
@@ -155,7 +155,7 @@ export const SendWorkspaceInvitationModal: React.FC<Props> = observer((props) =>
                               )}
                             />
                           </div>
-                          <div className="col-span-3">
+                          <div className="col-span-3 flex items-center gap-2">
                             <Controller
                               control={control}
                               name={`emails.${index}.role`}
@@ -166,6 +166,7 @@ export const SendWorkspaceInvitationModal: React.FC<Props> = observer((props) =>
                                   label={<span className="text-xs sm:text-sm">{ROLE[value]}</span>}
                                   onChange={onChange}
                                   optionsClassName="w-full"
+                                  className="flex-grow"
                                   input
                                 >
                                   {Object.entries(ROLE).map(([key, value]) => {
@@ -179,16 +180,16 @@ export const SendWorkspaceInvitationModal: React.FC<Props> = observer((props) =>
                                 </CustomSelect>
                               )}
                             />
+                            {fields.length > 1 && (
+                              <button
+                                type="button"
+                                className="grid place-items-center self-center rounded flex-shrink-0"
+                                onClick={() => remove(index)}
+                              >
+                                <X className="h-3.5 w-3.5 text-custom-text-200" />
+                              </button>
+                            )}
                           </div>
-                          {fields.length > 1 && (
-                            <button
-                              type="button"
-                              className="-ml-3 place-items-center self-center rounded"
-                              onClick={() => remove(index)}
-                            >
-                              <X className="h-3.5 w-3.5 text-custom-text-200" />
-                            </button>
-                          )}
                         </div>
                       ))}
                     </div>


### PR DESCRIPTION
#### Problem:

1. Remove button gets misaligned when error message is displayed in the workspace invite modal.

#### Solution:

1. Grouped role select and remove button for proper alignment.

#### Media:

Before-

https://github.com/makeplane/plane/assets/65252264/80e774e9-525c-42a2-afb0-78324b9863c5

After-

https://github.com/makeplane/plane/assets/65252264/27b61b9e-6cdb-46ab-9ad2-15674250c0bf

#### Plane issue: [WEB-618](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/a722a5c8-2987-463d-a233-775049ed28c0)