### PR TITLE
[WEB-1015] fix: kanban layout cycle and module quick add

### DIFF
--- a/web/store/issue/cycle/issue.store.ts
+++ b/web/store/issue/cycle/issue.store.ts
@@ -269,6 +269,10 @@ export class CycleIssues extends IssueHelperStore implements ICycleIssues {
       });
 
       const response = await this.createIssue(workspaceSlug, projectId, data, cycleId);
+
+      if (data.module_ids && data.module_ids.length > 0)
+        await this.rootStore.moduleIssues.addModulesToIssue(workspaceSlug, projectId, response.id, data.module_ids);
+
       this.rootIssueStore.rootStore.cycle.fetchCycleDetails(workspaceSlug, projectId, cycleId);
 
       const quickAddIssueIndex = this.issues[cycleId].findIndex((_issueId) => _issueId === data.id);

--- a/web/store/issue/module/issue.store.ts
+++ b/web/store/issue/module/issue.store.ts
@@ -274,6 +274,10 @@ export class ModuleIssues extends IssueHelperStore implements IModuleIssues {
       });
 
       const response = await this.createIssue(workspaceSlug, projectId, data, moduleId);
+
+      if (data.cycle_id && data.cycle_id !== "")
+        await this.rootStore.cycleIssues.addIssueToCycle(workspaceSlug, projectId, data.cycle_id, [response.id]);
+
       this.rootIssueStore.rootStore.module.fetchModuleDetails(workspaceSlug, projectId, moduleId);
 
       const quickAddIssueIndex = this.issues[moduleId].findIndex((_issueId) => _issueId === data.id);

--- a/web/store/issue/project-views/issue.store.ts
+++ b/web/store/issue/project-views/issue.store.ts
@@ -239,6 +239,12 @@ export class ProjectViewIssues extends IssueHelperStore implements IProjectViewI
 
       const response = await this.createIssue(workspaceSlug, projectId, data, viewId);
 
+      if (data.cycle_id && data.cycle_id !== "")
+        await this.rootStore.cycleIssues.addIssueToCycle(workspaceSlug, projectId, data.cycle_id, [response.id]);
+
+      if (data.module_ids && data.module_ids.length > 0)
+        await this.rootStore.moduleIssues.addModulesToIssue(workspaceSlug, projectId, response.id, data.module_ids);
+
       const quickAddIssueIndex = this.issues[viewId].findIndex((_issueId) => _issueId === data.id);
       if (quickAddIssueIndex >= 0)
         runInAction(() => {

--- a/web/store/issue/project/issue.store.ts
+++ b/web/store/issue/project/issue.store.ts
@@ -223,6 +223,12 @@ export class ProjectIssues extends IssueHelperStore implements IProjectIssues {
 
       const response = await this.createIssue(workspaceSlug, projectId, data);
 
+      if (data.cycle_id && data.cycle_id !== "")
+        await this.rootStore.cycleIssues.addIssueToCycle(workspaceSlug, projectId, data.cycle_id, [response.id]);
+
+      if (data.module_ids && data.module_ids.length > 0)
+        await this.rootStore.moduleIssues.addModulesToIssue(workspaceSlug, projectId, response.id, data.module_ids);
+
       const quickAddIssueIndex = this.issues[projectId].findIndex((_issueId) => _issueId === data.id);
       if (quickAddIssueIndex >= 0)
         runInAction(() => {


### PR DESCRIPTION
#### Problem:
- Quick add isn't functioning correctly in the kanban layout when grouped by cycle or module.

#### Resolution:
- Addressed this issue by implementing the required changes in the store.

#### Issue link: [[WEB-1015]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/c3314e14-96c2-41ab-9bb1-866bb26748f0)

#### Media:
| Before | After |
|--------|--------|
| ![2a6f61d4-cd52-438a-be91-a67ebb34a111](https://github.com/makeplane/plane/assets/121005188/e6c733f6-4ec1-4e2f-8f35-316a2d6cd054) | ![39544a49-b542-409a-be0e-60d65dd18c7e](https://github.com/makeplane/plane/assets/121005188/8384b3b6-fb35-4d13-a02d-8b4fed445a6e) | 