### PR TITLE
[WEB-1078] fix: view, api token and estimate modal description height

### DIFF
--- a/web/components/api-token/modal/form.tsx
+++ b/web/components/api-token/modal/form.tsx
@@ -146,7 +146,7 @@ export const CreateApiTokenForm: React.FC<Props> = (props) => {
                 onChange={onChange}
                 hasError={Boolean(errors.description)}
                 placeholder="Token description"
-                className="h-24 w-full text-sm"
+                className="min-h-24 w-full text-sm"
               />
             )}
           />
@@ -170,8 +170,8 @@ export const CreateApiTokenForm: React.FC<Props> = (props) => {
                           {value === "custom"
                             ? "Custom date"
                             : selectedOption
-                            ? selectedOption.label
-                            : "Set expiration date"}
+                              ? selectedOption.label
+                              : "Set expiration date"}
                         </div>
                       }
                       value={value}
@@ -207,8 +207,8 @@ export const CreateApiTokenForm: React.FC<Props> = (props) => {
                     ? `Expires ${renderFormattedDate(customDate)}`
                     : null
                   : watch("expired_at")
-                  ? `Expires ${getExpiryDate(watch("expired_at") ?? "")}`
-                  : null}
+                    ? `Expires ${getExpiryDate(watch("expired_at") ?? "")}`
+                    : null}
               </span>
             )}
           </div>

--- a/web/components/estimates/create-update-estimate-modal.tsx
+++ b/web/components/estimates/create-update-estimate-modal.tsx
@@ -256,7 +256,7 @@ export const CreateUpdateEstimateModal: React.FC<Props> = observer((props) => {
                               value={value}
                               placeholder="Description"
                               onChange={onChange}
-                              className="mt-3 h-32 resize-none text-sm"
+                              className="mt-3 min-h-32 resize-none text-sm"
                               hasError={Boolean(errors?.description)}
                             />
                           )}

--- a/web/components/views/form.tsx
+++ b/web/components/views/form.tsx
@@ -148,7 +148,7 @@ export const ProjectViewForm: React.FC<Props> = observer((props) => {
                   id="description"
                   name="description"
                   placeholder="Description"
-                  className="h-24 w-full resize-none text-sm"
+                  className="min-h-24 w-full resize-none text-sm"
                   hasError={Boolean(errors?.description)}
                   value={value}
                   onChange={onChange}

--- a/web/components/workspace/views/form.tsx
+++ b/web/components/workspace/views/form.tsx
@@ -137,7 +137,7 @@ export const WorkspaceViewForm: React.FC<Props> = observer((props) => {
                   value={value}
                   placeholder="Description"
                   onChange={onChange}
-                  className="h-24 w-full resize-none text-sm"
+                  className="min-h-24 w-full resize-none text-sm"
                   hasError={Boolean(errors?.description)}
                 />
               )}


### PR DESCRIPTION
#### Changes:
This PR addresses an issue with the description height in the View, Token, and Estimate Create modal, ensuring consistent and appropriate display of descriptions.

#### Issue link: [[WEB-1078]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/983771d4-98e4-4891-a4d3-1fcf91394502)

#### Media:
| Before | After |
|--------|--------|
| ![before](https://github.com/makeplane/plane/assets/121005188/8bdaade7-17e9-4f3c-9c4c-3ea096798990) | ![after](https://github.com/makeplane/plane/assets/121005188/dd0dccbd-ff10-4f79-9cbf-f19b8990035b) |
| ![before](https://github.com/makeplane/plane/assets/121005188/8c0d8145-40af-4ef9-8100-c97a3ca4be28) | ![after](https://github.com/makeplane/plane/assets/121005188/f1019c3f-9ede-4943-b607-46396bbc2b6b) |
| ![before](https://github.com/makeplane/plane/assets/121005188/5c95fffd-81d8-4090-8791-a90a334c7e88) | ![after](https://github.com/makeplane/plane/assets/121005188/37136e87-4852-491e-9747-7bfe3f1d49cc) |