### PR TITLE
[WEB-1009] chore: active cycle stats improvement

### DIFF
--- a/web/components/core/sidebar/single-progress-stats.tsx
+++ b/web/components/core/sidebar/single-progress-stats.tsx
@@ -1,7 +1,5 @@
 import React from "react";
 
-import { CircularProgressIndicator } from "@plane/ui";
-
 type TSingleProgressStatsProps = {
   title: any;
   completed: number;
@@ -26,9 +24,6 @@ export const SingleProgressStats: React.FC<TSingleProgressStatsProps> = ({
     <div className="w-1/2">{title}</div>
     <div className="flex w-1/2 items-center justify-end gap-1 px-2">
       <div className="flex h-5 items-center justify-center gap-1">
-        <span className="h-4 w-4">
-          <CircularProgressIndicator percentage={(completed / total) * 100} size={14} strokeWidth={2} />
-        </span>
         <span className="w-8 text-right">
           {isNaN(Math.round((completed / total) * 100)) ? "0" : Math.round((completed / total) * 100)}%
         </span>


### PR DESCRIPTION
#### Changes:
In this PR, I've updated the progress stats UI, specifically by removing the circular progress bar.

#### Issue link: [[WEB-1009]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/82dff199-9843-4a50-81c5-09b61fd2ada1)

#### Media:
| Before | After |
|--------|--------|
| ![before](https://github.com/makeplane/plane/assets/121005188/b27ce07b-a720-4191-a7fa-a485f9418fec) | ![after](https://github.com/makeplane/plane/assets/121005188/a4f3b799-a3a3-4ba1-933b-ebd83bde36f7) | 
