### PR TITLE
[WEB-1085] chore: pages order by options

### DIFF
--- a/web/constants/page.ts
+++ b/web/constants/page.ts
@@ -23,7 +23,6 @@ export const PAGE_SORTING_KEY_OPTIONS: {
   { key: "name", label: "Name" },
   { key: "created_at", label: "Date created" },
   { key: "updated_at", label: "Date modified" },
-  { key: "opened_at", label: "Last opened" },
 ];
 
 export const PAGE_SORT_BY_OPTIONS: {


### PR DESCRIPTION
#### Changes:
- This PR removes the "Last Opened" option from the pages order by dropdown.

#### Issue link: [[WEB-1085]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/62f293ab-fef7-47a7-93ca-bd33d90ab68c)

#### Media:
| Before | After |
|--------|--------|
| ![before](https://github.com/makeplane/plane/assets/121005188/f190b982-0244-419e-8b71-91a9aaefc1ff) | ![after](https://github.com/makeplane/plane/assets/121005188/19ec1733-1f83-4554-bba2-6db709be7d08) |