### PR TITLE
[WEB-1090] fix: toggle switch component off state appearance

### DIFF
--- a/packages/ui/src/button/toggle-switch.tsx
+++ b/packages/ui/src/button/toggle-switch.tsx
@@ -38,8 +38,10 @@ const ToggleSwitch: React.FC<IToggleSwitchProps> = (props) => {
           "inline-block self-center h-4 w-4 transform rounded-full shadow ring-0 transition duration-200 ease-in-out",
           {
             "translate-x-5 bg-white": value,
-            "h-2 w-2 translate-x-3": value && size === "sm",
-            "h-3 w-3 translate-x-4": value && size === "md",
+            "h-2 w-2": size === "sm",
+            "h-3 w-3": size === "md",
+            "translate-x-3": value && size === "sm",
+            "translate-x-4": value && size === "md",
             "translate-x-0.5 bg-custom-background-90": !value,
             "cursor-not-allowed": disabled,
           }


### PR DESCRIPTION
#### Changes:
This PR addresses an issue where the toggle switch component's off state was not appearing as intended. The changes implemented ensure that the off state of the switch toggle component is displayed correctly.

#### Issue link: [[WEB-1090]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/dc84ec4d-2538-4be3-8014-4470e457da0a)

#### Media:
| Before | After |
|--------|--------|
| ![before](https://github.com/makeplane/plane/assets/121005188/5019f09d-ccbe-4ffa-a098-783b65fe6fe7) | ![after](https://github.com/makeplane/plane/assets/121005188/b57c3a41-3ced-4ab1-938b-20185fef8f28) |