### PR TITLE
[WEB-1278] fix: notification mark all as read

### DIFF
--- a/packages/types/src/notifications.d.ts
+++ b/packages/types/src/notifications.d.ts
@@ -57,7 +57,7 @@ export interface INotificationIssueLite {
   state_group: string;
 }
 
-export type NotificationType = "created" | "assigned" | "watching" | null;
+export type NotificationType = "created" | "assigned" | "watching" | "all";
 
 export interface INotificationParams {
   snoozed?: boolean;

--- a/web/hooks/use-user-notifications.tsx
+++ b/web/hooks/use-user-notifications.tsx
@@ -3,14 +3,13 @@ import { useRouter } from "next/router";
 // swr
 import useSWR from "swr";
 import useSWRInfinite from "swr/infinite";
-// services
-import { UNREAD_NOTIFICATIONS_COUNT, getPaginatedNotificationKey } from "@/constants/fetch-keys";
-import { NotificationService } from "@/services/notification.service";
-// fetch-keys
-// type
 import type { NotificationType, NotificationCount, IMarkAllAsReadPayload } from "@plane/types";
 // ui
 import { TOAST_TYPE, setToast } from "@plane/ui";
+// constant
+import { UNREAD_NOTIFICATIONS_COUNT, getPaginatedNotificationKey } from "@/constants/fetch-keys";
+// services
+import { NotificationService } from "@/services/notification.service";
 
 const PER_PAGE = 30;
 
@@ -258,7 +257,7 @@ const useUserNotification = (): any => {
 
     if (snoozed) markAsReadParams = { archived: false, snoozed: true };
     else if (archived) markAsReadParams = { archived: true, snoozed: false };
-    else markAsReadParams = { archived: false, snoozed: false, type: selectedTab };
+    else markAsReadParams = { archived: false, snoozed: false, type: readNotification ? "all" : selectedTab };
 
     await userNotificationServices
       .markAllNotificationsAsRead(workspaceSlug.toString(), markAsReadParams)


### PR DESCRIPTION
#### Changes:
This PR includes a fix for the notification, specifically addressing the problem where the option to mark all notifications as read was not working in the unread notifications section.

#### Issue link: [[WEB-1278]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/d946cb39-7a89-465e-8841-c7929c2955a9)
