### PR TITLE
[WEB-836] fix: color picker overlapping with themes dropdown issue.

### DIFF
--- a/packages/ui/src/dropdowns/custom-select.tsx
+++ b/packages/ui/src/dropdowns/custom-select.tsx
@@ -91,7 +91,7 @@ const CustomSelect = (props: ICustomSelectProps) => {
         )}
       </>
       {isOpen && (
-        <Listbox.Options className="fixed z-10" onClick={() => closeDropdown()} static>
+        <Listbox.Options className="fixed z-20" onClick={() => closeDropdown()} static>
           <div
             className={cn(
               "my-1 overflow-y-scroll rounded-md border-[0.5px] border-custom-border-300 bg-custom-background-100 px-2 py-2.5 text-xs shadow-custom-shadow-rg focus:outline-none min-w-[12rem] whitespace-nowrap",


### PR DESCRIPTION
This PR address the issue in color picker, where it was overlapping with the themes dropdown.

 This PR is linked to [WEB-836](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/0a876c0a-abdd-4816-9751-9b878fad865c)