### PR TITLE
[WEB-816] fix: project total issue count mutation.

### DIFF
--- a/web/store/issue/project/issue.store.ts
+++ b/web/store/issue/project/issue.store.ts
@@ -3,12 +3,12 @@ import pull from "lodash/pull";
 import set from "lodash/set";
 import update from "lodash/update";
 import { action, makeObservable, observable, runInAction, computed } from "mobx";
+// types
+import { TIssue, TGroupedIssues, TSubGroupedIssues, TLoader, TUnGroupedIssues, ViewFlags } from "@plane/types";
 // base class
 import { IssueService, IssueArchiveService } from "@/services/issue";
-import { TIssue, TGroupedIssues, TSubGroupedIssues, TLoader, TUnGroupedIssues, ViewFlags } from "@plane/types";
 import { IssueHelperStore } from "../helpers/issue-helper.store";
 // services
-// types
 import { IIssueRootStore } from "../root.store";
 
 export interface IProjectIssues {
@@ -117,6 +117,7 @@ export class ProjectIssues extends IssueHelperStore implements IProjectIssues {
       });
 
       this.rootStore.issues.addIssue(response);
+      this.rootIssueStore.rootStore.projectRoot.project.fetchProjectDetails(workspaceSlug, projectId);
 
       return response;
     } catch (error) {
@@ -137,6 +138,7 @@ export class ProjectIssues extends IssueHelperStore implements IProjectIssues {
       });
 
       this.rootStore.issues.addIssue([response]);
+      this.rootIssueStore.rootStore.projectRoot.project.fetchProjectDetails(workspaceSlug, projectId);
 
       return response;
     } catch (error) {
@@ -164,6 +166,7 @@ export class ProjectIssues extends IssueHelperStore implements IProjectIssues {
       });
 
       this.rootStore.issues.removeIssue(issueId);
+      this.rootIssueStore.rootStore.projectRoot.project.fetchProjectDetails(workspaceSlug, projectId);
     } catch (error) {
       throw error;
     }
@@ -179,6 +182,8 @@ export class ProjectIssues extends IssueHelperStore implements IProjectIssues {
         });
         pull(this.issues[projectId], issueId);
       });
+
+      this.rootIssueStore.rootStore.projectRoot.project.fetchProjectDetails(workspaceSlug, projectId);
     } catch (error) {
       throw error;
     }
@@ -216,6 +221,7 @@ export class ProjectIssues extends IssueHelperStore implements IProjectIssues {
       });
 
       const response = await this.issueService.bulkDeleteIssues(workspaceSlug, projectId, { issue_ids: issueIds });
+      this.rootIssueStore.rootStore.projectRoot.project.fetchProjectDetails(workspaceSlug, projectId);
 
       return response;
     } catch (error) {


### PR DESCRIPTION
#### Problem
Project total issue count on the header was not mutating when we add/ remove any issue from the project. The project `total_issue_count` data is a part of project details object. So while adding/ removing any issue from the project we were not updating this data. 

#### Solution
Added a fetch request to project details endpoint in order to get the up to date value of `total_issue_count` for all CRUD related issue operations.

#### Media
* Before Fix

[scrnli_3_22_2024_5-38-01 PM.webm](https://github.com/makeplane/plane/assets/33979846/4713f86f-4793-4b90-bb1b-2ed3ad7f1002)

* After Fix

[scrnli_3_22_2024_5-36-34 PM.webm](https://github.com/makeplane/plane/assets/33979846/62bd0322-d7a6-48b0-b813-46a5ef061a52)

This PR is linked to [WEB-816](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/c9e85231-e1a4-4417-9d6e-95ace4e96461)
