### PR TITLE
[WEB-1143] fix: project context menu

### DIFF
--- a/web/components/cycles/quick-actions.tsx
+++ b/web/components/cycles/quick-actions.tsx
@@ -180,6 +180,7 @@ export const CycleQuickActions: React.FC<Props> = observer((props) => {
                 },
                 item.className
               )}
+              disabled={item.disabled}
             >
               {item.icon && <item.icon className={cn("h-3 w-3", item.iconClassName)} />}
               <div>

--- a/web/components/issues/issue-layouts/quick-action-dropdowns/all-issue.tsx
+++ b/web/components/issues/issue-layouts/quick-action-dropdowns/all-issue.tsx
@@ -181,6 +181,7 @@ export const AllIssueQuickActions: React.FC<IQuickActionProps> = observer((props
                 },
                 item.className
               )}
+              disabled={item.disabled}
             >
               {item.icon && <item.icon className={cn("h-3 w-3", item.iconClassName)} />}
               <div>

--- a/web/components/issues/issue-layouts/quick-action-dropdowns/archived-issue.tsx
+++ b/web/components/issues/issue-layouts/quick-action-dropdowns/archived-issue.tsx
@@ -143,6 +143,7 @@ export const ArchivedIssueQuickActions: React.FC<IQuickActionProps> = observer((
                 },
                 item.className
               )}
+              disabled={item.disabled}
             >
               {item.icon && <item.icon className={cn("h-3 w-3", item.iconClassName)} />}
               <div>

--- a/web/components/issues/issue-layouts/quick-action-dropdowns/cycle-issue.tsx
+++ b/web/components/issues/issue-layouts/quick-action-dropdowns/cycle-issue.tsx
@@ -201,6 +201,7 @@ export const CycleIssueQuickActions: React.FC<IQuickActionProps> = observer((pro
                 },
                 item.className
               )}
+              disabled={item.disabled}
             >
               {item.icon && <item.icon className={cn("h-3 w-3", item.iconClassName)} />}
               <div>

--- a/web/components/issues/issue-layouts/quick-action-dropdowns/draft-issue.tsx
+++ b/web/components/issues/issue-layouts/quick-action-dropdowns/draft-issue.tsx
@@ -127,6 +127,7 @@ export const DraftIssueQuickActions: React.FC<IQuickActionProps> = observer((pro
                 },
                 item.className
               )}
+              disabled={item.disabled}
             >
               {item.icon && <item.icon className={cn("h-3 w-3", item.iconClassName)} />}
               <div>

--- a/web/components/issues/issue-layouts/quick-action-dropdowns/module-issue.tsx
+++ b/web/components/issues/issue-layouts/quick-action-dropdowns/module-issue.tsx
@@ -198,6 +198,7 @@ export const ModuleIssueQuickActions: React.FC<IQuickActionProps> = observer((pr
                 },
                 item.className
               )}
+              disabled={item.disabled}
             >
               {item.icon && <item.icon className={cn("h-3 w-3", item.iconClassName)} />}
               <div>

--- a/web/components/issues/issue-layouts/quick-action-dropdowns/project-issue.tsx
+++ b/web/components/issues/issue-layouts/quick-action-dropdowns/project-issue.tsx
@@ -191,6 +191,7 @@ export const ProjectIssueQuickActions: React.FC<IQuickActionProps> = observer((p
                 },
                 item.className
               )}
+              disabled={item.disabled}
             >
               {item.icon && <item.icon className={cn("h-3 w-3", item.iconClassName)} />}
               <div>

--- a/web/components/modules/quick-actions.tsx
+++ b/web/components/modules/quick-actions.tsx
@@ -176,6 +176,7 @@ export const ModuleQuickActions: React.FC<Props> = observer((props) => {
                 },
                 item.className
               )}
+              disabled={item.disabled}
             >
               {item.icon && <item.icon className={cn("h-3 w-3", item.iconClassName)} />}
               <div>

--- a/web/components/pages/dropdowns/quick-actions.tsx
+++ b/web/components/pages/dropdowns/quick-actions.tsx
@@ -104,6 +104,7 @@ export const PageQuickActions: React.FC<Props> = observer((props) => {
                 item.action();
               }}
               className="flex items-center gap-2"
+              disabled={item.disabled}
             >
               {item.icon && <item.icon className="h-3 w-3" />}
               {item.title}

--- a/web/components/project/card.tsx
+++ b/web/components/project/card.tsx
@@ -123,14 +123,14 @@ export const ProjectCard: React.FC<Props> = observer((props) => {
       action: handleOpenInNewTab,
       title: "Open in new tab",
       icon: ExternalLink,
-      shouldRender: project.is_member,
+      shouldRender: project.is_member && !isArchived,
     },
     {
       key: "copy-link",
       action: handleCopyText,
       title: "Copy link",
       icon: LinkIcon,
-      shouldRender: true,
+      shouldRender: !isArchived,
     },
     {
       key: "restore",

--- a/web/components/views/quick-actions.tsx
+++ b/web/components/views/quick-actions.tsx
@@ -103,6 +103,7 @@ export const ViewQuickActions: React.FC<Props> = observer((props) => {
                 },
                 item.className
               )}
+              disabled={item.disabled}
             >
               {item.icon && <item.icon className={cn("h-3 w-3", item.iconClassName)} />}
               <div>

--- a/web/components/workspace/views/default-view-quick-action.tsx
+++ b/web/components/workspace/views/default-view-quick-action.tsx
@@ -104,6 +104,7 @@ export const DefaultWorkspaceViewQuickActions: React.FC<Props> = observer((props
                 },
                 item.className
               )}
+              disabled={item.disabled}
             >
               {item.icon && <item.icon className={cn("h-3 w-3", item.iconClassName)} />}
               <div>

--- a/web/components/workspace/views/quick-action.tsx
+++ b/web/components/workspace/views/quick-action.tsx
@@ -132,6 +132,7 @@ export const WorkspaceViewQuickActions: React.FC<Props> = observer((props) => {
                 },
                 item.className
               )}
+              disabled={item.disabled}
             >
               {item.icon && <item.icon className={cn("h-3 w-3", item.iconClassName)} />}
               <div>


### PR DESCRIPTION
#### Improvements:

1. Hide `Copy link` and `Open in new tab` options from the context menu of archived projects.
2. Disable options are now actually disabled and not just visually disabled in the quick actions drop-downs thorughout.

#### Plane issue: [WEB-1143](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/af511ba5-7a97-446b-b747-17dc0453351b)