### PR TITLE
[WEB-931] chore: kanban card padding improvement

### DIFF
--- a/web/components/issues/issue-layouts/kanban/block.tsx
+++ b/web/components/issues/issue-layouts/kanban/block.tsx
@@ -63,16 +63,16 @@ const KanbanIssueDetailsBlock: React.FC<IssueDetailsBlockProps> = observer((prop
 
       {issue?.is_draft ? (
         <Tooltip tooltipContent={issue.name} isMobile={isMobile}>
-          <span className="pb-1.5">{issue.name}</span>
+          <span>{issue.name}</span>
         </Tooltip>
       ) : (
         <Tooltip tooltipContent={issue.name} isMobile={isMobile}>
-          <span className="w-full line-clamp-1 cursor-pointer text-sm text-custom-text-100 pb-1.5">{issue.name}</span>
+          <span className="w-full line-clamp-1 cursor-pointer text-sm text-custom-text-100">{issue.name}</span>
         </Tooltip>
       )}
 
       <IssueProperties
-        className="flex flex-wrap items-center gap-2 whitespace-nowrap text-custom-text-300"
+        className="flex flex-wrap items-center gap-2 whitespace-nowrap text-custom-text-300 pt-1.5"
         issue={issue}
         displayProperties={displayProperties}
         activeLayout="Kanban"


### PR DESCRIPTION
#### Changes:
- There were issues with title padding in the Kanban layout that have been addressed.

#### Issue link:  [[WEB-931]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/445869ff-a8af-46c3-9c70-4c0f61715ba0)