### PR TITLE
[WEB - 1315] fix: user sign up and sign in on a deactivated account

### DIFF
--- a/apiserver/plane/app/views/user/base.py
+++ b/apiserver/plane/app/views/user/base.py
@@ -269,6 +269,7 @@ class ProfileEndpoint(BaseAPIView):
         serializer = ProfileSerializer(profile)
         return Response(serializer.data, status=status.HTTP_200_OK)
 
+    @invalidate_cache("/api/users/me/settings/")
     def patch(self, request):
         profile = Profile.objects.get(user=request.user)
         serializer = ProfileSerializer(

--- a/apiserver/plane/authentication/views/app/check.py
+++ b/apiserver/plane/authentication/views/app/check.py
@@ -57,6 +57,8 @@ class EmailCheckSignUpEndpoint(APIView):
                         ],
                         error_message="USER_ACCOUNT_DEACTIVATED",
                     )
+
+                # Raise user already exist
                 raise AuthenticationException(
                     error_code=AUTHENTICATION_ERROR_CODES[
                         "USER_ALREADY_EXIST"
@@ -120,7 +122,7 @@ class EmailCheckSignInEndpoint(APIView):
                         ],
                         error_message="USER_ACCOUNT_DEACTIVATED",
                     )
-
+                # Return true
                 return Response(
                     {
                         "status": True,
@@ -128,6 +130,8 @@ class EmailCheckSignInEndpoint(APIView):
                     },
                     status=status.HTTP_200_OK,
                 )
+
+            # Raise error
             raise AuthenticationException(
                 error_code=AUTHENTICATION_ERROR_CODES["USER_DOES_NOT_EXIST"],
                 error_message="USER_DOES_NOT_EXIST",

--- a/apiserver/plane/authentication/views/app/email.py
+++ b/apiserver/plane/authentication/views/app/email.py
@@ -215,6 +215,7 @@ class SignUpAuthEndpoint(View):
             )
             return HttpResponseRedirect(url)
 
+        # Existing user
         existing_user = User.objects.filter(email=email).first()
 
         if existing_user:

--- a/apiserver/plane/authentication/views/app/magic.py
+++ b/apiserver/plane/authentication/views/app/magic.py
@@ -99,25 +99,25 @@ class MagicSignInEndpoint(View):
         existing_user = User.objects.filter(email=email).first()
 
         if not existing_user:
-            if not existing_user.is_active:
-                exc = AuthenticationException(
-                    error_code=AUTHENTICATION_ERROR_CODES[
-                        "USER_ACCOUNT_DEACTIVATED"
-                    ],
-                    error_message="USER_ACCOUNT_DEACTIVATED",
-                )
-                params = exc.get_error_dict()
-                if next_path:
-                    params["next_path"] = str(next_path)
-                url = urljoin(
-                    base_host(request=request, is_app=True),
-                    "sign-in?" + urlencode(params),
-                )
-                return HttpResponseRedirect(url)
-
             exc = AuthenticationException(
                 error_code=AUTHENTICATION_ERROR_CODES["USER_DOES_NOT_EXIST"],
                 error_message="USER_DOES_NOT_EXIST",
+            )
+            params = exc.get_error_dict()
+            if next_path:
+                params["next_path"] = str(next_path)
+            url = urljoin(
+                base_host(request=request, is_app=True),
+                "sign-in?" + urlencode(params),
+            )
+            return HttpResponseRedirect(url)
+
+        if not existing_user.is_active:
+            exc = AuthenticationException(
+                error_code=AUTHENTICATION_ERROR_CODES[
+                    "USER_ACCOUNT_DEACTIVATED"
+                ],
+                error_message="USER_ACCOUNT_DEACTIVATED",
             )
             params = exc.get_error_dict()
             if next_path:
@@ -189,22 +189,6 @@ class MagicSignUpEndpoint(View):
         # Existing user
         existing_user = User.objects.filter(email=email).first()
         if not existing_user:
