### PR TITLE
Dropped version info from docker-compose files

### DIFF
--- a/deploy/selfhost/docker-compose.yml
+++ b/deploy/selfhost/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 x-app-env: &app-env
   environment:
     - NGINX_PORT=${NGINX_PORT:-80}

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 networks:
   dev_env:
     driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   web:
     container_name: web


### PR DESCRIPTION
According to the docker compose issue 11628 (https://github.com/docker/compose/issues/11628) the 'version' field in docker-compose files is outdated. It shows a warning like the following on hosts with a newer Docker version:

```
WARN[0000] /srv/plane/docker-compose.yaml: `version` is obsolete
```

Also, the specs itself state the version was only informative: https://github.com/compose-spec/compose-spec/blob/master/spec.md#version-and-name-top-level-elements

> The top-level `version` property is defined by the Compose
> Specification for backward compatibility. It is only informative.
> Compose doesn't use version to select an exact schema to
> validate the Compose file, but prefers the most recent schema
> when it's implemented.