### PR TITLE
[WEB-828] fix: peek overview delete modal

### DIFF
--- a/web/components/issues/peek-overview/view.tsx
+++ b/web/components/issues/peek-overview/view.tsx
@@ -96,10 +96,9 @@ export const IssueView: FC<IIssueView> = observer((props) => {
           isOpen={!!isDeleteIssueModalOpen}
           handleClose={() => {
             toggleDeleteIssueModal(null);
-            removeRoutePeekId();
           }}
           data={issue}
-          onSubmit={() => issueOperations.remove(workspaceSlug, projectId, issueId)}
+          onSubmit={() => issueOperations.remove(workspaceSlug, projectId, issueId).then(() => removeRoutePeekId())}
         />
       )}
 


### PR DESCRIPTION
#### Changes:
This PR include fix for the delete modal in the peek overview.

#### Issue link: [[WEB-828]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/247cefa6-25e8-47ab-bc07-5a561aaff077)
