### PR TITLE
[WEB-1096] fix: kanban collapsed vertical writing mode in firefox

### DIFF
--- a/web/styles/globals.css
+++ b/web/styles/globals.css
@@ -422,8 +422,10 @@ body {
 }
 
 .vertical-lr {
+  writing-mode: vertical-lr;
   -webkit-writing-mode: vertical-lr;
   -ms-writing-mode: vertical-lr;
+  width: fit-content;
 }
 
 div.web-view-spinner {


### PR DESCRIPTION
[WEB-1096](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/12d4c109-dc99-493d-9671-2e0e7d223fae)


This Fix adds the appropriate missing css to fix the writing mode for kanban collapsed mode