### PR TITLE
[WEB-1179] style: make editor height according to the content height

### DIFF
--- a/web/components/editor/rich-text-editor/rich-text-editor.tsx
+++ b/web/components/editor/rich-text-editor/rich-text-editor.tsx
@@ -51,7 +51,7 @@ export const RichTextEditor = forwardRef<EditorRefApi, RichTextEditorWrapperProp
         suggestions: mentionSuggestions,
       }}
       {...rest}
-      containerClassName={cn("relative min-h-[150px] pl-3", containerClassName)}
+      containerClassName={cn("relative pl-3", containerClassName)}
     />
   );
 });

--- a/web/components/editor/rich-text-editor/rich-text-read-only-editor.tsx
+++ b/web/components/editor/rich-text-editor/rich-text-read-only-editor.tsx
@@ -20,7 +20,7 @@ export const RichTextReadOnlyEditor = React.forwardRef<EditorReadOnlyRefApi, Ric
         }}
         {...props}
         // overriding the containerClassName to add relative class passed
-        containerClassName={cn(props.containerClassName, "relative border border-custom-border-200 p-3")}
+        containerClassName={cn(props.containerClassName, "relative pl-3")}
       />
     );
   }

--- a/web/components/inbox/content/issue-root.tsx
+++ b/web/components/inbox/content/issue-root.tsx
@@ -141,7 +141,7 @@ export const InboxIssueMainContent: React.FC<Props> = observer((props) => {
             disabled={!isEditable}
             issueOperations={issueOperations}
             setIsSubmitting={(value) => setIsSubmitting(value)}
-            containerClassName="-ml-3 border-none"
+            containerClassName="-ml-3 !mb-6 border-none"
           />
         )}
 

--- a/web/components/inbox/modals/create-edit-modal/create-root.tsx
+++ b/web/components/inbox/modals/create-edit-modal/create-root.tsx
@@ -133,7 +133,7 @@ export const InboxIssueCreateRoot: FC<TInboxIssueCreateRoot> = observer((props) 
         data={formData}
         handleData={handleFormData}
         editorRef={descriptionEditorRef}
-        containerClassName="border-[0.5px] border-custom-border-200 py-3"
+        containerClassName="border-[0.5px] border-custom-border-200 py-3 min-h-[150px]"
       />
       <InboxIssueProperties projectId={projectId} data={formData} handleData={handleFormData} />
       <div className="relative flex justify-between items-center gap-3">

--- a/web/components/inbox/modals/create-edit-modal/edit-root.tsx
+++ b/web/components/inbox/modals/create-edit-modal/edit-root.tsx
@@ -138,7 +138,7 @@ export const InboxIssueEditRoot: FC<TInboxIssueEditRoot> = observer((props) => {
         data={formData}
         handleData={handleFormData}
         editorRef={descriptionEditorRef}
-        containerClassName="border-[0.5px] border-custom-border-200 py-3"
+        containerClassName="border-[0.5px] border-custom-border-200 py-3 min-h-[150px]"
       />
       <InboxIssueProperties projectId={projectId} data={formData} handleData={handleFormData} isVisible />
       <div className="relative flex justify-end items-center gap-3">

--- a/web/components/inbox/modals/create-edit-modal/issue-description.tsx
+++ b/web/components/inbox/modals/create-edit-modal/issue-description.tsx
@@ -22,7 +22,7 @@ type TInboxIssueDescription = {
 
 // TODO: have to implement GPT Assistance
 export const InboxIssueDescription: FC<TInboxIssueDescription> = observer((props) => {
-  const {containerClassName, workspaceSlug, projectId, workspaceId, data, handleData, editorRef } = props;
+  const { containerClassName, workspaceSlug, projectId, workspaceId, data, handleData, editorRef } = props;
   // hooks
   const { loader } = useProjectInbox();
 

--- a/web/components/issues/issue-detail/main-content.tsx
+++ b/web/components/issues/issue-detail/main-content.tsx
@@ -98,7 +98,7 @@ export const IssueMainContent: React.FC<Props> = observer((props) => {
           disabled={!isEditable}
           issueOperations={issueOperations}
           setIsSubmitting={(value) => setIsSubmitting(value)}
-          containerClassName="-ml-3 border-none"
+          containerClassName="-ml-3 !mb-6 border-none"
         />
         {/* )} */}
 

--- a/web/components/issues/issue-modal/form.tsx
+++ b/web/components/issues/issue-modal/form.tsx
@@ -480,7 +480,7 @@ export const IssueFormRoot: FC<IssueFormProps> = observer((props) => {
                           ref={editorRef}
                           tabIndex={getTabIndex("description_html")}
                           placeholder={getDescriptionPlaceholder}
-                          containerClassName="border-[0.5px] border-custom-border-200 py-3"
+                          containerClassName="border-[0.5px] border-custom-border-200 py-3 min-h-[150px]"
                         />
                       )}
                     />

--- a/web/components/issues/peek-overview/issue-detail.tsx
+++ b/web/components/issues/peek-overview/issue-detail.tsx
@@ -82,7 +82,7 @@ export const PeekOverviewIssueDetails: FC<IPeekOverviewIssueDetails> = observer(
         disabled={disabled}
         issueOperations={issueOperations}
         setIsSubmitting={(value) => setIsSubmitting(value)}
-        containerClassName="-ml-3 border-none"
+        containerClassName="-ml-3 !mb-6 border-none"
       />
 
       {currentUser && (


### PR DESCRIPTION
#### Improvements:

1. The issue description earlier had a fixed minimum height which made sense when it had a border, now, with this PR, editor takes up the height according to the content height.

#### Media:

https://github.com/makeplane/plane/assets/65252264/39e66af4-6fd1-469a-9559-36470bfe4821

#### Plane issue: [WEB-1179](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/0a4c0088-21d8-48d7-91c3-06f2bdef9b53)