### PR TITLE
[WEB-936] chore: add loader when updating issue's cycle/ module in list and kanban layout.

### DIFF
--- a/web/components/inbox/modals/create-edit-modal/issue-properties.tsx
+++ b/web/components/inbox/modals/create-edit-modal/issue-properties.tsx
@@ -118,7 +118,7 @@ export const InboxIssueProperties: FC<TInboxIssueProperties> = observer((props) 
         <div className="h-7">
           <CycleDropdown
             value={data?.cycle_id || ""}
-            onChange={(cycleId) => handleData("cycle_id", cycleId)}
+            onChange={async (cycleId) => handleData("cycle_id", cycleId)}
             projectId={projectId}
             placeholder="Cycle"
             buttonVariant="border-with-text"
@@ -131,7 +131,7 @@ export const InboxIssueProperties: FC<TInboxIssueProperties> = observer((props) 
         <div className="h-7">
           <ModuleDropdown
             value={data?.module_ids || []}
-            onChange={(moduleIds) => handleData("module_ids", moduleIds)}
+            onChange={async (moduleIds) => handleData("module_ids", moduleIds)}
             projectId={projectId}
             placeholder="Modules"
             buttonVariant="border-with-text"

--- a/web/components/issues/issue-layouts/properties/all-properties.tsx
+++ b/web/components/issues/issue-layouts/properties/all-properties.tsx
@@ -148,7 +148,7 @@ export const IssueProperties: React.FC<IIssueProperties> = observer((props) => {
   };
 
   const handleModule = useCallback(
-    (moduleIds: string[] | null) => {
+    async (moduleIds: string[] | null) => {
       if (!issue || !issue.module_ids || !moduleIds) return;
 
       const updatedModuleIds = xor(issue.module_ids, moduleIds);
@@ -157,8 +157,8 @@ export const IssueProperties: React.FC<IIssueProperties> = observer((props) => {
       for (const moduleId of updatedModuleIds)
         if (issue.module_ids.includes(moduleId)) modulesToRemove.push(moduleId);
         else modulesToAdd.push(moduleId);
-      if (modulesToAdd.length > 0) issueOperations.addModulesToIssue(modulesToAdd);
-      if (modulesToRemove.length > 0) issueOperations.removeModulesFromIssue(modulesToRemove);
+      if (modulesToAdd.length > 0) await issueOperations.addModulesToIssue(modulesToAdd);
+      if (modulesToRemove.length > 0) await issueOperations.removeModulesFromIssue(modulesToRemove);
 
       captureIssueEvent({
         eventName: ISSUE_UPDATED,
@@ -171,10 +171,10 @@ export const IssueProperties: React.FC<IIssueProperties> = observer((props) => {
   );
 
   const handleCycle = useCallback(
-    (cycleId: string | null) => {
+    async (cycleId: string | null) => {
       if (!issue || issue.cycle_id === cycleId) return;
-      if (cycleId) issueOperations.addIssueToCycle?.(cycleId);
-      else issueOperations.removeIssueFromCycle?.(issue.cycle_id ?? "");
+      if (cycleId) await issueOperations.addIssueToCycle?.(cycleId);
+      else await issueOperations.removeIssueFromCycle?.(issue.cycle_id ?? "");
 
       captureIssueEvent({
         eventName: ISSUE_UPDATED,

--- a/web/components/issues/issue-modal/form.tsx
+++ b/web/components/issues/issue-modal/form.tsx
@@ -602,7 +602,7 @@ export const IssueFormRoot: FC<IssueFormProps> = observer((props) => {
                       <div className="h-7">
                         <CycleDropdown
                           projectId={projectId}
-                          onChange={(cycleId) => {
+                          onChange={async (cycleId) => {
                             onChange(cycleId);
                             handleFormChange();
                           }}
@@ -624,7 +624,7 @@ export const IssueFormRoot: FC<IssueFormProps> = observer((props) => {
                         <ModuleDropdown
                           projectId={projectId}
                           value={value ?? []}
-                          onChange={(moduleIds) => {
+                          onChange={async (moduleIds) => {
                             onChange(moduleIds);
                             handleFormChange();
                           }}


### PR DESCRIPTION
#### Problem
Updating cycle/ module detail of the issue through list and kanban layout doesn't have any loader leading to poor UX. 

#### Solution
Added loader while updating the above properties.

#### Media
* Before

[scrnli_4_18_2024_11-46-36 AM.webm](https://github.com/makeplane/plane/assets/33979846/99fa6c2c-0a0a-4129-83c3-2bcf52ad58c3)

**Note:** In the above demo I'm using local backend. In production server there will be some delay while updating these properties and no loader were implemented previously.

* After

[scrnli_4_18_2024_11-45-54 AM.webm](https://github.com/makeplane/plane/assets/33979846/480e43cd-90ad-4708-8fb5-42df6e118fe7)


This PR is linked to [WEB-936](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/af5465c3-99d2-440b-a481-177a9427a529)