### PR TITLE
[WEB-] chore: trigger command k from input fields and editors

### DIFF
--- a/web/components/command-palette/command-palette.tsx
+++ b/web/components/command-palette/command-palette.tsx
@@ -200,6 +200,11 @@ export const CommandPalette: FC = observer(() => {
 
       const keyPressed = key.toLowerCase();
       const cmdClicked = ctrlKey || metaKey;
+
+      if (cmdClicked && keyPressed === "k" && !isAnyModalOpen) {
+        e.preventDefault();
+        toggleCommandPaletteModal(true);
+      }
       // if on input, textarea or editor, don't do anything
       if (
         e.target instanceof HTMLTextAreaElement ||
@@ -209,10 +214,7 @@ export const CommandPalette: FC = observer(() => {
         return;
 
       if (cmdClicked) {
-        if (keyPressed === "k") {
-          e.preventDefault();
-          toggleCommandPaletteModal(true);
-        } else if (keyPressed === "c" && altKey) {
+        if (keyPressed === "c" && altKey) {
           e.preventDefault();
           copyIssueUrlToClipboard();
         } else if (keyPressed === "b") {


### PR DESCRIPTION
#### Problem:

1. Command K modal cannot be triggered from input fields, textarea and editors.

#### Solution:

1. Moved `Cmd + K` shortcut logic out of the input field restriction condition. Now, Command K modal can be triggered from anywhere, but cannot be opened if any other modal is open.

#### Media:

https://github.com/makeplane/plane/assets/65252264/1638d512-f0ce-46d5-84e4-b4870982e9ee

https://github.com/makeplane/plane/assets/65252264/c8dc0269-d8b2-4874-82e4-ef0cd9bd7aeb

#### Plane issue: [WEB-]()