### PR TITLE
[WEB-1026] chore: clear search query on project change

### DIFF
--- a/web/components/cycles/quick-actions.tsx
+++ b/web/components/cycles/quick-actions.tsx
@@ -168,15 +168,14 @@ export const CycleQuickActions: React.FC<Props> = observer((props) => {
             </span>
           </CustomMenu.MenuItem>
         )}
+        <hr className="my-2 border-custom-border-200" />
         {!isCompleted && isEditingAllowed && (
-          <div className="border-t pt-1 mt-1">
-            <CustomMenu.MenuItem onClick={handleDeleteCycle}>
-              <span className="flex items-center justify-start gap-2">
-                <Trash2 className="h-3 w-3" />
-                <span>Delete cycle</span>
-              </span>
-            </CustomMenu.MenuItem>
-          </div>
+          <CustomMenu.MenuItem onClick={handleDeleteCycle}>
+            <span className="flex items-center justify-start gap-2">
+              <Trash2 className="h-3 w-3" />
+              <span>Delete cycle</span>
+            </span>
+          </CustomMenu.MenuItem>
         )}
       </CustomMenu>
     </>

--- a/web/components/headers/projects.tsx
+++ b/web/components/headers/projects.tsx
@@ -13,7 +13,7 @@ import { FiltersDropdown } from "@/components/issues";
 import { ProjectFiltersSelection, ProjectOrderByDropdown } from "@/components/project";
 import { EUserWorkspaceRoles } from "@/constants/workspace";
 import { cn } from "@/helpers/common.helper";
