### PR TITLE
[WEB-566] feat: Added text to empty color picker boxes and other fixes

### DIFF
--- a/packages/editor/core/src/styles/table.css
+++ b/packages/editor/core/src/styles/table.css
@@ -98,7 +98,7 @@
   top: 0;
   bottom: -2px;
   width: 4px;
-  z-index: 99;
+  z-index: 5;
   background-color: #d9e4ff;
   pointer-events: none;
 }
@@ -111,7 +111,7 @@
 .tableWrapper .tableControls .rowsControl {
   transition: opacity ease-in 100ms;
   position: absolute;
-  z-index: 99;
+  z-index: 5;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -198,7 +198,7 @@
 
 .tableWrapper .tableControls .tableToolbox .toolboxItem:hover,
 .tableWrapper .tableControls .tableColorPickerToolbox .toolboxItem:hover {
-  background-color: rgba(var(--color-background-100), 0.5);
+  background-color: rgba(var(--color-background-80), 0.6);
 }
 
 .tableWrapper .tableControls .tableToolbox .toolboxItem .iconContainer,

--- a/packages/editor/core/src/ui/extensions/table/table/table-view.tsx
+++ b/packages/editor/core/src/ui/extensions/table/table/table-view.tsx
@@ -213,10 +213,11 @@ function createToolbox({
               { className: "colorPicker grid" },
               Object.entries(colors).map(([colorName, colorValue]) =>
                 h("div", {
-                  className: "colorPickerItem",
+                  className: "colorPickerItem flex items-center justify-center",
                   style: `background-color: ${colorValue.backgroundColor}; 
-                            color: ${colorValue.textColor || "inherit"};`,
-                  innerHTML: colorValue?.icon || "",
+          color: ${colorValue.textColor || "inherit"};`,
+                  innerHTML:
+                    colorValue.icon ?? `<span class="text-md" style:"color: ${colorValue.backgroundColor}>A</span>`,
                   onClick: () => onSelectColor(colorValue),
                 })
               )


### PR DESCRIPTION
## Description 

1. Added text to empty color picker boxes for both light and dark modes

| Light mode | Dark mode |
|--------|--------|
| <img width="911" alt="image" src="https://github.com/makeplane/plane/assets/73993394/0179499a-00ac-43c2-b3e1-a65654c95bef"> | <img width="911" alt="image" src="https://github.com/makeplane/plane/assets/73993394/5f5a6cf0-a0e5-47d0-bb37-5d6f546c26dd"> | 

2. This PR fixes the issue in which row/col action pickers in tables are shown over the modals if there's an editor behind it.

| Before | After |
|--------|--------|
| <img width="911" alt="image" src="https://github.com/makeplane/plane/assets/73993394/056a1875-2cad-4f7d-b772-317814a96aa1"> | <img width="911" alt="image" src="https://github.com/makeplane/plane/assets/73993394/92c46ccc-ad34-4adc-aa33-0888f91f1c68"> | 

3. Added more visible hover state for table operations using row and column picker actions