### PR TITLE
fix: test email command to use new SSL settings

### DIFF
--- a/apiserver/plane/db/management/commands/test_email.py
+++ b/apiserver/plane/db/management/commands/test_email.py
@@ -23,6 +23,7 @@ class Command(BaseCommand):
             EMAIL_HOST_PASSWORD,
             EMAIL_PORT,
             EMAIL_USE_TLS,
+            EMAIL_USE_SSL,
             EMAIL_FROM,
         ) = get_email_configuration()
 
@@ -32,6 +33,7 @@ class Command(BaseCommand):
             username=EMAIL_HOST_USER,
             password=EMAIL_HOST_PASSWORD,
             use_tls=EMAIL_USE_TLS == "1",
+            use_ssl=EMAIL_USE_SSL == "1",
             timeout=30,
         )
         # Prepare email details


### PR DESCRIPTION
This was missed in pull request #3732 and/or the command didn't exist yet then ...