### PR TITLE
[WEB-1210] chore: discard changes made after creating issue

### DIFF
--- a/web/components/issues/issue-modal/modal.tsx
+++ b/web/components/issues/issue-modal/modal.tsx
@@ -170,11 +170,9 @@ export const CreateUpdateIssueModal: React.FC<IssuesModalProps> = observer((prop
         path: router.asPath,
       });
       !createMore && handleClose();
-      if (createMore) {
-        issueTitleRef && issueTitleRef?.current?.focus();
-        setDescription("<p></p>");
-        setChangesMade(null);
-      }
+      if (createMore) issueTitleRef && issueTitleRef?.current?.focus();
+      setDescription("<p></p>");
+      setChangesMade(null);
       return response;
     } catch (error) {
       setToast({


### PR DESCRIPTION
#### Problem:

1. After creating an issue, if the user opens the create issue modal again and discard without entering a value, the `Save as draft issue` modal pops up even though there's no data in the form.

#### Solutiion:

1. Resetting the `changesMade` boolean flag to `null` after creating an issue.

#### Plane issue: [WEB-1210](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/d5fb2b7b-8327-423e-9a4a-9ce8565a056b)