### PR TITLE
[WEB-1109] chore: hide display properties in the calendar layout

### DIFF
--- a/web/constants/issue.ts
+++ b/web/constants/issue.ts
@@ -336,7 +336,7 @@ export const ISSUE_DISPLAY_FILTERS_BY_LAYOUT: {
     },
     calendar: {
       filters: ["priority", "state", "cycle", "module", "assignees", "mentions", "created_by", "labels", "start_date"],
-      display_properties: true,
+      display_properties: false,
       display_filters: {
         type: [null, "active", "backlog"],
       },


### PR DESCRIPTION
#### Improvements:

1. Hide display properties section from the calendar layout.

#### Plane issue: [WEB-1109](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/12f6eb23-6baf-46d3-8ed3-7abaa1947ba7)