### PR TITLE
[WEB-768] fix: project, module, cycle filter store infinite loop.

### DIFF
--- a/web/store/cycle_filter.store.ts
+++ b/web/store/cycle_filter.store.ts
@@ -1,4 +1,4 @@
-import { action, computed, observable, makeObservable, runInAction, autorun } from "mobx";
+import { action, computed, observable, makeObservable, runInAction, reaction } from "mobx";
 import { computedFn } from "mobx-utils";
 import set from "lodash/set";
 // types
@@ -49,11 +49,13 @@ export class CycleFilterStore implements ICycleFilterStore {
     // root store
     this.rootStore = _rootStore;
     // initialize display filters of the current project
-    autorun(() => {
-      const projectId = this.rootStore.app.router.projectId;
-      if (!projectId) return;
-      this.initProjectCycleFilters(projectId);
-    });
+    reaction(
+      () => this.rootStore.app.router.projectId,
+      (projectId) => {
+        if (!projectId) return;
+        this.initProjectCycleFilters(projectId);
+      }
+    );
   }
 
   /**
@@ -97,7 +99,7 @@ export class CycleFilterStore implements ICycleFilterStore {
         active_tab: displayFilters?.active_tab || "active",
         layout: displayFilters?.layout || "list",
       };
-      this.filters[projectId] = {};
+      this.filters[projectId] = this.filters[projectId] ?? {};
     });
   };
 

--- a/web/store/module_filter.store.ts
+++ b/web/store/module_filter.store.ts
@@ -1,4 +1,4 @@
-import { action, computed, observable, makeObservable, runInAction, autorun } from "mobx";
+import { action, computed, observable, makeObservable, runInAction, reaction } from "mobx";
 import { computedFn } from "mobx-utils";
 import set from "lodash/set";
 // types
@@ -49,11 +49,13 @@ export class ModuleFilterStore implements IModuleFilterStore {
     // root store
     this.rootStore = _rootStore;
     // initialize display filters of the current project
-    autorun(() => {
-      const projectId = this.rootStore.app.router.projectId;
-      if (!projectId) return;
-      this.initProjectModuleFilters(projectId);
-    });
+    reaction(
+      () => this.rootStore.app.router.projectId,
+      (projectId) => {
+        if (!projectId) return;
+        this.initProjectModuleFilters(projectId);
+      }
+    );
   }
 
   /**
@@ -98,7 +100,7 @@ export class ModuleFilterStore implements IModuleFilterStore {
         layout: displayFilters?.layout || "list",
         order_by: displayFilters?.order_by || "name",
       };
-      this.filters[projectId] = {};
+      this.filters[projectId] = this.filters[projectId] ?? {};
     });
   };
 

--- a/web/store/project/project_filter.store.ts
+++ b/web/store/project/project_filter.store.ts
@@ -1,4 +1,4 @@
-import { action, computed, observable, makeObservable, runInAction, autorun } from "mobx";
+import { action, computed, observable, makeObservable, runInAction, reaction } from "mobx";
 import { computedFn } from "mobx-utils";
 import set from "lodash/set";
 // types
@@ -49,11 +49,13 @@ export class ProjectFilterStore implements IProjectFilterStore {
     // root store
     this.rootStore = _rootStore;
     // initialize display filters of the current workspace
-    autorun(() => {
-      const workspaceSlug = this.rootStore.app.router.workspaceSlug;
-      if (!workspaceSlug) return;
-      this.initWorkspaceFilters(workspaceSlug);
-    });
+    reaction(
+      () => this.rootStore.app.router.workspaceSlug,
+      (workspaceSlug) => {
+        if (!workspaceSlug) return;
+        this.initWorkspaceFilters(workspaceSlug);
+      }
+    );
   }
 
   /**
@@ -96,7 +98,7 @@ export class ProjectFilterStore implements IProjectFilterStore {
       this.displayFilters[workspaceSlug] = {
         order_by: displayFilters?.order_by || "created_at",
       };
-      this.filters[workspaceSlug] = {};
+      this.filters[workspaceSlug] = this.filters[workspaceSlug] ?? {};
     });
   };
 


### PR DESCRIPTION
**Problem:**
When switching between projects for the very first time even for active cycles also, search & filter options were rendered.

![image](https://github.com/makeplane/plane/assets/94619783/890d0d5d-e268-4e72-a6f9-62834c8ce5a9)


**Solution:**

1. On debugging found that the filter store's **_autorun_** function was experiencing an infinite loop, so fixed it by replacing it with _**reaction**_.
2. and, also fixed the filter data loss on the project/workspace switch.


This PR is attached to the issue [WEB-768](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/159d1a2c-887b-4960-bbdb-b786c7b55e5e)