### PR TITLE
[WEB-1328] chore: magic sign-in redirection

### DIFF
--- a/apiserver/plane/authentication/provider/credentials/magic_code.py
+++ b/apiserver/plane/authentication/provider/credentials/magic_code.py
@@ -135,8 +135,10 @@ class MagicCodeProvider(CredentialAdapter):
                     payload={"email": str(email)},
                 )
         else:
+            magic_key = str(self.key)
+            email = magic_key.replace("magic_", "", 1)
             raise AuthenticationException(
                 error_code=AUTHENTICATION_ERROR_CODES["EXPIRED_MAGIC_CODE"],
                 error_message="EXPIRED_MAGIC_CODE",
-                payload={"email": str(self.key)},
+                payload={"email": str(email)},
             )

--- a/apiserver/plane/authentication/views/app/magic.py
+++ b/apiserver/plane/authentication/views/app/magic.py
@@ -145,7 +145,7 @@ class MagicSignInEndpoint(View):
                 path = (
                     str(next_path)
                     if next_path
-                    else str(process_workspace_project_invitations(user=user))
+                    else str(get_redirection_path(user=user))
                 )
             # redirect to referer path
             url = urljoin(base_host(request=request, is_app=True), path)


### PR DESCRIPTION
chore: 
- this pull request addresses the problem of redirecting to the previously accessed workspace after completing the sign-in process.
- resolved the `magic_` key error in the expired magic link code error message.

Issue Link: [WEB-1328](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/624ecc4f-f13f-4b32-9b9c-508d8427e98c)