### PR TITLE
[WEB-1445] fix: issue creation on sub groups when cycle/ module grouping is applied.

### DIFF
--- a/web/components/issues/issue-layouts/kanban/kanban-group.tsx
+++ b/web/components/issues/issue-layouts/kanban/kanban-group.tsx
@@ -169,9 +169,9 @@ export const KanbanGroup = observer((props: IKanbanGroup) => {
         preloadedData = { ...preloadedData, state_id: subGroupValue };
       } else if (subGroupByKey === "priority") {
         preloadedData = { ...preloadedData, priority: subGroupValue };
-      } else if (groupByKey === "cycle") {
+      } else if (subGroupByKey === "cycle") {
         preloadedData = { ...preloadedData, cycle_id: subGroupValue };
-      } else if (groupByKey === "module") {
+      } else if (subGroupByKey === "module") {
         preloadedData = { ...preloadedData, module_ids: [subGroupValue] };
       } else if (subGroupByKey === "labels" && subGroupValue != "None") {
         preloadedData = { ...preloadedData, label_ids: [subGroupValue] };


### PR DESCRIPTION
#### Problem
Display as group by Cycle/modules & sub-group by cycle/modules, assignee, labels, created by user is unable to create issue

#### Solution
We were checking for `groupByKey` instead of `subGroupByKey` while creating the issue in case of cycles and modules.

#### Media
* Before

https://github.com/makeplane/plane/assets/33979846/a227218f-7190-40be-867c-2559c4c159e1


* After

https://github.com/makeplane/plane/assets/33979846/60ac49fd-2ce8-4028-b1e5-72851ddf0ddc

Issue link [WEB-1445](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/06f732af-0c89-4253-85ac-7bf6950ab817)

