### PR TITLE
[WEB-1312] fix: trim file name before uploading

### DIFF
--- a/apiserver/plane/db/models/asset.py
+++ b/apiserver/plane/db/models/asset.py
@@ -12,8 +12,8 @@ from .base import BaseModel
 
 
 def get_upload_path(instance, filename):
+    filename = filename[:60]
     if instance.workspace_id is not None:
-        filename = filename[:60]
         return f"{instance.workspace.id}/{uuid4().hex}-{filename}"
     return f"user-{uuid4().hex}-{filename}"
 

--- a/apiserver/plane/db/models/asset.py
+++ b/apiserver/plane/db/models/asset.py
@@ -13,6 +13,7 @@ from .base import BaseModel
 
 def get_upload_path(instance, filename):
     if instance.workspace_id is not None:
+        filename = filename[:60]
         return f"{instance.workspace.id}/{uuid4().hex}-{filename}"
     return f"user-{uuid4().hex}-{filename}"
 

--- a/apiserver/plane/db/models/asset.py
+++ b/apiserver/plane/db/models/asset.py
@@ -12,7 +12,7 @@ from .base import BaseModel
 
 
 def get_upload_path(instance, filename):
-    filename = filename[:60]
+    filename = filename[:50]
     if instance.workspace_id is not None:
         return f"{instance.workspace.id}/{uuid4().hex}-{filename}"
     return f"user-{uuid4().hex}-{filename}"

--- a/packages/editor/core/src/ui/plugins/image/image-upload-handler.ts
+++ b/packages/editor/core/src/ui/plugins/image/image-upload-handler.ts
@@ -50,9 +50,12 @@ export async function startImageUpload(
   };
 
   try {
+    const fileNameTrimmed = trimFileName(file.name);
+    const fileWithTrimmedName = new File([file], fileNameTrimmed, { type: file.type });
+
     view.focus();
 
-    const src = await uploadAndValidateImage(file, uploadFile);
+    const src = await uploadAndValidateImage(fileWithTrimmedName, uploadFile);
 
     if (src == null) {
       throw new Error("Resolved image URL is undefined.");
@@ -111,4 +114,15 @@ async function uploadAndValidateImage(file: File, uploadFile: UploadImage): Prom
     // throw error to remove the placeholder
     throw error;
   }
+}
+
+function trimFileName(fileName: string, maxLength = 100) {
+  if (fileName.length > maxLength) {
+    const extension = fileName.split(".").pop();
+    const nameWithoutExtension = fileName.slice(0, -(extension?.length ?? 0 + 1));
+    const allowedNameLength = maxLength - (extension?.length ?? 0) - 1; // -1 for the dot
+    return `${nameWithoutExtension.slice(0, allowedNameLength)}.${extension}`;
+  }
+
+  return fileName;
 }

--- a/packages/editor/core/src/ui/plugins/image/image-upload-handler.ts
+++ b/packages/editor/core/src/ui/plugins/image/image-upload-handler.ts
@@ -53,6 +53,19 @@ export async function startImageUpload(
     const fileNameTrimmed = trimFileName(file.name);
     const fileWithTrimmedName = new File([file], fileNameTrimmed, { type: file.type });
 
+    const resolvedPos = view.state.doc.resolve(pos ?? 0);
+    const nodeBefore = resolvedPos.nodeBefore;
+
+    // if the image is at the start of the line i.e. when nodeBefore is null
+    if (nodeBefore === null) {
+      if (pos) {
+        // so that the image is not inserted at the next line, else incase the
+        // image is inserted at any line where there's some content, the
+        // position is kept as it is to be inserted at the next line
+        pos -= 1;
+      }
+    }
+
     view.focus();
 
     const src = await uploadAndValidateImage(fileWithTrimmedName, uploadFile);


### PR DESCRIPTION
## Description

Currently if the file name is more than 100 words, then the image upload fails in the editor. So now we trim the filename while keeping the extension in place to make it pass.

## Minor Bug fix

The image insertion position and the cursor position after the upload completes is now dependent on node before the current cursor position, i.e. if it has any content or not.