### PR TITLE
[WEB-1217] style: fix inconsistency in height of project type and lead dropdown in create project modal.

### DIFF
--- a/web/components/project/create-project-form.tsx
+++ b/web/components/project/create-project-form.tsx
@@ -365,7 +365,7 @@ export const CreateProjectForm: FC<Props> = observer((props) => {
               render={({ field: { value, onChange } }) => {
                 if (value === undefined || value === null || typeof value === "string")
                   return (
-                    <div className="h-7 flex-shrink-0" tabIndex={5}>
+                    <div className="flex-shrink-0" tabIndex={5}>
                       <MemberDropdown
                         value={value}
                         onChange={(lead) => onChange(lead === value ? null : lead)}


### PR DESCRIPTION
#### Problem
Height of `project type` and `project lead` were inconsistent in create project modal.

#### Solution
Added the required changes to adjust the height. 

#### Media
* Before
![image](https://github.com/makeplane/plane/assets/33979846/e2388fbc-9ab8-4244-9fc6-3fef6c7bf3f2)

* After
![image](https://github.com/makeplane/plane/assets/33979846/eb79b7eb-38ef-4a4d-a158-508f6eb3efc8)

**Plane Link: [WEB-1217](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/f181d357-f60f-4ef1-b646-7baa3a53ed36)**
