### PR TITLE
[WEB-1146] fix: module sub-header empty state validation

### DIFF
--- a/web/components/modules/modules-list-view.tsx
+++ b/web/components/modules/modules-list-view.tsx
@@ -4,7 +4,13 @@ import { useRouter } from "next/router";
 // components
 import { ListLayout } from "@/components/core/list";
 import { EmptyState } from "@/components/empty-state";
-import { ModuleCardItem, ModuleListItem, ModulePeekOverview, ModulesListGanttChartView } from "@/components/modules";
+import {
+  ModuleCardItem,
+  ModuleListItem,
+  ModulePeekOverview,
+  ModuleViewHeader,
+  ModulesListGanttChartView,
+} from "@/components/modules";
 import { CycleModuleBoardLayout, CycleModuleListLayout, GanttLayoutLoader } from "@/components/ui";
 // constants
 import { EmptyStateType } from "@/constants/empty-state";
@@ -67,6 +73,12 @@ export const ModulesListView: React.FC = observer(() => {
 
   return (
     <>
+      <div className="h-[50px] flex-shrink-0 w-full border-b border-custom-border-200 px-6 relative flex items-center gap-4 justify-between">
+        <div className="flex items-center">
+          <span className="block text-sm font-medium">Module name</span>
+        </div>
+        <ModuleViewHeader />
+      </div>
       {displayFilters?.layout === "list" && (
         <div className="h-full overflow-y-auto">
           <div className="flex h-full w-full justify-between">

--- a/web/pages/[workspaceSlug]/projects/[projectId]/modules/index.tsx
+++ b/web/pages/[workspaceSlug]/projects/[projectId]/modules/index.tsx
@@ -7,7 +7,7 @@ import { TModuleFilters } from "@plane/types";
 import { PageHead } from "@/components/core";
 import { EmptyState } from "@/components/empty-state";
 import { ModulesListHeader } from "@/components/headers";
-import { ModuleAppliedFiltersList, ModuleViewHeader, ModulesListView } from "@/components/modules";
+import { ModuleAppliedFiltersList, ModulesListView } from "@/components/modules";
 // types
 // hooks
 import ModulesListMobileHeader from "@/components/modules/moduels-list-mobile-header";
@@ -57,12 +57,6 @@ const ProjectModulesPage: NextPageWithLayout = observer(() => {
     <>
       <PageHead title={pageTitle} />
       <div className="h-full w-full flex flex-col">
-        <div className="h-[50px] flex-shrink-0 w-full border-b border-custom-border-200 px-6 relative flex items-center gap-4 justify-between">
-          <div className="flex items-center">
-            <span className="block text-sm font-medium">Module name</span>
-          </div>
-          <ModuleViewHeader />
-        </div>
         {calculateTotalFilters(currentProjectFilters ?? {}) !== 0 && (
           <div className="border-b border-custom-border-200 px-5 py-3">
             <ModuleAppliedFiltersList


### PR DESCRIPTION
#### Changes:
This PR resolves the sub-header rendering issue on the module list page.

#### Issue link: [[WEB-1146]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/0a79313e-1e04-4ea0-beea-695bcee4a3ac)

#### Media:
| Before | After |
|--------|--------|
| ![before](https://github.com/makeplane/plane/assets/121005188/36d79e0a-00f8-4cbe-8a50-a4b8527b4141) | ![after](https://github.com/makeplane/plane/assets/121005188/fcc02bda-bd38-406b-a151-86e2f3dc1cad) |