### PR TITLE
[WEB-1206] chore: bulk delete api logs

### DIFF
--- a/apiserver/plane/bgtasks/api_logs_task.py
+++ b/apiserver/plane/bgtasks/api_logs_task.py
@@ -1,0 +1,15 @@
+from django.utils import timezone
+from datetime import timedelta
+from plane.db.models import APIActivityLog
+from celery import shared_task
+
+
+@shared_task
+def delete_api_logs():
+    # Get the logs older than 30 days to delete
+    logs_to_delete = APIActivityLog.objects.filter(
+        created_at__lte=timezone.now() - timedelta(days=30)
+    )
+
+    # Delete the logs
+    logs_to_delete._raw_delete(logs_to_delete.db)

--- a/apiserver/plane/celery.py
+++ b/apiserver/plane/celery.py
@@ -32,6 +32,10 @@ app.conf.beat_schedule = {
         "task": "plane.bgtasks.email_notification_task.stack_email_notification",
         "schedule": crontab(minute="*/5"),
     },
+    "check-every-day-to-delete-api-logs": {
+        "task": "plane.bgtasks.api_logs_task.delete_api_logs",
+        "schedule": crontab(hour=8, minute=6),
+    },
 }
 
 # Load task modules from all registered Django app configs.

--- a/apiserver/plane/celery.py
+++ b/apiserver/plane/celery.py
@@ -34,7 +34,7 @@ app.conf.beat_schedule = {
     },
     "check-every-day-to-delete-api-logs": {
         "task": "plane.bgtasks.api_logs_task.delete_api_logs",
-        "schedule": crontab(hour=8, minute=6),
+        "schedule": crontab(hour=0, minute=0),
     },
 }
 

--- a/apiserver/plane/settings/common.py
+++ b/apiserver/plane/settings/common.py
@@ -293,6 +293,7 @@ CELERY_IMPORTS = (
     "plane.bgtasks.exporter_expired_task",
     "plane.bgtasks.file_asset_task",
     "plane.bgtasks.email_notification_task",
+    "plane.bgtasks.api_logs_task",
     # management tasks
     "plane.bgtasks.dummy_data_task",
 )


### PR DESCRIPTION
chore: 

- This pull request addresses the functionality of deleting API logs that are older than 30 days.

Issue Link: [WEB-1206](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/53a28821-eee6-482c-b77b-7e1cc49a2fe3)