### PR TITLE
[WEB-720] chore: reaction tooltip added

### DIFF
--- a/web/components/issues/issue-detail/reactions/issue-comment.tsx
+++ b/web/components/issues/issue-detail/reactions/issue-comment.tsx
@@ -4,7 +4,8 @@ import { observer } from "mobx-react-lite";
 import { TOAST_TYPE, Tooltip, setToast } from "@plane/ui";
 import { renderEmoji } from "helpers/emoji.helper";
 import { useIssueDetail, useMember } from "hooks/store";
-// ui
+// helper
+import { formatUserList } from "helpers/issue.helper";
 // types
 import { IUser } from "@plane/types";
 import { ReactionSelector } from "./reaction-selector";
@@ -81,11 +82,8 @@ export const IssueCommentReaction: FC<TIssueCommentReaction> = observer((props) 
         return reactionDetails ? getUserDetails(reactionDetails.actor)?.display_name : null;
       })
       .filter((displayName): displayName is string => !!displayName);
-
-    if (reactionUsers.length === 4) return `${reactionUsers.slice(0, 3).join(", ")}, and ${reactionUsers[3]}`;
-    if (reactionUsers.length > 3)
-      return `${reactionUsers.slice(0, 3).join(", ")}, and +${reactionUsers.length - 3} more`;
-    return reactionUsers.join(", ");
+    const formattedUsers = formatUserList(reactionUsers);
+    return formattedUsers;
   };
 
   return (

--- a/web/components/issues/issue-detail/reactions/issue-comment.tsx
+++ b/web/components/issues/issue-detail/reactions/issue-comment.tsx
@@ -82,6 +82,9 @@ export const IssueCommentReaction: FC<TIssueCommentReaction> = observer((props) 
       })
       .filter((displayName): displayName is string => !!displayName);
 
+    if (reactionUsers.length === 4) return `${reactionUsers.slice(0, 3).join(", ")}, and ${reactionUsers[3]}`;
+    if (reactionUsers.length > 3)
+      return `${reactionUsers.slice(0, 3).join(", ")}, and +${reactionUsers.length - 3} more`;
     return reactionUsers.join(", ");
   };
 

--- a/web/components/issues/issue-detail/reactions/issue-comment.tsx
+++ b/web/components/issues/issue-detail/reactions/issue-comment.tsx
@@ -5,7 +5,7 @@ import { TOAST_TYPE, Tooltip, setToast } from "@plane/ui";
 import { renderEmoji } from "helpers/emoji.helper";
 import { useIssueDetail, useMember } from "hooks/store";
 // helper
-import { formatUserList } from "helpers/issue.helper";
+import { formatTextList } from "helpers/issue.helper";
 // types
 import { IUser } from "@plane/types";
 import { ReactionSelector } from "./reaction-selector";
@@ -82,7 +82,7 @@ export const IssueCommentReaction: FC<TIssueCommentReaction> = observer((props) 
         return reactionDetails ? getUserDetails(reactionDetails.actor)?.display_name : null;
       })
       .filter((displayName): displayName is string => !!displayName);
-    const formattedUsers = formatUserList(reactionUsers);
+    const formattedUsers = formatTextList(reactionUsers);
     return formattedUsers;
   };
 

--- a/web/components/issues/issue-detail/reactions/issue.tsx
+++ b/web/components/issues/issue-detail/reactions/issue.tsx
@@ -1,10 +1,11 @@
 import { FC, useMemo } from "react";
 import { observer } from "mobx-react-lite";
-// components
-import { TOAST_TYPE, setToast } from "@plane/ui";
-import { renderEmoji } from "helpers/emoji.helper";
-import { useIssueDetail } from "hooks/store";
+// hooks
+import { useIssueDetail, useMember } from "hooks/store";
 // ui
+import { TOAST_TYPE, Tooltip, setToast } from "@plane/ui";
+// helpers
+import { renderEmoji } from "helpers/emoji.helper";
 // types
 import { IUser } from "@plane/types";
 import { ReactionSelector } from "./reaction-selector";
