### PR TITLE
[WEB - 1006] fix: remove caching when joining workspace

### DIFF
--- a/apiserver/plane/app/views/workspace/invite.py
+++ b/apiserver/plane/app/views/workspace/invite.py
@@ -170,6 +170,12 @@ class WorkspaceJoinEndpoint(BaseAPIView):
 
     @invalidate_cache(path="/api/workspaces/", user=False)
     @invalidate_cache(path="/api/users/me/workspaces/")
+    @invalidate_cache(
+        path="/api/workspaces/:slug/members/",
+        user=False,
+        multiple=True,
+        url_params=True,
+    )
     def post(self, request, slug, pk):
         workspace_invite = WorkspaceMemberInvite.objects.get(
             pk=pk, workspace__slug=slug


### PR DESCRIPTION
fix: 
- invalidate workspace members cache when someone accepts workspace invitation

[[WEB - 1006]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/4965f4b4-d903-4e70-90f2-4832ea5ca0a9)