### PR TITLE
[WEB-1071] chore: show sub-issue option added to profile display filter

### DIFF
--- a/web/constants/issue.ts
+++ b/web/constants/issue.ts
@@ -160,7 +160,7 @@ export const ISSUE_DISPLAY_FILTERS_BY_LAYOUT: {
       },
       extra_options: {
         access: true,
-        values: ["show_empty_groups"],
+        values: ["show_empty_groups", "sub_issue"],
       },
     },
     kanban: {


### PR DESCRIPTION
#### Changes:
- This PR adds show sub-issues option to profile display filter.

#### Issue link: [[WEB-1071]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/49fdcc9c-9c2e-419f-98be-4fed9c197f8d)

#### Media:
| Before | After |
|--------|--------|
| ![before](https://github.com/makeplane/plane/assets/121005188/fc194128-a9a7-4303-88da-453f733b26cb) | ![after](https://github.com/makeplane/plane/assets/121005188/90488153-b456-4b7f-85a0-8b5d4433d28f) | 
