### PR TITLE
[WEB-915] fix: updated issue description rendering when we switch between two issues via sub-issue

### DIFF
--- a/web/components/issues/issue-detail/main-content.tsx
+++ b/web/components/issues/issue-detail/main-content.tsx
@@ -28,6 +28,7 @@ export const IssueMainContent: React.FC<Props> = observer((props) => {
   const { workspaceSlug, projectId, issueId, issueOperations, is_editable } = props;
   // states
   const [isSubmitting, setIsSubmitting] = useState<"submitting" | "submitted" | "saved">("saved");
+  const [issueDescription, setIssueDescription] = useState<string | undefined>(undefined);
   // hooks
   const { currentUser } = useUser();
   const { projectStates } = useProjectState();
@@ -52,12 +53,16 @@ export const IssueMainContent: React.FC<Props> = observer((props) => {
 
   const currentIssueState = projectStates?.find((s) => s.id === issue.state_id);
 
-  const issueDescription =
-    issue.description_html !== undefined || issue.description_html !== null
-      ? issue.description_html != ""
-        ? issue.description_html
-        : "<p></p>"
-      : undefined;
+  useEffect(() => {
+    setIssueDescription(
+      issue.description_html !== undefined || issue.description_html !== null
+        ? issue.description_html != ""
+          ? issue.description_html
+          : "<p></p>"
+        : undefined
+    );
+    return () => setIssueDescription(undefined);
+  }, [issue.description_html]);
 
   return (
     <>
@@ -94,16 +99,18 @@ export const IssueMainContent: React.FC<Props> = observer((props) => {
           value={issue.name}
         />
 
-        <IssueDescriptionInput
-          workspaceSlug={workspaceSlug}
-          projectId={issue.project_id}
-          issueId={issue.id}
-          value={issueDescription}
-          initialValue={issueDescription}
-          disabled={!is_editable}
-          issueOperations={issueOperations}
-          setIsSubmitting={(value) => setIsSubmitting(value)}
-        />
+        {issue?.description_html === issueDescription && (
+          <IssueDescriptionInput
+            workspaceSlug={workspaceSlug}
+            projectId={issue.project_id}
+            issueId={issue.id}
+            value={issueDescription}
+            initialValue={issueDescription}
+            disabled={!is_editable}
+            issueOperations={issueOperations}
+            setIsSubmitting={(value) => setIsSubmitting(value)}
+          />
+        )}
 
         {currentUser && (
           <IssueReaction


### PR DESCRIPTION
This pull request addresses the issue wherein transitioning between issues on the issue detail page via sub-issues would maintain the parent description for the child issue. 