### PR TITLE
[WEB-1041] fix: preserve initial value on create more issues

### DIFF
--- a/web/components/issues/issue-modal/form.tsx
+++ b/web/components/issues/issue-modal/form.tsx
@@ -190,6 +190,7 @@ export const IssueFormRoot: FC<IssueFormProps> = observer((props) => {
 
     reset({
       ...defaultValues,
+      ...(isCreateMoreToggleEnabled ? { ...data } : {}),
       project_id: getValues("project_id"),
       description_html: data?.description_html ?? "<p></p>",
     });


### PR DESCRIPTION
#### Problem:
- The initial value is not retained when creating an issue with the "create more" toggle enabled.

#### Resolution:
- Resolve this by adjusting the form reset to include the provided data when the "create more" toggle is active.

#### Issue link: [[WEB-1041]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/ef0c79fb-6b77-410c-a57d-6fcce07adc2d)

#### Media:
| Before | After |
|--------|--------|
| ![93911db0-636e-4a50-bb14-3be5a754e412](https://github.com/makeplane/plane/assets/121005188/28478de4-f7f7-47c8-8f34-e950738d6b78) | ![d7fbb1fe-07c8-406d-b825-c0841f640522](https://github.com/makeplane/plane/assets/121005188/d635e012-b724-4d53-8c7f-077cfa76d7c8) | 