### PR TITLE
[WEB-1380] chore: fix sidebar expanding issue on sign out.

### DIFF
--- a/apiserver/plane/authentication/views/app/signout.py
+++ b/apiserver/plane/authentication/views/app/signout.py
@@ -1,6 +1,3 @@
-# Python imports
-from urllib.parse import urljoin
-
 # Django imports
 from django.views import View
 from django.contrib.auth import logout
@@ -23,8 +20,9 @@ class SignOutAuthEndpoint(View):
             user.save()
             # Log the user out
             logout(request)
-            url = urljoin(base_host(request=request, is_app=True))
-            return HttpResponseRedirect(url)
+            return HttpResponseRedirect(
+                base_host(request=request, is_app=True)
+            )
         except Exception:
             return HttpResponseRedirect(
                 base_host(request=request, is_app=True)

--- a/apiserver/plane/authentication/views/app/signout.py
+++ b/apiserver/plane/authentication/views/app/signout.py
@@ -23,9 +23,9 @@ class SignOutAuthEndpoint(View):
             user.save()
             # Log the user out
             logout(request)
-            url = urljoin(base_host(request=request, is_app=True), "sign-in")
+            url = urljoin(base_host(request=request, is_app=True))
             return HttpResponseRedirect(url)
         except Exception:
             return HttpResponseRedirect(
-                base_host(request=request, is_app=True), "sign-in"
+                base_host(request=request, is_app=True)
             )

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -97,7 +97,7 @@ services:
       - dev_env
     volumes:
       - ./apiserver:/code
-    command: ./bin/docker-entrypoint-api.sh
+    command: ./bin/docker-entrypoint-api-local.sh
     env_file:
       - ./apiserver/.env
     depends_on:

--- a/web/store/root.store.ts
+++ b/web/store/root.store.ts
@@ -79,6 +79,7 @@ export class RootStore {
   resetOnSignOut() {
     // handling the system theme when user logged out from the app
     localStorage.setItem("theme", "system");
+    localStorage.setItem("app_sidebar_collapsed", "false");
 
     this.workspaceRoot = new WorkspaceRootStore(this);
     this.projectRoot = new ProjectRootStore(this);
@@ -96,7 +97,7 @@ export class RootStore {
     this.dashboard = new DashboardStore(this);
     this.router = new RouterStore();
     this.commandPalette = new CommandPaletteStore();
-    this.theme = new ThemeStore(this);
+    // this.theme = new ThemeStore(this);
     this.eventTracker = new EventTrackerStore(this);
     this.instance = new InstanceStore();
     this.user = new UserStore(this);

--- a/web/store/root.store.ts
+++ b/web/store/root.store.ts
@@ -79,7 +79,6 @@ export class RootStore {
   resetOnSignOut() {
     // handling the system theme when user logged out from the app
     localStorage.setItem("theme", "system");
-    localStorage.setItem("app_sidebar_collapsed", "false");
 
     this.workspaceRoot = new WorkspaceRootStore(this);
     this.projectRoot = new ProjectRootStore(this);
@@ -97,7 +96,6 @@ export class RootStore {
     this.dashboard = new DashboardStore(this);
     this.router = new RouterStore();
     this.commandPalette = new CommandPaletteStore();
-    // this.theme = new ThemeStore(this);
     this.eventTracker = new EventTrackerStore(this);
     this.instance = new InstanceStore();
     this.user = new UserStore(this);


### PR DESCRIPTION
#### Problem
Clicking the `Sign Out` from the user profile settings expands the left sidebar menu.

#### Solution
Made changes in `resetOnSignOut` function to not reset ThemeStore.

#### Media
* Before

https://github.com/makeplane/plane/assets/33979846/b022705c-de28-4c39-841d-ed1903eb3b11

* After

https://github.com/makeplane/plane/assets/33979846/e9772dd0-7611-4a41-9969-4b95c403fcd1

#### Other fixes
* update sign-out redirect url.

Issue link [WEB-1380](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/48fe0a79-61aa-464b-b1b4-b8075d6e5e50)