### PR TITLE
[WEB-1070] chore: project active cycle linear progress and state list color consistency

### DIFF
--- a/web/constants/cycle.ts
+++ b/web/constants/cycle.ts
@@ -93,29 +93,24 @@ export const CYCLE_STATUS: {
 
 export const CYCLE_STATE_GROUPS_DETAILS = [
   {
-    key: "backlog_issues",
-    title: "Backlog",
-    color: "#F0F0F3",
-  },
-  {
-    key: "unstarted_issues",
-    title: "Unstarted",
-    color: "#FB923C",
+    key: "completed_issues",
+    title: "Completed",
+    color: "#6490FE",
   },
   {
     key: "started_issues",
     title: "Started",
-    color: "#FFC53D",
+    color: "#FDD97F",
   },
   {
-    key: "completed_issues",
-    title: "Completed",
-    color: "#d687ff",
+    key: "unstarted_issues",
+    title: "Unstarted",
+    color: "#FEB055",
   },
   {
-    key: "cancelled_issues",
-    title: "Cancelled",
-    color: "#ef4444",
+    key: "backlog_issues",
+    title: "Backlog",
+    color: "#F0F0F3",
   },
 ];
 


### PR DESCRIPTION
#### Changes:
This PR ensures that the colors used for the active cycle linear progress and state list are consistent. Previously, they were different, causing visual inconsistency. This change enhances the overall appearance and user experience of the project.

#### Issue link: [[WEB-1070]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/a9939739-42b3-4c7a-8883-2042eb35ed6f)

#### Media:
| Before | After |
|--------|--------|
| ![before](https://github.com/makeplane/plane/assets/121005188/6256ebfc-1ca8-4937-a86a-1c5a6c8c6487) | ![after](https://github.com/makeplane/plane/assets/121005188/bae1f65b-2f73-4896-b19e-029de2bef3c7)