### PR TITLE
[WEB-1019] chore: error state for unauthorized pages

### DIFF
--- a/apiserver/plane/app/views/page/base.py
+++ b/apiserver/plane/app/views/page/base.py
@@ -169,9 +169,15 @@ class PageViewSet(BaseViewSet):
 
     def retrieve(self, request, slug, project_id, pk=None):
         page = self.get_queryset().filter(pk=pk).first()
-        return Response(
-            PageDetailSerializer(page).data, status=status.HTTP_200_OK
-        )
+        if page is None:
+            return Response(
+                {"error": "Page not found"},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+        else:
+            return Response(
+                PageDetailSerializer(page).data, status=status.HTTP_200_OK
+            )
 
     def lock(self, request, slug, project_id, pk):
         page = Page.objects.filter(

--- a/web/components/pages/editor/header/options-dropdown.tsx
+++ b/web/components/pages/editor/header/options-dropdown.tsx
@@ -1,5 +1,5 @@
 import { observer } from "mobx-react";
-import { Clipboard, Copy, Link, Lock } from "lucide-react";
+import { ArchiveRestoreIcon, Clipboard, Copy, Link, Lock, LockOpen } from "lucide-react";
 // document editor
 import { EditorReadOnlyRefApi, EditorRefApi } from "@plane/document-editor";
 // ui
@@ -21,6 +21,9 @@ export const PageOptionsDropdown: React.FC<Props> = observer((props) => {
   const { editorRef, handleDuplicatePage, pageStore } = props;
   // store values
   const {
+    archived_at,
+    is_locked,
+    id,
     archive,
     lock,
     unlock,
@@ -99,7 +102,7 @@ export const PageOptionsDropdown: React.FC<Props> = observer((props) => {
     {
       key: "copy-page-link",
       action: () => {
-        copyUrlToClipboard(`${workspaceSlug}/projects/${projectId}/pages/${pageStore.id}`).then(() =>
+        copyUrlToClipboard(`${workspaceSlug}/projects/${projectId}/pages/${id}`).then(() =>
           setToast({
             type: TOAST_TYPE.SUCCESS,
             title: "Successful!",
@@ -119,32 +122,18 @@ export const PageOptionsDropdown: React.FC<Props> = observer((props) => {
       shouldRender: canCurrentUserDuplicatePage,
     },
     {
-      key: "lock-page",
-      action: handleLockPage,
-      label: "Lock page",
-      icon: Lock,
-      shouldRender: !pageStore.is_locked && canCurrentUserLockPage,
+      key: "lock-unlock-page",
+      action: is_locked ? handleUnlockPage : handleLockPage,
+      label: is_locked ? "Unlock page" : "Lock page",
+      icon: is_locked ? LockOpen : Lock,
+      shouldRender: canCurrentUserLockPage,
     },
     {
-      key: "unlock-page",
-      action: handleUnlockPage,
-      label: "Unlock page",
-      icon: Lock,
-      shouldRender: pageStore.is_locked && canCurrentUserLockPage,
-    },
-    {
-      key: "archive-page",
-      action: handleArchivePage,
-      label: "Archive page",
-      icon: ArchiveIcon,
-      shouldRender: !pageStore.archived_at && canCurrentUserArchivePage,
-    },
-    {
-      key: "restore-page",
-      action: handleRestorePage,
-      label: "Restore page",
-      icon: ArchiveIcon,
-      shouldRender: !!pageStore.archived_at && canCurrentUserArchivePage,
+      key: "archive-restore-page",
+      action: archived_at ? handleRestorePage : handleArchivePage,
+      label: archived_at ? "Restore page" : "Archive page",
+      icon: archived_at ? ArchiveRestoreIcon : ArchiveIcon,
+      shouldRender: canCurrentUserArchivePage,
     },
   ];
 
@@ -166,7 +155,7 @@ export const PageOptionsDropdown: React.FC<Props> = observer((props) => {
         return (
           <CustomMenu.MenuItem key={item.key} onClick={item.action} className="flex items-center gap-2">
             <item.icon className="h-3 w-3" />
-            <div className="text-custom-text-300">{item.label}</div>
+            {item.label}
           </CustomMenu.MenuItem>
         );
       })}

--- a/web/store/pages/project-page.store.ts
+++ b/web/store/pages/project-page.store.ts
@@ -148,7 +148,7 @@ export class ProjectPageStore implements IProjectPageStore {
       });
 
       return pages;
-    } catch {
+    } catch (error) {
       runInAction(() => {
         this.loader = undefined;
         this.error = {
@@ -156,6 +156,7 @@ export class ProjectPageStore implements IProjectPageStore {
           description: "Failed to fetch the pages, Please try again later.",
         };
       });
+      throw error;
     }
   };
 
@@ -181,7 +182,7 @@ export class ProjectPageStore implements IProjectPageStore {
       });
 
       return page;
-    } catch {
+    } catch (error) {
       runInAction(() => {
         this.loader = undefined;
         this.error = {
@@ -189,6 +190,7 @@ export class ProjectPageStore implements IProjectPageStore {
           description: "Failed to fetch the page, Please try again later.",
         };
       });
+      throw error;
     }
   };
 
@@ -213,7 +215,7 @@ export class ProjectPageStore implements IProjectPageStore {
       });
 
       return page;
-    } catch {
+    } catch (error) {
       runInAction(() => {
         this.loader = undefined;
         this.error = {
@@ -221,6 +223,7 @@ export class ProjectPageStore implements IProjectPageStore {
           description: "Failed to create a page, Please try again later.",
         };
       });
+      throw error;
     }
   };
 
@@ -235,7 +238,7 @@ export class ProjectPageStore implements IProjectPageStore {
 
       await this.service.remove(workspaceSlug, projectId, pageId);
       runInAction(() => unset(this.data, [pageId]));
-    } catch {
+    } catch (error) {
       runInAction(() => {
         this.loader = undefined;
         this.error = {
@@ -243,6 +246,7 @@ export class ProjectPageStore implements IProjectPageStore {
           description: "Failed to delete a page, Please try again later.",
         };
       });
+      throw error;
     }
   };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2747,7 +2747,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^18.2.42":
+"@types/react@*", "@types/react@18.2.42", "@types/react@^18.2.42":
   version "18.2.42"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.42.tgz#6f6b11a904f6d96dda3c2920328a97011a00aba7"
   integrity sha512-c1zEr96MjakLYus/wPnuWDo1/zErfdU9rNsIGmE+NV71nx88FG9Ttgo5dqorXTu/LImX2f63WBP986gJkMPNbA==


### PR DESCRIPTION
#### Problems:

1. If a person without access tries to view a private page, the screen gets stuck in a loading state.
2. Admins are able to make a page private.

#### Solutions:

1. Unauthorized pages now show an error state.
2. Only owners can make a page private/public.

#### Media:

<img width="1511" alt="image" src="https://github.com/makeplane/plane/assets/65252264/990d667d-09b6-4860-85e9-45b44da15ed2">

#### Other improvements:

1. All requests in the page store now throw an error from the catch block.
2. Refactored the logic to render items in the page quick actions menu.

#### Plane issue: [WEB-1019](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/cc16f200-e47b-4eb2-b4d3-1ab844057f94)