### PR TITLE
fix: `build lint pull request` CI running on draft PRs

### DIFF
--- a/.github/workflows/build-test-pull-request.yml
+++ b/.github/workflows/build-test-pull-request.yml
@@ -3,10 +3,11 @@ name: Build and Lint on Pull Request
 on:
   workflow_dispatch:
   pull_request:
-    types: ["opened", "synchronize"]
+    types: ["opened", "synchronize", "ready_for_review"]
 
 jobs:
   get-changed-files:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     outputs:
       apiserver_changed: ${{ steps.changed-files.outputs.apiserver_any_changed }}


### PR DESCRIPTION
- The PR adds a check inside the `Build Lint Pull Request` CI to only run the CI if the pull request is `ready_for_review` else the workflow won't run.