### PR TITLE
[WEB-1028] fix: enable comments and issue reactions for guest/ viewer.

### DIFF
--- a/web/components/issues/issue-detail/main-content.tsx
+++ b/web/components/issues/issue-detail/main-content.tsx
@@ -24,11 +24,12 @@ type Props = {
   issueId: string;
   issueOperations: TIssueOperations;
   isEditable: boolean;
+  isArchived: boolean;
   swrIssueDetails: TIssue | null | undefined;
 };
 
 export const IssueMainContent: React.FC<Props> = observer((props) => {
-  const { workspaceSlug, projectId, issueId, issueOperations, isEditable, swrIssueDetails } = props;
+  const { workspaceSlug, projectId, issueId, issueOperations, isEditable, isArchived, swrIssueDetails } = props;
   // states
   const [isSubmitting, setIsSubmitting] = useState<"submitting" | "submitted" | "saved">("saved");
   // hooks
@@ -105,6 +106,7 @@ export const IssueMainContent: React.FC<Props> = observer((props) => {
             projectId={projectId}
             issueId={issueId}
             currentUser={currentUser}
+            disabled={isArchived}
           />
         )}
 
@@ -126,7 +128,7 @@ export const IssueMainContent: React.FC<Props> = observer((props) => {
         disabled={!isEditable}
       />
 
-      <IssueActivity workspaceSlug={workspaceSlug} projectId={projectId} issueId={issueId} disabled={!isEditable} />
+      <IssueActivity workspaceSlug={workspaceSlug} projectId={projectId} issueId={issueId} disabled={isArchived} />
     </>
   );
 });

--- a/web/components/issues/issue-detail/root.tsx
+++ b/web/components/issues/issue-detail/root.tsx
@@ -365,6 +365,7 @@ export const IssueDetailRoot: FC<TIssueDetailRoot> = observer((props) => {
               issueId={issueId}
               issueOperations={issueOperations}
               isEditable={!is_archived && isEditable}
+              isArchived={is_archived}
             />
           </div>
           <div

--- a/web/components/issues/peek-overview/issue-detail.tsx
+++ b/web/components/issues/peek-overview/issue-detail.tsx
@@ -16,12 +16,13 @@ interface IPeekOverviewIssueDetails {
   issueId: string;
   issueOperations: TIssueOperations;
   disabled: boolean;
+  isArchived: boolean;
   isSubmitting: "submitting" | "submitted" | "saved";
   setIsSubmitting: (value: "submitting" | "submitted" | "saved") => void;
 }
 
 export const PeekOverviewIssueDetails: FC<IPeekOverviewIssueDetails> = observer((props) => {
-  const { workspaceSlug, issueId, issueOperations, disabled, isSubmitting, setIsSubmitting } = props;
+  const { workspaceSlug, issueId, issueOperations, disabled, isArchived, isSubmitting, setIsSubmitting } = props;
   // store hooks
   const { getProjectById } = useProject();
   const { currentUser } = useUser();
@@ -88,7 +89,7 @@ export const PeekOverviewIssueDetails: FC<IPeekOverviewIssueDetails> = observer(
           projectId={issue.project_id}
           issueId={issueId}
           currentUser={currentUser}
-          disabled={disabled}
+          disabled={isArchived}
         />
       )}
     </div>

--- a/web/components/issues/peek-overview/view.tsx
+++ b/web/components/issues/peek-overview/view.tsx
@@ -157,6 +157,7 @@ export const IssueView: FC<IIssueView> = observer((props) => {
                           issueId={issueId}
                           issueOperations={issueOperations}
                           disabled={disabled || is_archived}
+                          isArchived={is_archived}
                           isSubmitting={isSubmitting}
                           setIsSubmitting={(value) => setIsSubmitting(value)}
                         />
@@ -190,7 +191,7 @@ export const IssueView: FC<IIssueView> = observer((props) => {
                           workspaceSlug={workspaceSlug}
                           projectId={projectId}
                           issueId={issueId}
-                          disabled={disabled || is_archived}
+                          disabled={is_archived}
                         />
                       </div>
                     ) : (
@@ -203,6 +204,7 @@ export const IssueView: FC<IIssueView> = observer((props) => {
                               issueId={issueId}
                               issueOperations={issueOperations}
                               disabled={disabled || is_archived}
+                              isArchived={is_archived}
                               isSubmitting={isSubmitting}
                               setIsSubmitting={(value) => setIsSubmitting(value)}
                             />
@@ -228,7 +230,7 @@ export const IssueView: FC<IIssueView> = observer((props) => {
                               workspaceSlug={workspaceSlug}
                               projectId={projectId}
                               issueId={issueId}
-                              disabled={disabled || is_archived}
+                              disabled={is_archived}
                             />
                           </div>
                         </div>


### PR DESCRIPTION
#### Problem
Comments got disabled for guests/ viewers while we were disabling it for archived issue.

#### Solution
Added separate validation based on user role and issue archival status to only disable comments when issue is archived.

This PR is linked to [WEB-1028 ](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/e5f4c457-bfbf-45ce-8a9b-b68a19ab8242)