### PR TITLE
[WEB-879] fix: draft issue title logic

### DIFF
--- a/web/components/issues/issue-modal/draft-issue-layout.tsx
+++ b/web/components/issues/issue-modal/draft-issue-layout.tsx
@@ -84,7 +84,7 @@ export const DraftIssueLayout: React.FC<DraftIssueProps> = observer((props) => {
 
     const payload = {
       ...changesMade,
-      name: changesMade?.name && changesMade?.name?.trim() === "" ? changesMade.name?.trim() : "Untitled",
+      name: changesMade?.name && changesMade?.name?.trim() !== "" ? changesMade.name?.trim() : "Untitled",
     };
 
     await issueDraftService


### PR DESCRIPTION
#### Problem:
- When saving a draft issue, it's being titled as "Untitled" despite providing a title during creation.

#### Solution:
- A recent change has caused this logic breakdown. I've made the necessary adjustments to ensure it works as intended.

#### Issue link: [[WEB-879]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/8f3ce0d6-bf2f-4ec5-bbc5-f041f860f7d8)
