### PR TITLE
fix: creating of log directory in the docker containers

### DIFF
--- a/apiserver/Dockerfile.api
+++ b/apiserver/Dockerfile.api
@@ -48,7 +48,7 @@ USER root
 RUN apk --no-cache add "bash~=5.2"
 COPY ./bin ./bin/
 
-RUN mkdir /code/plane/logs
+RUN mkdir -p /code/plane/logs
 RUN chmod +x ./bin/takeoff ./bin/worker ./bin/beat
 RUN chmod -R 777 /code
 RUN chown -R captain:plane /code

--- a/apiserver/Dockerfile.dev
+++ b/apiserver/Dockerfile.dev
@@ -35,6 +35,7 @@ RUN addgroup -S plane && \
 
 COPY . .
 
+RUN mkdir -p /code/plane/logs
 RUN chown -R captain.plane /code
 RUN chmod -R +x /code/bin
 RUN chmod -R 777 /code


### PR DESCRIPTION
fix:
- add `-p` flag to the `mkdir` command to ignore the error if the folder already exists in the backend container for the logs.