### PR TITLE
[WEB-994] fix: pages list mutation between projects

### DIFF
--- a/web/components/pages/list/root.tsx
+++ b/web/components/pages/list/root.tsx
@@ -16,9 +16,9 @@ type TPagesListRoot = {
 export const PagesListRoot: FC<TPagesListRoot> = observer((props) => {
   const { pageType, projectId, workspaceSlug } = props;
   // store hooks
-  const { currentProjectFilteredPageIds } = useProjectPages(projectId);
+  const { getCurrentProjectFilteredPageIds } = useProjectPages(projectId);
   // derived values
-  const filteredPageIds = currentProjectFilteredPageIds(pageType);
+  const filteredPageIds = getCurrentProjectFilteredPageIds(pageType);
 
   if (!filteredPageIds) return <></>;
   return (

--- a/web/components/pages/list/root.tsx
+++ b/web/components/pages/list/root.tsx
@@ -13,12 +13,12 @@ type TPagesListRoot = {
 export const PagesListRoot: FC<TPagesListRoot> = observer((props) => {
   const { workspaceSlug, projectId } = props;
   // hooks
-  const { filteredPageIds } = useProjectPages(projectId);
+  const { currentProjectFilteredPageIds } = useProjectPages(projectId);
 
-  if (!filteredPageIds) return <></>;
+  if (!currentProjectFilteredPageIds) return <></>;
   return (
     <div className="relative w-full h-full overflow-hidden overflow-y-auto divide-y-[0.5px] divide-custom-border-200">
-      {filteredPageIds.map((pageId) => (
+      {currentProjectFilteredPageIds.map((pageId) => (
         <PageListBlock key={pageId} workspaceSlug={workspaceSlug} projectId={projectId} pageId={pageId} />
       ))}
     </div>

--- a/web/components/pages/list/root.tsx
+++ b/web/components/pages/list/root.tsx
@@ -1,24 +1,29 @@
 import { FC } from "react";
 import { observer } from "mobx-react";
+// types
+import { TPageNavigationTabs } from "@plane/types";
 // hooks
 import { useProjectPages } from "@/hooks/store";
 // components
 import { PageListBlock } from "./";
 
 type TPagesListRoot = {
-  workspaceSlug: string;
+  pageType: TPageNavigationTabs;
   projectId: string;
+  workspaceSlug: string;
 };
 
 export const PagesListRoot: FC<TPagesListRoot> = observer((props) => {
-  const { workspaceSlug, projectId } = props;
-  // hooks
+  const { pageType, projectId, workspaceSlug } = props;
+  // store hooks
   const { currentProjectFilteredPageIds } = useProjectPages(projectId);
+  // derived values
+  const filteredPageIds = currentProjectFilteredPageIds(pageType);
 
-  if (!currentProjectFilteredPageIds) return <></>;
+  if (!filteredPageIds) return <></>;
   return (
     <div className="relative w-full h-full overflow-hidden overflow-y-auto divide-y-[0.5px] divide-custom-border-200">
-      {currentProjectFilteredPageIds.map((pageId) => (
+      {filteredPageIds.map((pageId) => (
         <PageListBlock key={pageId} workspaceSlug={workspaceSlug} projectId={projectId} pageId={pageId} />
       ))}
     </div>

--- a/web/components/pages/list/tab-navigation.tsx
+++ b/web/components/pages/list/tab-navigation.tsx
@@ -1,12 +1,9 @@
-import { FC, useEffect } from "react";
-import { observer } from "mobx-react";
+import { FC } from "react";
 import Link from "next/link";
 // types
 import { TPageNavigationTabs } from "@plane/types";
 // helpers
 import { cn } from "@/helpers/common.helper";
-// hooks
-import { useProjectPages } from "@/hooks/store";
 
 type TPageTabNavigation = {
   workspaceSlug: string;
@@ -30,18 +27,12 @@ const pageTabs: { key: TPageNavigationTabs; label: string }[] = [
   },
 ];
 
-export const PageTabNavigation: FC<TPageTabNavigation> = observer((props) => {
+export const PageTabNavigation: FC<TPageTabNavigation> = (props) => {
   const { workspaceSlug, projectId, pageType } = props;
-  // store hooks
-  const { pageType: storePageType, updatePageType } = useProjectPages(projectId);
 
   const handleTabClick = (e: React.MouseEvent<HTMLAnchorElement>, tabKey: TPageNavigationTabs) => {
     if (tabKey === pageType) e.preventDefault();
   };
-
-  useEffect(() => {
-    if (storePageType !== pageType) updatePageType(pageType);
-  }, [storePageType, pageType, updatePageType]);
 
   return (
     <div className="relative flex items-center">
@@ -67,4 +58,4 @@ export const PageTabNavigation: FC<TPageTabNavigation> = observer((props) => {
       ))}
     </div>
   );
-});
+};

--- a/web/components/pages/list/tab-navigation.tsx
+++ b/web/components/pages/list/tab-navigation.tsx
@@ -1,9 +1,12 @@
 import { FC } from "react";
+import { observer } from "mobx-react";
 import Link from "next/link";
 // types
 import { TPageNavigationTabs } from "@plane/types";
 // helpers
 import { cn } from "@/helpers/common.helper";
+// hooks
+import { useProjectPages } from "@/hooks/store";
 
 type TPageTabNavigation = {
   workspaceSlug: string;
@@ -27,11 +30,14 @@ const pageTabs: { key: TPageNavigationTabs; label: string }[] = [
   },
 ];
 
-export const PageTabNavigation: FC<TPageTabNavigation> = (props) => {
+export const PageTabNavigation: FC<TPageTabNavigation> = observer((props) => {
   const { workspaceSlug, projectId, pageType } = props;
+  // store hooks
+  const { updatePageType } = useProjectPages(projectId);
 
   const handleTabClick = (e: React.MouseEvent<HTMLAnchorElement>, tabKey: TPageNavigationTabs) => {
     if (tabKey === pageType) e.preventDefault();
+    else updatePageType(tabKey);
   };
 
   return (
@@ -42,23 +48,20 @@ export const PageTabNavigation: FC<TPageTabNavigation> = (props) => {
           href={`/${workspaceSlug}/projects/${projectId}/pages?type=${tab.key}`}
           onClick={(e) => handleTabClick(e, tab.key)}
         >
-          <div>
-            <div
-              className={cn(`p-3 py-4 text-sm font-medium transition-all`, {
-                "text-custom-primary-100": tab.key === pageType,
-              })}
-            >
-              {tab.label}
-            </div>
-            <div
-              className={cn(`rounded-t border-t-2 transition-all`, {
-                "border-custom-primary-100": tab.key === pageType,
-                "border-transparent": tab.key !== pageType,
-              })}
-            />
-          </div>
+          <span
+            className={cn(`block p-3 py-4 text-sm font-medium transition-all`, {
+              "text-custom-primary-100": tab.key === pageType,
+            })}
+          >
+            {tab.label}
+          </span>
+          <div
+            className={cn(`rounded-t border-t-2 transition-all border-transparent`, {
+              "border-custom-primary-100": tab.key === pageType,
+            })}
+          />
         </Link>
       ))}
     </div>
   );
-};
+});

--- a/web/components/pages/list/tab-navigation.tsx
+++ b/web/components/pages/list/tab-navigation.tsx
@@ -1,4 +1,4 @@
-import { FC } from "react";
+import { FC, useEffect } from "react";
 import { observer } from "mobx-react";
 import Link from "next/link";
 // types
@@ -33,12 +33,15 @@ const pageTabs: { key: TPageNavigationTabs; label: string }[] = [
 export const PageTabNavigation: FC<TPageTabNavigation> = observer((props) => {
   const { workspaceSlug, projectId, pageType } = props;
   // store hooks
-  const { updatePageType } = useProjectPages(projectId);
+  const { pageType: storePageType, updatePageType } = useProjectPages(projectId);
 
   const handleTabClick = (e: React.MouseEvent<HTMLAnchorElement>, tabKey: TPageNavigationTabs) => {
     if (tabKey === pageType) e.preventDefault();
-    else updatePageType(tabKey);
   };
+
+  useEffect(() => {
+    if (storePageType !== pageType) updatePageType(pageType);
+  }, [storePageType, pageType, updatePageType]);
 
   return (
     <div className="relative flex items-center">

--- a/web/components/pages/pages-list-main-content.tsx
+++ b/web/components/pages/pages-list-main-content.tsx
@@ -22,10 +22,10 @@ type Props = {
 export const PagesListMainContent: React.FC<Props> = observer((props) => {
   const { children, pageType, projectId } = props;
   // store hooks
-  const { loader, currentProjectFilteredPageIds, currentProjectPageIds, filters } = useProjectPages(projectId);
+  const { loader, getCurrentProjectFilteredPageIds, getCurrentProjectPageIds, filters } = useProjectPages(projectId);
   // derived values
-  const pageIds = currentProjectPageIds(pageType);
-  const filteredPageIds = currentProjectFilteredPageIds(pageType);
+  const pageIds = getCurrentProjectPageIds(pageType);
+  const filteredPageIds = getCurrentProjectFilteredPageIds(pageType);
 
   if (loader === "init-loader") return <PageLoader />;
   // if no pages exist in the active page type

--- a/web/components/pages/pages-list-main-content.tsx
+++ b/web/components/pages/pages-list-main-content.tsx
@@ -23,16 +23,19 @@ export const PagesListMainContent: React.FC<Props> = observer((props) => {
   const { children, pageType, projectId } = props;
   // store hooks
   const { loader, currentProjectFilteredPageIds, currentProjectPageIds, filters } = useProjectPages(projectId);
+  // derived values
+  const pageIds = currentProjectPageIds(pageType);
+  const filteredPageIds = currentProjectFilteredPageIds(pageType);
 
   if (loader === "init-loader") return <PageLoader />;
   // if no pages exist in the active page type
-  if (currentProjectPageIds?.length === 0) {
+  if (pageIds?.length === 0) {
     if (pageType === "public") return <EmptyState type={EmptyStateType.PROJECT_PAGE_PUBLIC} />;
     if (pageType === "private") return <EmptyState type={EmptyStateType.PROJECT_PAGE_PRIVATE} />;
     if (pageType === "archived") return <EmptyState type={EmptyStateType.PROJECT_PAGE_ARCHIVED} />;
   }
   // if no pages match the filter criteria
-  if (currentProjectFilteredPageIds?.length === 0)
+  if (filteredPageIds?.length === 0)
     return (
       <div className="h-full w-full grid place-items-center">
         <div className="text-center">

--- a/web/components/pages/pages-list-main-content.tsx
+++ b/web/components/pages/pages-list-main-content.tsx
@@ -22,17 +22,17 @@ type Props = {
 export const PagesListMainContent: React.FC<Props> = observer((props) => {
   const { children, pageType, projectId } = props;
   // store hooks
-  const { loader, filteredPageIds, pageIds, filters } = useProjectPages(projectId);
+  const { loader, currentProjectFilteredPageIds, currentProjectPageIds, filters } = useProjectPages(projectId);
 
   if (loader === "init-loader") return <PageLoader />;
   // if no pages exist in the active page type
-  if (pageIds?.length === 0) {
+  if (currentProjectPageIds?.length === 0) {
     if (pageType === "public") return <EmptyState type={EmptyStateType.PROJECT_PAGE_PUBLIC} />;
     if (pageType === "private") return <EmptyState type={EmptyStateType.PROJECT_PAGE_PRIVATE} />;
     if (pageType === "archived") return <EmptyState type={EmptyStateType.PROJECT_PAGE_ARCHIVED} />;
   }
   // if no pages match the filter criteria
-  if (filteredPageIds?.length === 0)
+  if (currentProjectFilteredPageIds?.length === 0)
     return (
       <div className="h-full w-full grid place-items-center">
         <div className="text-center">

--- a/web/components/pages/pages-list-view.tsx
+++ b/web/components/pages/pages-list-view.tsx
@@ -18,10 +18,7 @@ export const PagesListView: React.FC<TPageView> = observer((props) => {
   // store hooks
   const { getAllPages } = useProjectPages(projectId);
   // fetching pages list
-  useSWR(
-    projectId && pageType ? `PROJECT_PAGES_${projectId}_${pageType}` : null,
-    projectId && pageType ? () => getAllPages(pageType) : null
-  );
+  useSWR(projectId ? `PROJECT_PAGES_${projectId}` : null, projectId ? () => getAllPages(pageType) : null);
 
   // pages loader
   return (

--- a/web/components/pages/pages-list-view.tsx
+++ b/web/components/pages/pages-list-view.tsx
@@ -18,7 +18,7 @@ export const PagesListView: React.FC<TPageView> = observer((props) => {
   // store hooks
   const { getAllPages } = useProjectPages(projectId);
   // fetching pages list
-  useSWR(projectId ? `PROJECT_PAGES_${projectId}` : null, projectId ? () => getAllPages() : null);
+  useSWR(projectId ? `PROJECT_PAGES_${projectId}` : null, projectId ? () => getAllPages(pageType) : null);
 
   // pages loader
   return (

--- a/web/components/pages/pages-list-view.tsx
+++ b/web/components/pages/pages-list-view.tsx
@@ -18,7 +18,7 @@ export const PagesListView: React.FC<TPageView> = observer((props) => {
   // store hooks
   const { getAllPages } = useProjectPages(projectId);
   // fetching pages list
-  useSWR(projectId ? `PROJECT_PAGES_${projectId}` : null, projectId ? () => getAllPages(pageType) : null);
+  useSWR(projectId ? `PROJECT_PAGES_${projectId}` : null, projectId ? () => getAllPages() : null);
 
   // pages loader
   return (

--- a/web/pages/[workspaceSlug]/projects/[projectId]/pages/index.tsx
+++ b/web/pages/[workspaceSlug]/projects/[projectId]/pages/index.tsx
@@ -36,7 +36,11 @@ const ProjectPagesPage: NextPageWithLayout = observer(() => {
       projectId={projectId.toString()}
       pageType={currentPageType()}
     >
-      <PagesListRoot workspaceSlug={workspaceSlug.toString()} projectId={projectId.toString()} />
+      <PagesListRoot
+        pageType={currentPageType()}
+        workspaceSlug={workspaceSlug.toString()}
+        projectId={projectId.toString()}
+      />
     </PagesListView>
   );
 });

--- a/web/store/pages/project-page.store.ts
+++ b/web/store/pages/project-page.store.ts
@@ -23,13 +23,13 @@ export interface IProjectPageStore {
   error: TError | undefined;
   filters: TPageFilters;
   // helper actions
-  currentProjectPageIds: (pageType: TPageNavigationTabs) => string[] | undefined;
-  currentProjectFilteredPageIds: (pageType: TPageNavigationTabs) => string[] | undefined;
+  getCurrentProjectPageIds: (pageType: TPageNavigationTabs) => string[] | undefined;
+  getCurrentProjectFilteredPageIds: (pageType: TPageNavigationTabs) => string[] | undefined;
   pageById: (pageId: string) => IPageStore | undefined;
   updateFilters: <T extends keyof TPageFilters>(filterKey: T, filterValue: TPageFilters[T]) => void;
   clearAllFilters: () => void;
   // actions
-  getAllPages: () => Promise<TPage[] | undefined>;
+  getAllPages: (pageType: TPageNavigationTabs) => Promise<TPage[] | undefined>;
   getPageById: (pageId: string) => Promise<TPage | undefined>;
   createPage: (pageData: Partial<TPage>) => Promise<TPage | undefined>;
   removePage: (pageId: string) => Promise<void>;
@@ -72,7 +72,7 @@ export class ProjectPageStore implements IProjectPageStore {
    * @description get the current project page ids based on the pageType
    * @param {TPageNavigationTabs} pageType
    */
-  currentProjectPageIds = computedFn((pageType: TPageNavigationTabs) => {
+  getCurrentProjectPageIds = computedFn((pageType: TPageNavigationTabs) => {
     const { projectId } = this.store.app.router;
     if (!projectId) return undefined;
     // helps to filter pages based on the pageType
@@ -88,7 +88,7 @@ export class ProjectPageStore implements IProjectPageStore {
    * @description get the current project filtered page ids based on the pageType
    * @param {TPageNavigationTabs} pageType
    */
-  currentProjectFilteredPageIds = computedFn((pageType: TPageNavigationTabs) => {
+  getCurrentProjectFilteredPageIds = computedFn((pageType: TPageNavigationTabs) => {
     const { projectId } = this.store.app.router;
     if (!projectId) return undefined;
 
@@ -130,12 +130,12 @@ export class ProjectPageStore implements IProjectPageStore {
   /**
    * @description fetch all the pages
    */
-  getAllPages = async () => {
+  getAllPages = async (pageType: TPageNavigationTabs) => {
     try {
       const { workspaceSlug, projectId } = this.store.app.router;
       if (!workspaceSlug || !projectId) return undefined;
 
-      const currentPageIds = this.currentProjectPageIds;
+      const currentPageIds = this.getCurrentProjectPageIds(pageType);
       runInAction(() => {
         this.loader = currentPageIds && currentPageIds.length > 0 ? `mutation-loader` : `init-loader`;
         this.error = undefined;


### PR DESCRIPTION
#### Problems:

1. Switching between projects did not update the list of pages.
2. Switching between tabs(Public, Private and Archived) rapidly did not update the list of pages.

#### Solutions:

1. Added the missing `projectId` check to the pages list computed function.
2. Updated the logic to update the active page tab.

#### Plane issue: [WEB-994](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/c70c0a3e-7a33-462d-98ca-357ae4e83390)