### PR TITLE
[WEB-789] fix: disabling issue property validation in issue edit modal

### DIFF
--- a/web/components/issues/issue-modal/draft-issue-layout.tsx
+++ b/web/components/issues/issue-modal/draft-issue-layout.tsx
@@ -49,23 +49,28 @@ export const DraftIssueLayout: React.FC<DraftIssueProps> = observer((props) => {
   const { captureIssueEvent } = useEventTracker();
 
   const handleClose = () => {
-    if (changesMade) {
-      Object.entries(changesMade).forEach(([key, value]) => {
-        const issueKey = key as keyof TIssue;
-        if (value === null || value === undefined || value === "") delete changesMade[issueKey];
-        if (typeof value === "object" && !value) delete changesMade[issueKey];
-        if (Array.isArray(value) && value.length === 0) delete changesMade[issueKey];
-        if (issueKey === "project_id") delete changesMade.project_id;
-        if (issueKey === "priority" && value && value === "none") delete changesMade.priority;
-        if (
-          issueKey === "description_html" &&
-          changesMade.description_html &&
-          isEmptyHtmlString(changesMade.description_html)
-        )
-          delete changesMade.description_html;
-      });
-      if (isEmpty(changesMade)) onClose(false);
-      else setIssueDiscardModal(true);
+    if (data?.id) {
+      onClose(false);
+      setIssueDiscardModal(false);
+    } else {
+      if (changesMade) {
+        Object.entries(changesMade).forEach(([key, value]) => {
+          const issueKey = key as keyof TIssue;
+          if (value === null || value === undefined || value === "") delete changesMade[issueKey];
+          if (typeof value === "object" && !value) delete changesMade[issueKey];
+          if (Array.isArray(value) && value.length === 0) delete changesMade[issueKey];
+          if (issueKey === "project_id") delete changesMade.project_id;
+          if (issueKey === "priority" && value && value === "none") delete changesMade.priority;
+          if (
+            issueKey === "description_html" &&
+            changesMade.description_html &&
+            isEmptyHtmlString(changesMade.description_html)
+          )
+            delete changesMade.description_html;
+        });
+        if (isEmpty(changesMade)) onClose(false);
+        else setIssueDiscardModal(true);
+      }
     }
   };
 


### PR DESCRIPTION
This fix involves disabling the validation check for issue properties within the issue edit modal. Previously, the modal enforced validation on issue properties, potentially causing issues with certain inputs. With this fix, validation has been disabled, allowing users to freely input or edit issue properties without encountering unnecessary restrictions, thereby enhancing the usability and flexibility of the issue edit modal.