### PR TITLE
[WEB-1419] chore: enable module creation with dates older than today.

### DIFF
--- a/web/components/modules/form.tsx
+++ b/web/components/modules/form.tsx
@@ -147,7 +147,6 @@ export const ModuleForm: React.FC<Props> = (props) => {
                     <DateRangeDropdown
                       buttonVariant="border-with-text"
                       className="h-7"
-                      minDate={new Date()}
                       value={{
                         from: getDate(startDateValue),
                         to: getDate(endDateValue),

--- a/web/components/modules/sidebar.tsx
+++ b/web/components/modules/sidebar.tsx
@@ -471,7 +471,6 @@ export const ModuleDetailsSidebar: React.FC<Props> = observer((props) => {
                       <DateRangeDropdown
                         buttonContainerClassName="w-full"
                         buttonVariant="background-with-text"
-                        minDate={new Date()}
                         value={{
                           from: startDate,
                           to: endDate,


### PR DESCRIPTION
#### Problem
Creating modules with start date older than toady was not allowed previously.

#### Solution
Removed the validation to allow users to set any start date. 

Issue link [WEB-1419](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/7c9010e6-ddbe-4b13-82dc-1a43a7a47d72)