### PR TITLE
[WEB-766] fix: Project issues mobile header visibility

### DIFF
--- a/web/components/issues/issues-mobile-header.tsx
+++ b/web/components/issues/issues-mobile-header.tsx
@@ -88,7 +88,7 @@ export const IssuesMobileHeader = observer(() => {
         onClose={() => setAnalyticsModal(false)}
         projectDetails={currentProjectDetails ?? undefined}
       />
-      <div className="flex justify-evenly border-b border-custom-border-200 py-2 z-[13] bg-custom-background-100">
+      <div className="md:hidden flex justify-evenly border-b border-custom-border-200 py-2 z-[13] bg-custom-background-100">
         <CustomMenu
           maxHeight={"md"}
           className="flex flex-grow justify-center text-sm text-custom-text-200"


### PR DESCRIPTION
**Problem:**

The mobile header was always there even in full screen.

![image](https://github.com/makeplane/plane/assets/94619783/4aab0d75-3f2a-4d07-a7c9-b883550d3e1d)


**Solution:**

Added media query to hide it on screens greater than 768px.



This PR is attached to issue [WEB-766](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/866e5514-f202-4f5a-87a3-9c393b2a50e4)