### PR TITLE
[WEB-1074] chore: clear search term on escape key

### DIFF
--- a/web/components/command-palette/command-modal.tsx
+++ b/web/components/command-palette/command-modal.tsx
@@ -178,7 +178,9 @@ export const CommandModal: React.FC = observer(() => {
                       return 0;
                     }}
                     onKeyDown={(e) => {
-                      // when search is empty and page is undefined
+                      // when search term is not empty, esc should clear the search term
+                      if (e.key === "Escape" && searchTerm) setSearchTerm("");
+
                       // when user tries to close the modal with esc
                       if (e.key === "Escape" && !page && !searchTerm) closePalette();
 


### PR DESCRIPTION
#### Problem:

1. Pressing `Esc` key on the Command K modal when search term is present doesn't do anything.

#### Solution:

1. Pressing `Esc` key now clears the search term.

#### Plane issue: [WEB-1074](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/1add9d74-8f45-4542-8d63-22b785fb6c00)