### PR TITLE
[WEB-1523] regression: focus changing issue with the peek overview editor

### DIFF
--- a/packages/editor/core/src/hooks/use-editor.tsx
+++ b/packages/editor/core/src/hooks/use-editor.tsx
@@ -112,7 +112,7 @@ export const useEditor = ({
     if (value === null || value === undefined) return;
     if (editor && !editor.isDestroyed && !editor.storage.image.uploadInProgress) {
       try {
-        editor.commands.setContent(value);
+        editor.commands.setContent(value, false, { preserveWhitespace: "full" });
         const currentSavedSelection = savedSelectionRef.current;
         if (currentSavedSelection) {
           const docLength = editor.state.doc.content.size;


### PR DESCRIPTION
## Description

1. The editor's focus sometimes randomly flickers due to syncing caused due to the regression caused by #4331 
2. The editor doesn't persist white spaces on sync.

So the setContent option trims whitespaces, so hence this was causing unexpected issues on repeated reassignments of the value. 

## The solution

```ts
editor.commands.setContent(value, false, { preserveWhitespace: "full" });
```

By setting `preserveWhitespace` as full while using `.setContent` we can solve this!!