### PR TITLE
[WEB-924] chore: remove `Add Issues` button from completed cycles header.

### DIFF
--- a/web/components/headers/cycle-issues.tsx
+++ b/web/components/headers/cycle-issues.tsx
@@ -142,6 +142,7 @@ export const CycleIssuesHeader: React.FC = observer(() => {
 
   // derived values
   const cycleDetails = cycleId ? getCycleById(cycleId.toString()) : undefined;
+  const isCompletedCycle = cycleDetails?.status?.toLocaleLowerCase() === "completed";
   const canUserCreateIssue =
     currentProjectRole && [EUserProjectRoles.ADMIN, EUserProjectRoles.MEMBER].includes(currentProjectRole);
 
@@ -269,7 +270,7 @@ export const CycleIssuesHeader: React.FC = observer(() => {
               />
             </FiltersDropdown>
 
-            {canUserCreateIssue && (
+            {canUserCreateIssue && !isCompletedCycle && (
               <>
                 <Button onClick={() => setAnalyticsModal(true)} variant="neutral-primary" size="sm">
                   Analytics

--- a/web/components/headers/cycle-issues.tsx
+++ b/web/components/headers/cycle-issues.tsx
@@ -270,21 +270,23 @@ export const CycleIssuesHeader: React.FC = observer(() => {
               />
             </FiltersDropdown>
 
-            {canUserCreateIssue && !isCompletedCycle && (
+            {canUserCreateIssue && (
               <>
                 <Button onClick={() => setAnalyticsModal(true)} variant="neutral-primary" size="sm">
                   Analytics
                 </Button>
-                <Button
-                  onClick={() => {
-                    setTrackElement("Cycle issues page");
-                    toggleCreateIssueModal(true, EIssuesStoreType.CYCLE);
-                  }}
-                  size="sm"
-                  prependIcon={<Plus />}
-                >
-                  Add Issue
-                </Button>
+                {!isCompletedCycle && (
+                  <Button
+                    onClick={() => {
+                      setTrackElement("Cycle issues page");
+                      toggleCreateIssueModal(true, EIssuesStoreType.CYCLE);
+                    }}
+                    size="sm"
+                    prependIcon={<Plus />}
+                  >
+                    Add Issue
+                  </Button>
+                )}
               </>
             )}
             <button


### PR DESCRIPTION
#### Media
* Before
![image](https://github.com/makeplane/plane/assets/33979846/05193fb3-df33-4f69-82f5-738c2fdb283c)

* After
![image](https://github.com/makeplane/plane/assets/33979846/48cf8f37-256c-4d94-baf5-cddf8f149a38)

This PR is linked to [WEB-924](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/825dd805-7419-4dfd-897b-20a30e0e7344)
