### PR TITLE
[WEB-1432] fix: redirection to parent issue detail page when it is from another project.

### DIFF
--- a/web/components/issues/issue-detail/parent-select.tsx
+++ b/web/components/issues/issue-detail/parent-select.tsx
@@ -103,7 +103,7 @@ export const IssueParentSelect: React.FC<TIssueParentSelect> = observer((props) 
           <div className="flex items-center gap-1 bg-green-500/20 text-green-700 rounded px-1.5 py-1">
             <Tooltip tooltipHeading="Title" tooltipContent={parentIssue.name} isMobile={isMobile}>
               <Link
-                href={`/${workspaceSlug}/projects/${projectId}/issues/${parentIssue?.id}`}
+                href={`/${workspaceSlug}/projects/${parentIssue.project_id}/issues/${parentIssue?.id}`}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-xs font-medium"


### PR DESCRIPTION
#### Problem
Redirection to parent issue detail page is throwing error when using a parent from another project. 

#### Solution
This was happening because we were using current project id to redirect instead of parent project id. 

Issue link [WEB-1432](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/3aeb1ab7-c69c-45a2-929d-95e1d2e1c732)