### PR TITLE
[WEB-843] fix: `chat with us` option not working in command k modal.

### DIFF
--- a/web/components/command-palette/actions/help-actions.tsx
+++ b/web/components/command-palette/actions/help-actions.tsx
@@ -69,7 +69,9 @@ export const CommandPaletteHelpActions: React.FC<Props> = (props) => {
       <Command.Item
         onSelect={() => {
           closePalette();
-          (window as any)?.$crisp.push(["do", "chat:open"]);
+          if (window) {
+            window.$crisp.push(["do", "chat:show"]);
+          }
         }}
         className="focus:outline-none"
       >


### PR DESCRIPTION
This PR address the issue with `chat with us` option not working in command k modal. 

This PR is linked to [WEB-843](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/0e6b4f0d-651d-4dc0-8373-b64a6ac34d79)