### PR TITLE
[WEB-685] fix: module empty state issue creation 

### DIFF
--- a/web/components/issues/issue-layouts/empty-states/module.tsx
+++ b/web/components/issues/issue-layouts/empty-states/module.tsx
@@ -77,8 +77,8 @@ export const ModuleEmptyState: React.FC<Props> = observer((props) => {
             isEmptyFilters
               ? undefined
               : () => {
-                  setTrackElement("Cycle issue empty state");
-                  toggleCreateIssueModal(true, EIssuesStoreType.CYCLE);
+                  setTrackElement("Module issue empty state");
+                  toggleCreateIssueModal(true, EIssuesStoreType.MODULE);
                 }
           }
           secondaryButtonOnClick={isEmptyFilters ? handleClearAllFilters : () => setModuleIssuesListModal(true)}


### PR DESCRIPTION
#### Problem:
1. "Create Issue" action on the empty state page of Module issues is not functioning.

#### Solution:
1.  Issue has been resolved, and necessary changes have been made to ensure it works as expected.

#### Issue link: [[WEB-685]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/f9fde7a4-88a0-403c-84e8-7e6353eb6143)