### PR TITLE
[WEB-1118] fix: table selections using drag handle fixed

### DIFF
--- a/packages/editor/core/src/lib/editor-commands.ts
+++ b/packages/editor/core/src/lib/editor-commands.ts
@@ -97,6 +97,9 @@ const replaceCodeBlockWithContent = (editor: Editor) => {
         const startPos = pos;
         const endPos = pos + node.nodeSize;
         const textContent = node.textContent;
+        if (textContent.length === 0) {
+          editor.chain().focus().toggleCodeBlock().run();
+        }
         replaceCodeBlock(startPos, endPos, textContent);
         return false;
       }

--- a/packages/editor/core/src/ui/extensions/table/table/table.ts
+++ b/packages/editor/core/src/ui/extensions/table/table/table.ts
@@ -218,15 +218,21 @@ export const Table = Node.create({
   addKeyboardShortcuts() {
     return {
       Tab: () => {
-        if (this.editor.commands.goToNextCell()) {
-          return true;
-        }
+        if (this.editor.isActive("table")) {
+          if (this.editor.isActive("listItem") || this.editor.isActive("taskItem")) {
+            return false;
+          }
+          if (this.editor.commands.goToNextCell()) {
+            return true;
+          }
 
-        if (!this.editor.can().addRowAfter()) {
-          return false;
-        }
+          if (!this.editor.can().addRowAfter()) {
+            return false;
+          }
 
-        return this.editor.chain().addRowAfter().goToNextCell().run();
+          return this.editor.chain().addRowAfter().goToNextCell().run();
+        }
+        return false;
       },
       "Shift-Tab": () => this.editor.commands.goToPreviousCell(),
       Backspace: deleteTableWhenAllCellsSelected,

--- a/packages/editor/core/src/ui/props.tsx
+++ b/packages/editor/core/src/ui/props.tsx
@@ -15,7 +15,6 @@ export function CoreEditorProps(editorClassName: string): EditorProps {
         if (["ArrowUp", "ArrowDown", "Enter"].includes(event.key)) {
           const slashCommand = document.querySelector("#slash-command");
           if (slashCommand) {
-            console.log("registered");
             return true;
           }
         }

--- a/packages/editor/extensions/src/extensions/drag-drop.tsx
+++ b/packages/editor/extensions/src/extensions/drag-drop.tsx
@@ -64,24 +64,31 @@ function absoluteRect(node: Element) {
 }
 
 function nodeDOMAtCoords(coords: { x: number; y: number }) {
-  return document.elementsFromPoint(coords.x, coords.y).find(
-    (elem: Element) =>
-      elem.parentElement?.matches?.(".ProseMirror") ||
-      elem.matches(
-        [
-          "li",
-          "p:not(:first-child)",
-          // allow p tag hovering and selection but only for direct children of table cells
-          "td > p:first-child",
-          "th > p:first-child",
-          ".code-block",
-          "blockquote",
-          "h1, h2, h3",
-          ".table-wrapper",
-          "[data-type=horizontalRule]",
-        ].join(", ")
-      )
-  );
+  const elements = document.elementsFromPoint(coords.x, coords.y);
+  const generalSelectors = [
+    "li",
+    "p:not(:first-child)",
+    ".code-block",
+    "blockquote",
+    "h1, h2, h3",
+    ".table-wrapper",
+    "[data-type=horizontalRule]",
+  ].join(", ");
+
+  for (const elem of elements) {
+    // if the element is a <p> tag that is the first child of a td or th
+    if (
+      (elem.matches("td > p:first-child") || elem.matches("th > p:first-child")) &&
+      elem?.textContent?.trim() !== ""
+    ) {
+      return elem; // Return only if p tag is not empty
+    }
+    // apply general selector
+    if (elem.matches(generalSelectors)) {
+      return elem;
+    }
+  }
+  return null;
 }
 
 function nodePosAtDOM(node: Element, view: EditorView, options: DragHandleOptions) {


### PR DESCRIPTION
## Fixes

1. Selections now occur properly, no matter the level of nesting.
2. Nesting with Tab for list items inside tables work as intended. 
3. Selection works for all kinds of nodes inside tables (or any nest able node)
4. Drag behaviour fixed for tables and block-quotes without clicking on it first.

## Demo (working with a list inside table inside table inside table....) 
https://github.com/makeplane/plane/assets/73993394/46931987-5cc8-4b06-8ae3-d981de1a44c7

For eg, this is how GitHub supports nested tables...
|                |ASCII                          |HTML                         |
|----------------|-------------------------------|-----------------------------|
|Single backticks|`'Isn't this fun?'`            |'Isn't this fun?'            |
|Quotes          |`"Isn't this fun?"`            |<table>  <thead>  <tr>  <th></th>  <th>ASCII</th>  <th>HTML</th>  </tr>  </thead>  <tbody>  <tr>  <td>Single backticks</td>  <td><code>'Isn't this fun?'</code></td>  <td>‘Isn’t this fun?’</td>  </tr>  <tr>  <td>Quotes</td>  <td><code>"Isn't this fun?"</code></td>  <td>“Isn’t this fun?”</td>  </tr>  <tr>  <td>Dashes</td>  <td><code>-- is en-dash, --- is em-dash</code></td>  <td>– is en-dash, — is em-dash</td>  </tr>  </tbody>  </table>      |
|Dashes          |`-- is en-dash, --- is em-dash`|-- is en-dash, --- is em-dash|

We support it too now ;)

https://github.com/makeplane/plane/assets/73993394/db3e38b3-4b6e-4a17-8232-f39edd0b1b80

### Additional fixes
1. toggling an empty codeBlock no longer throws an error defaulting to the default toggleCodeBlock behavior exposed by the `tiptap` apis.