### PR TITLE
[WEB-1327] chore: encode email before passing it as a query param

### DIFF
--- a/packages/constants/src/auth.ts
+++ b/packages/constants/src/auth.ts
@@ -130,7 +130,7 @@ const errorCodeMessages: {
         Your account is already registered.&nbsp;
         <Link
           className="underline underline-offset-4 font-medium hover:font-bold transition-all"
-          href={`/sign-in${email ? `?email=${email}` : ``}`}
+          href={`/sign-in${email ? `?email=${encodeURIComponent(email)}` : ``}`}
         >
           Sign In
         </Link>
@@ -171,7 +171,7 @@ const errorCodeMessages: {
         No account found.&nbsp;
         <Link
           className="underline underline-offset-4 font-medium hover:font-bold transition-all"
-          href={`/${email ? `?email=${email}` : ``}`}
+          href={`/${email ? `?email=${encodeURIComponent(email)}` : ``}`}
         >
           Create one
         </Link>

--- a/space/components/accounts/auth-forms/password.tsx
+++ b/space/components/accounts/auth-forms/password.tsx
@@ -68,7 +68,7 @@ export const PasswordForm: React.FC<Props> = (props) => {
       <div className="mt-2 w-full pb-3">
         {isSmtpConfigured ? (
           <Link
-            href={`/accounts/forgot-password?email=${email}`}
+            href={`/accounts/forgot-password?email=${encodeURIComponent(email)}`}
             className="text-xs font-medium text-custom-primary-100"
           >
             Forgot your password?

--- a/space/helpers/authentication.helper.tsx
+++ b/space/helpers/authentication.helper.tsx
@@ -116,7 +116,7 @@ const errorCodeMessages: {
         Your account is already registered.&nbsp;
         <Link
           className="underline underline-offset-4 font-medium hover:font-bold transition-all"
-          href={`/accounts/sign-in${email ? `?email=${email}` : ``}`}
+          href={`/accounts/sign-in${email ? `?email=${encodeURIComponent(email)}` : ``}`}
         >
           Sign In
         </Link>
@@ -155,7 +155,7 @@ const errorCodeMessages: {
         No account found.&nbsp;
         <Link
           className="underline underline-offset-4 font-medium hover:font-bold transition-all"
-          href={`/${email ? `?email=${email}` : ``}`}
+          href={`/${email ? `?email=${encodeURIComponent(email)}` : ``}`}
         >
           Create one
         </Link>

--- a/web/components/account/auth-forms/password.tsx
+++ b/web/components/account/auth-forms/password.tsx
@@ -75,7 +75,7 @@ export const AuthPasswordForm: React.FC<Props> = observer((props: Props) => {
         {isSMTPConfigured ? (
           <Link
             onClick={() => captureEvent(FORGOT_PASSWORD)}
-            href={`/accounts/forgot-password?email=${email}`}
+            href={`/accounts/forgot-password?email=${encodeURIComponent(email)}`}
             className="text-xs font-medium text-custom-primary-100"
           >
             Forgot your password?

--- a/web/helpers/authentication.helper.tsx
+++ b/web/helpers/authentication.helper.tsx
@@ -127,7 +127,7 @@ const errorCodeMessages: {
         Your account is already registered.&nbsp;
         <Link
           className="underline underline-offset-4 font-medium hover:font-bold transition-all"
-          href={`/sign-in${email ? `?email=${email}` : ``}`}
+          href={`/sign-in${email ? `?email=${encodeURIComponent(email)}` : ``}`}
         >
           Sign In
         </Link>
@@ -169,7 +169,7 @@ const errorCodeMessages: {
         No account found.&nbsp;
         <Link
           className="underline underline-offset-4 font-medium hover:font-bold transition-all"
-          href={`/${email ? `?email=${email}` : ``}`}
+          href={`/${email ? `?email=${encodeURIComponent(email)}` : ``}`}
         >
           Create one
         </Link>


### PR DESCRIPTION
#### Improvements:

1. Added URL encoding before passing the email as a query param to support special characters.

#### Plane issue: [WEB-1327](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/8c9a415c-5120-4f52-95f6-47b6b28aa912)