### PR TITLE
[WEB-1417] chore: fix size updating issue on create workspace form when multiple errors are shown.

### DIFF
--- a/web/components/onboarding/create-workspace.tsx
+++ b/web/components/onboarding/create-workspace.tsx
@@ -224,9 +224,9 @@ export const CreateWorkspace: React.FC<Props> = (props) => {
             )}
           />
           <p className="text-sm text-onboarding-text-300">You can only edit the slug of the URL</p>
-          {slugError && <span className="-mt-3 text-sm text-red-500">Workspace URL is already taken!</span>}
+          {slugError && <p className="-mt-3 text-sm text-red-500">Workspace URL is already taken!</p>}
           {invalidSlug && (
-            <span className="text-sm text-red-500">{`URL can only contain ( - ), ( _ ) & alphanumeric characters.`}</span>
+            <p className="text-sm text-red-500">{`URL can only contain ( - ), ( _ ) & alphanumeric characters.`}</p>
           )}
         </div>
         <hr className="w-full border-onboarding-border-100" />

--- a/web/components/workspace/create-workspace-form.tsx
+++ b/web/components/workspace/create-workspace-form.tsx
@@ -188,9 +188,9 @@ export const CreateWorkspaceForm: FC<Props> = observer((props) => {
               )}
             />
           </div>
-          {slugError && <span className="-mt-3 text-sm text-red-500">Workspace URL is already taken!</span>}
+          {slugError && <p className="-mt-3 text-sm text-red-500">Workspace URL is already taken!</p>}
           {invalidSlug && (
-            <span className="text-sm text-red-500">{`URL can only contain ( - ), ( _ ) & alphanumeric characters.`}</span>
+            <p className="text-sm text-red-500">{`URL can only contain ( - ), ( _ ) & alphanumeric characters.`}</p>
           )}
         </div>
         <div className="space-y-1 text-sm">


### PR DESCRIPTION
#### Problem
During the onboarding process, when the user reaches the workspace creation page and enters any alphanumeric characters or presses the space bar, the length of each field in the workspace creation window will dynamically adjust to validation length.

#### Solution
Updated `span` to `p` tag to show multiple errors on multiple line.

#### Media
* Before
<img width="1512" alt="image" src="https://github.com/makeplane/plane/assets/33979846/8ecaf6ad-d5a3-459e-8af9-7c2bc2fa21c3">

* After
<img width="1512" alt="image" src="https://github.com/makeplane/plane/assets/33979846/9e8aa8a1-be88-4efc-ac9c-e100d0084166">

Issue link [WEB-1417](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/ab1b851f-ce89-4e2b-9b25-56b326db6f27)


