### PR TITLE
[WEB-786] fix: create label inline overflow

### DIFF
--- a/web/components/labels/project-setting-label-list.tsx
+++ b/web/components/labels/project-setting-label-list.tsx
@@ -96,7 +96,7 @@ export const ProjectSettingsLabelList: React.FC = observer(() => {
           Add label
         </Button>
       </div>
-      <div className="h-full w-full py-8">
+      <div className="w-full py-8">
         {showLabelForm && (
           <div className="my-2 w-full rounded border border-custom-border-200 px-3.5 py-2">
             <CreateUpdateLabelInline

--- a/web/pages/[workspaceSlug]/projects/[projectId]/settings/labels.tsx
+++ b/web/pages/[workspaceSlug]/projects/[projectId]/settings/labels.tsx
@@ -19,7 +19,7 @@ const LabelsSettingsPage: NextPageWithLayout = observer(() => {
   return (
     <>
       <PageHead title={pageTitle} />
-      <div className="w-full gap-10 overflow-y-auto py-8 pr-9">
+      <div className="h-full w-full gap-10 overflow-y-auto py-8 pr-9">
         <ProjectSettingsLabelList />
       </div>
     </>


### PR DESCRIPTION
**Problem:**

Labels create colour select dropdown is overflowing the container and looking like it is cut.

![image](https://github.com/makeplane/plane/assets/94619783/a7676f52-f879-4fa9-bfa2-1ec4adbbc4b2)


**Solution:**

![image](https://github.com/makeplane/plane/assets/94619783/dad62662-61de-45b0-9098-cdfcc9b86e30)


This PR is attached to the issue [WEB-786](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/b12c02a8-4479-4bd8-872f-426831144f0b)