### PR TITLE
[WEB-1258] chore: prevent route change on canceling confirm dialog

### DIFF
--- a/web/hooks/use-reload-confirmation.tsx
+++ b/web/hooks/use-reload-confirmation.tsx
@@ -16,14 +16,15 @@ const useReloadConfirmations = (isActive = true) => {
   );
 
   const handleRouteChangeStart = useCallback(
-    (url: string) => {
+    (url: string, { shallow }: { shallow: boolean }) => {
       if (!isActive || !showAlert) return;
       const leave = confirm("Are you sure you want to leave? Changes you made may not be saved.");
       if (!leave) {
-        router.events.emit("routeChangeError");
+        router.events.emit("routeChangeError", new Error("Route change cancelled by user"), url, shallow);
+        throw "routeChange aborted.";
       }
     },
-    [isActive, showAlert, router.events]
+    [isActive, router.events, showAlert]
   );
 
   useEffect(() => {


### PR DESCRIPTION
#### Problem:

1. When data is being saved in issue description or pages and the user tries to navigate to some other link, a confirm dialog pops up. If the user cancels the navigation, they still get navigated to that route.

#### Solution:

1. Fixed `handleRouteChange` function to now prevent the user from navigating to the new route on Cancel.

#### Media:

https://github.com/makeplane/plane/assets/65252264/6baf0f9e-04e6-4ecf-81c0-823e4aabd6a5

#### Plane issue: [WEB-1258](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/e8ca2ee0-fbca-4ea8-9a70-bbea374eebf0)