### PR TITLE
[WED-731] fix: resetting changes made on "create more" toggle activation in issue create-edit modal

### DIFF
--- a/web/components/issues/issue-modal/modal.tsx
+++ b/web/components/issues/issue-modal/modal.tsx
@@ -171,7 +171,10 @@ export const CreateUpdateIssueModal: React.FC<IssuesModalProps> = observer((prop
         path: router.asPath,
       });
       !createMore && handleClose();
-      if (createMore) issueTitleRef && issueTitleRef?.current?.focus();
+      if (createMore) {
+        issueTitleRef && issueTitleRef?.current?.focus();
+        setChangesMade(null);
+      }
       return response;
     } catch (error) {
       setToast({


### PR DESCRIPTION
This fix addresses an issue where changes made in the issue create-edit modal were not reset when the "Create More" toggle was turned on. Previously, activating the "Create More" option did not revert any modifications made to the issue properties, leading to potential data inconsistencies. With this fix, changes made in the modal are properly reset upon toggling the "Create More" option, ensuring a clean slate for each new issue creation and maintaining data integrity.