### PR TITLE
[WEB-872] chore: add tooltip to peek overview header icons.

### DIFF
--- a/web/components/issues/peek-overview/header.tsx
+++ b/web/components/issues/peek-overview/header.tsx
@@ -112,22 +112,28 @@ export const IssuePeekOverviewHeader: FC<PeekOverviewHeaderProps> = observer((pr
       }`}
     >
       <div className="flex items-center gap-4">
-        <button onClick={removeRoutePeekId}>
-          <MoveRight className="h-4 w-4 text-custom-text-300 hover:text-custom-text-200" />
-        </button>
+        <Tooltip tooltipContent="Close the peek view" isMobile={isMobile}>
+          <button onClick={removeRoutePeekId}>
+            <MoveRight className="h-4 w-4 text-custom-text-300 hover:text-custom-text-200" />
+          </button>
+        </Tooltip>
 
-        <Link href={`/${issueLink}`} onClick={() => removeRoutePeekId()}>
-          <MoveDiagonal className="h-4 w-4 text-custom-text-300 hover:text-custom-text-200" />
-        </Link>
+        <Tooltip tooltipContent="Open issue in full screen" isMobile={isMobile}>
+          <Link href={`/${issueLink}`} onClick={() => removeRoutePeekId()}>
+            <MoveDiagonal className="h-4 w-4 text-custom-text-300 hover:text-custom-text-200" />
+          </Link>
+        </Tooltip>
         {currentMode && (
           <div className="flex flex-shrink-0 items-center gap-2">
             <CustomSelect
               value={currentMode}
               onChange={(val: any) => setPeekMode(val)}
               customButton={
-                <button type="button" className="">
-                  <currentMode.icon className="h-4 w-4 text-custom-text-300 hover:text-custom-text-200" />
-                </button>
+                <Tooltip tooltipContent="Toggle peek view layout" isMobile={isMobile}>
+                  <button type="button" className="">
+                    <currentMode.icon className="h-4 w-4 text-custom-text-300 hover:text-custom-text-200" />
+                  </button>
+                </Tooltip>
               }
             >
               {PEEK_OPTIONS.map((mode) => (


### PR DESCRIPTION
Added tooltips to peek overview `close`, `issue detail` and `toggle layout` icons.

#### Media
![image](https://github.com/makeplane/plane/assets/33979846/87a4dacd-2790-458b-bce4-f5e9d8d4d4c7)
![image](https://github.com/makeplane/plane/assets/33979846/e442e233-8215-4af1-bd21-a135a07bcf34)
![image](https://github.com/makeplane/plane/assets/33979846/3d22dd08-49b5-4b7a-bdf7-6ffa84f69007)

This PR is linked to [WEB-872](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/2dddb829-6c11-4535-8c99-723cd255e12c)