### PR TITLE
[WEB-1494] fix: email notification preferences

### DIFF
--- a/web/components/profile/preferences/email-notification-form.tsx
+++ b/web/components/profile/preferences/email-notification-form.tsx
@@ -99,9 +99,9 @@ export const EmailNotificationForm: FC<IEmailNotificationFormProps> = (props) =>
               render={({ field: { value, onChange } }) => (
                 <Checkbox
                   checked={value}
-                  intermediate={!value && watch("issue_completed")}
+                  indeterminate={!value && watch("issue_completed")}
                   onChange={() => {
-                    setValue("issue_completed", !value);
+                    setValue("issue_completed", !value, { shouldDirty: true });
                     onChange(!value);
                   }}
                   className="mx-2"


### PR DESCRIPTION
#### Changes:
This PR includes a fix for the email notification preferences state selection bug. Previously, selecting a state would select both the "state change" and "issue complete" options, but only the "state change" field was sent in the payload. I've made the necessary changes to ensure that the selection works as intended.

#### Issue link: [[WEB-1494]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/0bcc34a3-40d4-4dc5-8981-25c89a523ec8)

#### Media:
| Before | After |
|--------|--------|
| ![1494-(1)](https://github.com/makeplane/plane/assets/121005188/7ee534f7-4a30-4be0-b936-02cae79e69ca) | ![1494-(2)](https://github.com/makeplane/plane/assets/121005188/99af77d5-63c9-40da-a758-c0e6fb358a40) |


