### PR TITLE
[WEB-754] fix: cycle date check endpoint

### DIFF
--- a/web/components/cycles/modal.tsx
+++ b/web/components/cycles/modal.tsx
@@ -96,10 +96,10 @@ export const CycleCreateUpdateModal: React.FC<CycleModalProps> = (props) => {
       });
   };
 
-  const dateChecker = async (payload: CycleDateCheckData) => {
+  const dateChecker = async (projectId: string, payload: CycleDateCheckData) => {
     let status = false;
 
-    await cycleService.cycleDateCheck(workspaceSlug as string, projectId as string, payload).then((res) => {
+    await cycleService.cycleDateCheck(workspaceSlug, projectId, payload).then((res) => {
       status = res.status;
     });
 
@@ -117,13 +117,13 @@ export const CycleCreateUpdateModal: React.FC<CycleModalProps> = (props) => {
 
     if (payload.start_date && payload.end_date) {
       if (data?.start_date && data?.end_date)
-        isDateValid = await dateChecker({
+        isDateValid = await dateChecker(payload.project_id ?? projectId, {
           start_date: payload.start_date,
           end_date: payload.end_date,
           cycle_id: data.id,
         });
       else
-        isDateValid = await dateChecker({
+        isDateValid = await dateChecker(payload.project_id ?? projectId, {
           start_date: payload.start_date,
           end_date: payload.end_date,
         });


### PR DESCRIPTION
#### Problem:

1. Wrong `projectId` being sent in the cycle date check endpoint.

#### Solution:

1. Updated the function to use `projectId` from the form data.

#### Plane issue: [WEB-754](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/1b3bf391-850f-4a6a-8f9b-e0f1efcf2975)