### PR TITLE
[WEB - 779] fix: user caching when the user leaves/deletes the workspace

### DIFF
--- a/apiserver/plane/app/views/workspace/base.py
+++ b/apiserver/plane/app/views/workspace/base.py
@@ -1,48 +1,50 @@
 # Python imports
-from datetime import date
-from dateutil.relativedelta import relativedelta
 import csv
 import io
+from datetime import date
 
+from dateutil.relativedelta import relativedelta
+from django.db import IntegrityError
+from django.db.models import (
+    Count,
+    F,
+    Func,
+    OuterRef,
+    Prefetch,
+    Q,
+)
+from django.db.models.fields import DateField
+from django.db.models.functions import Cast, ExtractDay, ExtractWeek
 
 # Django imports
 from django.http import HttpResponse
-from django.db import IntegrityError
 from django.utils import timezone
-from django.db.models import (
-    Prefetch,
-    OuterRef,
-    Func,
-    F,
-    Q,
-    Count,
-)
-from django.db.models.functions import ExtractWeek, Cast, ExtractDay
-from django.db.models.fields import DateField
 
 # Third party modules
 from rest_framework import status
 from rest_framework.response import Response
+
+from plane.app.permissions import (
+    WorkSpaceAdminPermission,
+    WorkSpaceBasePermission,
+    WorkspaceEntityPermission,
+)
 
 # Module imports
 from plane.app.serializers import (
     WorkSpaceSerializer,
     WorkspaceThemeSerializer,
 )
-from plane.app.views.base import BaseViewSet, BaseAPIView
+from plane.app.views.base import BaseAPIView, BaseViewSet
 from plane.db.models import (
-    Workspace,
-    IssueActivity,
     Issue,
-    WorkspaceTheme,
+    IssueActivity,
+    Workspace,
     WorkspaceMember,
-)
-from plane.app.permissions import (
-    WorkSpaceBasePermission,
-    WorkSpaceAdminPermission,
-    WorkspaceEntityPermission,
+    WorkspaceTheme,
 )
 from plane.utils.cache import cache_response, invalidate_cache
+
 
 class WorkSpaceViewSet(BaseViewSet):
     model = Workspace
@@ -138,6 +140,7 @@ class WorkSpaceViewSet(BaseViewSet):
                     {"slug": "The workspace with the slug already exists"},
                     status=status.HTTP_410_GONE,
                 )
+
     @cache_response(60 * 60 * 2)
     def list(self, request, *args, **kwargs):
         return super().list(request, *args, **kwargs)
@@ -149,6 +152,7 @@ class WorkSpaceViewSet(BaseViewSet):
 
     @invalidate_cache(path="/api/workspaces/", user=False)
     @invalidate_cache(path="/api/users/me/workspaces/")
+    @invalidate_cache(path="/api/users/me/settings/")
     def destroy(self, request, *args, **kwargs):
         return super().destroy(request, *args, **kwargs)
 

--- a/apiserver/plane/app/views/workspace/member.py
+++ b/apiserver/plane/app/views/workspace/member.py
@@ -1,40 +1,42 @@
 # Django imports
 from django.db.models import (
-    Q,
+    CharField,
     Count,
+    Q,
 )
 from django.db.models.functions import Cast
-from django.db.models import CharField
 
 # Third party modules
 from rest_framework import status
 from rest_framework.response import Response
 
-# Module imports
-from plane.app.serializers import (
-    WorkSpaceMemberSerializer,
-    TeamSerializer,
-    UserLiteSerializer,
-    WorkspaceMemberAdminSerializer,
-    WorkspaceMemberMeSerializer,
-    ProjectMemberRoleSerializer,
-)
-from plane.app.views.base import BaseAPIView
-from .. import BaseViewSet
-from plane.db.models import (
-    User,
-    Workspace,
-    Team,
-    ProjectMember,
-    Project,
-    WorkspaceMember,
-)
 from plane.app.permissions import (
     WorkSpaceAdminPermission,
     WorkspaceEntityPermission,
     WorkspaceUserPermission,
 )
+
+# Module imports
+from plane.app.serializers import (
+    ProjectMemberRoleSerializer,
+    TeamSerializer,
+    UserLiteSerializer,
+    WorkspaceMemberAdminSerializer,
+    WorkspaceMemberMeSerializer,
+    WorkSpaceMemberSerializer,
+)
+from plane.app.views.base import BaseAPIView
+from plane.db.models import (
+    Project,
+    ProjectMember,
+    Team,
+    User,
+    Workspace,
+    WorkspaceMember,
+)
 from plane.utils.cache import cache_response, invalidate_cache
+
+from .. import BaseViewSet
 
 
 class WorkSpaceMemberViewSet(BaseViewSet):
@@ -147,6 +149,7 @@ class WorkSpaceMemberViewSet(BaseViewSet):
     @invalidate_cache(
         path="/api/workspaces/:slug/members/", url_params=True, user=False
     )
+    @invalidate_cache(path="/api/users/me/settings/")
     def destroy(self, request, slug, pk):
         # Check the user role who is deleting the user
         workspace_member = WorkspaceMember.objects.get(
@@ -214,6 +217,7 @@ class WorkSpaceMemberViewSet(BaseViewSet):
     @invalidate_cache(
         path="/api/workspaces/:slug/members/", url_params=True, user=False
     )
+    @invalidate_cache(path="/api/users/me/settings/")
     def leave(self, request, slug):
         workspace_member = WorkspaceMember.objects.get(
             workspace__slug=slug,


### PR DESCRIPTION
fix:
- user caching when the user leaves / deletes the workspace
- invalidate the cache `/users/me/settings/` cache

[[WEB - 779]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/8eda8a9e-5de2-4644-ae05-2d1638de1b3b)