### PR TITLE
make redis version same as the one in selfhosted docker-compose

### DIFF
--- a/deploy/coolify/coolify-docker-compose.yml
+++ b/deploy/coolify/coolify-docker-compose.yml
@@ -180,7 +180,7 @@ services:
 
   plane-redis:
     container_name: plane-redis
-    image: redis:6.2.7-alpine
+    image: redis:7.2.4-alpine
     restart: always
     volumes:
       - redisdata:/data

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -10,7 +10,7 @@ volumes:
 
 services:
   plane-redis:
-    image: redis:6.2.7-alpine
+    image: redis:7.2.4-alpine
     restart: unless-stopped
     networks:
       - dev_env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,7 +90,7 @@ services:
 
   plane-redis:
     container_name: plane-redis
-    image: redis:6.2.7-alpine
+    image: redis:7.2.4-alpine
     restart: always
     volumes:
       - redisdata:/data


### PR DESCRIPTION
The redis version in the selft hosted docker compose file was 7.2.4 while others was 6.2.7, making a commit to set all redis versions to 7.2.4 and make all of them consistent.