### PR TITLE
[WEB-1248] chore: applied filters update view button alignment improvement

### DIFF
--- a/web/components/issues/issue-layouts/filters/applied-filters/roots/archived-issue.tsx
+++ b/web/components/issues/issue-layouts/filters/applied-filters/roots/archived-issue.tsx
@@ -68,7 +68,7 @@ export const ArchivedIssueAppliedFiltersRoot: React.FC = observer(() => {
   if (Object.keys(appliedFilters).length === 0) return null;
 
   return (
-    <div className="flex items-center justify-between p-4 gap-2.5">
+    <div className="flex justify-between p-4 gap-2.5">
       <AppliedFiltersList
         appliedFilters={appliedFilters}
         handleClearAllFilters={handleClearAllFilters}

--- a/web/components/issues/issue-layouts/filters/applied-filters/roots/cycle-root.tsx
+++ b/web/components/issues/issue-layouts/filters/applied-filters/roots/cycle-root.tsx
@@ -77,7 +77,7 @@ export const CycleAppliedFiltersRoot: React.FC = observer(() => {
   if (Object.keys(appliedFilters).length === 0 || !workspaceSlug || !projectId) return null;
 
   return (
-    <div className="flex items-center justify-between p-4 gap-2.5">
+    <div className="flex justify-between p-4 gap-2.5">
       <AppliedFiltersList
         appliedFilters={appliedFilters}
         handleClearAllFilters={handleClearAllFilters}

--- a/web/components/issues/issue-layouts/filters/applied-filters/roots/draft-issue.tsx
+++ b/web/components/issues/issue-layouts/filters/applied-filters/roots/draft-issue.tsx
@@ -63,7 +63,7 @@ export const DraftIssueAppliedFiltersRoot: React.FC = observer(() => {
   if (Object.keys(appliedFilters).length === 0) return null;
 
   return (
-    <div className="flex items-center justify-between p-4 gap-2.5">
+    <div className="flex justify-between p-4 gap-2.5">
       <AppliedFiltersList
         appliedFilters={appliedFilters}
         handleClearAllFilters={handleClearAllFilters}

--- a/web/components/issues/issue-layouts/filters/applied-filters/roots/module-root.tsx
+++ b/web/components/issues/issue-layouts/filters/applied-filters/roots/module-root.tsx
@@ -76,7 +76,7 @@ export const ModuleAppliedFiltersRoot: React.FC = observer(() => {
   if (!workspaceSlug || !projectId || Object.keys(appliedFilters).length === 0) return null;
 
   return (
-    <div className="flex items-center justify-between p-4 gap-2.5">
+    <div className="flex justify-between p-4 gap-2.5">
       <AppliedFiltersList
         appliedFilters={appliedFilters}
         handleClearAllFilters={handleClearAllFilters}

--- a/web/components/issues/issue-layouts/filters/applied-filters/roots/project-root.tsx
+++ b/web/components/issues/issue-layouts/filters/applied-filters/roots/project-root.tsx
@@ -68,7 +68,7 @@ export const ProjectAppliedFiltersRoot: React.FC = observer(() => {
   if (Object.keys(appliedFilters).length === 0) return null;
 
   return (
-    <div className="flex items-center justify-between p-4 gap-2.5">
+    <div className="flex justify-between p-4 gap-2.5">
       <AppliedFiltersList
         appliedFilters={appliedFilters}
         handleClearAllFilters={handleClearAllFilters}

--- a/web/components/issues/issue-layouts/filters/applied-filters/roots/project-view-root.tsx
+++ b/web/components/issues/issue-layouts/filters/applied-filters/roots/project-view-root.tsx
@@ -95,7 +95,7 @@ export const ProjectViewAppliedFiltersRoot: React.FC = observer(() => {
   };
 
   return (
-    <div className="flex items-center justify-between gap-4 p-4">
+    <div className="flex justify-between gap-4 p-4">
       <AppliedFiltersList
         appliedFilters={appliedFilters ?? {}}
         handleClearAllFilters={handleClearAllFilters}
@@ -106,14 +106,11 @@ export const ProjectViewAppliedFiltersRoot: React.FC = observer(() => {
       />
 
       {!areFiltersEqual && (
-        <>
-          <div />
-          <div className="flex flex-shrink-0 items-center justify-center">
-            <Button variant="primary" size="sm" onClick={handleUpdateView}>
-              Update view
-            </Button>
-          </div>
-        </>
+        <div>
+          <Button variant="primary" size="sm" className="flex-shrink-0" onClick={handleUpdateView}>
+            Update view
+          </Button>
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
#### Changes:
This PR addresses an issue where the filter action button was incorrectly rendering at the center when the length of the applied filter exceeded 2 lines. This behavior was unintended, and this PR resolves it by making the necessary adjustments.

#### Issue link: [[WEB-1248]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/c513022e-6f86-46be-9278-7424a0644a2c)

#### Media:
| Before | After |
|--------|--------|
| ![before](https://github.com/makeplane/plane/assets/121005188/34d375a1-d974-4148-8079-ce77477c0fbd) | ![after](https://github.com/makeplane/plane/assets/121005188/9af43cf6-62c6-4ddc-9fae-a542a042ffe2) |