### PR TITLE
[WEB-815] fix: project order by dropdown

### DIFF
--- a/web/components/project/dropdowns/order-by.tsx
+++ b/web/components/project/dropdowns/order-by.tsx
@@ -40,7 +40,8 @@ export const ProjectOrderByDropdown: React.FC<Props> = (props) => {
           key={option.key}
           className="flex items-center justify-between gap-2"
           onClick={() => {
-            if (isDescending) onChange(`-${option.key}` as TProjectOrderByOptions);
+            if (isDescending)
+              onChange(option.key == "sort_order" ? option.key : (`-${option.key}` as TProjectOrderByOptions));
             else onChange(option.key);
           }}
         >


### PR DESCRIPTION
#### Problem:
- On the project list page, when the "Order By" dropdown is set to descending and the user attempts to switch to manual sorting, the page fails to render any results.
#### Solution:
- Resolved the issue by implementing necessary modifications.

#### Issue link: [[WEB-815]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/d3128a20-ba47-48a6-818a-35db955315b5)

#### Media:
| Before | After |
|--------|--------|
| ![before](https://github.com/makeplane/plane/assets/121005188/8e7ffbd1-a64d-47d0-b420-85309b1bb4df) | ![after](https://github.com/makeplane/plane/assets/121005188/2e238fcb-be20-497a-b4ba-c7fe1a4a300e) | 

