### PR TITLE
[WEB-870] chore: delete label modal content updated

### DIFF
--- a/web/components/labels/delete-label-modal.tsx
+++ b/web/components/labels/delete-label-modal.tsx
@@ -91,9 +91,9 @@ export const DeleteLabelModal: React.FC<Props> = observer((props) => {
                       </Dialog.Title>
                       <div className="mt-2">
                         <p className="text-sm text-custom-text-200">
-                          Are you sure you want to delete label-{" "}
-                          <span className="font-medium text-custom-text-100">{data?.name}</span>? The label will be
-                          removed from all the issues.
+                          Are you sure you wish to delete{" "}
+                          <span className="font-medium text-custom-text-100">{data?.name}</span>? This will remove the
+                          label from all the issue and from any views where the label is being filtered upon.
                         </p>
                       </div>
                     </div>


### PR DESCRIPTION
#### Changes:
- In this PR, I've revised the content of the modal for deleting labels.

#### Issue link: [[WEB-870]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/19590aab-328a-46ec-86bf-109e93f4112d)

#### Media:
| Before | After |
|--------|--------|
| ![before](https://github.com/makeplane/plane/assets/121005188/4a9215d9-e251-406d-806e-b2bc8a059b3b) | ![after](https://github.com/makeplane/plane/assets/121005188/3aa08ac6-1c17-40f6-9898-41a94a7a657a) | 