### PR TITLE
[WEB-1105] chore: show display name's first character in the avatar

### DIFF
--- a/web/components/dashboard/widgets/recent-collaborators/collaborators-list.tsx
+++ b/web/components/dashboard/widgets/recent-collaborators/collaborators-list.tsx
@@ -33,7 +33,7 @@ const CollaboratorListItem: React.FC<CollaboratorListItemProps> = observer((prop
       <div className="flex justify-center">
         <Avatar
           src={userDetails.avatar}
-          name={isCurrentUser ? "You" : userDetails.display_name}
+          name={userDetails.display_name}
           size={69}
           className="!text-3xl !font-medium"
           showTooltip={false}


### PR DESCRIPTION
#### Problem:

1. In the recent collaborators page, current user's profile displays `Y` as the avatar instead of the first character of the user's display name.

#### Solution:

1. Changed the avatar character to the first character of the current user's display name.

#### Plane issue: [WEB-1105](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/4d05cc28-5b5f-44cc-8f2f-1f27f2dae2bb)