### PR TITLE
[WEB-916] fix: description editor missing when using create more button in create issue modal.

### DIFF
--- a/web/components/issues/issue-modal/form.tsx
+++ b/web/components/issues/issue-modal/form.tsx
@@ -193,6 +193,7 @@ export const IssueFormRoot: FC<IssueFormProps> = observer((props) => {
     reset({
       ...defaultValues,
       project_id: getValues("project_id"),
+      description_html: data?.description_html ?? "<p></p>",
     });
     editorRef?.current?.clearEditor();
   };


### PR DESCRIPTION
#### Problem
The description editor was missing when trying to create more issues. This was because we were resetting `description_html` to `""` and we have a condition such that if `description_html` is empty/ null, we will not render it. 

#### Solution
To fix this issue, I updated the code to set proper value to `description_html`.