### PR TITLE
[WEB-1470] fix: project state setting state name

### DIFF
--- a/web/components/states/project-setting-state-list-item.tsx
+++ b/web/components/states/project-setting-state-list-item.tsx
@@ -54,7 +54,7 @@ export const StatesListItem: React.FC<Props> = observer((props) => {
       <div className="flex items-center gap-3">
         <StateGroupIcon stateGroup={state.group} color={state.color} height="16px" width="16px" />
         <div>
-          <h6 className="text-sm font-medium">{addSpaceIfCamelCase(state.name)}</h6>
+          <h6 className="text-sm font-medium">{state.name}</h6>
           <p className="text-xs text-custom-text-200">{state.description}</p>
         </div>
       </div>


### PR DESCRIPTION
#### Changes:
This PR resolves an issue related to state name formatting. Previously, if a user input a state name in camel casing, the state name would appear with spaces. I have made the necessary changes to ensure the state name appears as intended, without unwanted spaces.

#### Issue link: [[WEB-1470]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/1dba289a-c9b9-4794-8c92-26f2aba12e02)

#### Github Issue: [#4610](https://github.com/makeplane/plane/issues/4610)