### PR TITLE
[WEB-687] fix: project page empty state and empty state error handling 

### DIFF
--- a/web/components/empty-state/empty-state.tsx
+++ b/web/components/empty-state/empty-state.tsx
@@ -39,6 +39,10 @@ export const EmptyState: React.FC<EmptyStateProps> = (props) => {
   } = useUser();
   // theme
   const { resolvedTheme } = useTheme();
+
+  // if empty state type is not found
+  if (!EMPTY_STATE_DETAILS[type]) return null;
+
   // current empty state details
   const { key, title, description, path, primaryButton, secondaryButton, accessType, access } =
     EMPTY_STATE_DETAILS[type];

--- a/web/constants/empty-state.ts
+++ b/web/constants/empty-state.ts
@@ -69,7 +69,7 @@ export enum EmptyStateType {
   PROJECT_VIEW = "project-view",
   PROJECT_PAGE = "project-page",
   PROJECT_PAGE_ALL = "project-page-all",
-  PROJECT_PAGE_FAVORITE = "project-page-favorite",
+  PROJECT_PAGE_FAVORITE = "project-page-favorites",
   PROJECT_PAGE_PRIVATE = "project-page-private",
   PROJECT_PAGE_SHARED = "project-page-shared",
   PROJECT_PAGE_ARCHIVED = "project-page-archived",
@@ -475,8 +475,8 @@ const emptyStateDetails = {
       "Pages help you organise your thoughts to create wikis, discussions or even document heated takes for your project. Use it wisely!",
     path: "/empty-state/pages/all",
   },
-  "project-page-favorite": {
-    key: "project-page-favorite",
+  "project-page-favorites": {
+    key: "project-page-favorites",
     title: "No favorite pages yet",
     description: "Favorites for quick access? mark them and find them right here.",
     path: "/empty-state/pages/favorites",


### PR DESCRIPTION
#### Problem:
1. Project page is encountering an error on the favorite tab.

#### Solution:
1. Issue has been resolved by updating the tab key and the empty state key, which were previously different, causing the error. Additionally, error handling for the empty state has been implemented to prevent such errors in the future.


#### Issue link: [[WEB-687]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/675d2e60-c887-4633-a6a9-cc1705df6c5b)