### PR TITLE
[WEB-1236] chore: add `Create page` button to public/ private page empty state.

### DIFF
--- a/web/components/pages/pages-list-main-content.tsx
+++ b/web/components/pages/pages-list-main-content.tsx
@@ -8,7 +8,7 @@ import { PageLoader } from "@/components/pages";
 // constants
 import { EmptyStateType } from "@/constants/empty-state";
 // hooks
-import { useProjectPages } from "@/hooks/store";
+import { useApplication, useProjectPages } from "@/hooks/store";
 // assets
 import AllFiltersImage from "public/empty-state/pages/all-filters.svg";
 import NameFilterImage from "public/empty-state/pages/name-filter.svg";
@@ -23,6 +23,7 @@ export const PagesListMainContent: React.FC<Props> = observer((props) => {
   const { children, pageType, projectId } = props;
   // store hooks
   const { loader, getCurrentProjectFilteredPageIds, getCurrentProjectPageIds, filters } = useProjectPages(projectId);
+  const { commandPalette: commandPaletteStore } = useApplication();
   // derived values
   const pageIds = getCurrentProjectPageIds(pageType);
   const filteredPageIds = getCurrentProjectFilteredPageIds(pageType);
@@ -30,8 +31,24 @@ export const PagesListMainContent: React.FC<Props> = observer((props) => {
   if (loader === "init-loader") return <PageLoader />;
   // if no pages exist in the active page type
   if (pageIds?.length === 0) {
-    if (pageType === "public") return <EmptyState type={EmptyStateType.PROJECT_PAGE_PUBLIC} />;
-    if (pageType === "private") return <EmptyState type={EmptyStateType.PROJECT_PAGE_PRIVATE} />;
+    if (pageType === "public")
+      return (
+        <EmptyState
+          type={EmptyStateType.PROJECT_PAGE_PUBLIC}
+          primaryButtonOnClick={() => {
+            commandPaletteStore.toggleCreatePageModal(true);
+          }}
+        />
+      );
+    if (pageType === "private")
+      return (
+        <EmptyState
+          type={EmptyStateType.PROJECT_PAGE_PRIVATE}
+          primaryButtonOnClick={() => {
+            commandPaletteStore.toggleCreatePageModal(true);
+          }}
+        />
+      );
     if (pageType === "archived") return <EmptyState type={EmptyStateType.PROJECT_PAGE_ARCHIVED} />;
   }
   // if no pages match the filter criteria

--- a/web/constants/empty-state.ts
+++ b/web/constants/empty-state.ts
@@ -500,12 +500,22 @@ const emptyStateDetails = {
     title: "No private pages yet",
     description: "Keep your private thoughts here. When you're ready to share, the team's just a click away.",
     path: "/empty-state/pages/private",
+    primaryButton: {
+      text: "Create your first page",
+    },
+    accessType: "project",
+    access: EUserProjectRoles.MEMBER,
   },
   [EmptyStateType.PROJECT_PAGE_PUBLIC]: {
     key: EmptyStateType.PROJECT_PAGE_PUBLIC,
     title: "No public pages yet",
     description: "See pages shared with everyone in your project right here.",
     path: "/empty-state/pages/public",
+    primaryButton: {
+      text: "Create your first page",
+    },
+    accessType: "project",
+    access: EUserProjectRoles.MEMBER,
   },
   [EmptyStateType.PROJECT_PAGE_ARCHIVED]: {
     key: EmptyStateType.PROJECT_PAGE_ARCHIVED,


### PR DESCRIPTION
#### Problem
`Create page` button was not available for public and private page empty states.

#### Solution
Added those buttons to the empty states.

#### Media
* Before
![image](https://github.com/makeplane/plane/assets/33979846/1ae24d6e-c7c9-4026-9dcf-4d929e8a8d60)

* After
![image](https://github.com/makeplane/plane/assets/33979846/e270b2cb-b85b-4378-a4f3-b884ee446b5e)

**Plane link: [WEB-1236](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/7b3f27b3-4a96-4001-811b-3da6ec05ec16)**