### PR TITLE
[WEB-722] fix: label mutation in peek-overview & issue detail

### DIFF
--- a/web/components/issues/issue-detail/label/label-list.tsx
+++ b/web/components/issues/issue-detail/label/label-list.tsx
@@ -1,4 +1,5 @@
 import { FC } from "react";
+import { observer } from "mobx-react";
 // components
 import { useIssueDetail } from "hooks/store";
 import { LabelListItem } from "./label-list-item";
@@ -14,7 +15,7 @@ type TLabelList = {
   disabled: boolean;
 };
 
-export const LabelList: FC<TLabelList> = (props) => {
+export const LabelList: FC<TLabelList> = observer((props) => {
   const { workspaceSlug, projectId, issueId, labelOperations, disabled } = props;
   // hooks
   const {
@@ -40,4 +41,4 @@ export const LabelList: FC<TLabelList> = (props) => {
       ))}
     </>
   );
-};
+});


### PR DESCRIPTION
**Problem:**

Label mutation was not happening in the peek-overview & issue-detail on the label add & remove action.

**Solution:**

Selected label data was getting used from `store`, but the observer was not there to observe changes.

**Before:**

https://github.com/makeplane/plane/assets/94619783/a1b67af9-fbd7-4a74-a680-c5c6e30f9e15

**After:**


https://github.com/makeplane/plane/assets/94619783/aa993646-1982-4b8e-9b6d-33ff1115c312


This PR is attached to issue [WEB-722](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/6929621e-9a74-477a-8a66-23bee1f2f868)