### PR TITLE
[WEB-717] fix: delete issue modal UI fixes.

### DIFF
--- a/web/components/issues/issue-detail/root.tsx
+++ b/web/components/issues/issue-detail/root.tsx
@@ -376,7 +376,7 @@ export const IssueDetailRoot: FC<TIssueDetailRoot> = observer((props) => {
             />
           </div>
           <div
-            className="fixed right-0 z-[5] h-full w-full min-w-[300px] space-y-5 overflow-hidden border-l border-custom-border-200 bg-custom-sidebar-background-100 py-5 sm:w-1/2 md:relative md:w-1/3 lg:min-w-80 xl:min-w-96"
+            className="fixed right-0 z-[5] h-full w-full min-w-[300px] overflow-hidden border-l border-custom-border-200 bg-custom-sidebar-background-100 py-5 sm:w-1/2 md:relative md:w-1/3 lg:min-w-80 xl:min-w-96"
             style={themeStore.issueDetailSidebarCollapsed ? { right: `-${window?.innerWidth || 0}px` } : {}}
           >
             <IssueDetailsSidebar

--- a/web/components/issues/peek-overview/view.tsx
+++ b/web/components/issues/peek-overview/view.tsx
@@ -93,7 +93,6 @@ export const IssueView: FC<IIssueView> = observer((props) => {
           isOpen={isDeleteIssueModalOpen}
           handleClose={() => {
             toggleDeleteIssueModal(false);
-            removeRoutePeekId();
           }}
           data={issue}
           onSubmit={() => issueOperations.remove(workspaceSlug, projectId, issueId)}


### PR DESCRIPTION
#### Problems
1. When the close button within the delete modal popup is clicked, the peek overview gets automatically closed.
2. When clicking on 'Delete' or 'Archive Issue' to open the modal in the issue details sidebar, the entire sidebar shifts downward.

#### Solutions
1. Removed the `removeRoutePeekId` from the close action of the modal.
* Before

[scrnli_3_12_2024_3-13-26 PM.webm](https://github.com/makeplane/plane/assets/33979846/65503184-cdc2-4cbc-9b1a-f50097accae7)

* After

[scrnli_3_12_2024_3-06-22 PM.webm](https://github.com/makeplane/plane/assets/33979846/900430d3-0cb9-41e1-8950-6c3ca575db66)

2. Removed the style that was causing the issue. 
* Before

[scrnli_3_12_2024_1-52-40 PM.webm](https://github.com/makeplane/plane/assets/33979846/4359f122-e1ae-4648-82d1-104896bb3505)   

* After

[scrnli_3_12_2024_3-01-09 PM.webm](https://github.com/makeplane/plane/assets/33979846/91ba9ddb-1d8e-414f-b20f-bd58e6869aca)  

This PR is liked to [WEB-717](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/017f2ac3-e152-4302-98f0-f827b898e97d)

