### PR TITLE
[WEB-794] fix: issue card assignee empty state tooltip

### DIFF
--- a/web/components/dropdowns/member/index.tsx
+++ b/web/components/dropdowns/member/index.tsx
@@ -37,6 +37,7 @@ export const MemberDropdown: React.FC<Props> = observer((props) => {
     onChange,
     onClose,
     placeholder = "Members",
+    tooltipContent,
     placement,
     projectId,
     showTooltip = false,
@@ -123,7 +124,7 @@ export const MemberDropdown: React.FC<Props> = observer((props) => {
               className={buttonClassName}
               isActive={isOpen}
               tooltipHeading={placeholder}
-              tooltipContent={`${value?.length ?? 0} assignee${value?.length !== 1 ? "s" : ""}`}
+              tooltipContent={tooltipContent ?? `${value?.length ?? 0} assignee${value?.length !== 1 ? "s" : ""}`}
               showTooltip={showTooltip}
               variant={buttonVariant}
             >

--- a/web/components/dropdowns/member/types.d.ts
+++ b/web/components/dropdowns/member/types.d.ts
@@ -5,6 +5,7 @@ export type MemberDropdownProps = TDropdownProps & {
   dropdownArrow?: boolean;
   dropdownArrowClassName?: string;
   placeholder?: string;
+  tooltipContent?: string;
   onClose?: () => void;
 } & (
     | {

--- a/web/components/issues/issue-layouts/properties/all-properties.tsx
+++ b/web/components/issues/issue-layouts/properties/all-properties.tsx
@@ -340,6 +340,9 @@ export const IssueProperties: React.FC<IIssueProperties> = observer((props) => {
             multiple
             buttonVariant={issue.assignee_ids?.length > 0 ? "transparent-without-text" : "border-without-text"}
             buttonClassName={issue.assignee_ids?.length > 0 ? "hover:bg-transparent px-0" : ""}
+            showTooltip={issue?.assignee_ids.length === 0}
+            placeholder="Assignees"
+            tooltipContent=""
           />
         </div>
       </WithDisplayPropertiesHOC>


### PR DESCRIPTION
**Problem:**

Issue card empty assignee dropdown doesn't have a tooltip.

**Solution:**

Introduced a new variable to customize tooltip content.

![image](https://github.com/makeplane/plane/assets/94619783/be26c6d7-7989-4a26-b4ae-9bf3b60ed15f)


This PR is attached to issue [WEB-794](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/51f3f7d3-8c2f-46b4-92db-663340e7a8ce)