### PR TITLE
[WEB-1137] fix: Firefox distorted vertical text

### DIFF
--- a/web/components/issues/issue-layouts/kanban/headers/group-by-card.tsx
+++ b/web/components/issues/issue-layouts/kanban/headers/group-by-card.tsx
@@ -111,8 +111,8 @@ export const HeaderGroupByCard: FC<IHeaderGroupByCard> = observer((props) => {
         </div>
 
         <div
-          className={`relative flex items-center gap-1 overflow-hidden ${
-            verticalAlignPosition ? `flex-col` : `w-full flex-row`
+          className={`relative flex items-center gap-1 ${
+            verticalAlignPosition ? `flex-col` : `w-full flex-row overflow-hidden`
           }`}
         >
           <div


### PR DESCRIPTION
[WEB-1137](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/ae4f7850-f9f3-4552-a833-c2a62b8dd508)

This PR fixes the Vertical Skewed text of  Kanban header in Firefox.

<img width="1512" alt="image" src="https://github.com/makeplane/plane/assets/71900764/b70e2ee8-7a75-49d1-b462-fef12039feea">
