### PR TITLE
[WEB-932] fix: api token expiry time

### DIFF
--- a/web/components/api-token/modal/form.tsx
+++ b/web/components/api-token/modal/form.tsx
@@ -95,7 +95,7 @@ export const CreateApiTokenForm: React.FC<Props> = (props) => {
     else {
       const expiryDate = getExpiryDate(data.expired_at ?? "");
 
-      if (expiryDate) payload.expired_at = renderFormattedPayloadDate(expiryDate);
+      if (expiryDate) payload.expired_at = renderFormattedPayloadDate(new Date(expiryDate));
     }
 
     await onSubmit(payload).then(() => {
@@ -170,8 +170,8 @@ export const CreateApiTokenForm: React.FC<Props> = (props) => {
                           {value === "custom"
                             ? "Custom date"
                             : selectedOption
-                              ? selectedOption.label
-                              : "Set expiration date"}
+                            ? selectedOption.label
+                            : "Set expiration date"}
                         </div>
                       }
                       value={value}
@@ -207,8 +207,8 @@ export const CreateApiTokenForm: React.FC<Props> = (props) => {
                     ? `Expires ${renderFormattedDate(customDate)}`
                     : null
                   : watch("expired_at")
-                    ? `Expires ${getExpiryDate(watch("expired_at") ?? "")}`
-                    : null}
+                  ? `Expires ${getExpiryDate(watch("expired_at") ?? "")}`
+                  : null}
               </span>
             )}
           </div>


### PR DESCRIPTION
#### Problem:
- The API token key generation process currently sends NULL as the expiry time, regardless of the selected timeframe from the dropdown menu.

#### Resolution:
- Identified and resolved the issue by ensuring that the selected timeframe from the dropdown menu is properly reflected in the API token key generation process.

#### Issue link:  [[WEB-932]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/4d8af82a-b4d8-4ebb-8800-e477d2180d12)