### PR TITLE
[WEB-1386] chore: fix `update view` button to right even if no filters are applied.

### DIFF
--- a/web/components/issues/issue-layouts/filters/applied-filters/roots/project-view-root.tsx
+++ b/web/components/issues/issue-layouts/filters/applied-filters/roots/project-view-root.tsx
@@ -96,14 +96,16 @@ export const ProjectViewAppliedFiltersRoot: React.FC = observer(() => {
 
   return (
     <div className="flex justify-between gap-4 p-4">
-      <AppliedFiltersList
-        appliedFilters={appliedFilters ?? {}}
-        handleClearAllFilters={handleClearAllFilters}
-        handleRemoveFilter={handleRemoveFilter}
-        labels={projectLabels ?? []}
-        states={projectStates}
-        alwaysAllowEditing
-      />
+      <div>
+        <AppliedFiltersList
+          appliedFilters={appliedFilters ?? {}}
+          handleClearAllFilters={handleClearAllFilters}
+          handleRemoveFilter={handleRemoveFilter}
+          labels={projectLabels ?? []}
+          states={projectStates}
+          alwaysAllowEditing
+        />
+      </div>
 
       {!areFiltersEqual && (
         <div>


### PR DESCRIPTION
#### Problem
After clearing all filters from the view, the "Update View" button was moving to left side.

#### Solution
Added necessary adjustments to fix this issue.

### Media
* Before
<img width="1512" alt="image" src="https://github.com/makeplane/plane/assets/33979846/e03822ca-013f-4911-b863-891d01615137">

* After
<img width="1512" alt="image" src="https://github.com/makeplane/plane/assets/33979846/57c88630-65b2-4bc0-8271-6f3b22eb3f3c">


Issue link [WEB-1386](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/5277d3fe-18ee-44eb-993e-d0aa44e648e0)