### PR TITLE
[WEB-876] fix: Multiple editor instances cause weird issues with Tippy

### DIFF
--- a/packages/editor/core/src/ui/components/editor-container.tsx
+++ b/packages/editor/core/src/ui/components/editor-container.tsx
@@ -1,5 +1,6 @@
 import { Editor } from "@tiptap/react";
 import { FC, ReactNode } from "react";
+import { cn } from "src/lib/utils";
 
 interface EditorContainerProps {
   editor: Editor | null;
@@ -53,7 +54,7 @@ export const EditorContainer: FC<EditorContainerProps> = (props) => {
       onMouseLeave={() => {
         hideDragHandle?.();
       }}
-      className={`cursor-text ${editorClassNames} ${editor?.isFocused && editor?.isEditable ? "active-editor" : ""}`}
+      className={cn(`cursor-text`, { "active-editor": editor?.isFocused && editor?.isEditable }, editorClassNames)}
     >
       {children}
     </div>

--- a/packages/editor/core/src/ui/components/editor-container.tsx
+++ b/packages/editor/core/src/ui/components/editor-container.tsx
@@ -53,7 +53,7 @@ export const EditorContainer: FC<EditorContainerProps> = (props) => {
       onMouseLeave={() => {
         hideDragHandle?.();
       }}
-      className={`cursor-text ${editorClassNames}`}
+      className={`cursor-text ${editorClassNames} ${editor?.isFocused && editor?.isEditable ? "active-editor" : ""}`}
     >
       {children}
     </div>

--- a/packages/editor/core/src/ui/mentions/suggestion.ts
+++ b/packages/editor/core/src/ui/mentions/suggestion.ts
@@ -22,7 +22,7 @@ export const Suggestion = (suggestions: IMentionSuggestion[]) => ({
         // @ts-ignore
         popup = tippy("body", {
           getReferenceClientRect: props.clientRect,
-          appendTo: () => document.querySelector("#editor-container"),
+          appendTo: () => document.querySelector(".active-editor") ?? document.querySelector("#editor-container"),
           content: reactRenderer.element,
           showOnCreate: true,
           interactive: true,

--- a/packages/editor/extensions/src/extensions/slash-commands.tsx
+++ b/packages/editor/extensions/src/extensions/slash-commands.tsx
@@ -330,7 +330,7 @@ const renderItems = () => {
       // @ts-ignore
       popup = tippy("body", {
         getReferenceClientRect: props.clientRect,
-        appendTo: () => document.querySelector("#editor-container"),
+        appendTo: () => document.querySelector(".active-editor") ?? document.querySelector("#editor-container"),
         content: component.element,
         showOnCreate: true,
         interactive: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2733,7 +2733,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^18.2.42":
+"@types/react@*", "@types/react@18.2.42", "@types/react@^18.2.42":
   version "18.2.42"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.42.tgz#6f6b11a904f6d96dda3c2920328a97011a00aba7"
   integrity sha512-c1zEr96MjakLYus/wPnuWDo1/zErfdU9rNsIGmE+NV71nx88FG9Ttgo5dqorXTu/LImX2f63WBP986gJkMPNbA==


### PR DESCRIPTION
## Description 

This PR helps us to solve the bug in which Tippy instances (like Slash Commands/Mentions/etc) weren't able to find the correct editor position to append to in case of multiple editor instances. 

It detects the active editor when the editor is editable and focused onto, and adds an "active" class on it. The tippy containers are then appended to the editor with the active class now.