### PR TITLE
[WEB-1126] fix: inbox issue attachment upload

### DIFF
--- a/web/components/issues/attachment/attachment-upload.tsx
+++ b/web/components/issues/attachment/attachment-upload.tsx
@@ -1,11 +1,11 @@
 import { useCallback, useState } from "react";
 import { observer } from "mobx-react-lite";
 import { useDropzone } from "react-dropzone";
-// hooks
 // constants
 import { MAX_FILE_SIZE } from "@/constants/common";
 // helpers
 import { generateFileName } from "@/helpers/attachment.helper";
+// hooks
 import { useApplication } from "@/hooks/store";
 // types
 import { TAttachmentOperations } from "./root";
@@ -27,24 +27,28 @@ export const IssueAttachmentUpload: React.FC<Props> = observer((props) => {
   // states
   const [isLoading, setIsLoading] = useState(false);
 
-  const onDrop = useCallback((acceptedFiles: File[]) => {
-    const currentFile: File = acceptedFiles[0];
-    if (!currentFile || !workspaceSlug) return;
+  const onDrop = useCallback(
+    (acceptedFiles: File[]) => {
+      const currentFile: File = acceptedFiles[0];
+      if (!currentFile || !workspaceSlug) return;
 
-    const uploadedFile: File = new File([currentFile], generateFileName(currentFile.name), { type: currentFile.type });
-    const formData = new FormData();
-    formData.append("asset", uploadedFile);
-    formData.append(
-      "attributes",
-      JSON.stringify({
-        name: uploadedFile.name,
-        size: uploadedFile.size,
-      })
-    );
-    setIsLoading(true);
-    handleAttachmentOperations.create(formData).finally(() => setIsLoading(false));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+      const uploadedFile: File = new File([currentFile], generateFileName(currentFile.name), {
+        type: currentFile.type,
+      });
+      const formData = new FormData();
+      formData.append("asset", uploadedFile);
+      formData.append(
+        "attributes",
+        JSON.stringify({
+          name: uploadedFile.name,
+          size: uploadedFile.size,
+        })
+      );
+      setIsLoading(true);
+      handleAttachmentOperations.create(formData).finally(() => setIsLoading(false));
+    },
+    [handleAttachmentOperations, workspaceSlug]
+  );
 
   const { getRootProps, getInputProps, isDragActive, isDragReject, fileRejections } = useDropzone({
     onDrop,

--- a/web/components/issues/attachment/root.tsx
+++ b/web/components/issues/attachment/root.tsx
@@ -95,7 +95,7 @@ export const IssueAttachmentRoot: FC<TIssueAttachmentRoot> = (props) => {
         }
       },
     }),
-    [workspaceSlug, projectId, issueId, createAttachment, removeAttachment]
+    [captureIssueEvent, workspaceSlug, projectId, issueId, createAttachment, removeAttachment]
   );
 
   return (


### PR DESCRIPTION
#### Problem:

1. In inbox issues, trying to upload an attachment in any of the issues uploads that attachment to the first loaded issue.

#### Solution:

1. Updated the dependencies of the `useCallback` hook to updated the `issueId` on change of issue.

#### Plane issue: [WEB-1126](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/3adc414d-f499-4261-ba4a-0c501a5e1324)