### PR TITLE
[WEB-1012] fix: empty blocks due to virtualization in rare cases

### DIFF
--- a/web/components/core/render-if-visible-HOC.tsx
+++ b/web/components/core/render-if-visible-HOC.tsx
@@ -48,7 +48,7 @@ const RenderIfVisible: React.FC<Props> = (props) => {
           // } else {
           //   setShouldVisible(entries[0].isIntersecting);
           // }
-          setShouldVisible(entries[0].isIntersecting);
+          setShouldVisible(entries[entries.length - 1].isIntersecting);
         },
         {
           root: root?.current,


### PR DESCRIPTION
[WEB-1012](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/49e2b94e-f76e-4472-a3ea-73aadc335fc9)

This PR fixes a rare scenario when some issue blocks are blank instead of being rendered. This is done by making sure the intersection observer checks the last(latest) entry instead of the first one