### PR TITLE
[WEB-1492] fix: resolved issue creation error in layouts while group_by and sub_group_by filters applied in quick add

### DIFF
--- a/web/store/issue/cycle/issue.store.ts
+++ b/web/store/issue/cycle/issue.store.ts
@@ -148,20 +148,20 @@ export class CycleIssues extends IssueHelperStore implements ICycleIssues {
     const cycleIssueIds = this.issues[cycleId];
     if (!cycleIssueIds) return;
 
-    const _issues = this.rootIssueStore.issues.getIssuesByIds(cycleIssueIds, "un-archived");
-    if (!_issues) return [];
+    const currentIssues = this.rootIssueStore.issues.getIssuesByIds(cycleIssueIds, "un-archived");
+    if (!currentIssues) return [];
 
     let issues: TGroupedIssues | TSubGroupedIssues | TUnGroupedIssues = [];
 
     if (layout === "list" && orderBy) {
-      if (groupBy) issues = this.groupedIssues(groupBy, orderBy, _issues);
-      else issues = this.unGroupedIssues(orderBy, _issues);
+      if (groupBy) issues = this.groupedIssues(groupBy, orderBy, currentIssues);
+      else issues = this.unGroupedIssues(orderBy, currentIssues);
     } else if (layout === "kanban" && groupBy && orderBy) {
-      if (subGroupBy) issues = this.subGroupedIssues(subGroupBy, groupBy, orderBy, _issues);
-      else issues = this.groupedIssues(groupBy, orderBy, _issues);
-    } else if (layout === "calendar") issues = this.groupedIssues("target_date", "target_date", _issues, true);
-    else if (layout === "spreadsheet") issues = this.unGroupedIssues(orderBy ?? "-created_at", _issues);
-    else if (layout === "gantt_chart") issues = this.unGroupedIssues(orderBy ?? "sort_order", _issues);
+      if (subGroupBy) issues = this.subGroupedIssues(subGroupBy, groupBy, orderBy, currentIssues);
+      else issues = this.groupedIssues(groupBy, orderBy, currentIssues);
+    } else if (layout === "calendar") issues = this.groupedIssues("target_date", "target_date", currentIssues, true);
+    else if (layout === "spreadsheet") issues = this.unGroupedIssues(orderBy ?? "-created_at", currentIssues);
+    else if (layout === "gantt_chart") issues = this.unGroupedIssues(orderBy ?? "sort_order", currentIssues);
 
     return issues;
   }
@@ -301,14 +301,17 @@ export class CycleIssues extends IssueHelperStore implements ICycleIssues {
         });
       }
 
-      if (data.module_ids && data.module_ids.length > 0) {
+      const currentModuleIds =
+        data.module_ids && data.module_ids.length > 0 ? data.module_ids.filter((moduleId) => moduleId != "None") : [];
+
+      if (currentModuleIds.length > 0) {
         await this.rootStore.moduleIssues.changeModulesInIssue(
           workspaceSlug,
           projectId,
           response.id,
-          data.module_ids,
+          currentModuleIds,
           []
-        )
+        );
       }
 
       this.rootIssueStore.rootStore.cycle.fetchCycleDetails(workspaceSlug, projectId, cycleId);

--- a/web/store/issue/module/issue.store.ts
+++ b/web/store/issue/module/issue.store.ts
@@ -302,8 +302,9 @@ export class ModuleIssues extends IssueHelperStore implements IModuleIssues {
       }
 
       const currentCycleId = data.cycle_id !== "" && data.cycle_id === "None" ? undefined : data.cycle_id;
-      if (currentCycleId)
+      if (currentCycleId) {
         await this.rootStore.cycleIssues.addCycleToIssue(workspaceSlug, projectId, currentCycleId, response.id);
+      }
 
       this.rootIssueStore.rootStore.module.fetchModuleDetails(workspaceSlug, projectId, moduleId);
 

--- a/web/store/issue/module/issue.store.ts
+++ b/web/store/issue/module/issue.store.ts
@@ -1,6 +1,5 @@
 import concat from "lodash/concat";
 import pull from "lodash/pull";
-import isEmpty from "lodash/isEmpty";
 import set from "lodash/set";
 import uniq from "lodash/uniq";
 import update from "lodash/update";
