### PR TITLE
[WEB-871] chore: update leave project modal message in members settings page.

### DIFF
--- a/web/components/project/confirm-project-member-remove.tsx
+++ b/web/components/project/confirm-project-member-remove.tsx
@@ -41,7 +41,7 @@ export const ConfirmProjectMemberRemove: React.FC<Props> = observer((props) => {
     handleClose();
   };
 
-  if (!projectId) return;
+  if (!projectId) return <></>;
 
   const isCurrentUser = currentUser?.id === data?.id;
   const currentProjectDetails = getProjectById(projectId.toString());

--- a/web/components/project/confirm-project-member-remove.tsx
+++ b/web/components/project/confirm-project-member-remove.tsx
@@ -1,13 +1,14 @@
 import React, { useState } from "react";
 import { observer } from "mobx-react-lite";
+import { useRouter } from "next/router";
 import { AlertTriangle } from "lucide-react";
 import { Dialog, Transition } from "@headlessui/react";
-import { IUserLite } from "@plane/types";
-// hooks
-import { Button } from "@plane/ui";
-import { useUser } from "@/hooks/store";
-// ui
 // types
+import { IUserLite } from "@plane/types";
+// ui
+import { Button } from "@plane/ui";
+// hooks
+import { useProject, useUser } from "@/hooks/store";
 
 type Props = {
   data: IUserLite;
@@ -18,10 +19,14 @@ type Props = {
 
 export const ConfirmProjectMemberRemove: React.FC<Props> = observer((props) => {
   const { data, onSubmit, isOpen, onClose } = props;
+  // router
+  const router = useRouter();
+  const { projectId } = router.query;
   // states
   const [isDeleteLoading, setIsDeleteLoading] = useState(false);
   // store hooks
   const { currentUser } = useUser();
+  const { getProjectById } = useProject();
 
   const handleClose = () => {
     onClose();
@@ -36,7 +41,10 @@ export const ConfirmProjectMemberRemove: React.FC<Props> = observer((props) => {
     handleClose();
   };
 
+  if (!projectId) return;
+
   const isCurrentUser = currentUser?.id === data?.id;
+  const currentProjectDetails = getProjectById(projectId.toString());
 
   return (
     <Transition.Root show={isOpen} as={React.Fragment}>
@@ -76,9 +84,19 @@ export const ConfirmProjectMemberRemove: React.FC<Props> = observer((props) => {
                       </Dialog.Title>
                       <div className="mt-2">
                         <p className="text-sm text-custom-text-200">
-                          Are you sure you want to remove member-{" "}
-                          <span className="font-bold">{data?.display_name}</span>? They will no longer have access to
-                          this project. This action cannot be undone.
+                          {isCurrentUser ? (
+                            <>
+                              Are you sure you want to leave the{" "}
+                              <span className="font-bold">{currentProjectDetails?.name}</span> project? You will be able
+                              to join the project if invited again or if it{"'"}s public.
+                            </>
+                          ) : (
+                            <>
+                              Are you sure you want to remove member-{" "}
+                              <span className="font-bold">{data?.display_name}</span>? They will no longer have access
+                              to this project. This action cannot be undone.
+                            </>
+                          )}
                         </p>
                       </div>
                     </div>


### PR DESCRIPTION
#### Problem
When leaving the project through members settings page, the UX copy was incorrect. 

#### Solution
Updated the UX copy.

#### Media
* Before
![image](https://github.com/makeplane/plane/assets/33979846/509b5b95-f833-4153-8989-b9d85cb07242)

* After
![image](https://github.com/makeplane/plane/assets/33979846/5f028ca8-85ed-47db-8616-c0a2be705b20)

This PR is linked to [WEB-871](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/25613712-a939-4710-9dbb-f7cab1be0a51)