### PR TITLE
[WEB-793] style: hide cycle and module dropdown placeholder from list and kanban view.

### DIFF
--- a/web/components/dropdowns/cycle/index.tsx
+++ b/web/components/dropdowns/cycle/index.tsx
@@ -41,7 +41,7 @@ export const CycleDropdown: React.FC<Props> = observer((props) => {
     hideIcon = false,
     onChange,
     onClose,
-    placeholder = "Cycle",
+    placeholder = "",
     placement,
     projectId,
     showTooltip = false,
@@ -132,7 +132,7 @@ export const CycleDropdown: React.FC<Props> = observer((props) => {
               variant={buttonVariant}
             >
               {!hideIcon && <ContrastIcon className="h-3 w-3 flex-shrink-0" />}
-              {BUTTON_VARIANTS_WITH_TEXT.includes(buttonVariant) && (
+              {BUTTON_VARIANTS_WITH_TEXT.includes(buttonVariant) && (!!selectedName || !!placeholder) && (
                 <span className="flex-grow truncate max-w-40">{selectedName ?? placeholder}</span>
               )}
               {dropdownArrow && (

--- a/web/components/dropdowns/module/index.tsx
+++ b/web/components/dropdowns/module/index.tsx
@@ -46,7 +46,7 @@ type ButtonContentProps = {
   hideIcon: boolean;
   hideText: boolean;
   onChange: (moduleIds: string[]) => void;
-  placeholder: string;
+  placeholder?: string;
   showCount: boolean;
   showTooltip?: boolean;
   value: string | string[] | null;
@@ -75,13 +75,15 @@ const ButtonContent: React.FC<ButtonContentProps> = (props) => {
         {showCount ? (
           <div className="relative flex items-center gap-1 max-w-full">
             {!hideIcon && <DiceIcon className="h-3 w-3 flex-shrink-0" />}
-            <div className="max-w-40 flex-grow truncate">
-              {value.length > 0
-                ? value.length === 1
-                  ? `${getModuleById(value[0])?.name || "module"}`
-                  : `${value.length} Module${value.length === 1 ? "" : "s"}`
-                : placeholder}
-            </div>
+            {(value.length > 0 || !!placeholder) && (
+              <div className="max-w-40 flex-grow truncate">
+                {value.length > 0
+                  ? value.length === 1
+                    ? `${getModuleById(value[0])?.name || "module"}`
+                    : `${value.length} Module${value.length === 1 ? "" : "s"}`
+                  : placeholder}
+              </div>
+            )}
           </div>
         ) : value.length > 0 ? (
           <div className="flex max-w-full flex-grow flex-wrap items-center gap-2 truncate py-0.5">
@@ -158,7 +160,7 @@ export const ModuleDropdown: React.FC<Props> = observer((props) => {
     multiple,
     onChange,
     onClose,
-    placeholder = "Module",
+    placeholder = "",
     placement,
     projectId,
     showCount = false,

--- a/web/components/issues/issue-modal/form.tsx
+++ b/web/components/issues/issue-modal/form.tsx
@@ -601,6 +601,7 @@ export const IssueFormRoot: FC<IssueFormProps> = observer((props) => {
                             onChange(cycleId);
                             handleFormChange();
                           }}
+                          placeholder="Cycle"
                           value={value}
                           buttonVariant="border-with-text"
                           tabIndex={getTabIndex("cycle_id")}
@@ -622,6 +623,7 @@ export const IssueFormRoot: FC<IssueFormProps> = observer((props) => {
                             onChange(moduleIds);
                             handleFormChange();
                           }}
+                          placeholder="Modules"
                           buttonVariant="border-with-text"
                           tabIndex={getTabIndex("module_ids")}
                           multiple


### PR DESCRIPTION
#### Problem
When no cycle or module was selected in the issue card. A placeholder was visible for the Cycle and Modules leading to inconsistent UI. 

#### Solution
Made necessary changes to fix the issue.

#### Media
* Before Fix
![image](https://github.com/makeplane/plane/assets/33979846/fc461894-dbf5-48a2-a4b9-7fb407398796)

* After Fix
![image](https://github.com/makeplane/plane/assets/33979846/7389f6bd-e03c-40b7-8bb0-c80597e2499a)

This PR is linked to [WEB-793](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/87f8da62-3813-454f-811c-16543b630a10)