### PR TITLE
[WEB-1485] chore: remove enter key extension

### DIFF
--- a/packages/editor/rich-text-editor/src/ui/extensions/index.tsx
+++ b/packages/editor/rich-text-editor/src/ui/extensions/index.tsx
@@ -17,5 +17,6 @@ export const RichTextEditorExtensions = ({
 }: TArguments) => [
   SlashCommand(uploadFile),
   dragDropEnabled === true && DragAndDrop(setHideDragHandle),
-  EnterKeyExtension(onEnterKeyPress),
+  // TODO; add the extension conditionally for forms that don't require it
+  // EnterKeyExtension(onEnterKeyPress),
 ];


### PR DESCRIPTION
This PR removes the enter key extension from the rich text editor. The extension needs to be added conditionally based on the requirements, which will be taken care of later.

#### Plane issue: [WEB-1485](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/b0ab3149-acd0-4d6b-88cd-847bbdc5bb70)