### PR TITLE
[WEB-806] fix: initial empty state closure in issue Create/Edit modal

### DIFF
--- a/web/components/issues/issue-modal/draft-issue-layout.tsx
+++ b/web/components/issues/issue-modal/draft-issue-layout.tsx
@@ -53,7 +53,7 @@ export const DraftIssueLayout: React.FC<DraftIssueProps> = observer((props) => {
       Object.entries(changesMade).forEach(([key, value]) => {
         const issueKey = key as keyof TIssue;
         if (value === null || value === undefined || value === "") delete changesMade[issueKey];
-        if (typeof value === "object" && !value) delete changesMade[issueKey];
+        if (typeof value === "object" && isEmpty(value)) delete changesMade[issueKey];
         if (Array.isArray(value) && value.length === 0) delete changesMade[issueKey];
         if (issueKey === "project_id") delete changesMade.project_id;
         if (issueKey === "priority" && value && value === "none") delete changesMade.priority;
@@ -64,8 +64,13 @@ export const DraftIssueLayout: React.FC<DraftIssueProps> = observer((props) => {
         )
           delete changesMade.description_html;
       });
-      if (isEmpty(changesMade)) onClose(false);
-      else setIssueDiscardModal(true);
+      if (isEmpty(changesMade)) {
+        onClose(false);
+        setIssueDiscardModal(false);
+      } else setIssueDiscardModal(true);
+    } else {
+      onClose(false);
+      setIssueDiscardModal(false);
     }
   };
 


### PR DESCRIPTION
This fix addresses an issue where the initial empty state remained open upon opening the issue create/edit modal. Previously, when accessing the modal, the empty state would persist, causing inconvenience to users. With this fix, the modal now automatically closes the initial empty state upon opening, ensuring a smoother user experience and improved usability during issue creation or editing.