### PR TITLE
[WEB-1357] chore: user favorite sequence

### DIFF
--- a/apiserver/plane/db/models/favorite.py
+++ b/apiserver/plane/db/models/favorite.py
@@ -39,11 +39,11 @@ class UserFavorite(WorkspaceBaseModel):
 
     def save(self, *args, **kwargs):
         if self._state.adding:
-            largest_sort_order = UserFavorite.objects.filter(
-                workspace=self.workspace
-            ).aggregate(largest=models.Max("sort_order"))["largest"]
-            if largest_sort_order is not None:
-                self.sort_order = largest_sort_order + 10000
+            largest_sequence = UserFavorite.objects.filter(
+                workspace=self.project.workspace
+            ).aggregate(largest=models.Max("sequence"))["largest"]
+            if largest_sequence is not None:
+                self.sequence = largest_sequence + 10000
 
         super(UserFavorite, self).save(*args, **kwargs)
 


### PR DESCRIPTION
chore: 
- this pull request corrects the bug affecting the ability to mark items (e.g., cycle, module, issue, pages and views) as favorites due the key named sort order. 

Issue Link: [WEB-1357](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/04e14470-26fd-4b93-9ba8-b11e644acac3)