### PR TITLE
fix: crash while updating link text on the last node

### DIFF
--- a/packages/editor/document-editor/src/ui/components/links/link-edit-view.tsx
+++ b/packages/editor/document-editor/src/ui/components/links/link-edit-view.tsx
@@ -40,9 +40,11 @@ export const LinkEditView = ({
   const [positionRef, setPositionRef] = useState({ from: from, to: to });
   const [localUrl, setLocalUrl] = useState(viewProps.url);
 
-  const linkRemoved = useRef<Boolean>();
+  const linkRemoved = useRef<boolean>();
 
   const getText = (from: number, to: number) => {
+    if (to >= editor.state.doc.content.size) return "";
+
     const text = editor.state.doc.textBetween(from, to, "\n");
     return text;
   };
@@ -72,10 +74,12 @@ export const LinkEditView = ({
 
       const url = isValidUrl(localUrl) ? localUrl : viewProps.url;
 
+      if (to >= editor.state.doc.content.size) return;
+
       editor.view.dispatch(editor.state.tr.removeMark(from, to, editor.schema.marks.link));
       editor.view.dispatch(editor.state.tr.addMark(from, to, editor.schema.marks.link.create({ href: url })));
     },
-    [localUrl]
+    [localUrl, editor, from, to, viewProps.url]
   );
 
   const handleUpdateText = (text: string) => {


### PR DESCRIPTION
## Description

Fixed the bug that causes the editor to crash due to the internal implementation of `textBetween` implementation that uses nodeSize but on further debugging, crashes due to the [unhandled checks in Prosemirror's core library](https://discuss.prosemirror.net/t/feature-request-better-error-message-for-nodesbetween/4417) that threw this cryptic error `TypeError: Cannot read properties of undefined (reading 'nodeSize')` while editing text of links on the last node of the editor