### PR TITLE
[WEB-802] fix: handling undefined condition for issue title while saving the issue as draft

### DIFF
--- a/web/components/issues/issue-modal/draft-issue-layout.tsx
+++ b/web/components/issues/issue-modal/draft-issue-layout.tsx
@@ -84,7 +84,7 @@ export const DraftIssueLayout: React.FC<DraftIssueProps> = observer((props) => {
 
     const payload = {
       ...changesMade,
-      name: changesMade.name?.trim() === "" ? "Untitled" : changesMade.name?.trim(),
+      name: changesMade?.name && changesMade?.name?.trim() === "" ? changesMade.name?.trim() : "Untitled",
     };
 
     await issueDraftService


### PR DESCRIPTION
This PR Includes fixing the issue when we save the issue in the draft mode without giving the title, we are keeping the title as "Untitled" by default.