### PR TITLE
[WEB-1211] fix: inbox issue description revalidate

### DIFF
--- a/web/components/inbox/content/root.tsx
+++ b/web/components/inbox/content/root.tsx
@@ -30,7 +30,11 @@ export const InboxContentRoot: FC<TInboxContentRoot> = observer((props) => {
       : null,
     workspaceSlug && projectId && inboxIssueId
       ? () => fetchInboxIssueById(workspaceSlug, projectId, inboxIssueId)
-      : null
+      : null,
+    {
+      revalidateOnFocus: false,
+      revalidateIfStale: false,
+    }
   );
 
   const isEditable = !!currentProjectRole && currentProjectRole >= EUserProjectRoles.MEMBER;


### PR DESCRIPTION
#### Problem:

1. Inbox issue description re-fetches on focus, overwriting any saving action going on, specifically image upload.

#### Solution:

1. Disable issue details re-fetch on focus.

#### Media:

https://github.com/makeplane/plane/assets/65252264/9e38219d-2eef-4f35-8890-7fc8c757bf16

#### Plane issue: [WEB-1211](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/057c28ef-d30f-4331-aa43-25870f5ba12c)