### PR TITLE
[WEB-1271] fix: show only joined projects in the filters list

### DIFF
--- a/web/components/issues/issue-layouts/filters/header/filters/project.tsx
+++ b/web/components/issues/issue-layouts/filters/header/filters/project.tsx
@@ -23,9 +23,9 @@ export const FilterProjects: React.FC<Props> = observer((props) => {
   const [itemsToRender, setItemsToRender] = useState(5);
   const [previewEnabled, setPreviewEnabled] = useState(true);
   // store
-  const { getProjectById, workspaceProjectIds } = useProject();
+  const { getProjectById, joinedProjectIds } = useProject();
   // derived values
-  const projects = workspaceProjectIds?.map((projectId) => getProjectById(projectId)!) ?? null;
+  const projects = joinedProjectIds?.map((projectId) => getProjectById(projectId)!) ?? null;
   const appliedFiltersCount = appliedFilters?.length ?? 0;
 
   const sortedOptions = useMemo(() => {


### PR DESCRIPTION
#### Problem:

1. Project filters shows the list of all the projects, even the un-joined ones.

#### Solution:

1. Access `joinedProjectIds` from the project store to display the list of projects.

#### Plane issue: [WEB-1271](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/093fcc3c-51a5-4e5b-9880-46439819117d)