### PR TITLE
[WEB-905] fix: make entire Kanban issue block clickable

### DIFF
--- a/web/components/issues/issue-layouts/kanban/block.tsx
+++ b/web/components/issues/issue-layouts/kanban/block.tsx
@@ -61,9 +61,11 @@ const KanbanIssueDetailsBlock: React.FC<IssueDetailsBlockProps> = observer((prop
           <span>{issue.name}</span>
         </Tooltip>
       ) : (
-        <Tooltip tooltipContent={issue.name} isMobile={isMobile}>
-          <span className="w-full line-clamp-1 cursor-pointer text-sm text-custom-text-100">{issue.name}</span>
-        </Tooltip>
+        <div className="w-full line-clamp-1 cursor-pointer text-sm text-custom-text-100 pb-1.5">
+          <Tooltip tooltipContent={issue.name} isMobile={isMobile}>
+            <span>{issue.name}</span>
+          </Tooltip>
+        </div>
       )}
 
       <IssueProperties

--- a/web/components/issues/issue-layouts/kanban/block.tsx
+++ b/web/components/issues/issue-layouts/kanban/block.tsx
@@ -45,15 +45,10 @@ const KanbanIssueDetailsBlock: React.FC<IssueDetailsBlockProps> = observer((prop
   const { isMobile } = usePlatformOS();
   const { getProjectIdentifierById } = useProject();
 
-  const handleEventPropagation = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    e.preventDefault();
-  };
-
   return (
     <>
       <WithDisplayPropertiesHOC displayProperties={displayProperties || {}} displayPropertyKey="key">
-        <div className="relative" onClick={handleEventPropagation}>
+        <div className="relative">
           <div className="line-clamp-1 text-xs text-custom-text-300">
             {getProjectIdentifierById(issue.project_id)}-{issue.sequence_id}
           </div>

--- a/web/components/issues/issue-layouts/kanban/block.tsx
+++ b/web/components/issues/issue-layouts/kanban/block.tsx
@@ -61,7 +61,7 @@ const KanbanIssueDetailsBlock: React.FC<IssueDetailsBlockProps> = observer((prop
           <span>{issue.name}</span>
         </Tooltip>
       ) : (
-        <div className="w-full line-clamp-1 cursor-pointer text-sm text-custom-text-100 pb-1.5">
+        <div className="w-full line-clamp-1 cursor-pointer text-sm text-custom-text-100 mb-1.5">
           <Tooltip tooltipContent={issue.name} isMobile={isMobile}>
             <span>{issue.name}</span>
           </Tooltip>

--- a/web/components/issues/issue-layouts/kanban/block.tsx
+++ b/web/components/issues/issue-layouts/kanban/block.tsx
@@ -45,6 +45,11 @@ const KanbanIssueDetailsBlock: React.FC<IssueDetailsBlockProps> = observer((prop
   const { isMobile } = usePlatformOS();
   const { getProjectIdentifierById } = useProject();
 
+  const handleEventPropagation = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    e.preventDefault();
+  };
+
   return (
     <>
       <WithDisplayPropertiesHOC displayProperties={displayProperties || {}} displayPropertyKey="key">
@@ -52,7 +57,12 @@ const KanbanIssueDetailsBlock: React.FC<IssueDetailsBlockProps> = observer((prop
           <div className="line-clamp-1 text-xs text-custom-text-300">
             {getProjectIdentifierById(issue.project_id)}-{issue.sequence_id}
           </div>
-          <div className="absolute -top-1 right-0 hidden group-hover/kanban-block:block">{quickActions(issue)}</div>
+          <div
+            className="absolute -top-1 right-0 hidden group-hover/kanban-block:block"
+            onClick={handleEventPropagation}
+          >
+            {quickActions(issue)}
+          </div>
         </div>
       </WithDisplayPropertiesHOC>
 


### PR DESCRIPTION
[WEB-905](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/b056c127-e5f7-4dd7-bdc2-a03d6c60fb48)

This PR fixes the bug that was stopping from making the entire Kanban block as clickable
This also fixes the regression that caused the kanban title tooltip to be aligned center rather than left