### PR TITLE
[WEB-667] fix: unable to deselect project lead in create project modal

### DIFF
--- a/web/components/project/create-project-modal.tsx
+++ b/web/components/project/create-project-modal.tsx
@@ -86,7 +86,6 @@ export const CreateProjectModal: FC<Props> = observer((props) => {
     control,
     watch,
     setValue,
-    getValues,
   } = useForm<IProject>({
     defaultValues,
     reValidateMode: "onChange",
@@ -172,11 +171,6 @@ export const CreateProjectModal: FC<Props> = observer((props) => {
     const alphanumericValue = projectIdentifierSanitizer(value);
     setIsChangeInIdentifierRequired(false);
     onChange(alphanumericValue);
-  };
-
-  const handleLeadChange = (onChange: any, lead: string | null) => {
-    if (lead === getValues("project_lead")) onChange(null);
-    else onChange(lead);
   };
 
   return (
@@ -412,7 +406,7 @@ export const CreateProjectModal: FC<Props> = observer((props) => {
                               <div className="h-7 flex-shrink-0" tabIndex={5}>
                                 <MemberDropdown
                                   value={value}
-                                  onChange={(lead) => handleLeadChange(onChange, lead)}
+                                  onChange={(lead) => onChange(lead === value ? null : lead)}
                                   placeholder="Lead"
                                   multiple={false}
                                   buttonVariant="border-with-text"

--- a/web/components/project/create-project-modal.tsx
+++ b/web/components/project/create-project-modal.tsx
@@ -86,6 +86,7 @@ export const CreateProjectModal: FC<Props> = observer((props) => {
     control,
     watch,
     setValue,
+    getValues,
   } = useForm<IProject>({
     defaultValues,
     reValidateMode: "onChange",
@@ -171,6 +172,11 @@ export const CreateProjectModal: FC<Props> = observer((props) => {
     const alphanumericValue = projectIdentifierSanitizer(value);
     setIsChangeInIdentifierRequired(false);
     onChange(alphanumericValue);
+  };
+
+  const handleLeadChange = (onChange: any, lead: string | null) => {
+    if (lead === getValues("project_lead")) onChange(null);
+    else onChange(lead);
   };
 
   return (
@@ -406,7 +412,7 @@ export const CreateProjectModal: FC<Props> = observer((props) => {
                               <div className="h-7 flex-shrink-0" tabIndex={5}>
                                 <MemberDropdown
                                   value={value}
-                                  onChange={onChange}
+                                  onChange={(lead) => handleLeadChange(onChange, lead)}
                                   placeholder="Lead"
                                   multiple={false}
                                   buttonVariant="border-with-text"


### PR DESCRIPTION
**Problem:**

Unable to deselect the project lead in create project modal, if once selected.

**Solution:**

If the selected lead is getting clicked again, then deselect the selected lead.

https://github.com/makeplane/plane/assets/94619783/5451a623-5768-4f20-a535-2774787f6ea6

This PR is attached to the issue [WEB-667](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/d410d5d7-8189-4150-bc30-027072e9ec8e)