### PR TITLE
[WEB-1256] fix: accept image as a valid comment

### DIFF
--- a/space/helpers/string.helper.ts
+++ b/space/helpers/string.helper.ts
@@ -52,7 +52,7 @@ export const checkEmailValidity = (email: string): boolean => {
 
 export const isEmptyHtmlString = (htmlString: string) => {
   // Remove HTML tags using regex
-  const cleanText = DOMPurify.sanitize(htmlString, { ALLOWED_TAGS: [] });
+  const cleanText = DOMPurify.sanitize(htmlString, { ALLOWED_TAGS: ["img"] });
   // Trim the string and check if it's empty
   return cleanText.trim() === "";
 };

--- a/web/helpers/string.helper.ts
+++ b/web/helpers/string.helper.ts
@@ -174,10 +174,10 @@ export const getFetchKeysForIssueMutation = (options: {
   const ganttFetchKey = cycleId
     ? { ganttFetchKey: CYCLE_ISSUES_WITH_PARAMS(cycleId.toString(), ganttParams) }
     : moduleId
-    ? { ganttFetchKey: MODULE_ISSUES_WITH_PARAMS(moduleId.toString(), ganttParams) }
-    : viewId
-    ? { ganttFetchKey: VIEW_ISSUES(viewId.toString(), viewGanttParams) }
-    : { ganttFetchKey: PROJECT_ISSUES_LIST_WITH_PARAMS(projectId?.toString() ?? "", ganttParams) };
+      ? { ganttFetchKey: MODULE_ISSUES_WITH_PARAMS(moduleId.toString(), ganttParams) }
+      : viewId
+        ? { ganttFetchKey: VIEW_ISSUES(viewId.toString(), viewGanttParams) }
+        : { ganttFetchKey: PROJECT_ISSUES_LIST_WITH_PARAMS(projectId?.toString() ?? "", ganttParams) };
 
   return {
     ...ganttFetchKey,
@@ -230,7 +230,7 @@ export const checkEmailValidity = (email: string): boolean => {
 
 export const isEmptyHtmlString = (htmlString: string) => {
   // Remove HTML tags using regex
-  const cleanText = DOMPurify.sanitize(htmlString, { ALLOWED_TAGS: [] });
+  const cleanText = DOMPurify.sanitize(htmlString, { ALLOWED_TAGS: ["img"] });
   // Trim the string and check if it's empty
   return cleanText.trim() === "";
 };


### PR DESCRIPTION
#### Problem:

1. Uploading only an image as a comment is not supported.

#### Solution:

1. Updated the sanitize method to **very strictly** accept `img` tags.

#### Media:

| Before | After |
|--------|--------|
| <video src="https://github.com/makeplane/plane/assets/65252264/96cd1db2-ede3-4b5c-9ec1-899ecdd8a013"></video> | <video src="https://github.com/makeplane/plane/assets/65252264/f7c9d80f-81ea-4967-8d76-d5d09dbb90d5"></video> | 

#### Plane issue: [WEB-1256](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/b4cfc31b-627c-4744-a4c2-3804c46356a0)