### PR TITLE
fix: email ssl setting not getting saved

### DIFF
--- a/apiserver/plane/license/management/commands/configure_instance.py
+++ b/apiserver/plane/license/management/commands/configure_instance.py
@@ -89,6 +89,12 @@ class Command(BaseCommand):
                 "is_encrypted": False,
             },
             {
+                "key": "EMAIL_USE_SSL",
+                "value": os.environ.get("EMAIL_USE_SSL", "0"),
+                "category": "SMTP",
+                "is_encrypted": False,
+            },
+            {
                 "key": "OPENAI_API_KEY",
                 "value": os.environ.get("OPENAI_API_KEY"),
                 "category": "OPENAI",


### PR DESCRIPTION
The `Turn SSL off/on` setting did not get saved on PATCH because it was missing in config keys.