### PR TITLE
[WEB-1526] feat: add auto merge behaviour to task lists and fix infinite backspace case

### DIFF
--- a/packages/editor/core/src/styles/editor.css
+++ b/packages/editor/core/src/styles/editor.css
@@ -152,6 +152,10 @@ ul[data-type="taskList"] li > label input[type="checkbox"] {
   }
 }
 
+ul[data-type="taskList"] li > div > p {
+  margin-top: 10px;
+}
+
 ul[data-type="taskList"] li[data-checked="true"] > div > p {
   color: rgb(var(--color-text-400));
   text-decoration: line-through;

--- a/packages/editor/core/src/styles/editor.css
+++ b/packages/editor/core/src/styles/editor.css
@@ -110,6 +110,11 @@ ul[data-type="taskList"] li > label input[type="checkbox"]:checked:hover {
   }
 }
 
+/* the p tag just after the ul tag */
+ul[data-type="taskList"] + p {
+  margin-top: 0.4rem !important;
+}
+
 ul[data-type="taskList"] li > label input[type="checkbox"] {
   position: relative;
   -webkit-appearance: none;

--- a/packages/editor/core/src/ui/extensions/keymap.tsx
+++ b/packages/editor/core/src/ui/extensions/keymap.tsx
@@ -16,8 +16,6 @@ declare module "@tiptap/core" {
 }
 
 function autoJoin(tr: Transaction, newTr: Transaction, nodeTypes: NodeType[]) {
-  if (!tr.isGeneric) return false;
-
   // Find all ranges where we might want to join.
   const ranges: Array<number> = [];
   for (let i = 0; i < tr.mapping.maps.length; i++) {

--- a/packages/editor/core/src/ui/extensions/keymap.tsx
+++ b/packages/editor/core/src/ui/extensions/keymap.tsx
@@ -15,7 +15,7 @@ declare module "@tiptap/core" {
   }
 }
 
-function autoJoin(tr: Transaction, newTr: Transaction, nodeType: NodeType) {
+function autoJoin(tr: Transaction, newTr: Transaction, nodeTypes: NodeType[]) {
   if (!tr.isGeneric) return false;
 
   // Find all ranges where we might want to join.
@@ -28,7 +28,7 @@ function autoJoin(tr: Transaction, newTr: Transaction, nodeType: NodeType) {
 
   // Figure out which joinable points exist inside those ranges,
   // by checking all node boundaries in their parent nodes.
-  const joinable = [];
+  const joinable: number[] = [];
   for (let i = 0; i < ranges.length; i += 2) {
     const from = ranges[i],
       to = ranges[i + 1];
@@ -40,7 +40,7 @@ function autoJoin(tr: Transaction, newTr: Transaction, nodeType: NodeType) {
       if (!after) break;
       if (index && joinable.indexOf(pos) == -1) {
         const before = parent.child(index - 1);
-        if (before.type == after.type && before.type === nodeType) joinable.push(pos);
+        if (before.type == after.type && nodeTypes.includes(before.type)) joinable.push(pos);
       }
       pos += after.nodeSize;
     }
@@ -88,25 +88,15 @@ export const CustomKeymap = Extension.create({
           // Create a new transaction.
           const newTr = newState.tr;
 
-          let joined = false;
-          for (const transaction of transactions) {
-            const anotherJoin = autoJoin(transaction, newTr, newState.schema.nodes["orderedList"]);
-            joined = anotherJoin || joined;
-          }
-          if (joined) {
-            return newTr;
-          }
-        },
-      }),
-      new Plugin({
-        key: new PluginKey("unordered-list-merging"),
-        appendTransaction(transactions, oldState, newState) {
-          // Create a new transaction.
-          const newTr = newState.tr;
+          const joinableNodes = [
+            newState.schema.nodes["orderedList"],
+            newState.schema.nodes["taskList"],
+            newState.schema.nodes["bulletList"],
+          ];
 
           let joined = false;
           for (const transaction of transactions) {
-            const anotherJoin = autoJoin(transaction, newTr, newState.schema.nodes["bulletList"]);
+            const anotherJoin = autoJoin(transaction, newTr, joinableNodes);
             joined = anotherJoin || joined;
           }
           if (joined) {


### PR DESCRIPTION
## Description 

1. If you try to delete a task list item from the between, and then join the separated task lists together, the auto merging stops to work which further leads to the `Tab` key not working reliably.

Before

2. Then the tab behavior gets weird if the case is like 

```
 [x] item 1
 [x] item 2
      [x] indented item 1
 [x] $
      [x] indented item 2
  [x] item 4
```

3. Fixed all possible cases for auto merging of lists.
4. Fixes issues with other spacing issues in task lists

Where the $ sign is the cursor position, here the weird infinite loop occurs which is now fixed!