@@ -20,10 +21,11 @@ export const IssueReaction: FC<TIssueReaction> = observer((props) => {
   const { workspaceSlug, projectId, issueId, currentUser } = props;
   // hooks
   const {
-    reaction: { getReactionsByIssueId, reactionsByUser },
+    reaction: { getReactionsByIssueId, reactionsByUser, getReactionById },
     createReaction,
     removeReaction,
   } = useIssueDetail();
+  const { getUserDetails } = useMember();
 
   const reactionIds = getReactionsByIssueId(issueId);
   const userReactions = reactionsByUser(issueId, currentUser.id).map((r) => r.reaction);
@@ -72,6 +74,17 @@ export const IssueReaction: FC<TIssueReaction> = observer((props) => {
     [workspaceSlug, projectId, issueId, currentUser, createReaction, removeReaction, userReactions]
   );
 
+  const getReactionUsers = (reaction: string): string => {
+    const reactionUsers = (reactionIds?.[reaction] || [])
+      .map((reactionId) => {
+        const reactionDetails = getReactionById(reactionId);
+        return reactionDetails ? getUserDetails(reactionDetails.actor_id)?.display_name : null;
+      })
+      .filter((displayName): displayName is string => !!displayName);
+
+    return reactionUsers.join(", ");
+  };
+
   return (
     <div className="mt-4 relative flex items-center gap-1.5">
       <ReactionSelector size="md" position="top" value={userReactions} onSelect={issueReactionOperations.react} />
@@ -81,19 +94,21 @@ export const IssueReaction: FC<TIssueReaction> = observer((props) => {
           (reaction) =>
             reactionIds[reaction]?.length > 0 && (
               <>
-                <button
-                  type="button"
-                  onClick={() => issueReactionOperations.react(reaction)}
-                  key={reaction}
-                  className={`flex h-full items-center gap-1 rounded-md px-2 py-1 text-sm text-custom-text-100 ${
-                    userReactions.includes(reaction) ? "bg-custom-primary-100/10" : "bg-custom-background-80"
-                  }`}
-                >
-                  <span>{renderEmoji(reaction)}</span>
-                  <span className={userReactions.includes(reaction) ? "text-custom-primary-100" : ""}>
-                    {(reactionIds || {})[reaction].length}{" "}
-                  </span>
-                </button>
+                <Tooltip tooltipContent={getReactionUsers(reaction)}>
+                  <button
+                    type="button"
+                    onClick={() => issueReactionOperations.react(reaction)}
+                    key={reaction}
+                    className={`flex h-full items-center gap-1 rounded-md px-2 py-1 text-sm text-custom-text-100 ${
+                      userReactions.includes(reaction) ? "bg-custom-primary-100/10" : "bg-custom-background-80"
+                    }`}
+                  >
+                    <span>{renderEmoji(reaction)}</span>
+                    <span className={userReactions.includes(reaction) ? "text-custom-primary-100" : ""}>
+                      {(reactionIds || {})[reaction].length}{" "}
+                    </span>
+                  </button>
+                </Tooltip>
               </>
             )
         )}

--- a/web/components/issues/issue-detail/reactions/issue.tsx
+++ b/web/components/issues/issue-detail/reactions/issue.tsx
@@ -82,6 +82,9 @@ export const IssueReaction: FC<TIssueReaction> = observer((props) => {
       })
       .filter((displayName): displayName is string => !!displayName);
 
+    if (reactionUsers.length === 4) return `${reactionUsers.slice(0, 3).join(", ")}, and ${reactionUsers[3]}`;
+    if (reactionUsers.length > 3)
+      return `${reactionUsers.slice(0, 3).join(", ")}, and +${reactionUsers.length - 3} more`;
     return reactionUsers.join(", ");
   };
 

--- a/web/components/issues/issue-detail/reactions/issue.tsx
+++ b/web/components/issues/issue-detail/reactions/issue.tsx
@@ -6,6 +6,7 @@ import { useIssueDetail, useMember } from "hooks/store";
 import { TOAST_TYPE, Tooltip, setToast } from "@plane/ui";
 // helpers
 import { renderEmoji } from "helpers/emoji.helper";
+import { formatUserList } from "helpers/issue.helper";
 // types
 import { IUser } from "@plane/types";
 import { ReactionSelector } from "./reaction-selector";
@@ -82,10 +83,8 @@ export const IssueReaction: FC<TIssueReaction> = observer((props) => {
       })
       .filter((displayName): displayName is string => !!displayName);
 
-    if (reactionUsers.length === 4) return `${reactionUsers.slice(0, 3).join(", ")}, and ${reactionUsers[3]}`;
-    if (reactionUsers.length > 3)
-      return `${reactionUsers.slice(0, 3).join(", ")}, and +${reactionUsers.length - 3} more`;
-    return reactionUsers.join(", ");
+    const formattedUsers = formatUserList(reactionUsers);
+    return formattedUsers;
   };
 
   return (

--- a/web/components/issues/issue-detail/reactions/issue.tsx
+++ b/web/components/issues/issue-detail/reactions/issue.tsx
@@ -6,7 +6,7 @@ import { useIssueDetail, useMember } from "hooks/store";
 import { TOAST_TYPE, Tooltip, setToast } from "@plane/ui";
 // helpers
 import { renderEmoji } from "helpers/emoji.helper";
-import { formatUserList } from "helpers/issue.helper";
+import { formatTextList } from "helpers/issue.helper";
 // types
 import { IUser } from "@plane/types";
 import { ReactionSelector } from "./reaction-selector";
@@ -83,7 +83,7 @@ export const IssueReaction: FC<TIssueReaction> = observer((props) => {
       })
       .filter((displayName): displayName is string => !!displayName);
 
-    const formattedUsers = formatUserList(reactionUsers);
+    const formattedUsers = formatTextList(reactionUsers);
     return formattedUsers;
   };
 

--- a/web/helpers/issue.helper.ts
+++ b/web/helpers/issue.helper.ts
@@ -185,20 +185,20 @@ export function getChangedIssuefields(formData: Partial<TIssue>, dirtyFields: { 
   return changedFields;
 }
 
-export const formatUserList = (users: string[]): string => {
-  const userCount = users.length;
-  switch (userCount) {
+export const formatTextList = (TextArray: string[]): string => {
+  const count = TextArray.length;
+  switch (count) {
     case 0:
       return "";
     case 1:
-      return users[0];
+      return TextArray[0];
     case 2:
-      return `${users[0]} and ${users[1]}`;
+      return `${TextArray[0]} and ${TextArray[1]}`;
     case 3:
-      return `${users.slice(0, 2).join(", ")}, and ${users[2]}`;
+      return `${TextArray.slice(0, 2).join(", ")}, and ${TextArray[2]}`;
     case 4:
-      return `${users.slice(0, 3).join(", ")}, and ${users[3]}`;
+      return `${TextArray.slice(0, 3).join(", ")}, and ${TextArray[3]}`;
     default:
-      return `${users.slice(0, 3).join(", ")}, and +${userCount - 3} more`;
+      return `${TextArray.slice(0, 3).join(", ")}, and +${count - 3} more`;
   }
 };

--- a/web/helpers/issue.helper.ts
+++ b/web/helpers/issue.helper.ts
@@ -184,3 +184,21 @@ export function getChangedIssuefields(formData: Partial<TIssue>, dirtyFields: { 
 
   return changedFields;
 }
+
+export const formatUserList = (users: string[]): string => {
+  const userCount = users.length;
+  switch (userCount) {
+    case 0:
+      return "";
+    case 1:
+      return users[0];
+    case 2:
+      return `${users[0]} and ${users[1]}`;
+    case 3:
+      return `${users.slice(0, 2).join(", ")}, and ${users[2]}`;
+    case 4:
+      return `${users.slice(0, 3).join(", ")}, and ${users[3]}`;
+    default:
+      return `${users.slice(0, 3).join(", ")}, and +${userCount - 3} more`;
+  }
+};


### PR DESCRIPTION
#### Improvement:
This PR includes enhancements for issue reactions. Previously, tooltips were absent. I have now added tooltips to the reactions so that users can see who reacted.

#### Issue link: [[WEB-720]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/ba64a7c3-59db-4992-9e5e-71766b5e449f)

#### Media:
| Before | After |
|--------|--------|
| ![b4d360e1-cd16-47f0-9f48-318f1b98bc58](https://github.com/makeplane/plane/assets/121005188/46263dc4-89d4-4062-99fb-ab0ba188ff96) | ![2b9e7d16-d60b-44b0-8c5d-b531c49fa214](https://github.com/makeplane/plane/assets/121005188/d3b9d34e-9324-4c5d-b41f-2edcbe547f55) | 

