### PR TITLE
fix: space project board pageType

### DIFF
--- a/space/lib/wrappers/auth-wrapper.tsx
+++ b/space/lib/wrappers/auth-wrapper.tsx
@@ -26,7 +26,7 @@ export const AuthWrapper: FC<TAuthWrapper> = observer((props) => {
     revalidateOnFocus: false,
   });
 
-  if (isSWRLoading || isLoading)
+  if (isSWRLoading || (isLoading && pageType === EPageTypes.AUTHENTICATED))
     return (
       <div className="relative flex h-screen w-full items-center justify-center">
         <Spinner />

--- a/space/pages/[workspace_slug]/[project_slug]/index.tsx
+++ b/space/pages/[workspace_slug]/[project_slug]/index.tsx
@@ -33,7 +33,7 @@ const WorkspaceProjectPage = (props: any) => {
   });
 
   return (
-    <AuthWrapper pageType={EPageTypes.AUTHENTICATED}>
+    <AuthWrapper pageType={EPageTypes.PUBLIC}>
       <ProjectLayout>
         <Head>
           <title>{SITE_TITLE}</title>


### PR DESCRIPTION
#### Changes:
This PR includes the following changes:
- Changed project board page type from authenticated to public.
- Added validation in the authentication wrapper to display user fetch loader only when the path is authenticated.