### PR TITLE
[WEB - 691]: Remove caching on DEBUG and server restart

### DIFF
--- a/apiserver/bin/takeoff
+++ b/apiserver/bin/takeoff
@@ -21,11 +21,15 @@ SIGNATURE=$(echo "$HOSTNAME$MAC_ADDRESS$CPU_INFO$MEMORY_INFO$DISK_INFO" | sha256
 export MACHINE_SIGNATURE=$SIGNATURE
 
 # Register instance
-python manage.py register_instance $MACHINE_SIGNATURE
+python manage.py register_instance "$MACHINE_SIGNATURE"
+
 # Load the configuration variable
 python manage.py configure_instance
 
 # Create the default bucket
 python manage.py create_bucket
 
-exec gunicorn -w $GUNICORN_WORKERS -k uvicorn.workers.UvicornWorker plane.asgi:application --bind 0.0.0.0:${PORT:-8000} --max-requests 1200 --max-requests-jitter 1000 --access-logfile -
+# Clear Cache before starting to remove stale values
+python manage.py clear_cache
+
+exec gunicorn -w "$GUNICORN_WORKERS" -k uvicorn.workers.UvicornWorker plane.asgi:application --bind 0.0.0.0:"${PORT:-8000}" --max-requests 1200 --max-requests-jitter 1000 --access-logfile -

--- a/apiserver/bin/takeoff.local
+++ b/apiserver/bin/takeoff.local
@@ -21,12 +21,15 @@ SIGNATURE=$(echo "$HOSTNAME$MAC_ADDRESS$CPU_INFO$MEMORY_INFO$DISK_INFO" | sha256
 export MACHINE_SIGNATURE=$SIGNATURE
 
 # Register instance
-python manage.py register_instance $MACHINE_SIGNATURE
+python manage.py register_instance "$MACHINE_SIGNATURE"
 # Load the configuration variable
 python manage.py configure_instance
 
 # Create the default bucket
 python manage.py create_bucket
+
+# Clear Cache before starting to remove stale values
+python manage.py clear_cache
 
 python manage.py runserver 0.0.0.0:8000 --settings=plane.settings.local
 

--- a/apiserver/plane/db/management/commands/clear_cache.py
+++ b/apiserver/plane/db/management/commands/clear_cache.py
@@ -1,0 +1,17 @@
+# Django imports
+from django.core.cache import cache
+from django.core.management import BaseCommand
+
+
+class Command(BaseCommand):
+    help = "Clear Cache before starting the server to remove stale values"
+
+    def handle(self, *args, **options):
+        try:
+            cache.clear()
+            self.stdout.write(self.style.SUCCESS("Cache Cleared"))
+            return
+        except Exception:
+            # Another ClientError occurred
+            self.stdout.write(self.style.ERROR("Failed to clear cache"))
+            return


### PR DESCRIPTION
fix: 
- Clear cache when the server is started to remove old stale values in case of schema and response changes.
- Remove caching of APIs in `DEBUG` mode for quick iterations.