### PR TITLE
[WEB-1361] fix: comments access specifier mutation issue.

### DIFF
--- a/web/components/issues/issue-detail/issue-activity/comments/comment-block.tsx
+++ b/web/components/issues/issue-detail/issue-activity/comments/comment-block.tsx
@@ -1,4 +1,5 @@
 import { FC, ReactNode } from "react";
+import { observer } from "mobx-react";
 import { MessageCircle } from "lucide-react";
 // hooks
 import { calculateTimeAgo } from "@/helpers/date-time.helper";
@@ -12,7 +13,7 @@ type TIssueCommentBlock = {
   children: ReactNode;
 };
 
-export const IssueCommentBlock: FC<TIssueCommentBlock> = (props) => {
+export const IssueCommentBlock: FC<TIssueCommentBlock> = observer((props) => {
   const { commentId, ends, quickActions, children } = props;
   // hooks
   const {
@@ -63,4 +64,4 @@ export const IssueCommentBlock: FC<TIssueCommentBlock> = (props) => {
       </div>
     </div>
   );
-};
+});

--- a/web/components/issues/issue-detail/issue-activity/comments/comment-card.tsx
+++ b/web/components/issues/issue-detail/issue-activity/comments/comment-card.tsx
@@ -1,4 +1,5 @@
 import { FC, useEffect, useRef, useState } from "react";
+import { observer } from "mobx-react";
 import { useForm } from "react-hook-form";
 import { Check, Globe2, Lock, Pencil, Trash2, X } from "lucide-react";
 import { EditorReadOnlyRefApi, EditorRefApi } from "@plane/lite-text-editor";
@@ -28,7 +29,7 @@ type TIssueCommentCard = {
   disabled?: boolean;
 };
 
-export const IssueCommentCard: FC<TIssueCommentCard> = (props) => {
+export const IssueCommentCard: FC<TIssueCommentCard> = observer((props) => {
   const {
     workspaceSlug,
     projectId,
@@ -90,7 +91,7 @@ export const IssueCommentCard: FC<TIssueCommentCard> = (props) => {
       quickActions={
         <>
           {!disabled && currentUser?.id === comment.actor && (
-            <CustomMenu ellipsis>
+            <CustomMenu ellipsis closeOnSelect>
               <CustomMenu.MenuItem onClick={() => setIsEditing(true)} className="flex items-center gap-1">
                 <Pencil className="h-3 w-3" />
                 Edit comment
@@ -196,4 +197,4 @@ export const IssueCommentCard: FC<TIssueCommentCard> = (props) => {
       </>
     </IssueCommentBlock>
   );
-};
+});


### PR DESCRIPTION
#### Problem
No mutation happening when comment is changed to public to private and vice verse

#### Solution
This was happening because the comment component was not wrapped around `observer`. 

#### Media
* Before

[scrnli_5_20_2024_1-24-17 AM.webm](https://github.com/makeplane/plane/assets/33979846/11cbc6b8-de84-4786-97f4-44a2cc9dcac6)

* After

[scrnli_5_20_2024_1-22-57 AM.webm](https://github.com/makeplane/plane/assets/33979846/448d9183-3123-43bb-a228-7ba89d7da256)

This PR is linked to [WEB-1361](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/4bd80be3-abd8-4980-bbaa-fb6495c64ee0)