### PR TITLE
[WEB-585] chore: list layout scrollbar improvement

### DIFF
--- a/web/components/issues/issue-layouts/list/default.tsx
+++ b/web/components/issues/issue-layouts/list/default.tsx
@@ -123,7 +123,10 @@ const GroupByList: React.FC<IGroupByList> = (props) => {
   const isGroupByCreatedBy = group_by === "created_by";
 
   return (
-    <div ref={containerRef} className="vertical-scrollbar scrollbar-lg relative h-full w-full overflow-auto">
+    <div
+      ref={containerRef}
+      className="vertical-scrollbar scrollbar-lg relative h-full w-full overflow-auto vertical-scrollbar-margin-top-md"
+    >
       {groups &&
         groups.length > 0 &&
         groups.map(

--- a/web/styles/globals.css
+++ b/web/styles/globals.css
@@ -602,6 +602,9 @@ div.web-view-spinner div.bar12 {
 .horizontal-scrollbar::-webkit-scrollbar-corner {
   background-color: transparent;
 }
+.vertical-scrollbar-margin-top-md::-webkit-scrollbar-track {
+  margin-top: 44px;
+}
 
 /* scrollbar sm size */
 .scrollbar-sm::-webkit-scrollbar {


### PR DESCRIPTION
#### Improvement:
This PR contains improvements for the scrollbar in the list layout. Previously, the scrollbar was overlapping with the group header. I've made the necessary changes to ensure it appears as intended.

#### Issue link: [[WEB-585]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/dc2eb949-029e-4d14-a78a-b08f63421581)

#### Media:
<img width="1262" alt="Screenshot 2024-03-11 at 7 41 13 PM" src="https://github.com/makeplane/plane/assets/121005188/0444f693-1ee6-4cee-bd8c-11be8d2f06fc">

