### PR TITLE
[WEB-1067] fix: enter key extension

### DIFF
--- a/packages/editor/rich-text-editor/src/ui/extensions/index.tsx
+++ b/packages/editor/rich-text-editor/src/ui/extensions/index.tsx
@@ -17,6 +17,5 @@ export const RichTextEditorExtensions = ({
 }: TArguments) => [
   SlashCommand(uploadFile),
   dragDropEnabled === true && DragAndDrop(setHideDragHandle),
-  // TODO; add the extension conditionally for forms that don't require it
-  // EnterKeyExtension(onEnterKeyPress),
+  onEnterKeyPress && EnterKeyExtension(onEnterKeyPress),
 ];


### PR DESCRIPTION
#### Changes:
This PR includes a fix for the Enter key extension in the rich text editor. Previously, the Enter key extension was applied in every instance without any condition, which caused unintended behavior. I have added a required condition to ensure the Enter key extension is only applied when appropriate.

#### Issue link: [[WEB-1067]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/b38430cd-7172-4af6-85b1-3cec2e2532af)