### PR TITLE
[WEB-686] chore: app sidebar label update

### DIFF
--- a/web/components/workspace/sidebar-menu.tsx
+++ b/web/components/workspace/sidebar-menu.tsx
@@ -65,7 +65,7 @@ export const WorkspaceSidebarMenu = observer(() => {
                         })}
                       />
                     }
-                    {!themeStore?.sidebarCollapsed && link.label}
+                    <p className="leading-5">{!themeStore?.sidebarCollapsed && link.label}</p>
                     {!themeStore?.sidebarCollapsed && link.key === "active-cycles" && (
                       <Crown className="h-3.5 w-3.5 text-amber-400" />
                     )}

--- a/web/constants/dashboard.ts
+++ b/web/constants/dashboard.ts
@@ -1,6 +1,6 @@
 import { linearGradientDef } from "@nivo/core";
 // assets
-import { BarChart2, Briefcase, CheckCircle, LayoutGrid } from "lucide-react";
+import { BarChart2, Briefcase, CheckCircle, Home } from "lucide-react";
 import { ContrastIcon } from "@plane/ui";
 import { Props } from "components/icons/types";
 import CompletedIssuesDark from "public/empty-state/dashboard/dark/completed-issues.svg";
@@ -257,12 +257,12 @@ export const SIDEBAR_MENU_ITEMS: {
   Icon: React.FC<Props>;
 }[] = [
   {
-    key: "dashboard",
-    label: "Dashboard",
+    key: "home",
+    label: "Home",
     href: ``,
     access: EUserWorkspaceRoles.GUEST,
     highlight: (pathname: string, baseUrl: string) => pathname === `${baseUrl}`,
-    Icon: LayoutGrid,
+    Icon: Home,
   },
   {
     key: "analytics",


### PR DESCRIPTION
#### Changes:
This PR includes updates to the app sidebar dashboard label, changing it to "Home", and also updating the associated icon.

#### Issue link: [[WEB-686]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/1fec8074-a291-479f-9f3c-fa690efe8d8c)

#### Media:
| Before | After | 
|--------|--------|
| ![before](https://github.com/makeplane/plane/assets/121005188/9b8d3b8d-e657-48c5-be45-903338b99147) | ![after](https://github.com/makeplane/plane/assets/121005188/d6a08619-2a17-4908-8cc6-d44d683ba041)  |