### PR TITLE
[WEB-747] chore: issue reaction response

### DIFF
--- a/packages/types/src/issues/issue_reaction.d.ts
+++ b/packages/types/src/issues/issue_reaction.d.ts
@@ -1,7 +1,7 @@
 export type TIssueReaction = {
-  actor_id: string;
+  actor: string;
   id: string;
-  issue_id: string;
+  issue: string;
   reaction: string;
 };
 

--- a/web/components/issues/issue-detail/reactions/issue.tsx
+++ b/web/components/issues/issue-detail/reactions/issue.tsx
@@ -79,7 +79,7 @@ export const IssueReaction: FC<TIssueReaction> = observer((props) => {
     const reactionUsers = (reactionIds?.[reaction] || [])
       .map((reactionId) => {
         const reactionDetails = getReactionById(reactionId);
-        return reactionDetails ? getUserDetails(reactionDetails.actor_id)?.display_name : null;
+        return reactionDetails ? getUserDetails(reactionDetails.actor)?.display_name : null;
       })
       .filter((displayName): displayName is string => !!displayName);
 

--- a/web/store/issue/issue-details/reaction.store.ts
+++ b/web/store/issue/issue-details/reaction.store.ts
@@ -84,7 +84,7 @@ export class IssueReactionStore implements IIssueReactionStore {
       if (reactions?.[reaction])
         reactions?.[reaction].map((reactionId) => {
           const currentReaction = this.getReactionById(reactionId);
-          if (currentReaction && currentReaction.actor_id === userId) _userReactions.push(currentReaction);
+          if (currentReaction && currentReaction.actor === userId) _userReactions.push(currentReaction);
         });
     });
 
@@ -151,7 +151,7 @@ export class IssueReactionStore implements IIssueReactionStore {
   ) => {
     try {
       const userReactions = this.reactionsByUser(issueId, userId);
-      const currentReaction = find(userReactions, { actor_id: userId, reaction: reaction });
+      const currentReaction = find(userReactions, { actor: userId, reaction: reaction });
 
       if (currentReaction && currentReaction.id) {
         runInAction(() => {


### PR DESCRIPTION
#### Chore:
This PR addresses the issue of initial non-display of reactions tooltip. There was a change in the response where we were receiving 'actor_id' which has now been replaced with 'actor'. I have resolved this issue and updated the store accordingly to ensure it functions as intended.

Issue link: [[WEB-747]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/953f392a-9cf4-48e6-8e84-6f911f965fca)