### PR TITLE
[WEB-383] fix: rendering state and members from different projects in sub-issues

### DIFF
--- a/web/components/issues/sub-issues/properties.tsx
+++ b/web/components/issues/sub-issues/properties.tsx
@@ -72,8 +72,8 @@ export const IssueProperty: React.FC<IIssueProperty> = (props) => {
           }
           disabled={!disabled}
           multiple
-          buttonVariant={issue.assignee_ids.length > 0 ? "transparent-without-text" : "border-without-text"}
-          buttonClassName={issue.assignee_ids.length > 0 ? "hover:bg-transparent px-0" : ""}
+          buttonVariant={(issue?.assignee_ids || []).length > 0 ? "transparent-without-text" : "border-without-text"}
+          buttonClassName={(issue?.assignee_ids || []).length > 0 ? "hover:bg-transparent px-0" : ""}
         />
       </div>
     </div>


### PR DESCRIPTION
This PR addresses an issue where the state and members from different projects were not rendered correctly in sub-issues. Prior to the fix, sub-issues were not properly displaying the state and members associated with their respective projects. Additionally, this update includes exception handling for creating issues from different projects, ensuring smooth issue creation across project boundaries without encountering errors.