### PR TITLE
[WEB-1207] chore: avoid trimming of editor content

### DIFF
--- a/packages/editor/core/src/hooks/use-editor.tsx
+++ b/packages/editor/core/src/hooks/use-editor.tsx
@@ -3,7 +3,6 @@ import { useImperativeHandle, useRef, MutableRefObject, useState, useEffect } fr
 import { CoreEditorProps } from "src/ui/props";
 import { CoreEditorExtensions } from "src/ui/extensions";
 import { EditorProps } from "@tiptap/pm/view";
-import { getTrimmedHTML } from "src/lib/utils";
 import { DeleteImage } from "src/types/delete-image";
 import { IMentionHighlight, IMentionSuggestion } from "src/types/mention-suggestion";
 import { RestoreImage } from "src/types/restore-image";
@@ -86,7 +85,7 @@ export const useEditor = ({
       setSavedSelection(editor.state.selection);
     },
     onUpdate: async ({ editor }) => {
-      onChange?.(editor.getJSON(), getTrimmedHTML(editor.getHTML()));
+      onChange?.(editor.getJSON(), editor.getHTML());
     },
     onDestroy: async () => {
       handleEditorReady?.(false);


### PR DESCRIPTION
#### Problem:

1. All the editors trim the editor content by removing the empty `<p></p>` tags from either ends, thus while writing the issue description, if the user intentionally adds some line breaks and the debounce kicks in between the typing, it removes those line breaks.

#### Solution:

1. Removed the hardcoded trimming logic from the editor core, if needed trimming can be implemented wherever required using the exported `getTrimmedHTML` helper function from the editor core.

#### Media:

| Before | After |
|--------|--------|
| <video src="https://github.com/makeplane/plane/assets/65252264/a584706a-4686-49f6-a05d-bfe90bdf5c23"></video> | <video src="https://github.com/makeplane/plane/assets/65252264/b9ac4a60-9e41-4036-9b7f-ad087bbec7dc"></video> | 

#### Plane issue: [WEB-1207](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/c3393cad-6e5f-44ca-820a-c410a4d57d24)