### PR TITLE
[WEB-795] fix: prevent custom menu button from opening cycle/ module details page when closed.

### DIFF
--- a/packages/ui/src/dropdowns/custom-menu.tsx
+++ b/packages/ui/src/dropdowns/custom-menu.tsx
@@ -131,6 +131,7 @@ const CustomMenu = (props: ICustomMenuDropdownProps) => {
                     ref={setReferenceElement}
                     type="button"
                     onClick={(e) => {
+                      e.preventDefault();
                       e.stopPropagation();
                       isOpen ? closeDropdown() : openDropdown();
                       if (menuButtonOnClick) menuButtonOnClick();
@@ -157,6 +158,7 @@ const CustomMenu = (props: ICustomMenuDropdownProps) => {
                         : "cursor-pointer hover:bg-custom-background-80"
                     } ${buttonClassName}`}
                     onClick={(e) => {
+                      e.preventDefault();
                       e.stopPropagation();
                       isOpen ? closeDropdown() : openDropdown();
                       if (menuButtonOnClick) menuButtonOnClick();


### PR DESCRIPTION
#### Problem
When closing custom menu button in modules/ cycles card, the users were redirected to module/ cycle details page. 

#### Solution
Added `event.preventDefault()` to the `onClick` event listener of the menu button to prevent it from calling Module/ Cycle card's redirect event. 

#### Media
* Before Fix

[scrnli_3_21_2024_5-03-08 PM.webm](https://github.com/makeplane/plane/assets/33979846/a917e805-d3be-45a0-addb-d822073d9158)

* After Fix

[scrnli_3_21_2024_5-01-07 PM.webm](https://github.com/makeplane/plane/assets/33979846/949c1ba7-8981-4bc3-9510-879710cccf4b)

This PR is linked to [WEB-795](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/b4297059-1b98-4e9e-a3ae-699c3f5c0f0f)
