### PR TITLE
[WEB-663] fix: project members settings flickering

### DIFF
--- a/web/components/project/member-select.tsx
+++ b/web/components/project/member-select.tsx
@@ -49,14 +49,14 @@ export const MemberSelect: React.FC<Props> = observer((props) => {
     <CustomSearchSelect
       value={value}
       label={
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 h-5">
           {selectedOption && <Avatar name={selectedOption.member?.display_name} src={selectedOption.member?.avatar} />}
           {selectedOption ? (
             selectedOption.member?.display_name
           ) : (
             <div className="flex items-center gap-2">
               <Ban className="h-3.5 w-3.5 rotate-90 text-custom-sidebar-text-400" />
-              <span className="py-0.5 text-sm text-custom-sidebar-text-400">None</span>
+              <span className="text-sm text-custom-sidebar-text-400">None</span>
             </div>
           )}
         </div>

--- a/web/components/project/project-settings-member-defaults.tsx
+++ b/web/components/project/project-settings-member-defaults.tsx
@@ -63,11 +63,14 @@ export const ProjectSettingsMemberDefaults: React.FC = observer(() => {
     });
 
     await updateProject(workspaceSlug.toString(), projectId.toString(), {
-      default_assignee: formData.default_assignee === "none" ? null : formData.default_assignee,
-      project_lead: formData.project_lead === "none" ? null : formData.project_lead,
+      default_assignee:
+        formData.default_assignee === "none"
+          ? null
+          : formData.default_assignee ?? currentProjectDetails?.default_assignee,
+      project_lead:
+        formData.project_lead === "none" ? null : formData.project_lead ?? currentProjectDetails?.project_lead,
     })
       .then(() => {
-        fetchProjectDetails(workspaceSlug.toString(), projectId.toString());
         setToast({
           title: "Success",
           type: TOAST_TYPE.SUCCESS,


### PR DESCRIPTION
**Problem:**

1. When either the project lead or default assignee is changed, the other property automatically changes to None for a blink.
2. Default assignee & project lead container have slight differences in height when one of the property have value as None.

**Solution:**

1. While updating project details, one of the property value was going as undefined, so fixed it by checking for its value in currentProjectDetails.
2. Gave fixed height to both property container's.

_**Before:**_

https://github.com/makeplane/plane/assets/94619783/51b11d07-f15a-4af6-9d5b-21ca1f7ff4e9

_**After:**_

https://github.com/makeplane/plane/assets/94619783/632701e0-fa98-40fd-8ab1-9951b4f63a78


This PR is attached to [WEB-663](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/949f4a54-e68b-4db7-bee6-4ce12998aa7f)
