### PR TITLE
[WEB-833] chore: remove `create a new issue` option from command k modal if no projects are there.

### DIFF
--- a/web/components/command-palette/command-modal.tsx
+++ b/web/components/command-palette/command-modal.tsx
@@ -40,7 +40,7 @@ const issueService = new IssueService();
 
 export const CommandModal: React.FC = observer(() => {
   // hooks
-  const { getProjectById } = useProject();
+  const { getProjectById, workspaceProjectIds } = useProject();
   const { isMobile } = usePlatformOS();
   // states
   const [placeholder, setPlaceholder] = useState("Type a command or search...");
@@ -282,22 +282,24 @@ export const CommandModal: React.FC = observer(() => {
                               setSearchTerm={(newSearchTerm) => setSearchTerm(newSearchTerm)}
                             />
                           )}
-                          <Command.Group heading="Issue">
-                            <Command.Item
-                              onSelect={() => {
-                                closePalette();
-                                setTrackElement("Command Palette");
-                                toggleCreateIssueModal(true);
-                              }}
-                              className="focus:bg-custom-background-80"
-                            >
-                              <div className="flex items-center gap-2 text-custom-text-200">
-                                <LayersIcon className="h-3.5 w-3.5" />
-                                Create new issue
-                              </div>
-                              <kbd>C</kbd>
-                            </Command.Item>
-                          </Command.Group>
+                          {workspaceSlug && workspaceProjectIds && workspaceProjectIds.length > 0 && (
+                            <Command.Group heading="Issue">
+                              <Command.Item
+                                onSelect={() => {
+                                  closePalette();
+                                  setTrackElement("Command Palette");
+                                  toggleCreateIssueModal(true);
+                                }}
+                                className="focus:bg-custom-background-80"
+                              >
+                                <div className="flex items-center gap-2 text-custom-text-200">
+                                  <LayersIcon className="h-3.5 w-3.5" />
+                                  Create new issue
+                                </div>
+                                <kbd>C</kbd>
+                              </Command.Item>
+                            </Command.Group>
+                          )}
 
                           {workspaceSlug && (
                             <Command.Group heading="Project">


### PR DESCRIPTION
This PR address the issue in command k modal where the `create a new issue` option was available even if no projects is being created leading to poor user experience. 

This PR is linked to [WEB-833](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/0cb5fb41-34bb-45fc-adf4-fd978bafd2ce)