### PR TITLE
[WEB-1171] fix: peek overview in Gantt chart full screen view

### DIFF
--- a/web/components/gantt-chart/chart/root.tsx
+++ b/web/components/gantt-chart/chart/root.tsx
@@ -161,7 +161,7 @@ export const ChartViewRoot: FC<ChartViewRootProps> = observer((props) => {
   return (
     <div
       className={cn("relative flex flex-col h-full select-none rounded-sm bg-custom-background-100 shadow", {
-        "fixed inset-0 z-[999999] bg-custom-background-100": fullScreenMode,
+        "fixed inset-0 z-20 bg-custom-background-100": fullScreenMode,
         "border-[0.5px] border-custom-border-200": border,
       })}
     >

--- a/yarn.lock
+++ b/yarn.lock
@@ -2755,7 +2755,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^18.2.42":
+"@types/react@*", "@types/react@18.2.42", "@types/react@^18.2.42":
   version "18.2.42"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.42.tgz#6f6b11a904f6d96dda3c2920328a97011a00aba7"
   integrity sha512-c1zEr96MjakLYus/wPnuWDo1/zErfdU9rNsIGmE+NV71nx88FG9Ttgo5dqorXTu/LImX2f63WBP986gJkMPNbA==


### PR DESCRIPTION
#### Problem:

1. The peek overview doesn't open in Gantt chart full screen view.

#### Solution:

1. Decreased the `z-index` of the Gantt chart full screen view to 20.

#### Media:

https://github.com/makeplane/plane/assets/65252264/4d41d8e5-f1b2-48cb-8345-dc6ffd531c80

#### Plane issue: [WEB-1171](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/260dad4a-083b-4a46-ab9f-be2bc8a8b956)