### PR TITLE
[WEB-849] fix: workspace setting sidebar role access

### DIFF
--- a/web/layouts/settings-layout/workspace/sidebar.tsx
+++ b/web/layouts/settings-layout/workspace/sidebar.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { observer } from "mobx-react";
 import Link from "next/link";
 import { useRouter } from "next/router";
 // hooks
@@ -6,7 +7,7 @@ import { EUserWorkspaceRoles, WORKSPACE_SETTINGS_LINKS } from "@/constants/works
 import { useUser } from "@/hooks/store";
 // constants
 
-export const WorkspaceSettingsSidebar = () => {
+export const WorkspaceSettingsSidebar = observer(() => {
   // router
   const router = useRouter();
   const { workspaceSlug } = router.query;
@@ -44,4 +45,4 @@ export const WorkspaceSettingsSidebar = () => {
       </div>
     </div>
   );
-};
+});


### PR DESCRIPTION
#### Problem:
- When reloading workspace settings, the settings sidebar only shows limited options, even though I have an admin user role.

#### Solution:
- After looking into it, I've found that the observer was missing. So, we added it to fix the issue.

Issue link: [[WEB-849]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/6693ab00-d535-42a4-b6b9-d565502b24a7)