### PR TITLE
Changed the crisp-wrapper to only use crisp when env is set

### DIFF
--- a/web/lib/wrappers/crisp-wrapper.tsx
+++ b/web/lib/wrappers/crisp-wrapper.tsx
@@ -21,16 +21,18 @@ const CrispWrapper: FC<ICrispWrapper> = (props) => {
     if (typeof window && user?.email) {
       window.$crisp = [];
       window.CRISP_WEBSITE_ID = process.env.NEXT_PUBLIC_CRISP_ID;
-      (function () {
-        const d = document;
-        const s = d.createElement("script");
-        s.src = "https://client.crisp.chat/l.js";
-        s.async = true;
-        d.getElementsByTagName("head")[0].appendChild(s);
-        window.$crisp.push(["set", "user:email", [user.email]]);
-        window.$crisp.push(["do", "chat:hide"]);
-        window.$crisp.push(["do", "chat:close"]);
-      })();
+      if (window.CRISP_WEBSITE_ID != null) {
+        (function () {
+          const d = document;
+          const s = d.createElement("script");
+          s.src = "https://client.crisp.chat/l.js";
+          s.async = true;
+          d.getElementsByTagName("head")[0].appendChild(s);
+          window.$crisp.push(["set", "user:email", [user.email]]);
+          window.$crisp.push(["do", "chat:hide"]);
+          window.$crisp.push(["do", "chat:close"]);
+        })();
+      }
     }
   }, [user?.email]);
 


### PR DESCRIPTION
This PR changes the `crisp-wrapper` to only mount `crisp` when there is a `CRISP_WEBSITE_ID` inside the env-variables. With those changes, no call to the website of crisp will be made when there is no usage for it. This improves the privacy of self-hosted instances as mentioned on #3608