### PR TITLE
[WEB-] chore: remove input field label from the create page modal

### DIFF
--- a/packages/editor/extensions/src/styles/drag-drop.css
+++ b/packages/editor/extensions/src/styles/drag-drop.css
@@ -65,14 +65,17 @@
 }
 
 .ProseMirror:not(.dragging) .ProseMirror-selectednode::after {
+  --horizontal-offset: 5px;
+
   content: "";
   position: absolute;
   top: 0;
-  left: -5px;
+  left: calc(-1 * var(--horizontal-offset));
   height: 100%;
-  width: 100%;
+  width: calc(100% + (var(--horizontal-offset) * 2));
   background-color: rgba(var(--color-primary-100), 0.2);
   border-radius: 4px;
+  pointer-events: none;
 }
 
 .ProseMirror img {

--- a/web/components/pages/modals/page-form.tsx
+++ b/web/components/pages/modals/page-form.tsx
@@ -39,26 +39,17 @@ export const PageForm: React.FC<Props> = (props) => {
     <form onSubmit={handlePageFormSubmit}>
       <div className="space-y-4">
         <h3 className="text-lg font-medium leading-6 text-custom-text-100">Create Page</h3>
-
-        <div className="space-y-2">
-          <div>
-            <div className="text-custom-text-200">Name</div>
-            <div className="text-xs text-custom-text-300">
-              Max length of the name should be less than 255 characters
-            </div>
-          </div>
-          <Input
-            id="name"
-            type="text"
-            value={formData.name}
-            onChange={(e) => handleFormData("name", e.target.value)}
-            placeholder="Title"
-            className="w-full resize-none text-lg"
-            tabIndex={1}
-            required
-            maxLength={255}
-          />
-        </div>
+        <Input
+          id="name"
+          type="text"
+          value={formData.name}
+          onChange={(e) => handleFormData("name", e.target.value)}
+          placeholder="Title"
+          className="w-full resize-none text-lg"
+          tabIndex={1}
+          required
+          maxLength={255}
+        />
       </div>
 
       <div className="mt-5 relative flex items-center justify-between gap-2">


### PR DESCRIPTION
#### Improvements:

1. Removed the redundant input field label from the Page title field in the create Page modal.

#### Media:

| Before | After |
|--------|--------|
| <img width="1134" alt="image" src="https://github.com/makeplane/plane/assets/65252264/cac20f4e-f474-4894-8b68-5735a3076721"> | <img width="1134" alt="image" src="https://github.com/makeplane/plane/assets/65252264/f494845b-f395-456f-a428-0c67e12ecdf4"> | 

#### Plane issue: [WEB-]()