### PR TITLE
[WEB-759] fix: calendar-layout draggable wrapper condition

### DIFF
--- a/web/components/issues/issue-layouts/calendar/calendar.tsx
+++ b/web/components/issues/issue-layouts/calendar/calendar.tsx
@@ -174,6 +174,7 @@ export const CalendarChart: React.FC<Props> = observer((props) => {
               viewId={viewId}
               readOnly={readOnly}
               isDragDisabled
+              isMobileView
             />
           </div>
         </div>

--- a/web/components/issues/issue-layouts/calendar/issue-blocks.tsx
+++ b/web/components/issues/issue-layouts/calendar/issue-blocks.tsx
@@ -7,7 +7,6 @@ import { CalendarQuickAddIssueForm, CalendarIssueBlockRoot } from "components/is
 import { renderFormattedPayloadDate } from "helpers/date-time.helper";
 // types
 import { TIssue, TIssueMap } from "@plane/types";
-import useSize from "hooks/use-window-size";
 
 type Props = {
   date: Date;
@@ -26,6 +25,7 @@ type Props = {
   addIssuesToView?: (issueIds: string[]) => Promise<any>;
   viewId?: string;
   readOnly?: boolean;
+  isMobileView?: boolean;
 };
 
 export const CalendarIssueBlocks: React.FC<Props> = observer((props) => {
@@ -41,11 +41,10 @@ export const CalendarIssueBlocks: React.FC<Props> = observer((props) => {
     addIssuesToView,
     viewId,
     readOnly,
+    isMobileView = false,
   } = props;
   // states
   const [showAllIssues, setShowAllIssues] = useState(false);
-  // hooks
-  const [windowWidth] = useSize();
 
   const formattedDatePayload = renderFormattedPayloadDate(date);
   const totalIssues = issueIdList?.length ?? 0;
@@ -54,8 +53,8 @@ export const CalendarIssueBlocks: React.FC<Props> = observer((props) => {
 
   return (
     <>
-      {issueIdList?.slice(0, showAllIssues || windowWidth <= 768 ? issueIdList.length : 4).map((issueId, index) =>
-        windowWidth > 768 ? (
+      {issueIdList?.slice(0, showAllIssues || isMobileView ? issueIdList.length : 4).map((issueId, index) =>
+        !isMobileView ? (
           <Draggable key={issueId} draggableId={issueId} index={index} isDragDisabled={isDragDisabled}>
             {(provided, snapshot) => (
               <div


### PR DESCRIPTION
**Problem:**

Hidden mobile-view content was also getting wrapped with draggable when the window width exceeds 768px.

![image](https://github.com/makeplane/plane/assets/94619783/e7fc6998-5c5c-4a4f-9d63-24a1449d14d0)


**Solution:**

Introduced new variable to identify mobile-view or desktop-view.

![image](https://github.com/makeplane/plane/assets/94619783/496582f5-ce6e-4d7e-aed5-c9f517773c94)


This PR is attached to issue [WEB-759](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/d9a23f6d-d238-4a00-9c83-8abd2936117a)