### PR TITLE
[WEB-1336] fix: issue dates conflict in the calendar layout

### DIFF
--- a/apiserver/plane/app/views/search.py
+++ b/apiserver/plane/app/views/search.py
@@ -289,6 +289,7 @@ class IssueSearchEndpoint(BaseAPIView):
             issues.values(
                 "name",
                 "id",
+                "start_date",
                 "sequence_id",
                 "project__name",
                 "project__identifier",

--- a/packages/types/src/project/projects.d.ts
+++ b/packages/types/src/project/projects.d.ts
@@ -147,6 +147,7 @@ export interface ISearchIssueResponse {
   project__identifier: string;
   project__name: string;
   sequence_id: number;
+  start_date: string | null;
   state__color: string;
   state__group: TStateGroups;
   state__name: string;

--- a/web/components/core/modals/existing-issues-list-modal.tsx
+++ b/web/components/core/modals/existing-issues-list-modal.tsx
@@ -1,17 +1,17 @@
 import React, { useEffect, useState } from "react";
 import { Rocket, Search, X } from "lucide-react";
 import { Combobox, Dialog, Transition } from "@headlessui/react";
+// types
 import { ISearchIssueResponse, TProjectIssuesSearchParams } from "@plane/types";
-// services
+// ui
 import { Button, Loader, ToggleSwitch, Tooltip, TOAST_TYPE, setToast } from "@plane/ui";
+// hooks
 import useDebounce from "@/hooks/use-debounce";
 import { usePlatformOS } from "@/hooks/use-platform-os";
+// services
 import { ProjectService } from "@/services/project";
-// hooks
 // components
 import { IssueSearchModalEmptyState } from "./issue-search-modal-empty-state";
-// ui
-// types
 
 type Props = {
   workspaceSlug: string | undefined;
@@ -21,6 +21,7 @@ type Props = {
   searchParams: Partial<TProjectIssuesSearchParams>;
   handleOnSubmit: (data: ISearchIssueResponse[]) => Promise<void>;
   workspaceLevelToggle?: boolean;
+  shouldHideIssue?: (issue: ISearchIssueResponse) => boolean;
 };
 
 const projectService = new ProjectService();
@@ -34,6 +35,7 @@ export const ExistingIssuesListModal: React.FC<Props> = (props) => {
     searchParams,
     handleOnSubmit,
     workspaceLevelToggle = false,
+    shouldHideIssue,
   } = props;
   // states
   const [isLoading, setIsLoading] = useState(false);
@@ -86,6 +88,8 @@ export const ExistingIssuesListModal: React.FC<Props> = (props) => {
         setIsLoading(false);
       });
   }, [debouncedSearchTerm, isOpen, isWorkspaceLevel, projectId, workspaceSlug]);
+
+  const filteredIssues = issues.filter((issue) => !shouldHideIssue?.(issue));
 
   return (
     <>
@@ -207,16 +211,16 @@ export const ExistingIssuesListModal: React.FC<Props> = (props) => {
                       </Loader>
                     ) : (
                       <>
-                        {issues.length === 0 ? (
+                        {filteredIssues.length === 0 ? (
                           <IssueSearchModalEmptyState
                             debouncedSearchTerm={debouncedSearchTerm}
                             isSearching={isSearching}
-                            issues={issues}
+                            issues={filteredIssues}
                             searchTerm={searchTerm}
                           />
                         ) : (
-                          <ul className={`text-sm text-custom-text-100 ${issues.length > 0 ? "p-2" : ""}`}>
-                            {issues.map((issue) => {
+                          <ul className={`text-sm text-custom-text-100 ${filteredIssues.length > 0 ? "p-2" : ""}`}>
+                            {filteredIssues.map((issue) => {
                               const selected = selectedIssues.some((i) => i.id === issue.id);
 
                               return (


### PR DESCRIPTION
#### Problem:

In the calendar layout, user can add an issue to a due date less than the start date of the issue by dragging or by the selecting issues from the existing issues list.

#### Solution:

1. Disable drag and drop when an issue is dropped on a due date which is less than its start date.
2. HId issues with start date more than the due date to which the issues are being added.

#### Media:

1. While using drag and drop-

https://github.com/makeplane/plane/assets/65252264/bfdde885-b6e4-429c-b958-5d748da64ce8

2. While adding issues from the issues list modal-

https://github.com/makeplane/plane/assets/65252264/f56df54c-ecff-413e-bae7-be158008a12e

#### Plane issue: [WEB-1336](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/3598c005-1d78-4551-a773-de5aa7afcb83)