### PR TITLE
[WEB-1260] fix: my activity user image overflow

### DIFF
--- a/web/components/profile/overview/activity.tsx
+++ b/web/components/profile/overview/activity.tsx
@@ -44,13 +44,11 @@ export const ProfileActivity = observer(() => {
             <div className="space-y-5">
               {userProfileActivity.results.map((activity) => (
                 <div key={activity.id} className="flex gap-3">
-                  <div className="flex-shrink-0">
+                  <div className="flex-shrink-0 grid place-items-center overflow-hidden rounded h-6 w-6">
                     {activity.actor_detail?.avatar && activity.actor_detail?.avatar !== "" ? (
                       <img
                         src={activity.actor_detail?.avatar}
                         alt={activity.actor_detail?.display_name}
-                        height={24}
-                        width={24}
                         className="rounded"
                       />
                     ) : (
@@ -72,7 +70,9 @@ export const ProfileActivity = observer(() => {
                         </span>
                       )}
                     </p>
-                    <p className="text-xs text-custom-text-200 whitespace-nowrap ">{calculateTimeAgo(activity.created_at)}</p>
+                    <p className="text-xs text-custom-text-200 whitespace-nowrap ">
+                      {calculateTimeAgo(activity.created_at)}
+                    </p>
                   </div>
                 </div>
               ))}


### PR DESCRIPTION
#### Changes:
This PR fixes the overflow issue with the user pic in the my activity section.

#### Issue link: [[WEB-1260]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/32954326-cf68-4dc0-835b-be930416eb74)

#### Media:
| Before | After |
|--------|--------|
| ![before](https://github.com/makeplane/plane/assets/121005188/220f16c5-af9d-4e60-9d57-45a554342d7a) | ![after](https://github.com/makeplane/plane/assets/121005188/1091efa6-1521-469f-a33d-870f6cd9a26f) |
