### PR TITLE
[WEB-818] fix: sub-issue and attachment delete not working in the peek overview

### DIFF
--- a/web/components/issues/attachment/attachment-detail.tsx
+++ b/web/components/issues/attachment/attachment-detail.tsx
@@ -1,16 +1,16 @@
 import { FC } from "react";
-import { getFileIcon } from "components/icons";
-import { convertBytesToSize, getFileExtension, getFileName } from "helpers/attachment.helper";
-import { renderFormattedDate } from "helpers/date-time.helper";
-import { truncateText } from "helpers/string.helper";
-import { useIssueDetail, useMember } from "hooks/store";
-import { usePlatformOS } from "hooks/use-platform-os";
 import { observer } from "mobx-react";
 import Link from "next/link";
 import { AlertCircle, X } from "lucide-react";
+import { Tooltip } from "@plane/ui";
+import { getFileIcon } from "@/components/icons";
+import { convertBytesToSize, getFileExtension, getFileName } from "@/helpers/attachment.helper";
+import { renderFormattedDate } from "@/helpers/date-time.helper";
+import { truncateText } from "@/helpers/string.helper";
+import { useIssueDetail, useMember } from "@/hooks/store";
+import { usePlatformOS } from "@/hooks/use-platform-os";
 // hooks
 // ui
-import { Tooltip } from "@plane/ui";
 // components
 // icons
 // helper

--- a/web/components/issues/attachment/attachment-detail.tsx
+++ b/web/components/issues/attachment/attachment-detail.tsx
@@ -1,4 +1,11 @@
-import { FC, useState } from "react";
+import { FC } from "react";
+import { getFileIcon } from "components/icons";
+import { convertBytesToSize, getFileExtension, getFileName } from "helpers/attachment.helper";
+import { renderFormattedDate } from "helpers/date-time.helper";
+import { truncateText } from "helpers/string.helper";
+import { useIssueDetail, useMember } from "hooks/store";
+import { usePlatformOS } from "hooks/use-platform-os";
+import { observer } from "mobx-react";
 import Link from "next/link";
 import { AlertCircle, X } from "lucide-react";
 // hooks
@@ -6,13 +13,7 @@ import { AlertCircle, X } from "lucide-react";
 import { Tooltip } from "@plane/ui";
 // components
 // icons
-import { getFileIcon } from "@/components/icons";
 // helper
-import { convertBytesToSize, getFileExtension, getFileName } from "@/helpers/attachment.helper";
-import { renderFormattedDate } from "@/helpers/date-time.helper";
-import { truncateText } from "@/helpers/string.helper";
-import { useIssueDetail, useMember } from "@/hooks/store";
-import { usePlatformOS } from "@/hooks/use-platform-os";
 import { IssueAttachmentDeleteModal } from "./delete-attachment-confirmation-modal";
 // types
 import { TAttachmentOperations } from "./root";
@@ -25,16 +26,17 @@ type TIssueAttachmentsDetail = {
   disabled?: boolean;
 };
 
