### PR TITLE
[WEB-545] chore: completed cycle empty state validation

### DIFF
--- a/web/components/issues/issue-layouts/empty-states/cycle.tsx
+++ b/web/components/issues/issue-layouts/empty-states/cycle.tsx
@@ -62,12 +62,14 @@ export const CycleEmptyState: React.FC<Props> = observer((props) => {
 
   const isCompletedCycleSnapshotAvailable = !isEmpty(cycleDetails?.progress_snapshot ?? {});
 
-  const emptyStateType = isCompletedCycleSnapshotAvailable
+  const isCompletedAndEmpty = isCompletedCycleSnapshotAvailable || cycleDetails?.status.toLowerCase() === "completed";
+
+  const emptyStateType = isCompletedAndEmpty
     ? EmptyStateType.PROJECT_CYCLE_COMPLETED_NO_ISSUES
     : isEmptyFilters
     ? EmptyStateType.PROJECT_EMPTY_FILTER
     : EmptyStateType.PROJECT_CYCLE_NO_ISSUES;
-  const additionalPath = isCompletedCycleSnapshotAvailable ? undefined : activeLayout ?? "list";
+  const additionalPath = isCompletedAndEmpty ? undefined : activeLayout ?? "list";
   const emptyStateSize = isEmptyFilters ? "lg" : "sm";
 
   return (
@@ -86,7 +88,7 @@ export const CycleEmptyState: React.FC<Props> = observer((props) => {
           additionalPath={additionalPath}
           size={emptyStateSize}
           primaryButtonOnClick={
-            !isCompletedCycleSnapshotAvailable && !isEmptyFilters
+            !isCompletedAndEmpty && !isEmptyFilters
               ? () => {
                   setTrackElement("Cycle issue empty state");
                   toggleCreateIssueModal(true, EIssuesStoreType.CYCLE);
@@ -94,9 +96,7 @@ export const CycleEmptyState: React.FC<Props> = observer((props) => {
               : undefined
           }
           secondaryButtonOnClick={
-            !isCompletedCycleSnapshotAvailable && isEmptyFilters
-              ? handleClearAllFilters
-              : () => setCycleIssuesListModal(true)
+            !isCompletedAndEmpty && isEmptyFilters ? handleClearAllFilters : () => setCycleIssuesListModal(true)
           }
         />
       </div>


### PR DESCRIPTION
#### Improvement:
This PR includes enhancements for validating the empty state of completed cycles.

#### Issue link: [[WEB-545]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/975c6621-99ed-4a45-9c4b-7129a85abc1b)