### PR TITLE
[WEB-480] fix: tab key behaviour fixed for tabIndex containing editor instances

### DIFF
--- a/packages/editor/core/src/hooks/use-editor.tsx
+++ b/packages/editor/core/src/hooks/use-editor.tsx
@@ -35,6 +35,7 @@ interface CustomEditorProps {
   };
   handleEditorReady?: (value: boolean) => void;
   placeholder?: string | ((isFocused: boolean) => string);
+  tabIndex?: number;
 }
 
 export const useEditor = ({
@@ -49,6 +50,7 @@ export const useEditor = ({
   extensions = [],
   onChange,
   forwardedRef,
+  tabIndex,
   restoreFile,
   handleEditorReady,
   mentionHandler,
@@ -72,6 +74,7 @@ export const useEditor = ({
           uploadFile,
         },
         placeholder,
+        tabIndex,
       }),
       ...extensions,
     ],

--- a/packages/editor/core/src/ui/extensions/index.tsx
+++ b/packages/editor/core/src/ui/extensions/index.tsx
@@ -44,12 +44,14 @@ type TArguments = {
     uploadFile: UploadImage;
   };
   placeholder?: string | ((isFocused: boolean) => string);
+  tabIndex?: number;
 };
 
 export const CoreEditorExtensions = ({
   mentionConfig,
   fileConfig: { deleteFile, restoreFile, cancelUploadImage, uploadFile },
   placeholder,
+  tabIndex,
 }: TArguments) => [
   StarterKit.configure({
     bulletList: {
@@ -84,7 +86,7 @@ export const CoreEditorExtensions = ({
     },
   }),
   CustomKeymap,
-  ListKeymap,
+  ListKeymap({ tabIndex }),
   CustomLinkExtension.configure({
     openOnClick: true,
     autolink: true,

--- a/packages/editor/document-editor/src/ui/index.tsx
+++ b/packages/editor/document-editor/src/ui/index.tsx
@@ -76,6 +76,7 @@ const DocumentEditor = (props: IDocumentEditor) => {
       setHideDragHandle: setHideDragHandleFunction,
     }),
     placeholder,
+    tabIndex,
   });
 
   const editorContainerClassNames = getEditorClassNames({

--- a/packages/editor/lite-text-editor/src/ui/index.tsx
+++ b/packages/editor/lite-text-editor/src/ui/index.tsx
@@ -63,6 +63,7 @@ const LiteTextEditor = (props: ILiteTextEditor) => {
     extensions: LiteTextEditorExtensions(onEnterKeyPress),
     mentionHandler,
     placeholder,
+    tabIndex,
   });
 
   const editorContainerClassName = getEditorClassNames({

--- a/packages/editor/rich-text-editor/src/ui/index.tsx
+++ b/packages/editor/rich-text-editor/src/ui/index.tsx
@@ -81,6 +81,7 @@ const RichTextEditor = (props: IRichTextEditor) => {
       dragDropEnabled,
       setHideDragHandle: setHideDragHandleFunction,
     }),
+    tabIndex,
     mentionHandler,
     placeholder,
   });


### PR DESCRIPTION
## Description

Tab key behaviour fixed for `tabIndex` containing editor instances containing while keeping the sane behaviour for lists and code blocks' tab key methods...