### PR TITLE
[WEB-1205] chore: hide bot accounts from the collabortors list

### DIFF
--- a/web/components/dashboard/widgets/recent-collaborators/collaborators-list.tsx
+++ b/web/components/dashboard/widgets/recent-collaborators/collaborators-list.tsx
@@ -26,7 +26,7 @@ const CollaboratorListItem: React.FC<CollaboratorListItemProps> = observer((prop
   const userDetails = getUserDetails(userId);
   const isCurrentUser = userId === currentUser?.id;
 
-  if (!userDetails) return null;
+  if (!userDetails || userDetails.is_bot) return null;
 
   return (
     <Link href={`/${workspaceSlug}/profile/${userId}`} className="group text-center">


### PR DESCRIPTION
#### Improvements:

1. HId all bot accounts from the collaborators list widget in the dashboard.

#### Plane issue: [WEB-1205](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/6541a26d-4fef-4974-9976-6a65f72eede0)