### PR TITLE
[WEB-559] fix: dropdowns should close on tab key

### DIFF
--- a/web/hooks/use-dropdown-key-down.tsx
+++ b/web/hooks/use-dropdown-key-down.tsx
@@ -9,23 +9,25 @@ type TUseDropdownKeyDown = {
 };
 
 export const useDropdownKeyDown: TUseDropdownKeyDown = (onEnterKeyDown, onEscKeyDown, stopPropagation = true) => {
-  const stopEventPropagation = (event: React.KeyboardEvent<HTMLElement>) => {
-    if (stopPropagation) {
-      event.stopPropagation();
-      event.preventDefault();
-    }
-  };
+  const stopEventPropagation = useCallback(
+    (event: React.KeyboardEvent<HTMLElement>) => {
+      if (stopPropagation) {
+        event.stopPropagation();
+        event.preventDefault();
+      }
+    },
+    [stopPropagation]
+  );
 
   const handleKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLElement>) => {
       if (event.key === "Enter") {
         stopEventPropagation(event);
-
         onEnterKeyDown();
       } else if (event.key === "Escape") {
         stopEventPropagation(event);
         onEscKeyDown();
-      }
+      } else if (event.key === "Tab") onEscKeyDown();
     },
     [onEnterKeyDown, onEscKeyDown, stopEventPropagation]
   );


### PR DESCRIPTION
#### Problem:

1. A dropdown, opened using the tab key, can only be closed by clicking outside the dropdown.

#### Solution:

1. Added `Tab` `keyDown` listener to the dropdown which closes the dropdown on hitting `Tab` or `Shift + Tab`.

#### Plane issue: [WEB-559](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/4b3df168-2755-4c18-aa3d-594f5ff46b26)