### PR TITLE
[WEB-1498] style: fix comments reaction alignment.

### DIFF
--- a/web/components/issues/issue-detail/reactions/reaction-selector.tsx
+++ b/web/components/issues/issue-detail/reactions/reaction-selector.tsx
@@ -44,11 +44,11 @@ export const ReactionSelector: React.FC<Props> = (props) => {
             leaveTo="opacity-0 translate-y-1"
           >
             <Popover.Panel
-              className={`absolute -left-2 z-10 bg-custom-sidebar-background-100 ${
+              className={`absolute z-10 bg-custom-sidebar-background-100 ${
                 position === "top" ? "-top-12" : "-bottom-12"
               }`}
             >
-              <div className="rounded-md border border-custom-border-200 bg-custom-sidebar-background-100 p-1 shadow-custom-shadow-sm">
+              <div className="rounded-md border border-custom-border-200 bg-custom-sidebar-background-100 p-1">
                 <div className="flex gap-x-1">
                   {reactionEmojis.map((emoji) => (
                     <button


### PR DESCRIPTION
#### Media
* Before
<img width="380" alt="image" src="https://github.com/makeplane/plane/assets/33979846/f2c355ef-0676-43b7-9b58-139119120891">

* After
<img width="401" alt="image" src="https://github.com/makeplane/plane/assets/33979846/b0847c16-c55d-4913-8da6-23c1fa5c732e">


Issue link [WEB-1498](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/f93ba0fb-b3fb-461c-92c4-1189349a8590)