### PR TITLE
[WEB-1131] fix: button click propagation stopped

### DIFF
--- a/packages/editor/extensions/src/extensions/slash-commands.tsx
+++ b/packages/editor/extensions/src/extensions/slash-commands.tsx
@@ -315,7 +315,10 @@ const CommandList = ({ items, command }: { items: CommandItemProps[]; command: a
               "bg-custom-background-80": index === selectedIndex,
             }
           )}
-          onClick={() => selectItem(index)}
+          onClick={(e) => {
+            e.stopPropagation();
+            selectItem(index);
+          }}
         >
           <span className="grid place-items-center flex-shrink-0">{item.icon}</span>
           <p className="flex-grow truncate">{item.title}</p>


### PR DESCRIPTION
## Fixes

Focus of line changes to next line When user tries to create To-do list , Bullet List, Numbered List , Quote, Code using the bubble menu by stopping the `onClick` event propagation to other the editor container.