### PR TITLE
Add Calendar layout to Global Issues page

### DIFF
--- a/web/components/headers/global-issues.tsx
+++ b/web/components/headers/global-issues.tsx
@@ -4,12 +4,12 @@ import { useRouter } from "next/router";
 // icons
 import { PlusIcon } from "lucide-react";
 // types
-import { IIssueDisplayFilterOptions, IIssueDisplayProperties, IIssueFilterOptions } from "@plane/types";
+import { IIssueDisplayFilterOptions, IIssueDisplayProperties, IIssueFilterOptions, TIssueLayouts } from "@plane/types";
 // ui
 import { Breadcrumbs, Button, LayersIcon } from "@plane/ui";
 // components
 import { BreadcrumbLink } from "@/components/common";
-import { DisplayFiltersSelection, FiltersDropdown, FilterSelection } from "@/components/issues";
+import { DisplayFiltersSelection, FiltersDropdown, FilterSelection, LayoutSelection } from "@/components/issues";
 import { CreateUpdateWorkspaceViewModal } from "@/components/workspace";
 // constants
 import { EIssueFilterType, EIssuesStoreType, ISSUE_DISPLAY_FILTERS_BY_LAYOUT } from "@/constants/issue";
@@ -22,7 +22,7 @@ export const GlobalIssuesHeader: React.FC = observer(() => {
   const [createViewModal, setCreateViewModal] = useState(false);
   // router
   const router = useRouter();
-  const { workspaceSlug, globalViewId } = router.query;
+  const { workspaceSlug, globalViewId, projectId } = router.query;
   // store hooks
   const {
     issuesFilter: { filters, updateFilters },
@@ -36,6 +36,22 @@ export const GlobalIssuesHeader: React.FC = observer(() => {
   } = useMember();
 
   const issueFilters = globalViewId ? filters[globalViewId.toString()] : undefined;
+  const activeLayout = issueFilters?.displayFilters?.layout;
+
+  const handleLayoutChange = useCallback(
+    (layout: TIssueLayouts) => {
+    // (updatedDisplayFilter: Partial<IIssueDisplayFilterOptions>) => {
+      if (!workspaceSlug) return;
+      updateFilters(
+        workspaceSlug.toString(),
+        undefined,
+        EIssueFilterType.DISPLAY_FILTERS,
+        { layout: layout },
+        globalViewId.toString(),
+      );
+    },
+    [workspaceSlug, updateFilters, globalViewId]
+  );
 
   const handleFiltersUpdate = useCallback(
     (key: keyof IIssueFilterOptions, value: string | string[]) => {
@@ -110,6 +126,11 @@ export const GlobalIssuesHeader: React.FC = observer(() => {
         </div>
         <div className="flex items-center gap-2">
           <>
+            <LayoutSelection
+              layouts={["calendar", "spreadsheet"]}
+              onChange={(layout) => handleLayoutChange(layout)}
+              selectedLayout={activeLayout}
+            />
             <FiltersDropdown title="Filters" placement="bottom-end">
               <FilterSelection
                 layoutDisplayFiltersOptions={ISSUE_DISPLAY_FILTERS_BY_LAYOUT.my_issues.spreadsheet}

--- a/web/components/issues/issue-layouts/calendar/base-calendar-root.tsx
+++ b/web/components/issues/issue-layouts/calendar/base-calendar-root.tsx
@@ -13,7 +13,7 @@ import { useIssues, useUser } from "@/hooks/store";
 import { useIssuesActions } from "@/hooks/use-issues-actions";
 // ui
 // types
-import { IQuickActionProps } from "../list/list-view-types";
+import { IQuickActionProps, TRenderQuickActions } from "../list/list-view-types";
 import { handleDragDrop } from "./utils";
 
 type CalendarStoreType =
@@ -79,6 +79,21 @@ export const BaseCalendarRoot = observer((props: IBaseCalendarRoot) => {
     }
   };
 
+  const renderQuickActions: TRenderQuickActions = ({ issue, parentRef, customActionButton, placement }) => (
+    <QuickActions
+      parentRef={parentRef}
+      customActionButton={customActionButton}
+      issue={issue}
+      handleDelete={async () => removeIssue(issue.project_id, issue.id)}
+      handleUpdate={async (data) => updateIssue && updateIssue(issue.project_id, issue.id, data)}
+      handleRemoveFromView={async () => removeIssueFromView && removeIssueFromView(issue.project_id, issue.id)}
+      handleArchive={async () => archiveIssue && archiveIssue(issue.project_id, issue.id)}
+      handleRestore={async () => restoreIssue && restoreIssue(issue.project_id, issue.id)}
+      readOnly={!isEditingAllowed || isCompletedCycle}
+      placements={placement}
+    />
+  );
+
   return (
     <>
       <div className="h-full w-full overflow-hidden bg-custom-background-100 pt-4">
@@ -89,22 +104,7 @@ export const BaseCalendarRoot = observer((props: IBaseCalendarRoot) => {
             groupedIssueIds={groupedIssueIds}
             layout={displayFilters?.calendar?.layout}
             showWeekends={displayFilters?.calendar?.show_weekends ?? false}
-            quickActions={({ issue, parentRef, customActionButton, placement }) => (
-              <QuickActions
-                parentRef={parentRef}
-                customActionButton={customActionButton}
-                issue={issue}
-                handleDelete={async () => removeIssue(issue.project_id, issue.id)}
-                handleUpdate={async (data) => updateIssue && updateIssue(issue.project_id, issue.id, data)}
-                handleRemoveFromView={async () =>
-                  removeIssueFromView && removeIssueFromView(issue.project_id, issue.id)
-                }
-                handleArchive={async () => archiveIssue && archiveIssue(issue.project_id, issue.id)}
-                handleRestore={async () => restoreIssue && restoreIssue(issue.project_id, issue.id)}
-                readOnly={!isEditingAllowed || isCompletedCycle}
-                placements={placement}
-              />
-            )}
+            quickActions={renderQuickActions}
             addIssuesToView={addIssuesToView}
             quickAddCallback={issues.quickAddIssue}
             viewId={viewId}

--- a/web/components/issues/issue-layouts/calendar/calendar-view.tsx
+++ b/web/components/issues/issue-layouts/calendar/calendar-view.tsx
@@ -1,0 +1,151 @@
+import React, { useRef } from "react";
+import { DraggableLocation, DragDropContext, DropResult } from "@hello-pangea/dnd";
+import { observer } from "mobx-react-lite";
+import { EIssueFilterType, EIssuesStoreType } from "@/constants/issue";
+import {
+  TIssue,
+  IIssueDisplayFilterOptions,
+  IIssueDisplayProperties,
+  IIssueMap,
+  TGroupedIssues,
+  IIssueFilterOptions,
+  TIssueMap,
+  TIssueKanbanFilters,
+} from "@plane/types";
+// components
+import { Spinner, TOAST_TYPE, setToast } from "@plane/ui";
+import { CalendarChart } from "@/components/issues";
+import { useProject } from "@/hooks/store";
+import { TRenderQuickActions } from "../list/list-view-types";
+import { handleDragDrop } from "./utils";
+import { IWorkspaceIssuesFilter } from "@/store/issue/workspace";
+// types
+//hooks
+
+type Props = {
+  // displayProperties: IIssueDisplayProperties;
+  // displayFilters: IIssueDisplayFilterOptions;
+  // handleDisplayFilterUpdate: (data: Partial<IIssueDisplayFilterOptions>) => void;
+  // issueIds: string[] | undefined;
+  // quickActions: TRenderQuickActions;
+  // updateIssue: ((projectId: string, issueId: string, data: Partial<TIssue>) => Promise<void>) | undefined;
+  // openIssuesListModal?: (() => void) | null;
+  // quickAddCallback?: (
+  //   workspaceSlug: string,
+  //   projectId: string,
+  //   data: TIssue,
+  //   viewId?: string
+  // ) => Promise<TIssue | undefined>;
+  // viewId?: string;
+  // canEditProperties: (projectId: string | undefined) => boolean;
+  // enableQuickCreateIssue?: boolean;
+  // disableIssueCreation?: boolean;
+  // isWorkspaceLevel?: boolean;
+
+  // issues
+  issuesFilterStore: IWorkspaceIssuesFilter,
+  issues: TIssueMap,
+  // issueIds: string[],
+  groupedIssueIds: TGroupedIssues,
+  // Layout
+  // layout: "month" | "week" | undefined;
+  // showWeekends: boolean;
+  // handlers
+  quickActions: TRenderQuickActions;
+  quickAddIssues?: (
+  // quickAddCallback?: (
+    workspaceSlug: string,
+    projectId: string,
+    data: TIssue,
+    viewId?: string
+  ) => Promise<TIssue | undefined>;
+  addIssuesToView?: (issueIds: string[]) => Promise<any>;
+  // handleDisplayFilterUpdate?: (
+  //   projectId: string,
+  //   filterType: EIssueFilterType,
+  //   filters: IIssueFilterOptions | IIssueDisplayFilterOptions | IIssueDisplayProperties | TIssueKanbanFilters
+  // ) => Promise<void>;
+  // updateIssue?: (projectId: string, issueId: string, data: Partial<TIssue>) => Promise<void>;
+  viewId?: string;
+  readOnly?: boolean;
+  updateFilters?: (
+    projectId: string,
+    filterType: EIssueFilterType,
+    filters: IIssueFilterOptions | IIssueDisplayFilterOptions | IIssueDisplayProperties | TIssueKanbanFilters
+  ) => Promise<void>
+  isWorkspaceLevel?: boolean;
+  // handleDragDrop?: (
+  //   source: DraggableLocation,
+  //   destination: DraggableLocation,
+  //   workspaceSlug: string | undefined,
+  //   projectId: string | undefined,
+  //   issueMap: IIssueMap,
+  //   issueWithIds: TGroupedIssues,
+  //   updateIssue?: ((projectId: string, issueId: string, data: TIssue) => Promise<void>) | undefined
+  // ) => Promise<void>
+};
+
+export const CalendarView: React.FC<Props> = observer((props: Props) => {
+  const {
+    issuesFilterStore,
+    issues,
+    groupedIssueIds,
+    // layout,
+    // showWeekends,
+    quickActions,
+    quickAddIssues,
+    // updateIssue,
+    addIssuesToView,
+    viewId,
+    readOnly,
+    updateFilters,
+    isWorkspaceLevel = true
+  } = props;
+  // refs
+  const containerRef = useRef<HTMLTableElement | null>(null);
+  const portalRef = useRef<HTMLDivElement | null>(null);
+
+  const { currentProjectDetails } = useProject();
+
+  const isEstimateEnabled: boolean = currentProjectDetails?.estimate !== null;
+
+  const displayFilters = issuesFilterStore.issueFilters.displayFilters;
+  console.log("CalendarView.displayFilters", displayFilters)
+
+  const onDragEnd = async (result: DropResult) => {
+    if (!result) return;
+
+    // return if not dropped on the correct place
+    if (!result.destination) return;
+
+    // return if dropped on the same date
+    if (result.destination.droppableId === result.source.droppableId) return;
+
+    if (handleDragDrop) {
+      await handleDragDrop
+    }
+  };
+
+  return (
+    <div className="relative flex flex-col h-full w-full overflow-x-hidden whitespace-nowrap rounded-lg bg-custom-background-200 text-custom-text-200">
+      <div ref={containerRef} className="vertical-scrollbar horizontal-scrollbar scrollbar-lg h-full w-full bg-custom-background-100 pt-4">
+        <DragDropContext onDragEnd={onDragEnd}>
+          <CalendarChart
+            issuesFilterStore={issuesFilterStore}
+            issues={issues}
+            groupedIssueIds={groupedIssueIds}
+            layout={displayFilters?.calendar?.layout}
+            showWeekends={displayFilters?.calendar?.show_weekends ?? false}
+            quickActions={quickActions}
+            quickAddIssue={quickAddIssues}
+            addIssuesToView={addIssuesToView}
+            viewId={viewId}
+            // readOnly={!isEditingAllowed || isCompletedCycle}
+            readOnly={readOnly}
+            updateFilters={updateFilters}
+          />
+        </DragDropContext>
+      </div>
+    </div>
+  );
+});

--- a/web/components/issues/issue-layouts/calendar/index.ts
+++ b/web/components/issues/issue-layouts/calendar/index.ts
@@ -1,5 +1,6 @@
 export * from "./dropdowns";
 export * from "./roots";
+export * from "./calendar-view";
 export * from "./calendar";
 export * from "./types.d";
 export * from "./day-tile";

--- a/web/constants/issue.ts
+++ b/web/constants/issue.ts
@@ -262,6 +262,27 @@ export const ISSUE_DISPLAY_FILTERS_BY_LAYOUT: {
         values: ["sub_issue"],
       },
     },
+    calendar: {
+      filters: [
+        "priority",
+        "state_group",
+        "labels",
+        "assignees",
+        "created_by",
+        "subscriber",
+        "project",
+        "start_date",
+        "target_date",
+      ],
+      display_properties: true,
+      display_filters: {
+        type: [null, "active", "backlog"],
+      },
+      extra_options: {
+        access: true,
+        values: ["sub_issue"],
+      },
+    },
     list: {
       filters: [
         "priority",

--- a/web/hooks/use-issues-actions.tsx
+++ b/web/hooks/use-issues-actions.tsx
@@ -558,6 +558,7 @@ const useGlobalIssueActions = () => {
       filterType: EIssueFilterType,
       filters: IIssueFilterOptions | IIssueDisplayFilterOptions | IIssueDisplayProperties | TIssueKanbanFilters
     ) => {
+      // TODO: Cannot change layout yet, maybe because of this?
       if (!globalViewId || !workspaceSlug) return;
       return await issuesFilter.updateFilters(workspaceSlug, projectId, filterType, filters, globalViewId);
     },

--- a/web/store/issue/workspace/filter.store.ts
+++ b/web/store/issue/workspace/filter.store.ts
@@ -37,7 +37,7 @@ export interface IWorkspaceIssuesFilter {
     projectId: string | undefined,
     filterType: EIssueFilterType,
     filters: IIssueFilterOptions | IIssueDisplayFilterOptions | IIssueDisplayProperties | TIssueKanbanFilters,
-    viewId: string
+    viewId: string,
   ) => Promise<void>;
   //helper action
   getIssueFilters: (viewId: string | undefined) => IIssueFilters | undefined;
@@ -123,7 +123,7 @@ export class WorkspaceIssuesFilter extends IssueFilterHelperStore implements IWo
       };
 
       const _filters = this.handleIssuesLocalFilters.get(EIssuesStoreType.GLOBAL, workspaceSlug, undefined, viewId);
-      displayFilters = this.computedDisplayFilters(_filters?.display_filters, { layout: "spreadsheet" });
+      displayFilters = this.computedDisplayFilters(_filters?.display_filters); // TODO: Is this wrong?
       displayProperties = this.computedDisplayProperties(_filters?.display_properties);
       kanbanFilters = {
         group_by: _filters?.kanban_filters?.group_by || [],
@@ -224,15 +224,16 @@ export class WorkspaceIssuesFilter extends IssueFilterHelperStore implements IWo
           if (this.requiresServerUpdate(updatedDisplayFilters))
             this.rootIssueStore.workspaceIssues.fetchIssues(workspaceSlug, viewId, "mutation");
 
-          if (["all-issues", "assigned", "created", "subscribed"].includes(viewId))
+          if (["all-issues", "assigned", "created", "subscribed"].includes(viewId)) {
             this.handleIssuesLocalFilters.set(EIssuesStoreType.GLOBAL, type, workspaceSlug, undefined, viewId, {
               display_filters: _filters.displayFilters,
             });
-          else
+          }
+          else {
             await this.issueFilterService.updateView(workspaceSlug, viewId, {
               display_filters: _filters.displayFilters,
             });
-
+          }
           break;
         case EIssueFilterType.DISPLAY_PROPERTIES:
           const updatedDisplayProperties = filters as IIssueDisplayProperties;


### PR DESCRIPTION
# Why

Part of #4131 

# What

- Split out renderQuickActions for BaseCalendarRoot
- Update `headers/global-issues.tsx` to add LayoutSelection
- Add `calendar-view.tsx`
- Add CalendarView to `issue-layouts/roots/all-issue-layout-root.tsx`
- Add types to `web/constants/issue.ts`
- Add issue grouping to `issue.store.ts`
- Minor updates to `filter.store.ts`

# Questions / TODOs

- [ ] This PR doesn't allow changing Calendar layout (month vs week, show vs hide weekends) yet, but I'm not sure what I'm missing
- [ ] I'm not sure if I'm updating `displayFilters = this.computedDisplayFilters(_filters?.display_filters);` correctly in filter.store.ts 
- [ ] I'm not sure if `issue-layouts/calendar/calendar-view.tsx` is the idiomatic/proper way & proper place to do it