@@ -148,20 +147,20 @@ export class ModuleIssues extends IssueHelperStore implements IModuleIssues {
     const moduleIssueIds = this.issues[moduleId];
     if (!moduleIssueIds) return;
 
-    const _issues = this.rootIssueStore.issues.getIssuesByIds(moduleIssueIds, "un-archived");
-    if (!_issues) return [];
+    const currentIssues = this.rootIssueStore.issues.getIssuesByIds(moduleIssueIds, "un-archived");
+    if (!currentIssues) return [];
 
     let issues: TGroupedIssues | TSubGroupedIssues | TUnGroupedIssues = [];
 
     if (layout === "list" && orderBy) {
-      if (groupBy) issues = this.groupedIssues(groupBy, orderBy, _issues);
-      else issues = this.unGroupedIssues(orderBy, _issues);
+      if (groupBy) issues = this.groupedIssues(groupBy, orderBy, currentIssues);
+      else issues = this.unGroupedIssues(orderBy, currentIssues);
     } else if (layout === "kanban" && groupBy && orderBy) {
-      if (subGroupBy) issues = this.subGroupedIssues(subGroupBy, groupBy, orderBy, _issues);
-      else issues = this.groupedIssues(groupBy, orderBy, _issues);
-    } else if (layout === "calendar") issues = this.groupedIssues("target_date", "target_date", _issues, true);
-    else if (layout === "spreadsheet") issues = this.unGroupedIssues(orderBy ?? "-created_at", _issues);
-    else if (layout === "gantt_chart") issues = this.unGroupedIssues(orderBy ?? "sort_order", _issues);
+      if (subGroupBy) issues = this.subGroupedIssues(subGroupBy, groupBy, orderBy, currentIssues);
+      else issues = this.groupedIssues(groupBy, orderBy, currentIssues);
+    } else if (layout === "calendar") issues = this.groupedIssues("target_date", "target_date", currentIssues, true);
+    else if (layout === "spreadsheet") issues = this.unGroupedIssues(orderBy ?? "-created_at", currentIssues);
+    else if (layout === "gantt_chart") issues = this.unGroupedIssues(orderBy ?? "sort_order", currentIssues);
 
     return issues;
   }
@@ -302,9 +301,9 @@ export class ModuleIssues extends IssueHelperStore implements IModuleIssues {
         });
       }
 
-      if (data.cycle_id && data.cycle_id !== "") {
-        await this.rootStore.cycleIssues.addCycleToIssue(workspaceSlug, projectId, data.cycle_id, response.id)
-      }
+      const currentCycleId = data.cycle_id !== "" && data.cycle_id === "None" ? undefined : data.cycle_id;
+      if (currentCycleId)
+        await this.rootStore.cycleIssues.addCycleToIssue(workspaceSlug, projectId, currentCycleId, response.id);
 
       this.rootIssueStore.rootStore.module.fetchModuleDetails(workspaceSlug, projectId, moduleId);
 

--- a/web/store/issue/project-views/issue.store.ts
+++ b/web/store/issue/project-views/issue.store.ts
@@ -252,17 +252,21 @@ export class ProjectViewIssues extends IssueHelperStore implements IProjectViewI
         data.module_ids && data.module_ids.length > 0 ? data.module_ids.filter((moduleId) => moduleId != "None") : [];
 
       const multipleIssuePromises = [];
-      if (currentCycleId)
+      if (currentCycleId) {
         multipleIssuePromises.push(
           this.rootStore.cycleIssues.addCycleToIssue(workspaceSlug, projectId, currentCycleId, response.id)
         );
+      }
 
-      if (currentModuleIds.length > 0)
+      if (currentModuleIds.length > 0) {
         multipleIssuePromises.push(
           this.rootStore.moduleIssues.changeModulesInIssue(workspaceSlug, projectId, response.id, currentModuleIds, [])
         );
+      }
 
