### PR TITLE
[WEB-929] fix: comment text editor user mention validation added

### DIFF
--- a/space/components/editor/lite-text-editor.tsx
+++ b/space/components/editor/lite-text-editor.tsx
@@ -34,10 +34,9 @@ export const LiteTextEditor = React.forwardRef<EditorRefApi, LiteTextEditorWrapp
     return !!ref && typeof ref === "object" && "current" in ref;
   }
   const isEmpty =
-    props.initialValue === "" ||
     props.initialValue?.trim() === "" ||
     props.initialValue === "<p></p>" ||
-    isEmptyHtmlString(props.initialValue ?? "");
+    (isEmptyHtmlString(props.initialValue ?? "") && !props.initialValue?.includes("mention-component"));
 
   return (
     <div className="border border-custom-border-200 rounded p-3 space-y-3">

--- a/web/components/editor/lite-text-editor/lite-text-editor.tsx
+++ b/web/components/editor/lite-text-editor/lite-text-editor.tsx
@@ -59,10 +59,9 @@ export const LiteTextEditor = React.forwardRef<EditorRefApi, LiteTextEditorWrapp
   });
 
   const isEmpty =
-    props.initialValue === "" ||
     props.initialValue?.trim() === "" ||
     props.initialValue === "<p></p>" ||
-    isEmptyHtmlString(props.initialValue ?? "");
+    (isEmptyHtmlString(props.initialValue ?? "") && !props.initialValue?.includes("mention-component"));
 
   function isMutableRefObject<T>(ref: React.ForwardedRef<T>): ref is React.MutableRefObject<T | null> {
     return !!ref && typeof ref === "object" && "current" in ref;


### PR DESCRIPTION
#### Problem:
- Recent refactoring of the editor has altered the validation for empty comments, causing the comment button to be disabled when mentioning someone.

#### Resolution:
- I have addressed this issue by implementing necessary validation.

#### Issue link: [[WEB-929]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/e0508ce6-df5c-41c5-b3b4-955c855c2b40)