### PR TITLE
[WEB-821] fix: profile activity load more button visibility

### DIFF
--- a/web/pages/profile/activity.tsx
+++ b/web/pages/profile/activity.tsx
@@ -41,17 +41,19 @@ const ProfileActivityPage: NextPageWithLayout = observer(() => {
       />
     );
 
+  const isLoadMoreVisible = pageCount < totalPages && resultsCount !== 0;
+
   return (
     <>
       <PageHead title="Profile - Activity" />
-      <section className="mx-auto mt-5 md:mt-16 h-full w-full flex flex-col overflow-hidden px-8 pb-8 lg:w-3/5">
-        <div className="flex items-center border-b border-custom-border-100 gap-4 pb-3.5">
+      <section className="mx-auto h-full w-full flex flex-col overflow-hidden px-8 pb-8 lg:w-3/5">
+        <div className="flex items-center border-b border-custom-border-100 gap-4 pb-3.5 mt-5 md:mt-16">
           <SidebarHamburgerToggle onClick={() => themeStore.toggleSidebar()} />
           <h3 className="text-xl font-medium">Activity</h3>
         </div>
-        <div className="h-full flex flex-col overflow-y-auto vertical-scrollbar scrollbar-md">
+        <div className="h-full w-full flex flex-col overflow-y-auto vertical-scrollbar scrollbar-md">
           {activityPages}
-          {pageCount < totalPages && resultsCount !== 0 && (
+          {isLoadMoreVisible && (
             <div className="flex items-center justify-center text-xs w-full">
               <Button variant="accent-primary" size="sm" onClick={handleLoadMore}>
                 Load more


### PR DESCRIPTION
#### Problems:

1. Profile activity page's `Load more` button isn't visible.

#### Solutions:

1. Updated the scroll container styling to make the button visible.

#### Plane issue: [WEB-821](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/86cc4a32-16a0-44e9-9621-6eb5aac0decb)