### PR TITLE
[WEB-869] chore: fix assignee and parent UI inconsistency in create issue modal.

### DIFF
--- a/web/components/issues/issue-modal/form.tsx
+++ b/web/components/issues/issue-modal/form.tsx
@@ -535,7 +535,7 @@ export const IssueFormRoot: FC<IssueFormProps> = observer((props) => {
                           handleFormChange();
                         }}
                         buttonVariant={value?.length > 0 ? "transparent-without-text" : "border-with-text"}
-                        buttonClassName={value?.length > 0 ? "hover:bg-transparent px-0" : ""}
+                        buttonClassName={value?.length > 0 ? "hover:bg-transparent" : ""}
                         placeholder="Assignees"
                         multiple
                         tabIndex={getTabIndex("assignee_ids")}
@@ -657,33 +657,23 @@ export const IssueFormRoot: FC<IssueFormProps> = observer((props) => {
                     )}
                   />
                 )}
-                <CustomMenu
-                  customButton={
-                    <button
-                      type="button"
-                      className="flex w-full cursor-pointer items-center justify-between gap-1 rounded border-[0.5px] border-custom-border-300 px-2 py-1 text-xs text-custom-text-200 hover:bg-custom-background-80"
-                    >
-                      {watch("parent_id") ? (
-                        <div className="flex items-center gap-1 text-custom-text-200">
-                          <LayoutPanelTop className="h-3 w-3 flex-shrink-0" />
-                          <span className="whitespace-nowrap">
-                            {selectedParentIssue &&
-                              `${selectedParentIssue.project__identifier}-
-                                  ${selectedParentIssue.sequence_id}`}
-                          </span>
-                        </div>
-                      ) : (
-                        <div className="flex items-center gap-1 text-custom-text-300">
-                          <LayoutPanelTop className="h-3 w-3 flex-shrink-0" />
-                          <span className="whitespace-nowrap">Add parent</span>
-                        </div>
-                      )}
-                    </button>
-                  }
-                  placement="bottom-start"
-                  tabIndex={getTabIndex("parent_id")}
-                >
-                  {watch("parent_id") ? (
+                {watch("parent_id") ? (
+                  <CustomMenu
+                    customButton={
+                      <button
+                        type="button"
+                        className="flex cursor-pointer items-center justify-between gap-1 rounded border-[0.5px] border-custom-border-300 px-2 py-1.5 text-xs hover:bg-custom-background-80"
+                      >
+                        <LayoutPanelTop className="h-3 w-3 flex-shrink-0" />
+                        <span className="whitespace-nowrap">
+                          {selectedParentIssue &&
+                            `${selectedParentIssue.project__identifier}-${selectedParentIssue.sequence_id}`}
+                        </span>
+                      </button>
+                    }
+                    placement="bottom-start"
+                    tabIndex={getTabIndex("parent_id")}
+                  >
                     <>
                       <CustomMenu.MenuItem className="!p-1" onClick={() => setParentIssueListModalOpen(true)}>
                         Change parent issue
@@ -698,12 +688,17 @@ export const IssueFormRoot: FC<IssueFormProps> = observer((props) => {
                         Remove parent issue
                       </CustomMenu.MenuItem>
                     </>
-                  ) : (
-                    <CustomMenu.MenuItem className="!p-1" onClick={() => setParentIssueListModalOpen(true)}>
-                      Select parent Issue
-                    </CustomMenu.MenuItem>
-                  )}
-                </CustomMenu>
+                  </CustomMenu>
+                ) : (
+                  <button
+                    type="button"
+                    className="flex cursor-pointer items-center justify-between gap-1 rounded border-[0.5px] border-custom-border-300 px-2 py-1.5 text-xs hover:bg-custom-background-80"
+                    onClick={() => setParentIssueListModalOpen(true)}
+                  >
+                    <LayoutPanelTop className="h-3 w-3 flex-shrink-0" />
+                    <span className="whitespace-nowrap">Add parent</span>
+                  </button>
+                )}
                 <Controller
                   control={control}
                   name="parent_id"


### PR DESCRIPTION
#### Problems
* There was no horizontal padding in selected assignee component.
![image](https://github.com/makeplane/plane/assets/33979846/b10cac40-ba47-485a-a67e-1d7f87d381bd)

* Height difference in the add parent badge as compared to other properties. And text color is also different.
![image](https://github.com/makeplane/plane/assets/33979846/bf673ca9-ad96-4fa9-8758-c569bcb7793a)

* Add parent button opens a dropdown with a single option of select parent
  - Feels like i have to go through an additional step to link to parent.
  
    [scrnli_4_3_2024_4-07-23 PM.webm](https://github.com/makeplane/plane/assets/33979846/9381ca67-f67e-4d94-a565-a1d10f2afdd0)

  
#### Solutions
* Added proper padding in selected assignee component.
![image](https://github.com/makeplane/plane/assets/33979846/939c6955-a019-4c6d-81c8-86fd5fb299ce)

* Fixed the height and text color of Add parent button.
![image](https://github.com/makeplane/plane/assets/33979846/7ca077a5-019f-4c94-83cd-0dbcf5a67bc0)

* Made necessary changes so that we do not have to go through that additional step to link the parent.

     [scrnli_4_3_2024_4-06-16 PM.webm](https://github.com/makeplane/plane/assets/33979846/9538bc23-74c2-4cd0-8e4b-e726f7f113ff)

This PR is linked to [WEB-869](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/a9c18f55-0436-46bb-86ef-61d0658a679d)