### PR TITLE
[WEB-658] fix: multiple toast alerts on adding existing issues

### DIFF
--- a/web/components/core/modals/existing-issues-list-modal.tsx
+++ b/web/components/core/modals/existing-issues-list-modal.tsx
@@ -64,12 +64,6 @@ export const ExistingIssuesListModal: React.FC<Props> = (props) => {
     await handleOnSubmit(selectedIssues).finally(() => setIsSubmitting(false));
 
     handleClose();
-
-    setToast({
-      type: TOAST_TYPE.SUCCESS,
-      title: "Success",
-      message: `Issue${selectedIssues.length > 1 ? "s" : ""} added successfully`,
-    });
   };
 
   useEffect(() => {
@@ -180,7 +174,10 @@ export const ExistingIssuesListModal: React.FC<Props> = (props) => {
                     )}
                   </div>
 
-                  <Combobox.Options static className="max-h-80 scroll-py-2 overflow-y-auto vertical-scrollbar scrollbar-md">
+                  <Combobox.Options
+                    static
+                    className="max-h-80 scroll-py-2 overflow-y-auto vertical-scrollbar scrollbar-md"
+                  >
                     {searchTerm !== "" && (
                       <h5 className="mx-2 text-[0.825rem] text-custom-text-200">
                         Search results for{" "}


### PR DESCRIPTION
#### Problem:

1. On adding an existing issue to a completed cycle, both, success and error, toast alerts were getting displayed.

#### Solution:

1. Removed the success toast alert.

#### Media:

Before-

https://github.com/makeplane/plane/assets/65252264/57d6927f-d9f7-4503-bb3e-f886a602812c

After-

https://github.com/makeplane/plane/assets/65252264/9909ee98-d181-4d01-a71e-fa0140e22165

#### Plane issue: [WEB-658](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/a572308b-7586-4542-8355-cbc8e4814a36)