### PR TITLE
[WEB-767] fix: Labels overflow in peek, detail view

### DIFF
--- a/web/components/issues/issue-detail/label/create-label.tsx
+++ b/web/components/issues/issue-detail/label/create-label.tsx
@@ -7,6 +7,8 @@ import { IIssueLabel } from "@plane/types";
 // hooks
 import { Input, TOAST_TYPE, setToast } from "@plane/ui";
 import { useIssueDetail } from "@/hooks/store";
+// helpers
+import { cn } from "helpers/common.helper";
 // ui
 // types
 import { TLabelOperations } from "./root";
@@ -29,6 +31,7 @@ export const LabelCreate: FC<ILabelCreate> = (props) => {
   // hooks
   const {
     issue: { getIssueById },
+    peekIssue,
   } = useIssueDetail();
   // state
   const [isCreateToggle, setIsCreateToggle] = useState(false);
@@ -82,13 +85,13 @@ export const LabelCreate: FC<ILabelCreate> = (props) => {
       </div>
 
       {isCreateToggle && (
-        <form className="flex items-center gap-x-2" onSubmit={handleSubmit(handleLabel)}>
+        <form className="relative flex items-center gap-x-2" onSubmit={handleSubmit(handleLabel)}>
           <div>
             <Controller
               name="color"
               control={control}
               render={({ field: { value, onChange } }) => (
-                <Popover className="relative">
+                <Popover>
                   <>
                     <Popover.Button className="grid place-items-center outline-none">
                       {value && value?.trim() !== "" && (
@@ -110,8 +113,14 @@ export const LabelCreate: FC<ILabelCreate> = (props) => {
                       leaveFrom="opacity-100 translate-y-0"
                       leaveTo="opacity-0 translate-y-1"
                     >
-                      <Popover.Panel className="absolute z-10 mt-1.5 max-w-xs px-2 sm:px-0">
-                        <TwitterPicker color={value} onChange={(value) => onChange(value.hex)} />
+                      <Popover.Panel
+                        className={cn("absolute z-10 mt-1.5 max-w-xs px-2 sm:px-0", !peekIssue ? "right-0" : "")}
+                      >
+                        <TwitterPicker
+                          triangle={!peekIssue ? "hide" : "top-left"}
+                          color={value}
+                          onChange={(value) => onChange(value.hex)}
+                        />
                       </Popover.Panel>
                     </Transition>
                   </>

--- a/web/components/issues/issue-detail/label/select/label-select.tsx
+++ b/web/components/issues/issue-detail/label/select/label-select.tsx
@@ -56,7 +56,7 @@ export const IssueLabelSelect: React.FC<IIssueLabelSelect> = observer((props) =>
     query === "" ? options : options?.filter((option) => option.query.toLowerCase().includes(query.toLowerCase()));
 
   const { styles, attributes } = usePopper(referenceElement, popperElement, {
-    placement: "bottom-start",
+    placement: "bottom-end",
     modifiers: [
       {
         name: "preventOverflow",


### PR DESCRIPTION
**Problem:**

Labels dropdown, and colour picker while creating a new label overflowing in issue peek and detail view.

![image](https://github.com/makeplane/plane/assets/94619783/38a9a960-46e3-455d-83de-dd0273c86b93)

![image](https://github.com/makeplane/plane/assets/94619783/f9981214-c631-4dec-8ed4-cecba537e4ac)

![image](https://github.com/makeplane/plane/assets/94619783/b0bb885b-5d6a-4e83-88f7-e3914bade81e)


**Solution:**


https://github.com/makeplane/plane/assets/94619783/7dac56b8-4ed5-4289-9817-d1b6fb7e4b79


This PR is attached to the issue [WEB-767](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/e786caac-5d65-4a2f-8246-8c135058d179)