### PR TITLE
[WEB-839] fix: display error message in project settings page.

### DIFF
--- a/web/components/project/create-project-form.tsx
+++ b/web/components/project/create-project-form.tsx
@@ -226,7 +226,7 @@ export const CreateProjectForm: FC<Props> = observer((props) => {
                 control={control}
                 name="name"
                 rules={{
-                  required: "Title is required",
+                  required: "Name is required",
                   maxLength: {
                     value: 255,
                     message: "Title should be less than 255 characters",
@@ -240,7 +240,7 @@ export const CreateProjectForm: FC<Props> = observer((props) => {
                     value={value}
                     onChange={handleNameChange(onChange)}
                     hasError={Boolean(errors.name)}
-                    placeholder="Project title"
+                    placeholder="Project name"
                     className="w-full focus:border-blue-400"
                     tabIndex={1}
                   />

--- a/web/components/project/form.tsx
+++ b/web/components/project/form.tsx
@@ -232,6 +232,9 @@ export const ProjectDetailsForm: FC<IProjectDetailsForm> = (props) => {
               />
             )}
           />
+          <span className="text-xs text-red-500">
+            <>{errors?.name?.message}</>
+          </span>
         </div>
         <div className="flex flex-col gap-1">
           <h4 className="text-sm">Description</h4>
@@ -252,7 +255,7 @@ export const ProjectDetailsForm: FC<IProjectDetailsForm> = (props) => {
             )}
           />
         </div>
-        <div className="flex w-full items-center justify-between gap-10">
+        <div className="flex w-full justify-between gap-10">
           <div className="flex w-1/2 flex-col gap-1">
             <h4 className="text-sm">Project ID</h4>
             <div className="relative">
@@ -297,6 +300,9 @@ export const ProjectDetailsForm: FC<IProjectDetailsForm> = (props) => {
                 <Info className="absolute right-2 top-2.5 h-4 w-4 text-custom-text-400" />
               </Tooltip>
             </div>
+            <span className="text-xs text-red-500">
+              <>{errors?.identifier?.message}</>
+            </span>
           </div>
           <div className="flex w-1/2 flex-col gap-1">
             <h4 className="text-sm">Network</h4>


### PR DESCRIPTION
#### Problems
* No error message was displayed in project settings page.
* The project name input was called as `project title` in create project modal leading to inconsistency between the modal and project settings page. 

#### Solutions
* Added the error message in project settings page.
* updated `project title` to `project name` in create project modal.

#### Media
* Before
![image](https://github.com/makeplane/plane/assets/33979846/f25dd801-79b2-4fdd-8938-bfb13044d3f6)
![image](https://github.com/makeplane/plane/assets/33979846/8b301172-4de7-49ae-b419-ffee75f81589)

* After
![image](https://github.com/makeplane/plane/assets/33979846/bb84d035-ca45-4375-9455-45fc4bbaeaa1)
![image](https://github.com/makeplane/plane/assets/33979846/91e44507-e90c-415c-b7cc-8f97ac04b929)

![image](https://github.com/makeplane/plane/assets/33979846/7847f3ac-785b-4440-817f-d71bfe7febdb)

This PR is linked to [WEB-839](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/b8636810-b7cb-4089-b6e3-4d630e4b53f6)