### PR TITLE
[WEB-675] fix: analytics dialog close on outside click

### DIFF
--- a/web/components/analytics/project-modal/modal.tsx
+++ b/web/components/analytics/project-modal/modal.tsx
@@ -36,32 +36,34 @@ export const ProjectAnalyticsModal: React.FC<Props> = observer((props) => {
           leaveFrom="translate-x-0"
           leaveTo="translate-x-full"
         >
-          <Dialog.Panel className="fixed inset-0 z-20 h-full w-full overflow-y-auto">
-            <div
-              className={`fixed right-0 top-0 z-20 h-full bg-custom-background-100 shadow-custom-shadow-md ${
-                fullScreen ? "w-full p-2" : "w-full sm:w-full md:w-1/2"
-              }`}
-            >
+          <div className="fixed inset-0 z-20 h-full w-full overflow-y-auto">
+            <Dialog.Panel>
               <div
-                className={`flex h-full flex-col overflow-hidden border-custom-border-200 bg-custom-background-100 text-left ${
-                  fullScreen ? "rounded-lg border" : "border-l"
+                className={`fixed right-0 top-0 z-20 h-full bg-custom-background-100 shadow-custom-shadow-md ${
+                  fullScreen ? "w-full p-2" : "w-full sm:w-full md:w-1/2"
                 }`}
               >
-                <ProjectAnalyticsModalHeader
-                  fullScreen={fullScreen}
-                  handleClose={handleClose}
-                  setFullScreen={setFullScreen}
-                  title={cycleDetails?.name ?? moduleDetails?.name ?? projectDetails?.name ?? ""}
-                />
-                <ProjectAnalyticsModalMainContent
-                  fullScreen={fullScreen}
-                  cycleDetails={cycleDetails}
-                  moduleDetails={moduleDetails}
-                  projectDetails={projectDetails}
-                />
+                <div
+                  className={`flex h-full flex-col overflow-hidden border-custom-border-200 bg-custom-background-100 text-left ${
+                    fullScreen ? "rounded-lg border" : "border-l"
+                  }`}
+                >
+                  <ProjectAnalyticsModalHeader
+                    fullScreen={fullScreen}
+                    handleClose={handleClose}
+                    setFullScreen={setFullScreen}
+                    title={cycleDetails?.name ?? moduleDetails?.name ?? projectDetails?.name ?? ""}
+                  />
+                  <ProjectAnalyticsModalMainContent
+                    fullScreen={fullScreen}
+                    cycleDetails={cycleDetails}
+                    moduleDetails={moduleDetails}
+                    projectDetails={projectDetails}
+                  />
+                </div>
               </div>
-            </div>
-          </Dialog.Panel>
+            </Dialog.Panel>
+          </div>
         </Transition.Child>
       </Dialog>
     </Transition.Root>


### PR DESCRIPTION
**Problem:**

When the analytics section is open, clicking outside of the dialog does not closing the dialog.

![image](https://github.com/makeplane/plane/assets/94619783/fcf93db9-e0e4-4f42-9360-1078dad8aa84)


**Solution:**

Wrapped the Dialog with div & its class.


https://github.com/makeplane/plane/assets/94619783/46d95dc8-bd64-4541-8441-3b0ae92cc0b0


This PR is attached to issue [WEB-675](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/b70bcaf6-1df8-4aa0-b1fd-e801b3894e1c)