### PR TITLE
[WEB-1476] style: fix padding on project icon in workspace sidebar.

### DIFF
--- a/web/components/project/sidebar-list-item.tsx
+++ b/web/components/project/sidebar-list-item.tsx
@@ -287,7 +287,7 @@ export const ProjectSidebarListItem: React.FC<Props> = observer((props) => {
                 "group relative flex w-full items-center rounded-md py-1 text-custom-sidebar-text-100 hover:bg-custom-sidebar-background-80",
                 {
                   "bg-custom-sidebar-background-80": isMenuActive,
-                  "pl-8": disableDrag,
+                  "pl-7": disableDrag && !isCollapsed,
                 }
               )}
             >
@@ -327,7 +327,7 @@ export const ProjectSidebarListItem: React.FC<Props> = observer((props) => {
                   )}
                 >
                   <div
-                    className={cn("flex w-full flex-grow items-center gap-1 truncate -ml-1", {
+                    className={cn("flex w-full flex-grow items-center gap-1 truncate", {
                       "justify-center": isCollapsed,
                     })}
                   >


### PR DESCRIPTION
#### Media
* Before
<img width="889" alt="image" src="https://github.com/makeplane/plane/assets/33979846/c55f467b-d0ef-44a1-a04e-bcd465863c9e">

* After
<img width="912" alt="image" src="https://github.com/makeplane/plane/assets/33979846/bf5b806e-7098-403a-9b90-981df84a1b8d">
<img width="372" alt="image" src="https://github.com/makeplane/plane/assets/33979846/18ac99bb-b5ca-443b-9b60-712c0f7bc8ae">


Issue link [WEB-1476](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/255ae7d8-3fff-4199-aa96-f36384c95231)