-      if (multipleIssuePromises && multipleIssuePromises.length > 0) await Promise.all(multipleIssuePromises);
+      if (multipleIssuePromises && multipleIssuePromises.length > 0) {
+        await Promise.all(multipleIssuePromises);
+      }
 
       return response;
     } catch (error) {

--- a/web/store/issue/project-views/issue.store.ts
+++ b/web/store/issue/project-views/issue.store.ts
@@ -1,9 +1,9 @@
 import pull from "lodash/pull";
 import set from "lodash/set";
 import { action, observable, makeObservable, computed, runInAction } from "mobx";
+import { TIssue, TLoader, TGroupedIssues, TSubGroupedIssues, TUnGroupedIssues, ViewFlags } from "@plane/types";
 // base class
 import { IssueService } from "@/services/issue/issue.service";
-import { TIssue, TLoader, TGroupedIssues, TSubGroupedIssues, TUnGroupedIssues, ViewFlags } from "@plane/types";
 import { IssueHelperStore } from "../helpers/issue-helper.store";
 // services
 // types
@@ -97,20 +97,20 @@ export class ProjectViewIssues extends IssueHelperStore implements IProjectViewI
     const viewIssueIds = this.issues[viewId];
     if (!viewIssueIds) return;
 
-    const _issues = this.rootStore.issues.getIssuesByIds(viewIssueIds, "un-archived");
-    if (!_issues) return [];
+    const currentIssues = this.rootStore.issues.getIssuesByIds(viewIssueIds, "un-archived");
+    if (!currentIssues) return [];
 
     let issues: TGroupedIssues | TSubGroupedIssues | TUnGroupedIssues = [];
 
     if (layout === "list" && orderBy) {
-      if (groupBy) issues = this.groupedIssues(groupBy, orderBy, _issues);
-      else issues = this.unGroupedIssues(orderBy, _issues);
+      if (groupBy) issues = this.groupedIssues(groupBy, orderBy, currentIssues);
+      else issues = this.unGroupedIssues(orderBy, currentIssues);
     } else if (layout === "kanban" && groupBy && orderBy) {
-      if (subGroupBy) issues = this.subGroupedIssues(subGroupBy, groupBy, orderBy, _issues);
-      else issues = this.groupedIssues(groupBy, orderBy, _issues);
-    } else if (layout === "calendar") issues = this.groupedIssues("target_date", "target_date", _issues, true);
-    else if (layout === "spreadsheet") issues = this.unGroupedIssues(orderBy ?? "-created_at", _issues);
-    else if (layout === "gantt_chart") issues = this.unGroupedIssues(orderBy ?? "sort_order", _issues);
+      if (subGroupBy) issues = this.subGroupedIssues(subGroupBy, groupBy, orderBy, currentIssues);
+      else issues = this.groupedIssues(groupBy, orderBy, currentIssues);
+    } else if (layout === "calendar") issues = this.groupedIssues("target_date", "target_date", currentIssues, true);
+    else if (layout === "spreadsheet") issues = this.unGroupedIssues(orderBy ?? "-created_at", currentIssues);
+    else if (layout === "gantt_chart") issues = this.unGroupedIssues(orderBy ?? "sort_order", currentIssues);
 
     return issues;
   }
@@ -247,19 +247,22 @@ export class ProjectViewIssues extends IssueHelperStore implements IProjectViewI
         });
       }
 
-      if (data.cycle_id && data.cycle_id !== "") {
-        await this.rootStore.cycleIssues.addCycleToIssue(workspaceSlug, projectId, data.cycle_id, response.id)
-      }
+      const currentCycleId = data.cycle_id !== "" && data.cycle_id === "None" ? undefined : data.cycle_id;
+      const currentModuleIds =
+        data.module_ids && data.module_ids.length > 0 ? data.module_ids.filter((moduleId) => moduleId != "None") : [];
 