-            if not existing_user.is_active:
-                exc = AuthenticationException(
-                    error_code=AUTHENTICATION_ERROR_CODES[
-                        "USER_ACCOUNT_DEACTIVATED"
-                    ],
-                    error_message="USER_ACCOUNT_DEACTIVATED",
-                )
-                params = exc.get_error_dict()
-                if next_path:
-                    params["next_path"] = str(next_path)
-                url = urljoin(
-                    base_host(request=request, is_app=True),
-                    "?" + urlencode(params),
-                )
-                return HttpResponseRedirect(url)
-
             exc = AuthenticationException(
                 error_code=AUTHENTICATION_ERROR_CODES["USER_ALREADY_EXIST"],
                 error_message="USER_ALREADY_EXIST",

--- a/apiserver/plane/authentication/views/space/magic.py
+++ b/apiserver/plane/authentication/views/space/magic.py
@@ -176,23 +176,8 @@ class MagicSignUpSpaceEndpoint(View):
             return HttpResponseRedirect(url)
         # Existing User
         existing_user = User.objects.filter(email=email).first()
+        # Already existing
         if existing_user:
-            if not existing_user.is_active:
-                exc = AuthenticationException(
-                    error_code=AUTHENTICATION_ERROR_CODES[
-                        "USER_ACCOUNT_DEACTIVATED"
-                    ],
-                    error_message="USER_ACCOUNT_DEACTIVATED",
-                )
-                params = exc.get_error_dict()
-                if next_path:
-                    params["next_path"] = str(next_path)
-                url = urljoin(
-                    base_host(request=request, is_space=True),
-                    "?" + urlencode(params),
-                )
-                return HttpResponseRedirect(url)
-
             exc = AuthenticationException(
                 error_code=AUTHENTICATION_ERROR_CODES["USER_ALREADY_EXIST"],
                 error_message="USER_ALREADY_EXIST",

--- a/apiserver/plane/license/api/serializers/instance.py
+++ b/apiserver/plane/license/api/serializers/instance.py
@@ -11,13 +11,14 @@ class InstanceSerializer(BaseSerializer):
 
     class Meta:
         model = Instance
-        fields = "__all__"
-        read_only_fields = [
-            "id",
-            "instance_id",
+        exclude = [
             "license_key",
             "api_key",
             "version",
+        ]
+        read_only_fields = [
+            "id",
+            "instance_id",
             "email",
             "last_checked_at",
             "is_setup_done",

--- a/apiserver/plane/license/api/views/admin.py
+++ b/apiserver/plane/license/api/views/admin.py
@@ -107,7 +107,7 @@ class InstanceAdminSignUpEndpoint(View):
             )
             url = urljoin(
                 base_host(request=request, is_admin=True),
-                "setup?" + urlencode(exc.get_error_dict()),
+                "?" + urlencode(exc.get_error_dict()),
             )
             return HttpResponseRedirect(url)
 
@@ -119,7 +119,7 @@ class InstanceAdminSignUpEndpoint(View):
             )
             url = urljoin(
                 base_host(request=request, is_admin=True),
-                "setup?" + urlencode(exc.get_error_dict()),
+                "?" + urlencode(exc.get_error_dict()),
             )
             return HttpResponseRedirect(url)
 
@@ -148,7 +148,7 @@ class InstanceAdminSignUpEndpoint(View):
             )
             url = urljoin(
                 base_host(request=request, is_admin=True),
-                "setup?" + urlencode(exc.get_error_dict()),
+                "?" + urlencode(exc.get_error_dict()),
             )
             return HttpResponseRedirect(url)
 
@@ -170,7 +170,7 @@ class InstanceAdminSignUpEndpoint(View):
             )
             url = urljoin(
                 base_host(request=request, is_admin=True),
-                "setup?" + urlencode(exc.get_error_dict()),
+                "?" + urlencode(exc.get_error_dict()),
             )
             return HttpResponseRedirect(url)
 
@@ -192,7 +192,7 @@ class InstanceAdminSignUpEndpoint(View):
             )
             url = urljoin(
                 base_host(request=request, is_admin=True),
-                "setup?" + urlencode(exc.get_error_dict()),
+                "?" + urlencode(exc.get_error_dict()),
             )
             return HttpResponseRedirect(url)
         else:
@@ -214,7 +214,7 @@ class InstanceAdminSignUpEndpoint(View):
                 )
                 url = urljoin(
                     base_host(request=request, is_admin=True),
-                    "setup?" + urlencode(exc.get_error_dict()),
+                    "?" + urlencode(exc.get_error_dict()),
                 )
                 return HttpResponseRedirect(url)
 

--- a/apiserver/plane/license/api/views/instance.py
+++ b/apiserver/plane/license/api/views/instance.py
@@ -39,7 +39,6 @@ class InstanceEndpoint(BaseAPIView):
     def get(self, request):
         instance = Instance.objects.first()
 
-        print("Instance: ", instance)
         # get the instance
         if instance is None:
             return Response(
@@ -56,8 +55,6 @@ class InstanceEndpoint(BaseAPIView):
             IS_GITHUB_ENABLED,
             GITHUB_APP_NAME,
             EMAIL_HOST,
-            EMAIL_HOST_USER,
-            EMAIL_HOST_PASSWORD,
             ENABLE_MAGIC_LINK_LOGIN,
             ENABLE_EMAIL_PASSWORD,
             SLACK_CLIENT_ID,
@@ -82,14 +79,6 @@ class InstanceEndpoint(BaseAPIView):
                 {
                     "key": "EMAIL_HOST",
                     "default": os.environ.get("EMAIL_HOST", ""),
-                },
-                {
-                    "key": "EMAIL_HOST_USER",
-                    "default": os.environ.get("EMAIL_HOST_USER", ""),
-                },
-                {
-                    "key": "EMAIL_HOST_PASSWORD",
-                    "default": os.environ.get("EMAIL_HOST_PASSWORD", ""),
                 },
                 {
                     "key": "ENABLE_MAGIC_LINK_LOGIN",


### PR DESCRIPTION
- Fixes: the magic sign up by moving the inactive user check below the fetch.
- Fixes: The `last_workspace_id` redirection by invalidating the cache
- Refactor: remove unused variables and print statement

[[WEB - 1315]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/1645f06f-5e8c-4e0a-a44e-ab58419beae3)