### PR TITLE
[WEB-1366] fix: show untitle for blank page titles

### DIFF
--- a/web/store/pages/page.store.ts
+++ b/web/store/pages/page.store.ts
@@ -76,7 +76,7 @@ export class PageStore implements IPageStore {
     page: TPage
   ) {
     this.id = page?.id || undefined;
-    this.name = page?.name || undefined;
+    this.name = page?.name?.trim() === "" ? "" : undefined;
     this.description_html = page?.description_html || undefined;
     this.color = page?.color || undefined;
     this.labels = page?.labels || undefined;


### PR DESCRIPTION
#### Bug fix:

1. Show `Untitled` for pages without a title.

#### Plane issue: [WEB-1366](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/58ef54ab-9ef8-4aaa-8c07-34ddea9d9195)