### PR TITLE
[WEB-1282] fix: profile issue kanban group collapse and expand toggle

### DIFF
--- a/web/components/issues/issue-layouts/kanban/base-kanban-root.tsx
+++ b/web/components/issues/issue-layouts/kanban/base-kanban-root.tsx
@@ -182,14 +182,14 @@ export const BaseKanBanRoot: React.FC<IBaseKanBanLayout> = observer((props: IBas
   };
 
   const handleKanbanFilters = (toggle: "group_by" | "sub_group_by", value: string) => {
-    if (workspaceSlug && projectId) {
+    if (workspaceSlug) {
       let kanbanFilters = issuesFilter?.issueFilters?.kanbanFilters?.[toggle] || [];
       if (kanbanFilters.includes(value)) {
         kanbanFilters = kanbanFilters.filter((_value) => _value != value);
       } else {
         kanbanFilters.push(value);
       }
-      updateFilters(projectId.toString(), EIssueFilterType.KANBAN_FILTERS, {
+      updateFilters(projectId?.toString() ?? "", EIssueFilterType.KANBAN_FILTERS, {
         [toggle]: kanbanFilters,
       });
     }


### PR DESCRIPTION
#### Changes:
This PR includes a fix for the profile issue in the kanban layout, addressing the problem with group expand and collapse functionality.

#### Issue link: [[WEB-1282]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/60296723-1275-4d8d-b873-cb21979a8424)

#### Media:
| Before | After |
|--------|--------|
| ![1282(B)](https://github.com/makeplane/plane/assets/121005188/490dbd99-ced4-4937-b369-7a1388b28599) | ![1282(A)](https://github.com/makeplane/plane/assets/121005188/af78b055-b59f-4a7d-9d6d-9ec0b7ab93e1) |