### PR TITLE
[WEB-1208] fix: todo list item word break

### DIFF
--- a/packages/editor/core/src/styles/editor.css
+++ b/packages/editor/core/src/styles/editor.css
@@ -72,8 +72,14 @@ ul[data-type="taskList"] li {
 }
 
 ul[data-type="taskList"] li > label {
+  position: absolute;
+  left: -5px;
   margin: 0.1rem 0.15rem 0 0;
   user-select: none;
+}
+
+ul[data-type="taskList"] li > div {
+  margin-left: 1.15rem;
 }
 
 ul[data-type="taskList"] li > label input[type="checkbox"] {

--- a/packages/editor/core/src/ui/extensions/index.tsx
+++ b/packages/editor/core/src/ui/extensions/index.tsx
@@ -113,7 +113,7 @@ export const CoreEditorExtensions = ({
   }),
   TaskItem.configure({
     HTMLAttributes: {
-      class: "flex",
+      class: "relative",
     },
     nested: true,
   }),

--- a/packages/editor/core/src/ui/read-only/extensions.tsx
+++ b/packages/editor/core/src/ui/read-only/extensions.tsx
@@ -79,7 +79,7 @@ export const CoreReadOnlyEditorExtensions = (mentionConfig: {
   }),
   TaskItem.configure({
     HTMLAttributes: {
-      class: "flex pointer-events-none",
+      class: "relative pointer-events-none",
     },
     nested: true,
   }),


### PR DESCRIPTION
#### Improvements:

1. Todo list item sentences now break into next line for longer words.

#### Media:

| Before | After |
|--------|--------|
| <video src="https://github.com/makeplane/plane/assets/65252264/d4b5a1a5-a05b-4d8d-8629-94ede6652b64"></video> | <video src="https://github.com/makeplane/plane/assets/65252264/bf2ecdaf-3f61-4ed1-aadb-4920f9f5dfbb"></video> |

#### Plane issue: [WEB-1208](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/d96663ff-97b9-405b-90ae-23b34dc9684c)