-export const IssueAttachmentsDetail: FC<TIssueAttachmentsDetail> = (props) => {
+export const IssueAttachmentsDetail: FC<TIssueAttachmentsDetail> = observer((props) => {
   // props
   const { attachmentId, handleAttachmentOperations, disabled } = props;
   // store hooks
   const { getUserDetails } = useMember();
   const {
     attachment: { getAttachmentById },
+    isDeleteAttachmentModalOpen,
+    toggleDeleteAttachmentModal,
   } = useIssueDetail();
   // states
-  const [attachmentDeleteModal, setAttachmentDeleteModal] = useState<boolean>(false);
   const { isMobile } = usePlatformOS();
   const attachment = attachmentId && getAttachmentById(attachmentId);
 
@@ -42,8 +44,8 @@ export const IssueAttachmentsDetail: FC<TIssueAttachmentsDetail> = (props) => {
   return (
     <>
       <IssueAttachmentDeleteModal
-        isOpen={attachmentDeleteModal}
-        setIsOpen={setAttachmentDeleteModal}
+        isOpen={isDeleteAttachmentModalOpen}
+        setIsOpen={() => toggleDeleteAttachmentModal(false)}
         handleAttachmentOperations={handleAttachmentOperations}
         data={attachment}
       />
@@ -81,15 +83,11 @@ export const IssueAttachmentsDetail: FC<TIssueAttachmentsDetail> = (props) => {
         </Link>
 
         {!disabled && (
-          <button
-            onClick={() => {
-              setAttachmentDeleteModal(true);
-            }}
-          >
+          <button onClick={() => toggleDeleteAttachmentModal(true)}>
             <X className="h-4 w-4 text-custom-text-200 hover:text-custom-text-100" />
           </button>
         )}
       </div>
     </>
   );
-};
+});

--- a/web/components/issues/peek-overview/header.tsx
+++ b/web/components/issues/peek-overview/header.tsx
@@ -53,7 +53,7 @@ export type PeekOverviewHeaderProps = {
   issueId: string;
   isArchived: boolean;
   disabled: boolean;
-  toggleDeleteIssueModal: (value: boolean) => void;
+  toggleDeleteIssueModal: (issueId: string | null) => void;
   toggleArchiveIssueModal: (value: boolean) => void;
   handleRestoreIssue: () => void;
   isSubmitting: "submitting" | "submitted" | "saved";
@@ -188,7 +188,7 @@ export const IssuePeekOverviewHeader: FC<PeekOverviewHeaderProps> = observer((pr
           )}
           {!disabled && (
             <Tooltip tooltipContent="Delete" isMobile={isMobile}>
-              <button type="button" onClick={() => toggleDeleteIssueModal(true)}>
+              <button type="button" onClick={() => toggleDeleteIssueModal(issueId)}>
                 <Trash2 className="h-4 w-4 text-custom-text-300 hover:text-custom-text-200" />
               </button>
             </Tooltip>

--- a/web/components/issues/peek-overview/view.tsx
+++ b/web/components/issues/peek-overview/view.tsx
@@ -91,22 +91,14 @@ export const IssueView: FC<IIssueView> = observer((props) => {
         />
       )}
 
-      {issue && !is_archived && (
+      {issue && isDeleteIssueModalOpen === issue.id && (
         <DeleteIssueModal
-          isOpen={isDeleteIssueModalOpen}
+          isOpen={!!isDeleteIssueModalOpen}
           handleClose={() => {
-            toggleDeleteIssueModal(false);
+            toggleDeleteIssueModal(null);
+            removeRoutePeekId();
           }}
           data={issue}
-          onSubmit={() => issueOperations.remove(workspaceSlug, projectId, issueId)}
-        />
-      )}
-
-      {issue && is_archived && (
-        <DeleteIssueModal
-          data={issue}
-          isOpen={isDeleteIssueModalOpen}
-          handleClose={() => toggleDeleteIssueModal(false)}
           onSubmit={() => issueOperations.remove(workspaceSlug, projectId, issueId)}
         />
       )}

--- a/web/components/issues/sub-issues/issue-list-item.tsx
+++ b/web/components/issues/sub-issues/issue-list-item.tsx
@@ -158,7 +158,7 @@ export const IssueListItem: React.FC<ISubIssues> = observer((props) => {
                 <CustomMenu.MenuItem
                   onClick={() => {
                     handleIssueCrudState("delete", parentIssueId, issue);
-                    toggleDeleteIssueModal(true);
+                    toggleDeleteIssueModal(issue.id);
                   }}
                 >
                   <div className="flex items-center gap-2">

--- a/web/components/issues/sub-issues/root.tsx
+++ b/web/components/issues/sub-issues/root.tsx
@@ -523,7 +523,7 @@ export const SubIssuesRoot: FC<ISubIssuesRoot> = observer((props) => {
                 isOpen={issueCrudState?.delete?.toggle}
                 handleClose={() => {
                   handleIssueCrudState("delete", null, null);
-                  toggleDeleteIssueModal(false);
+                  toggleDeleteIssueModal(null);
                 }}
                 data={issueCrudState?.delete?.issue as TIssue}
                 onSubmit={async () =>

--- a/web/store/issue/issue-details/root.store.ts
+++ b/web/store/issue/issue-details/root.store.ts
@@ -51,6 +51,7 @@ export interface IIssueDetail
   isArchiveIssueModalOpen: boolean;
   isRelationModalOpen: TIssueRelationTypes | null;
   isSubIssuesModalOpen: boolean;
+  isDeleteAttachmentModalOpen: boolean;
   // computed
   isAnyModalOpen: boolean;
   // actions
@@ -62,6 +63,7 @@ export interface IIssueDetail
   toggleArchiveIssueModal: (value: boolean) => void;
   toggleRelationModal: (value: TIssueRelationTypes | null) => void;
   toggleSubIssuesModal: (value: boolean) => void;
+  toggleDeleteAttachmentModal: (value: boolean) => void;
   // store
   rootIssueStore: IIssueRootStore;
   issue: IIssueStore;
@@ -86,6 +88,7 @@ export class IssueDetail implements IIssueDetail {
   isArchiveIssueModalOpen: boolean = false;
   isRelationModalOpen: TIssueRelationTypes | null = null;
   isSubIssuesModalOpen: boolean = false;
+  isDeleteAttachmentModalOpen: boolean = false;
   // store
   rootIssueStore: IIssueRootStore;
   issue: IIssueStore;
@@ -110,6 +113,7 @@ export class IssueDetail implements IIssueDetail {
       isArchiveIssueModalOpen: observable.ref,
       isRelationModalOpen: observable.ref,
       isSubIssuesModalOpen: observable.ref,
+      isDeleteAttachmentModalOpen: observable.ref,
       // computed
       isAnyModalOpen: computed,
       // action
@@ -121,6 +125,7 @@ export class IssueDetail implements IIssueDetail {
       toggleArchiveIssueModal: action,
       toggleRelationModal: action,
       toggleSubIssuesModal: action,
+      toggleDeleteAttachmentModal: action,
     });
 
     // store
@@ -146,7 +151,8 @@ export class IssueDetail implements IIssueDetail {
       this.isDeleteIssueModalOpen ||
       this.isArchiveIssueModalOpen ||
       Boolean(this.isRelationModalOpen) ||
-      this.isSubIssuesModalOpen
+      this.isSubIssuesModalOpen ||
+      this.isDeleteAttachmentModalOpen
     );
   }
 
@@ -159,6 +165,7 @@ export class IssueDetail implements IIssueDetail {
   toggleArchiveIssueModal = (value: boolean) => (this.isArchiveIssueModalOpen = value);
   toggleRelationModal = (value: TIssueRelationTypes | null) => (this.isRelationModalOpen = value);
   toggleSubIssuesModal = (value: boolean) => (this.isSubIssuesModalOpen = value);
+  toggleDeleteAttachmentModal = (value: boolean) => (this.isDeleteAttachmentModalOpen = value);
 
   // issue
   fetchIssue = async (

--- a/web/store/issue/issue-details/root.store.ts
+++ b/web/store/issue/issue-details/root.store.ts
@@ -47,7 +47,7 @@ export interface IIssueDetail
   isCreateIssueModalOpen: boolean;
   isIssueLinkModalOpen: boolean;
   isParentIssueModalOpen: boolean;
-  isDeleteIssueModalOpen: boolean;
+  isDeleteIssueModalOpen: string | null;
   isArchiveIssueModalOpen: boolean;
   isRelationModalOpen: TIssueRelationTypes | null;
   isSubIssuesModalOpen: boolean;
@@ -59,9 +59,9 @@ export interface IIssueDetail
   toggleCreateIssueModal: (value: boolean) => void;
   toggleIssueLinkModal: (value: boolean) => void;
   toggleParentIssueModal: (value: boolean) => void;
-  toggleDeleteIssueModal: (value: boolean) => void;
+  toggleDeleteIssueModal: (issueId: string | null) => void;
   toggleArchiveIssueModal: (value: boolean) => void;
-  toggleRelationModal: (value: TIssueRelationTypes | null) => void;
+  toggleRelationModal: (relationType: TIssueRelationTypes | null) => void;
   toggleSubIssuesModal: (value: boolean) => void;
   toggleDeleteAttachmentModal: (value: boolean) => void;
   // store
@@ -84,7 +84,7 @@ export class IssueDetail implements IIssueDetail {
   isCreateIssueModalOpen: boolean = false;
   isIssueLinkModalOpen: boolean = false;
   isParentIssueModalOpen: boolean = false;
-  isDeleteIssueModalOpen: boolean = false;
+  isDeleteIssueModalOpen: string | null = null;
   isArchiveIssueModalOpen: boolean = false;
   isRelationModalOpen: TIssueRelationTypes | null = null;
   isSubIssuesModalOpen: boolean = false;
@@ -148,9 +148,9 @@ export class IssueDetail implements IIssueDetail {
       this.isCreateIssueModalOpen ||
       this.isIssueLinkModalOpen ||
       this.isParentIssueModalOpen ||
-      this.isDeleteIssueModalOpen ||
+      !!this.isDeleteIssueModalOpen ||
       this.isArchiveIssueModalOpen ||
-      Boolean(this.isRelationModalOpen) ||
+      !!this.isRelationModalOpen ||
       this.isSubIssuesModalOpen ||
       this.isDeleteAttachmentModalOpen
     );
@@ -161,9 +161,9 @@ export class IssueDetail implements IIssueDetail {
   toggleCreateIssueModal = (value: boolean) => (this.isCreateIssueModalOpen = value);
   toggleIssueLinkModal = (value: boolean) => (this.isIssueLinkModalOpen = value);
   toggleParentIssueModal = (value: boolean) => (this.isParentIssueModalOpen = value);
-  toggleDeleteIssueModal = (value: boolean) => (this.isDeleteIssueModalOpen = value);
+  toggleDeleteIssueModal = (issueId: string | null) => (this.isDeleteIssueModalOpen = issueId);
   toggleArchiveIssueModal = (value: boolean) => (this.isArchiveIssueModalOpen = value);
-  toggleRelationModal = (value: TIssueRelationTypes | null) => (this.isRelationModalOpen = value);
+  toggleRelationModal = (relationType: TIssueRelationTypes | null) => (this.isRelationModalOpen = relationType);
   toggleSubIssuesModal = (value: boolean) => (this.isSubIssuesModalOpen = value);
   toggleDeleteAttachmentModal = (value: boolean) => (this.isDeleteAttachmentModalOpen = value);
 


### PR DESCRIPTION
#### Problems:

1. On trying to delete a sub-issue from the peek overview, delete confirmation for the parent issue also pops up making it impossible to delete the sub-issue and user mistakenly deletes the parent issue.
2. On clicking on the delete attachment confirmation modal, the attachment doesn't get deleted and the peek overview closes.

#### Solutions:

1. Open the delete confirmation modal only for the sub-issue and not for the parent issue.
2. Prevent the peek overview from closing on trying to delete an attachment.

#### Media:

1. Sub-issue deletion-

https://github.com/makeplane/plane/assets/65252264/4141c06c-b1c3-4513-818e-39850252bbf2

2. Attachment deletion-

https://github.com/makeplane/plane/assets/65252264/9d589eab-1079-4a4a-b355-284d25d109c7

#### Plane issue: [WEB-818](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/de67eb4b-4290-4db4-83f0-875fd735c2e2)