### PR TITLE
[WEB-1310] chore: page title can be blank

### DIFF
--- a/web/components/pages/editor/title.tsx
+++ b/web/components/pages/editor/title.tsx
@@ -38,7 +38,7 @@ export const PageEditorTitle: React.FC<Props> = observer((props) => {
             style={{
               lineHeight: "1.2",
             }}
-            placeholder="Untitled Page"
+            placeholder="Untitled"
             onKeyDown={(e) => {
               if (e.key === "Enter") {
                 e.preventDefault();
@@ -60,7 +60,7 @@ export const PageEditorTitle: React.FC<Props> = observer((props) => {
           >
             <span
               className={cn({
-                "text-red-500": title.length === 0 || title.length > 255,
+                "text-red-500": title.length > 255,
               })}
             >
               {title.length}

--- a/web/components/pages/list/block.tsx
+++ b/web/components/pages/list/block.tsx
@@ -25,7 +25,7 @@ export const PageListBlock: FC<TPageListBlock> = observer((props) => {
 
   return (
     <ListItem
-      title={getPageName(name ?? "")}
+      title={getPageName(name)}
       itemLink={`/${workspaceSlug}/projects/${projectId}/pages/${pageId}`}
       actionableItems={
         <BlockItemAction workspaceSlug={workspaceSlug} projectId={projectId} pageId={pageId} parentRef={parentRef} />

--- a/web/components/pages/list/block.tsx
+++ b/web/components/pages/list/block.tsx
@@ -3,6 +3,8 @@ import { observer } from "mobx-react";
 // components
 import { ListItem } from "@/components/core/list";
 import { BlockItemAction } from "@/components/pages/list";
+// helpers
+import { getPageName } from "@/helpers/page.helper";
 // hooks
 import { usePage } from "@/hooks/store";
 import { usePlatformOS } from "@/hooks/use-platform-os";
@@ -23,9 +25,11 @@ export const PageListBlock: FC<TPageListBlock> = observer((props) => {
 
   return (
     <ListItem
-      title={name ?? ""}
+      title={getPageName(name ?? "")}
       itemLink={`/${workspaceSlug}/projects/${projectId}/pages/${pageId}`}
-      actionableItems={<BlockItemAction workspaceSlug={workspaceSlug} projectId={projectId} pageId={pageId} parentRef={parentRef} />}
+      actionableItems={
+        <BlockItemAction workspaceSlug={workspaceSlug} projectId={projectId} pageId={pageId} parentRef={parentRef} />
+      }
       isMobile={isMobile}
       parentRef={parentRef}
     />

--- a/web/helpers/page.helper.ts
+++ b/web/helpers/page.helper.ts
@@ -72,3 +72,13 @@ export const shouldFilterPage = (page: TPage, filters: TPageFilterProps | undefi
 
   return fallsInFilters;
 };
+
+/**
+ * @description returns the name of the project after checking for untitled page
+ * @param {string} name
+ * @returns {string}
+ */
+export const getPageName = (name: string) => {
+  if (!name || name.trim() === "") return "Untitled";
+  return name;
+};

--- a/web/helpers/page.helper.ts
+++ b/web/helpers/page.helper.ts
@@ -75,10 +75,11 @@ export const shouldFilterPage = (page: TPage, filters: TPageFilterProps | undefi
 
 /**
  * @description returns the name of the project after checking for untitled page
- * @param {string} name
+ * @param {string | undefined} name
  * @returns {string}
  */
-export const getPageName = (name: string) => {
+export const getPageName = (name: string | undefined) => {
+  if (name === undefined) return "";
   if (!name || name.trim() === "") return "Untitled";
   return name;
 };

--- a/web/store/pages/project-page.store.ts
+++ b/web/store/pages/project-page.store.ts
@@ -105,9 +105,7 @@ export class ProjectPageStore implements IProjectPageStore {
     let filteredPages = pagesByType.filter(
       (p) =>
         p.project === projectId &&
-        getPageName(p.name ?? "")
-          .toLowerCase()
-          .includes(this.filters.searchQuery.toLowerCase()) &&
+        getPageName(p.name).toLowerCase().includes(this.filters.searchQuery.toLowerCase()) &&
         shouldFilterPage(p, this.filters.filters)
     );
     filteredPages = orderPages(filteredPages, this.filters.sortKey, this.filters.sortBy);

--- a/web/store/pages/project-page.store.ts
+++ b/web/store/pages/project-page.store.ts
@@ -5,7 +5,7 @@ import { computedFn } from "mobx-utils";
 // types
 import { TPage, TPageFilters, TPageNavigationTabs } from "@plane/types";
 // helpers
-import { filterPagesByPageType, orderPages, shouldFilterPage } from "@/helpers/page.helper";
+import { filterPagesByPageType, getPageName, orderPages, shouldFilterPage } from "@/helpers/page.helper";
 // services
 import { PageService } from "@/services/page.service";
 // store
@@ -105,7 +105,9 @@ export class ProjectPageStore implements IProjectPageStore {
     let filteredPages = pagesByType.filter(
       (p) =>
         p.project === projectId &&
-        p.name?.toLowerCase().includes(this.filters.searchQuery.toLowerCase()) &&
+        getPageName(p.name ?? "")
+          .toLowerCase()
+          .includes(this.filters.searchQuery.toLowerCase()) &&
         shouldFilterPage(p, this.filters.filters)
     );
     filteredPages = orderPages(filteredPages, this.filters.sortKey, this.filters.sortBy);


### PR DESCRIPTION
#### Improvements:

1. Page title can now be blank. Blank titles will be display as `Untitled`.

#### Plane issue: [WEB-1310](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/97bf4bda-e0d1-425f-a8fc-1e1383a3512a)