### PR TITLE
[WEB-822] fix: sub issue peek overview mutation

### DIFF
--- a/web/components/issues/issue-detail/parent-select.tsx
+++ b/web/components/issues/issue-detail/parent-select.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { Pencil, X } from "lucide-react";
 // hooks
 // components
-import { Tooltip } from "@plane/ui";
+import { TOAST_TYPE, Tooltip, setToast } from "@plane/ui";
 import { ParentIssuesListModal } from "@/components/issues";
 // ui
 // helpers
@@ -30,7 +30,13 @@ export const IssueParentSelect: React.FC<TIssueParentSelect> = observer((props) 
   const {
     issue: { getIssueById },
   } = useIssueDetail();
-  const { isParentIssueModalOpen, toggleParentIssueModal } = useIssueDetail();
+  const {
+    isParentIssueModalOpen,
+    toggleParentIssueModal,
+    removeSubIssue,
+    subIssues: { setSubIssueHelpers },
+  } = useIssueDetail();
+
   // derived values
   const issue = getIssueById(issueId);
   const parentIssue = issue?.parent_id ? getIssueById(issue.parent_id) : undefined;
@@ -44,6 +50,25 @@ export const IssueParentSelect: React.FC<TIssueParentSelect> = observer((props) 
       toggleParentIssueModal(false);
     } catch (error) {
       console.error("something went wrong while fetching the issue");
+    }
+  };
+
+  const handleRemoveSubIssue = async (
+    workspaceSlug: string,
+    projectId: string,
+    parentIssueId: string,
+    issueId: string
+  ) => {
+    try {
+      setSubIssueHelpers(parentIssueId, "issue_loader", issueId);
+      await removeSubIssue(workspaceSlug, projectId, parentIssueId, issueId);
+      setSubIssueHelpers(parentIssueId, "issue_loader", issueId);
+    } catch (error) {
+      setToast({
+        type: TOAST_TYPE.ERROR,
+        title: "Error",
+        message: "Something went wrong",
+      });
     }
   };
 
@@ -92,7 +117,7 @@ export const IssueParentSelect: React.FC<TIssueParentSelect> = observer((props) 
                   onClick={(e) => {
                     e.preventDefault();
                     e.stopPropagation();
-                    handleParentIssue(null);
+                    handleRemoveSubIssue(workspaceSlug, projectId, parentIssue.id, issueId);
                   }}
                 >
                   <X className="h-2.5 w-2.5 text-custom-text-300 hover:text-red-500" />


### PR DESCRIPTION
#### Problem:
- In the Issue detail page, when we open the peek overview of a sub-issue and remove its parent, the mutation is not reflected on the Issue detail page.

#### Resolution:
- Resolve this problem by implementing the necessary changes.

#### Issue link: [[WEB-822]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/61606fab-cb8e-45aa-b395-961fdd1a757d)

#### Media:
| Before | After |
|--------|--------|
| ![before](https://github.com/makeplane/plane/assets/121005188/a112001b-d4e2-4ad6-a495-ab9f25dbc84a) | ![after](https://github.com/makeplane/plane/assets/121005188/ccd5db46-55e6-42af-994f-e53c63bd7dfe) | 