### PR TITLE
[WEB-1511] style: fix overlapping of response container in AI popover.

### DIFF
--- a/web/components/core/modals/gpt-assistant-popover.tsx
+++ b/web/components/core/modals/gpt-assistant-popover.tsx
@@ -210,11 +210,7 @@ export const GptAssistantPopover: React.FC<Props> = (props) => {
             {response !== "" && (
               <div className="page-block-section max-h-[8rem] text-sm">
                 Response:
-                <RichTextReadOnlyEditor
-                  initialValue={`<p>${response}</p>`}
-                  containerClassName={response ? "-mx-3 -my-3" : ""}
-                  ref={responseRef}
-                />
+                <RichTextReadOnlyEditor initialValue={`<p>${response}</p>`} ref={responseRef} />
               </div>
             )}
             {invalidResponse && (


### PR DESCRIPTION
#### Media
* Before
<img width="945" alt="image" src="https://github.com/makeplane/plane/assets/33979846/96cea547-2c5c-431d-8891-bcb979ae5ac7">

* After
<img width="929" alt="image" src="https://github.com/makeplane/plane/assets/33979846/021bffca-d67a-41f8-9c88-546cf08b2feb">

Issue link [WEB-1511](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/33ceface-0e9a-4dbc-96c3-1b9b7bdcb077)
