### PR TITLE
[WEB-1325] fix: inbox issue store update logic.

### DIFF
--- a/web/store/inbox/project-inbox.store.ts
+++ b/web/store/inbox/project-inbox.store.ts
@@ -212,16 +212,15 @@ export class ProjectInboxStore implements IProjectInboxStore {
   createOrUpdateInboxIssue = (inboxIssues: TInboxIssue[], workspaceSlug: string, projectId: string) => {
     if (inboxIssues && inboxIssues.length > 0) {
       inboxIssues.forEach((inbox: TInboxIssue) => {
-        const inboxIssueDetail = this.getIssueInboxByIssueId(inbox?.issue?.id);
-        if (inboxIssueDetail)
-          update(this.inboxIssues, [inbox?.issue?.id], (existingInboxIssue) => ({
-            ...existingInboxIssue,
+        const existingInboxIssueDetail = this.getIssueInboxByIssueId(inbox?.issue?.id);
+        if (existingInboxIssueDetail)
+          Object.assign(existingInboxIssueDetail, {
             ...inbox,
             issue: {
-              ...existingInboxIssue?.issue,
-              ...inbox?.issue,
+              ...existingInboxIssueDetail.issue,
+              ...inbox.issue,
             },
-          }));
+          });
         else
           set(this.inboxIssues, [inbox?.issue?.id], new InboxIssueStore(workspaceSlug, projectId, inbox, this.store));
       });


### PR DESCRIPTION
#### Problem
Issue details weren't updating properly after filter application, leading to errors.

#### Solution
The issue occured from the removal of non-enumerable `actions` during inbox update. Using lodash's `update` method created a new object without copying these actions. The fix involved switching to `Object.assign` method for proper data transfer.