### PR TITLE
[WEB-1134] fix: module link mutation issue

### DIFF
--- a/web/components/modules/sidebar.tsx
+++ b/web/components/modules/sidebar.tsx
@@ -644,6 +644,8 @@ export const ModuleDetailsSidebar: React.FC<Props> = observer((props) => {
           </div>
 
           <div className="flex w-full flex-col items-center justify-start gap-2 border-t border-custom-border-200 px-1.5 py-5">
+            {/* Accessing link outside the disclosure as mobx is not  considering the children inside Disclosure as part of the component hence not observing their state change*/}
+            <div className="hidden">{moduleDetails?.link_module?.length}</div>
             <Disclosure>
               {({ open }) => (
                 <div className={`relative  flex  h-full w-full flex-col ${open ? "" : "flex-row"}`}>

--- a/web/components/modules/sidebar.tsx
+++ b/web/components/modules/sidebar.tsx
@@ -645,8 +645,7 @@ export const ModuleDetailsSidebar: React.FC<Props> = observer((props) => {
 
           <div className="flex w-full flex-col items-center justify-start gap-2 border-t border-custom-border-200 px-1.5 py-5">
             {/* Accessing link outside the disclosure as mobx is not  considering the children inside Disclosure as part of the component hence not observing their state change*/}
-            <div className="hidden">{moduleDetails?.link_module?.length}</div>
-            <Disclosure>
+            <Disclosure defaultOpen={!!moduleDetails?.link_module?.length}>
               {({ open }) => (
                 <div className={`relative  flex  h-full w-full flex-col ${open ? "" : "flex-row"}`}>
                   <Disclosure.Button className="flex w-full items-center justify-between gap-2 p-1.5">


### PR DESCRIPTION
[WEB-1134](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/8655410a-d3cb-4887-85ac-10ae8b892c77)

This PR fixes the module link mutation issue by referring the link_module property outside the disclosure. This could be the because of how <Disclosure> component is implemented.