-import { useApplication, useEventTracker, useMember, useProject, useProjectFilter, useUser } from "@/hooks/store";
+import { useApplication, useEventTracker, useMember, useProjectFilter, useUser } from "@/hooks/store";
 import useOutsideClickDetector from "@/hooks/use-outside-click-detector";
 
 export const ProjectsHeader = observer(() => {
@@ -30,7 +30,6 @@ export const ProjectsHeader = observer(() => {
   const {
     membership: { currentWorkspaceRole },
   } = useUser();
-  const { workspaceProjectIds } = useProject();
   const {
     currentWorkspaceDisplayFilters: displayFilters,
     currentWorkspaceFilters: filters,
@@ -89,52 +88,50 @@ export const ProjectsHeader = observer(() => {
         </div>
       </div>
       <div className="w-full flex items-center justify-end gap-3">
-        {workspaceProjectIds && workspaceProjectIds?.length > 0 && (
-          <div className="flex items-center">
-            {!isSearchOpen && (
-              <button
-                type="button"
-                className="-mr-1 p-2 hover:bg-custom-background-80 rounded text-custom-text-400 grid place-items-center"
-                onClick={() => {
-                  setIsSearchOpen(true);
-                  inputRef.current?.focus();
-                }}
-              >
-                <Search className="h-3.5 w-3.5" />
-              </button>
-            )}
-            <div
-              className={cn(
-                "ml-auto flex items-center justify-start gap-1 rounded-md border border-transparent bg-custom-background-100 text-custom-text-400 w-0 transition-[width] ease-linear overflow-hidden opacity-0",
-                {
-                  "w-64 px-2.5 py-1.5 border-custom-border-200 opacity-100": isSearchOpen,
-                }
-              )}
+        <div className="flex items-center">
+          {!isSearchOpen && (
+            <button
+              type="button"
+              className="-mr-1 p-2 hover:bg-custom-background-80 rounded text-custom-text-400 grid place-items-center"
+              onClick={() => {
+                setIsSearchOpen(true);
+                inputRef.current?.focus();
+              }}
             >
               <Search className="h-3.5 w-3.5" />
-              <input
-                ref={inputRef}
-                className="w-full max-w-[234px] border-none bg-transparent text-sm text-custom-text-100 focus:outline-none"
-                placeholder="Search"
-                value={searchQuery}
-                onChange={(e) => updateSearchQuery(e.target.value)}
-                onKeyDown={handleInputKeyDown}
-              />
-              {isSearchOpen && (
-                <button
-                  type="button"
-                  className="grid place-items-center"
-                  onClick={() => {
-                    updateSearchQuery("");
-                    setIsSearchOpen(false);
-                  }}
-                >
-                  <X className="h-3 w-3" />
-                </button>
-              )}
-            </div>
+            </button>
+          )}
+          <div
+            className={cn(
+              "ml-auto flex items-center justify-start gap-1 rounded-md border border-transparent bg-custom-background-100 text-custom-text-400 w-0 transition-[width] ease-linear overflow-hidden opacity-0",
+              {
+                "w-64 px-2.5 py-1.5 border-custom-border-200 opacity-100": isSearchOpen,
+              }
+            )}
+          >
+            <Search className="h-3.5 w-3.5" />
+            <input
+              ref={inputRef}
+              className="w-full max-w-[234px] border-none bg-transparent text-sm text-custom-text-100 placeholder:text-custom-text-400 focus:outline-none"
+              placeholder="Search"
+              value={searchQuery}
+              onChange={(e) => updateSearchQuery(e.target.value)}
+              onKeyDown={handleInputKeyDown}
+            />
+            {isSearchOpen && (
+              <button
+                type="button"
+                className="grid place-items-center"
+                onClick={() => {
+                  updateSearchQuery("");
+                  setIsSearchOpen(false);
+                }}
+              >
+                <X className="h-3 w-3" />
+              </button>
+            )}
           </div>
-        )}
+        </div>
         <ProjectOrderByDropdown
           value={displayFilters?.order_by}
           onChange={(val) => {

--- a/web/components/inbox/inbox-filter/sorting/order-by.tsx
+++ b/web/components/inbox/inbox-filter/sorting/order-by.tsx
@@ -42,7 +42,7 @@ export const InboxIssueOrderByDropdown: FC = observer(() => {
           {inboxSorting?.order_by?.includes(option.key) && <Check className="h-3 w-3" />}
         </CustomMenu.MenuItem>
       ))}
-      <hr className="my-2" />
+      <hr className="my-2 border-custom-border-200" />
       {INBOX_ISSUE_SORT_BY_OPTIONS.map((option) => (
         <CustomMenu.MenuItem
           key={option.key}

--- a/web/components/modules/dropdowns/order-by.tsx
+++ b/web/components/modules/dropdowns/order-by.tsx
@@ -46,7 +46,7 @@ export const ModuleOrderByDropdown: React.FC<Props> = (props) => {
           {value?.includes(option.key) && <Check className="h-3 w-3" />}
         </CustomMenu.MenuItem>
       ))}
-      <hr className="my-2" />
+      <hr className="my-2 border-custom-border-200" />
       <CustomMenu.MenuItem
         className="flex items-center justify-between gap-2"
         onClick={() => {

--- a/web/components/modules/quick-actions.tsx
+++ b/web/components/modules/quick-actions.tsx
@@ -163,15 +163,14 @@ export const ModuleQuickActions: React.FC<Props> = observer((props) => {
             </span>
           </CustomMenu.MenuItem>
         )}
+        <hr className="my-2 border-custom-border-200" />
         {isEditingAllowed && (
-          <div className="border-t pt-1 mt-1">
-            <CustomMenu.MenuItem onClick={handleDeleteModule}>
-              <span className="flex items-center justify-start gap-2">
-                <Trash2 className="h-3 w-3" />
-                <span>Delete module</span>
-              </span>
-            </CustomMenu.MenuItem>
-          </div>
+          <CustomMenu.MenuItem onClick={handleDeleteModule}>
+            <span className="flex items-center justify-start gap-2">
+              <Trash2 className="h-3 w-3" />
+              <span>Delete module</span>
+            </span>
+          </CustomMenu.MenuItem>
         )}
       </CustomMenu>
     </>

--- a/web/components/pages/list/order-by.tsx
+++ b/web/components/pages/list/order-by.tsx
@@ -47,7 +47,7 @@ export const PageOrderByDropdown: React.FC<Props> = (props) => {
           {sortKey === option.key && <Check className="h-3 w-3" />}
         </CustomMenu.MenuItem>
       ))}
-      <hr className="my-2" />
+      <hr className="my-2 border-custom-border-200" />
       <CustomMenu.MenuItem
         className="flex items-center justify-between gap-2"
         onClick={() => {

--- a/web/components/project/dropdowns/order-by.tsx
+++ b/web/components/project/dropdowns/order-by.tsx
@@ -49,7 +49,7 @@ export const ProjectOrderByDropdown: React.FC<Props> = (props) => {
           {value?.includes(option.key) && <Check className="h-3 w-3" />}
         </CustomMenu.MenuItem>
       ))}
-      <hr className="my-2" />
+      <hr className="my-2 border-custom-border-200" />
       <CustomMenu.MenuItem
         className="flex items-center justify-between gap-2"
         onClick={() => {

--- a/web/store/cycle_filter.store.ts
+++ b/web/store/cycle_filter.store.ts
@@ -63,6 +63,7 @@ export class CycleFilterStore implements ICycleFilterStore {
       (projectId) => {
         if (!projectId) return;
         this.initProjectCycleFilters(projectId);
+        this.searchQuery = "";
       }
     );
   }

--- a/web/store/module_filter.store.ts
+++ b/web/store/module_filter.store.ts
@@ -63,6 +63,7 @@ export class ModuleFilterStore implements IModuleFilterStore {
       (projectId) => {
         if (!projectId) return;
         this.initProjectModuleFilters(projectId);
+        this.searchQuery = "";
       }
     );
   }

--- a/web/store/pages/project-page.store.ts
+++ b/web/store/pages/project-page.store.ts
@@ -1,6 +1,6 @@
 import set from "lodash/set";
 import unset from "lodash/unset";
-import { makeObservable, observable, runInAction, action } from "mobx";
+import { makeObservable, observable, runInAction, action, reaction } from "mobx";
 import { computedFn } from "mobx-utils";
 // types
 import { TPage, TPageFilters, TPageNavigationTabs } from "@plane/types";
@@ -64,8 +64,16 @@ export class ProjectPageStore implements IProjectPageStore {
       createPage: action,
       removePage: action,
     });
-
+    // service
     this.service = new PageService();
+    // initialize display filters of the current project
+    reaction(
+      () => this.store.app.router.projectId,
+      (projectId) => {
+        if (!projectId) return;
+        this.filters.searchQuery = "";
+      }
+    );
   }
 
   /**

--- a/web/store/project/project_filter.store.ts
+++ b/web/store/project/project_filter.store.ts
@@ -59,6 +59,7 @@ export class ProjectFilterStore implements IProjectFilterStore {
       (workspaceSlug) => {
         if (!workspaceSlug) return;
         this.initWorkspaceFilters(workspaceSlug);
+        this.searchQuery = "";
       }
     );
   }


### PR DESCRIPTION
#### Problem:

1. When searching for a page, cycle or a module using the input field, the search query persists across projects. The search query also persists for projects list search across workspaces.

#### Solution:

1. Added a `reaction` in the respective stores to clear the search query on `projectId` change from the route.

#### Other improvements:

1. Fixed the empty state of modules list page on search via query.

#### Plane issue: [WEB-1026](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/a493b265-1371-4b0d-a1f5-fbef6975e017)