-      if (data.module_ids && data.module_ids.length > 0) {
-        await this.rootStore.moduleIssues.changeModulesInIssue(
-          workspaceSlug,
-          projectId,
-          response.id,
-          data.module_ids,
-          []
-        )
-      }
+      const multipleIssuePromises = [];
+      if (currentCycleId)
+        multipleIssuePromises.push(
+          this.rootStore.cycleIssues.addCycleToIssue(workspaceSlug, projectId, currentCycleId, response.id)
+        );
+
+      if (currentModuleIds.length > 0)
+        multipleIssuePromises.push(
+          this.rootStore.moduleIssues.changeModulesInIssue(workspaceSlug, projectId, response.id, currentModuleIds, [])
+        );
+
+      if (multipleIssuePromises && multipleIssuePromises.length > 0) await Promise.all(multipleIssuePromises);
 
       return response;
     } catch (error) {

--- a/web/store/issue/project/issue.store.ts
+++ b/web/store/issue/project/issue.store.ts
@@ -257,17 +257,21 @@ export class ProjectIssues extends IssueHelperStore implements IProjectIssues {
         data.module_ids && data.module_ids.length > 0 ? data.module_ids.filter((moduleId) => moduleId != "None") : [];
 
       const multipleIssuePromises = [];
-      if (currentCycleId)
+      if (currentCycleId) {
         multipleIssuePromises.push(
           this.rootStore.cycleIssues.addCycleToIssue(workspaceSlug, projectId, currentCycleId, response.id)
         );
+      }
 
-      if (currentModuleIds.length > 0)
+      if (currentModuleIds.length > 0) {
         multipleIssuePromises.push(
           this.rootStore.moduleIssues.changeModulesInIssue(workspaceSlug, projectId, response.id, currentModuleIds, [])
         );
+      }
 
-      if (multipleIssuePromises && multipleIssuePromises.length > 0) await Promise.all(multipleIssuePromises);
+      if (multipleIssuePromises && multipleIssuePromises.length > 0) {
+        await Promise.all(multipleIssuePromises);
+      }
 
       return response;
     } catch (error) {

--- a/web/store/issue/project/issue.store.ts
+++ b/web/store/issue/project/issue.store.ts
@@ -103,20 +103,20 @@ export class ProjectIssues extends IssueHelperStore implements IProjectIssues {
     const projectIssueIds = this.issues[projectId];
     if (!projectIssueIds) return;
 
-    const _issues = this.rootStore.issues.getIssuesByIds(projectIssueIds, "un-archived");
-    if (!_issues) return [];
+    const currentIssues = this.rootStore.issues.getIssuesByIds(projectIssueIds, "un-archived");
+    if (!currentIssues) return [];
 
     let issues: TGroupedIssues | TSubGroupedIssues | TUnGroupedIssues = [];
 
     if (layout === "list" && orderBy) {
-      if (groupBy) issues = this.groupedIssues(groupBy, orderBy, _issues);
-      else issues = this.unGroupedIssues(orderBy, _issues);
+      if (groupBy) issues = this.groupedIssues(groupBy, orderBy, currentIssues);
+      else issues = this.unGroupedIssues(orderBy, currentIssues);
     } else if (layout === "kanban" && groupBy && orderBy) {
-      if (subGroupBy) issues = this.subGroupedIssues(subGroupBy, groupBy, orderBy, _issues);
-      else issues = this.groupedIssues(groupBy, orderBy, _issues);
-    } else if (layout === "calendar") issues = this.groupedIssues("target_date", "target_date", _issues, true);
-    else if (layout === "spreadsheet") issues = this.unGroupedIssues(orderBy ?? "-created_at", _issues);
-    else if (layout === "gantt_chart") issues = this.unGroupedIssues(orderBy ?? "sort_order", _issues);
+      if (subGroupBy) issues = this.subGroupedIssues(subGroupBy, groupBy, orderBy, currentIssues);
+      else issues = this.groupedIssues(groupBy, orderBy, currentIssues);
+    } else if (layout === "calendar") issues = this.groupedIssues("target_date", "target_date", currentIssues, true);
+    else if (layout === "spreadsheet") issues = this.unGroupedIssues(orderBy ?? "-created_at", currentIssues);
+    else if (layout === "gantt_chart") issues = this.unGroupedIssues(orderBy ?? "sort_order", currentIssues);
 
     return issues;
   }
@@ -244,7 +244,7 @@ export class ProjectIssues extends IssueHelperStore implements IProjectIssues {
       const response = await this.createIssue(workspaceSlug, projectId, data);
 
       const quickAddIssueIndex = this.issues[projectId].findIndex((_issueId) => _issueId === data.id);
-      
+
       if (quickAddIssueIndex >= 0) {
         runInAction(() => {
           this.issues[projectId].splice(quickAddIssueIndex, 1);
@@ -252,20 +252,23 @@ export class ProjectIssues extends IssueHelperStore implements IProjectIssues {
         });
       }
 
-      //TODO: error handling needs to be improved for rare cases
-      if (data.cycle_id && data.cycle_id !== "") {
-        await this.rootStore.cycleIssues.addCycleToIssue(workspaceSlug, projectId, data.cycle_id, response.id)
-      }
+      const currentCycleId = data.cycle_id !== "" && data.cycle_id === "None" ? undefined : data.cycle_id;
+      const currentModuleIds =
+        data.module_ids && data.module_ids.length > 0 ? data.module_ids.filter((moduleId) => moduleId != "None") : [];
 
-      if (data.module_ids && data.module_ids.length > 0) {
-        await this.rootStore.moduleIssues.changeModulesInIssue(
-          workspaceSlug,
-          projectId,
-          response.id,
-          data.module_ids,
-          []
-        )
-      }
+      const multipleIssuePromises = [];
+      if (currentCycleId)
+        multipleIssuePromises.push(
+          this.rootStore.cycleIssues.addCycleToIssue(workspaceSlug, projectId, currentCycleId, response.id)
+        );
+
+      if (currentModuleIds.length > 0)
+        multipleIssuePromises.push(
+          this.rootStore.moduleIssues.changeModulesInIssue(workspaceSlug, projectId, response.id, currentModuleIds, [])
+        );
+
+      if (multipleIssuePromises && multipleIssuePromises.length > 0) await Promise.all(multipleIssuePromises);
+
       return response;
     } catch (error) {
       this.fetchIssues(workspaceSlug, projectId, "mutation");


### PR DESCRIPTION
### Summary
This PR resolves two main issues:
1. **Quick Add Issue Error**: In all issue layouts, when creating an issue using quick add under the "None" category, an error alert is thrown, and an error appears in the request, even though the expected behavior works correctly.
2. **Issue Creation with Filters**: When creating an issue with filters applied for sub_group_by as Module and group_by as Cycle, the issue was switching between multiple filters before returning to the original position.


### Changes
1. Project issue store
2. Project-view issue store
3. Cycle issue store
4. Module issue store


### Issue link: [[WEB-1492]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/b31f2021-62a1-43cf-aae1-aed6d432c26d)