### PR TITLE
[WEB-1147] fix: issue description persistence when moving across issues

### DIFF
--- a/web/components/inbox/content/issue-root.tsx
+++ b/web/components/inbox/content/issue-root.tsx
@@ -135,7 +135,7 @@ export const InboxIssueMainContent: React.FC<Props> = observer((props) => {
             workspaceSlug={workspaceSlug}
             projectId={issue.project_id}
             issueId={issue.id}
-            swrIssueDescription={null}
+            swrIssueDescription={issue.description_html ?? "<p></p>"}
             initialValue={issue.description_html ?? "<p></p>"}
             disabled={!isEditable}
             issueOperations={issueOperations}

--- a/web/components/issues/peek-overview/issue-detail.tsx
+++ b/web/components/issues/peek-overview/issue-detail.tsx
@@ -77,7 +77,7 @@ export const PeekOverviewIssueDetails: FC<IPeekOverviewIssueDetails> = observer(
         issueId={issue.id}
         initialValue={issueDescription}
         // for now peek overview doesn't have live syncing while tab changes
-        swrIssueDescription={null}
+        swrIssueDescription={issueDescription}
         disabled={disabled}
         issueOperations={issueOperations}
         setIsSubmitting={(value) => setIsSubmitting(value)}


### PR DESCRIPTION
#### Problem:

Issue description persists when-

1. a child issue is opened from the list of sub-issue in the peek overview.
2. switching between inbox issues rapidly.

#### Plane issue: [WEB-1147](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/9164ec94-047d-466c-a6cf-a28ac7a58bd0)