### PR TITLE
[WEB-797] fix: project list dropdown placement

### DIFF
--- a/web/components/dropdowns/module/index.tsx
+++ b/web/components/dropdowns/module/index.tsx
@@ -73,7 +73,7 @@ const ButtonContent: React.FC<ButtonContentProps> = (props) => {
     return (
       <>
         {showCount ? (
-          <div className="relative flex items-center gap-1">
+          <div className="relative flex items-center gap-1 max-w-full">
             {!hideIcon && <DiceIcon className="h-3 w-3 flex-shrink-0" />}
             <div className="max-w-40 flex-grow truncate">
               {value.length > 0

--- a/web/components/issues/issue-layouts/properties/all-properties.tsx
+++ b/web/components/issues/issue-layouts/properties/all-properties.tsx
@@ -257,8 +257,9 @@ export const IssueProperties: React.FC<IIssueProperties> = observer((props) => {
       {/* basic properties */}
       {/* state */}
       <WithDisplayPropertiesHOC displayProperties={displayProperties} displayPropertyKey="state">
-        <div className="h-5 truncate">
+        <div className="h-5">
           <StateDropdown
+            buttonContainerClassName="truncate max-w-40"
             value={issue.state_id}
             onChange={handleState}
             projectId={issue.project_id}
@@ -348,6 +349,7 @@ export const IssueProperties: React.FC<IIssueProperties> = observer((props) => {
       <WithDisplayPropertiesHOC displayProperties={displayProperties} displayPropertyKey="modules">
         <div className="h-5">
           <ModuleDropdown
+            buttonContainerClassName="truncate max-w-40"
             projectId={issue?.project_id}
             value={issue?.module_ids ?? []}
             onChange={handleModule}
@@ -362,8 +364,9 @@ export const IssueProperties: React.FC<IIssueProperties> = observer((props) => {
 
       {/* cycles */}
       <WithDisplayPropertiesHOC displayProperties={displayProperties} displayPropertyKey="cycle">
-        <div className="h-5 truncate">
+        <div className="h-5">
           <CycleDropdown
+            buttonContainerClassName="truncate max-w-40"
             projectId={issue?.project_id}
             value={issue?.cycle_id}
             onChange={handleCycle}


### PR DESCRIPTION
#### Problem:
- The project list layout state and cycle select dropdown do not adjust their positions based on available space.
#### Solution:
- Identified and resolved the dropdown positioning bug.

#### Issue link: [[WEB-797]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/179e472f-fdc9-4b3f-b1f1-9899ea380004)

#### Media:
| Before | After |
|--------|--------|
| ![c9622010-308d-44c3-9017-fa713b33408f](https://github.com/makeplane/plane/assets/121005188/d748a24c-a920-4e62-bea1-83d7ccc6267a) | ![fe485fc8-f769-4ad7-b614-e2e78dff7c8f](https://github.com/makeplane/plane/assets/121005188/52b9b72f-4c2e-43cd-b0a3-93b21259aea9) | 









