### PR TITLE
[WEB-787] fix: profile cover upload

### DIFF
--- a/web/pages/profile/index.tsx
+++ b/web/pages/profile/index.tsx
@@ -215,6 +215,7 @@ const ProfileSettingsPage: NextPageWithLayout = observer(() => {
                           onChange={(imageUrl) => onChange(imageUrl)}
                           control={control}
                           value={value ?? "https://images.unsplash.com/photo-1506383796573-caf02b4a79ab"}
+                          isProfileCover
                         />
                       )}
                     />


### PR DESCRIPTION
#### Problem:
- The profile cover upload feature is malfunctioning and remains stuck in the uploading state.

#### Resolution:
- The problem stemmed from the use of the workspace asset endpoint, which require the workspace slug, which is missing in the current flow. To address this, I've made adjustments by updating the upload endpoint to the user asset, resolving the issue.

#### Issue link: [[WEB-787]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/6ef3f541-49fc-4839-80bc-e42260b532ed)