### PR TITLE
[WEB-665] fix Padding in the project dropdown.

### DIFF
--- a/web/components/project/sidebar-list.tsx
+++ b/web/components/project/sidebar-list.tsx
@@ -116,9 +116,14 @@ export const ProjectSidebarList: FC = observer(() => {
       )}
       <div
         ref={containerRef}
-        className={cn("h-full space-y-2 overflow-y-auto px-4 vertical-scrollbar scrollbar-md", {
-          "border-t border-custom-sidebar-border-300": isScrolled,
-        })}
+        className={cn(
+          "h-full space-y-2 !overflow-y-scroll pl-4 vertical-scrollbar",
+          isCollapsed ? "scrollbar-sm" : "scrollbar-md",
+          {
+            "border-t border-custom-sidebar-border-300": isScrolled,
+            "pr-1": !isCollapsed,
+          }
+        )}
       >
         <DragDropContext onDragEnd={onDragEnd}>
           <Droppable droppableId="favorite-projects">


### PR DESCRIPTION
#### Problem
The padding of the menu items in project dropdown was inconsistent.

#### Solution
Removed the empty space between the project menu item and scroll bar by adding necessary styles.

#### Media
* Before Fix

[scrnli_3_8_2024_11-40-49 AM.webm](https://github.com/makeplane/plane/assets/33979846/d8f03586-a9bf-4065-a360-d1d42f6f6d70)

* After Fix

[scrnli_3_8_2024_11-38-10 AM.webm](https://github.com/makeplane/plane/assets/33979846/9e1fb932-8a15-4a49-828b-0157b8898afa)

This PR is linked to [WEB-665](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/73624fa4-e646-4ad4-ae59-162f76c02fca)
