### PR TITLE
[WEB-1051] fix: filter state option order

### DIFF
--- a/web/components/issues/issue-layouts/filters/header/filters/state.tsx
+++ b/web/components/issues/issue-layouts/filters/header/filters/state.tsx
@@ -26,7 +26,7 @@ export const FilterState: React.FC<Props> = observer((props) => {
   const sortedOptions = useMemo(() => {
     const filteredOptions = (states ?? []).filter((s) => s.name.toLowerCase().includes(searchQuery.toLowerCase()));
 
-    return sortBy(filteredOptions, [(s) => !(appliedFilters ?? []).includes(s.id), (s) => s.name.toLowerCase()]);
+    return sortBy(filteredOptions, [(s) => !(appliedFilters ?? []).includes(s.id)]);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchQuery]);
 


### PR DESCRIPTION
#### Problem:
- Currently, filter state options are listed alphabetically instead of following intended order: 
Backlog group > Unstarted group > Started group > Completed group > Cancelled group.

#### Solution:
- I've reordered the filter state options to match the correct sequence.

#### Issue link: [[WEB-1051]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/4528f851-ae35-4c7b-91a0-2193eaf5e92f)

#### Media:
| Before | After |
|--------|--------|
| ![WEB-1051-B](https://github.com/makeplane/plane/assets/121005188/b53eb83e-f213-4b22-b196-f02e5ba07780) | ![WEB-1051-A](https://github.com/makeplane/plane/assets/121005188/a9f17cdf-5521-45f9-b44f-45416834104c) | 