### PR TITLE
[WEB - 1518] fix: cache invalidation on new members invite

### DIFF
--- a/apiserver/plane/authentication/utils/workspace_project_join.py
+++ b/apiserver/plane/authentication/utils/workspace_project_join.py
@@ -4,6 +4,7 @@ from plane.db.models import (
     WorkspaceMember,
     WorkspaceMemberInvite,
 )
+from plane.utils.cache import invalidate_cache_directly
 
 
 def process_workspace_project_invitations(user):
@@ -25,6 +26,16 @@ def process_workspace_project_invitations(user):
         ],
         ignore_conflicts=True,
     )
+
+    [
+        invalidate_cache_directly(
+            path=f"/api/workspaces/{str(workspace_member_invite.workspace.slug)}/members/",
+            url_params=False,
+            user=False,
+            multiple=True,
+        )
+        for workspace_member_invite in workspace_member_invites
+    ]
 
     # Check if user has any project invites
     project_member_invites = ProjectMemberInvite.objects.filter(

--- a/apiserver/plane/utils/cache.py
+++ b/apiserver/plane/utils/cache.py
@@ -66,7 +66,7 @@ def invalidate_cache_directly(
         custom_path = path if path is not None else request.get_full_path()
     auth_header = (
         None
-        if request.user.is_anonymous
+        if request and request.user.is_anonymous
         else str(request.user.id) if user else None
     )
     key = generate_cache_key(custom_path, auth_header)


### PR DESCRIPTION
fix: 
- cache invalidation on new members invite who don't have account on the platform.
This issue occurs for invited used who does not have an account already on the platform.

Fixes #4166 


**Ticket** - [[WEB - 1518]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/5761717a-bb52-447b-bfb9-69572ab5ba6e)