### PR TITLE
[WEB-899] fix: issue description was not rendering in the issue create/edit modal

### DIFF
--- a/web/components/issues/issue-modal/form.tsx
+++ b/web/components/issues/issue-modal/form.tsx
@@ -461,34 +461,36 @@ export const IssueFormRoot: FC<IssueFormProps> = observer((props) => {
                         />
                       )}
                     </div>
-                    <Controller
-                      name="description_html"
-                      control={control}
-                      render={({ field: { value, onChange } }) => (
-                        <RichTextEditorWithRef
-                          cancelUploadImage={fileService.cancelUpload}
-                          uploadFile={fileService.getUploadFileFunction(workspaceSlug as string)}
-                          deleteFile={fileService.getDeleteImageFunction(workspaceId)}
-                          restoreFile={fileService.getRestoreImageFunction(workspaceId)}
-                          ref={editorRef}
-                          debouncedUpdatesEnabled={false}
-                          value={
-                            !value || value === "" || (typeof value === "object" && Object.keys(value).length === 0)
-                              ? watch("description_html")
-                              : value
-                          }
-                          initialValue={data?.description_html}
-                          customClassName="min-h-[7rem] border-custom-border-100"
-                          onChange={(description: any, description_html: string) => {
-                            onChange(description_html);
-                            handleFormChange();
-                          }}
-                          mentionHighlights={mentionHighlights}
-                          mentionSuggestions={mentionSuggestions}
-                          tabIndex={getTabIndex("description_html")}
-                        />
-                      )}
-                    />
+                    {data?.description_html && watch("description_html") && (
+                      <Controller
+                        name="description_html"
+                        control={control}
+                        render={({ field: { value, onChange } }) => (
+                          <RichTextEditorWithRef
+                            cancelUploadImage={fileService.cancelUpload}
+                            uploadFile={fileService.getUploadFileFunction(workspaceSlug as string)}
+                            deleteFile={fileService.getDeleteImageFunction(workspaceId)}
+                            restoreFile={fileService.getRestoreImageFunction(workspaceId)}
+                            ref={editorRef}
+                            debouncedUpdatesEnabled={false}
+                            value={
+                              !value || value === "" || (typeof value === "object" && Object.keys(value).length === 0)
+                                ? watch("description_html")
+                                : value
+                            }
+                            initialValue={data?.description_html}
+                            customClassName="min-h-[7rem] border-custom-border-100"
+                            onChange={(description: any, description_html: string) => {
+                              onChange(description_html);
+                              handleFormChange();
+                            }}
+                            mentionHighlights={mentionHighlights}
+                            mentionSuggestions={mentionSuggestions}
+                            tabIndex={getTabIndex("description_html")}
+                          />
+                        )}
+                      />
+                    )}
                   </Fragment>
                 )}
               </div>

--- a/web/components/issues/issue-modal/modal.tsx
+++ b/web/components/issues/issue-modal/modal.tsx
@@ -75,6 +75,7 @@ export const CreateUpdateIssueModal: React.FC<IssuesModalProps> = observer((prop
   const { createIssue, updateIssue } = useIssuesActions(storeType);
 
   const fetchIssueDetail = async (issueId: string | undefined) => {
+    setDescription(undefined);
     if (!workspaceSlug) return;
 
     if (!projectId || issueId === undefined) {


### PR DESCRIPTION
This PR fixes the issue that the user is not able to see the issue description in the initial modal open in the issue create/edit modal