### PR TITLE
[WEB-1021] fix: empty state action button permission

### DIFF
--- a/web/components/empty-state/empty-state.tsx
+++ b/web/components/empty-state/empty-state.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { observer } from "mobx-react";
 import Image from "next/image";
 import Link from "next/link";
 
@@ -23,7 +24,7 @@ export type EmptyStateProps = {
   secondaryButtonOnClick?: () => void;
 };
 
-export const EmptyState: React.FC<EmptyStateProps> = (props) => {
+export const EmptyState: React.FC<EmptyStateProps> = observer((props) => {
   const {
     type,
     size = "lg",
@@ -173,4 +174,4 @@ export const EmptyState: React.FC<EmptyStateProps> = (props) => {
       )}
     </>
   );
-};
+});


### PR DESCRIPTION
#### Problem:
- Dashboard empty state button remains disabled upon initial load, even when the user has admin permissions.

#### Resolution:
- I've resolved this by adding mobx observer into the empty state component.

#### Issue link: [[WEB-1021]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/dbcf79b4-3f8d-497c-bb55-b93f57b3d888)

#### Media:
| Before | After |
|--------|--------|
| ![before](https://github.com/makeplane/plane/assets/121005188/d4aa79ec-335c-4965-a678-47006de089dc) | ![after](https://github.com/makeplane/plane/assets/121005188/681d89f0-bb38-4a23-a31d-76d246843355) | 