### PR TITLE
[WEB-1113] fix: set focus on editor conditionally after image upload

### DIFF
--- a/packages/editor/core/src/ui/plugins/upload-image.tsx
+++ b/packages/editor/core/src/ui/plugins/upload-image.tsx
@@ -158,7 +158,7 @@ export async function startImageUpload(
     const transaction = view.state.tr.insert(pos - 1, node).setMeta(uploadKey, { remove: { id } });
 
     view.dispatch(transaction);
-    view.focus();
+    if (view.hasFocus()) view.focus();
     editor.storage.image.uploadInProgress = false;
   } catch (error) {
     removePlaceholder(editor, view, id);


### PR DESCRIPTION
#### Improvements:

1. After an image is uploaded in any editor, the focus needs to persist, if the focus is changed to some other field while the image is being uploaded, it should stay there even after the upload has completed.

#### Media:

https://github.com/makeplane/plane/assets/65252264/fb73cfe7-2073-4b7b-85fb-14b6db5ca35f

#### Plane issue: [WEB-1113](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/46614455-dbce-4f80-90e3-9e12b05ee544)