### PR TITLE
[WEB-864] chore: increase data dropdown close icon size for consistency.

### DIFF
--- a/web/components/dropdowns/date.tsx
+++ b/web/components/dropdowns/date.tsx
@@ -149,7 +149,7 @@ export const DateDropdown: React.FC<Props> = (props) => {
             )}
             {isClearable && !disabled && isDateSelected && (
               <X
-                className={cn("h-2 w-2 flex-shrink-0", clearIconClassName)}
+                className={cn("h-2.5 w-2.5 flex-shrink-0", clearIconClassName)}
                 onClick={(e) => {
                   e.stopPropagation();
                   onChange(null);


### PR DESCRIPTION
#### Problem
Remove icons on the start and due dates of create issue modal are very small in size, this creates a problem that it is harder to click and remove a date.
![image](https://github.com/makeplane/plane/assets/33979846/5906037c-9363-4615-b4e9-5735d9bf63ca)


#### Solution
Current icon size was 8px. Increased it to 10px so that it is consistent with everywhere else in the product.
![image](https://github.com/makeplane/plane/assets/33979846/88ff5540-8848-4b0a-8023-55eca4eebb7f)

This PR is linked to [WEB-864](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/6a4d2f28-c5ea-480c-88fa-c4238c35bc11)