### PR TITLE
[WEB-1265] chore: project publish modal improvement

### DIFF
--- a/web/components/project/publish-project/modal.tsx
+++ b/web/components/project/publish-project/modal.tsx
@@ -139,13 +139,7 @@ export const PublishProjectModal: React.FC<Props> = observer((props) => {
   const handlePublishProject = async (payload: IProjectPublishSettings) => {
     if (!workspaceSlug) return;
 
-    return publishProject(workspaceSlug.toString(), project.id, payload)
-      .then((res) => {
-        handleClose();
-        // window.open(`${plane_deploy_url}/${workspaceSlug}/${project.id}`, "_blank");
-        return res;
-      })
-      .catch((err) => err);
+    return publishProject(workspaceSlug.toString(), project.id, payload);
   };
 
   const handleUpdatePublishSettings = async (payload: IProjectPublishSettings) => {
@@ -174,10 +168,6 @@ export const PublishProjectModal: React.FC<Props> = observer((props) => {
     setIsUnPublishing(true);
 
     await unPublishProject(workspaceSlug.toString(), project.id, publishId)
-      .then((res) => {
-        handleClose();
-        return res;
-      })
       .catch(() =>
         setToast({
           type: TOAST_TYPE.ERROR,


### PR DESCRIPTION
#### Changes:
Currently, when the project is published, the modal is closing, which is not intended behavior. The modal should remain open after publishing so that the user can copy the publish URL. I've resolved this issue by making necessary adjustments.

#### Issue link: [[WEB-1265]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/bf9fd6a9-caed-45c1-adcb-bd7dae937667)

#### Media:
| Before | After |
|--------|--------|
| ![before](https://github.com/makeplane/plane/assets/121005188/2e9f9327-79cb-4d67-a235-890b1fc3d6d8) | ![after](https://github.com/makeplane/plane/assets/121005188/13d2601f-dcb7-4c2e-9913-78521b6e879b) |