### PR TITLE
[WEB-627] fix: kanban card state name overflow

### DIFF
--- a/web/components/issues/issue-layouts/properties/all-properties.tsx
+++ b/web/components/issues/issue-layouts/properties/all-properties.tsx
@@ -240,7 +240,7 @@ export const IssueProperties: React.FC<IIssueProperties> = observer((props) => {
       {/* basic properties */}
       {/* state */}
       <WithDisplayPropertiesHOC displayProperties={displayProperties} displayPropertyKey="state">
-        <div className="h-5">
+        <div className="h-5 truncate">
           <StateDropdown
             value={issue.state_id}
             onChange={handleState}


### PR DESCRIPTION
#### Improvement:
This PR addresses the issue of state name overflow in the kanban layout when the state name is longer.

#### Media:
| Before | After |
|--------|--------|
|  ![before](https://github.com/makeplane/plane/assets/121005188/ce44bbfd-fc78-4059-8bf6-61fb7b13724f) |  ![after](https://github.com/makeplane/plane/assets/121005188/42251767-2959-4288-b445-3e16397d2a4e)  |

#### Issue link: [[WEB-627]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/ff1c6deb-750a-4dd4-b612-1da4038dc261)