### PR TITLE
[WEB-912] chore: remove placeholder from estimate property if no estimates are selected.

### DIFF
--- a/web/components/dropdowns/estimate.tsx
+++ b/web/components/dropdowns/estimate.tsx
@@ -48,7 +48,7 @@ export const EstimateDropdown: React.FC<Props> = observer((props) => {
     hideIcon = false,
     onChange,
     onClose,
-    placeholder = "Estimate",
+    placeholder = "",
     placement,
     projectId,
     showTooltip = false,
@@ -197,7 +197,7 @@ export const EstimateDropdown: React.FC<Props> = observer((props) => {
               variant={buttonVariant}
             >
               {!hideIcon && <Triangle className="h-3 w-3 flex-shrink-0" />}
-              {BUTTON_VARIANTS_WITH_TEXT.includes(buttonVariant) && (
+              {(selectedEstimate || placeholder) && BUTTON_VARIANTS_WITH_TEXT.includes(buttonVariant) && (
                 <span className="flex-grow truncate">{selectedEstimate !== null ? selectedEstimate : placeholder}</span>
               )}
               {dropdownArrow && (

--- a/web/components/issues/issue-layouts/spreadsheet/columns/estimate-column.tsx
+++ b/web/components/issues/issue-layouts/spreadsheet/columns/estimate-column.tsx
@@ -21,6 +21,7 @@ export const SpreadsheetEstimateColumn: React.FC<Props> = observer((props: Props
         onChange={(data) =>
           onChange(issue, { estimate_point: data }, { changed_property: "estimate_point", change_details: data })
         }
+        placeholder="Estimate"
         projectId={issue.project_id}
         disabled={disabled}
         buttonVariant="transparent-with-text"


### PR DESCRIPTION
This PR removes placeholder from estimate property button if no estimates are selected in all the layout providing a consistent UI across all properties. 

#### Media
* Before
![image](https://github.com/makeplane/plane/assets/33979846/0687cf43-55de-4585-b9cd-9ac52e21e252)
![image](https://github.com/makeplane/plane/assets/33979846/53996687-c4a9-4e0b-a0a5-5db04b4f409e)

* After
![image](https://github.com/makeplane/plane/assets/33979846/19727880-d5f7-40dd-8059-8cc0cd9b2232)
![image](https://github.com/makeplane/plane/assets/33979846/a7578f4b-3c0e-47ae-a984-d0de82f28215)

This PR is linked to [WEB-912](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/024461e5-e2fc-4548-8502-22940c019d5b)