### PR TITLE
[WEB-1063] style: fix activity/ comment overflow issue.

### DIFF
--- a/web/components/issues/issue-detail/issue-activity/activity/actions/helpers/activity-block.tsx
+++ b/web/components/issues/issue-detail/issue-activity/activity/actions/helpers/activity-block.tsx
@@ -38,7 +38,7 @@ export const IssueActivityBlockComponent: FC<TIssueActivityBlockComponent> = (pr
       <div className="flex-shrink-0 ring-6 w-7 h-7 rounded-full overflow-hidden flex justify-center items-center z-[4] bg-custom-background-80 text-custom-text-200">
         {icon ? icon : <Network className="w-3.5 h-3.5" />}
       </div>
-      <div className="w-full text-custom-text-200">
+      <div className="w-full truncate text-custom-text-200">
         <IssueUser activityId={activityId} customUserName={customUserName} />
         <span> {children} </span>
         <span>

--- a/web/components/issues/issue-detail/issue-activity/comments/comment-block.tsx
+++ b/web/components/issues/issue-detail/issue-activity/comments/comment-block.tsx
@@ -48,8 +48,8 @@ export const IssueCommentBlock: FC<TIssueCommentBlock> = observer((props) => {
           <MessageCircle className="w-3 h-3" color="#6b7280" />
         </div>
       </div>
-      <div className="w-full relative flex ">
-        <div className="w-full space-y-1">
+      <div className="w-full truncate relative flex ">
+        <div className="w-full truncate space-y-1">
           <div>
             <div className="text-xs capitalize">
               {comment.actor_detail.is_bot


### PR DESCRIPTION
#### Problem
Issue activity and comment were overflowing.

#### Solution
Add necessary adjustments to fix this issue.

#### Media
* Before
<img width="1512" alt="image" src="https://github.com/makeplane/plane/assets/33979846/814da933-00eb-4784-866f-a40c8cdb5ad2">


* After
<img width="1512" alt="image" src="https://github.com/makeplane/plane/assets/33979846/f39d11c4-48eb-4e2d-91a4-06e52ba1ad7d">



This PR is linked to [WEB-1063](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/180329a6-b863-4bfa-bf48-b242c091d4b9)