### PR TITLE
[WEB-1537] fix: inline code block size fixed for headers, etc

### DIFF
--- a/packages/editor/core/src/ui/extensions/code-inline/index.tsx
+++ b/packages/editor/core/src/ui/extensions/code-inline/index.tsx
@@ -33,7 +33,7 @@ export const CustomCodeInlineExtension = Mark.create<CodeOptions>({
     return {
       HTMLAttributes: {
         class:
-          "rounded bg-custom-background-80 px-1 py-[2px] font-mono font-medium text-orange-500 border-[0.5px] border-custom-border-200 text-sm",
+          "rounded bg-custom-background-80 px-1 py-[2px] font-mono font-medium text-orange-500 border-[0.5px] border-custom-border-200",
         spellcheck: "false",
       },
     };

--- a/packages/editor/core/src/ui/extensions/code/utils/replace-code-block-with-text.ts
+++ b/packages/editor/core/src/ui/extensions/code/utils/replace-code-block-with-text.ts
@@ -1,0 +1,124 @@
+import { Editor, findParentNode } from "@tiptap/core";
+
+type ReplaceCodeBlockParams = {
+  editor: Editor;
+  from: number;
+  to: number;
+  textContent: string;
+  cursorPosInsideCodeblock: number;
+};
+
+export function replaceCodeWithText(editor: Editor): void {
+  try {
+    const { from, to } = editor.state.selection;
+    const cursorPosInsideCodeblock = from;
+    let replaced = false;
+
+    editor.state.doc.nodesBetween(from, to, (node, pos) => {
+      if (node.type === editor.state.schema.nodes.codeBlock) {
+        const startPos = pos;
+        const endPos = pos + node.nodeSize;
+        const textContent = node.textContent;
+
+        if (textContent.length === 0) {
+          editor.chain().focus().toggleCodeBlock().run();
+        } else {
+          transformCodeBlockToParagraphs({
+            editor,
+            from: startPos,
+            to: endPos,
+            textContent,
+            cursorPosInsideCodeblock,
+          });
+        }
+
+        replaced = true;
+        return false;
+      }
+    });
+
+    if (!replaced) {
+      console.log("No code block to replace.");
+    }
+  } catch (error) {
+    console.error("An error occurred while replacing code block content:", error);
+  }
+}
+
+function transformCodeBlockToParagraphs({
+  editor,
+  from,
+  to,
+  textContent,
+  cursorPosInsideCodeblock,
+}: ReplaceCodeBlockParams): void {
+  const { schema } = editor.state;
+  const { paragraph } = schema.nodes;
+  const docSize = editor.state.doc.content.size;
+
+  if (from < 0 || to > docSize || from > to) {
+    console.error("Invalid range for replacement: ", from, to, "in a document of size", docSize);
+    return;
+  }
+
+  // Split the textContent by new lines to handle each line as a separate paragraph for Windows (\r\n) and Unix (\n)
+  const lines = textContent.split(/\r?\n/);
+  const tr = editor.state.tr;
+  let insertPos = from;
+
+  // Remove the code block first
+  tr.delete(from, to);
+
+  // For each line, create a paragraph node and insert it
+  lines.forEach((line) => {
+    // if the line is empty, create a paragraph node with no content
+    const paragraphNode = line.length === 0 ? paragraph.create({}) : paragraph.create({}, schema.text(line));
+    tr.insert(insertPos, paragraphNode);
+    insertPos += paragraphNode.nodeSize;
+  });
+
+  // Now persist the focus to the converted paragraph
+  const parentNodeOffset = findParentNode((node) => node.type === schema.nodes.codeBlock)(editor.state.selection)?.pos;
+
+  if (parentNodeOffset === undefined) throw new Error("Invalid code block offset");
+
+  const lineNumber = getLineNumber(textContent, cursorPosInsideCodeblock, parentNodeOffset);
+  const cursorPosOutsideCodeblock = cursorPosInsideCodeblock + (lineNumber - 1);
+
+  editor.view.dispatch(tr);
+  editor.chain().focus(cursorPosOutsideCodeblock).run();
+}
+
+/**
+ * Calculates the line number where the cursor is located inside the code block.
+ * Assumes the indexing of the content inside the code block is like ProseMirror's indexing.
+ *
+ * @param {string} textContent - The content of the code block.
+ * @param {number} cursorPosition - The absolute cursor position in the document.
+ * @param {number} codeBlockNodePos - The starting position of the code block node in the document.
+ * @returns {number} The 1-based line number where the cursor is located.
+ */
+function getLineNumber(textContent: string, cursorPosition: number, codeBlockNodePos: number): number {
+  // Split the text content into lines, handling both Unix and Windows newlines
+  const lines = textContent.split(/\r?\n/);
+  const cursorPosInsideCodeblockRelative = cursorPosition - codeBlockNodePos;
+
+  let startPosition = 0;
+  let lineNumber = 0;
+
+  for (let i = 0; i < lines.length; i++) {
+    // Calculate the end position of the current line
+    const endPosition = startPosition + lines[i].length + 1; // +1 for the newline character
+
+    // Check if the cursor position is within the current line
+    if (cursorPosInsideCodeblockRelative >= startPosition && cursorPosInsideCodeblockRelative <= endPosition) {
+      lineNumber = i + 1; // Line numbers are 1-based
+      break;
+    }
+
+    // Update the start position for the next line
+    startPosition = endPosition;
+  }
+
+  return lineNumber;
+}

--- a/packages/editor/core/src/ui/extensions/custom-list-keymap/list-keymap.ts
+++ b/packages/editor/core/src/ui/extensions/custom-list-keymap/list-keymap.ts
@@ -69,7 +69,7 @@ export const ListKeymap = ({ tabIndex }: { tabIndex?: number }) =>
 
             return handled;
           } catch (e) {
-            console.log("error in handling Backspac:", e);
+            console.log("Error in handling Delete:", e);
             return false;
           }
         },
@@ -104,7 +104,7 @@ export const ListKeymap = ({ tabIndex }: { tabIndex?: number }) =>
 
             return handled;
           } catch (e) {
-            console.log("error in handling Backspac:", e);
+            console.log("Error in handling Backspace:", e);
             return false;
           }
         },


### PR DESCRIPTION
## Description

1. Fix the size of the inline code block.
2. And also fixes the issue of the editor losing focus when code block is toggled off

## Detailed Info on Point 2
Refactoring the code block toggling feature and persisting focus across the toggle fixed.

#### Changes
1. **Function Separation**:
   - **`replaceCodeWithText`**: Main function that identifies code blocks within the selected range and triggers their transformation.
   - **`transformCodeBlockToParagraphs`**: Handles the transformation of a code block into multiple paragraph nodes.
   - **`getLineNumber`**: Calculates the line number where the cursor is located within the code block.

3. **Newline Handling for varying OS**:
   - Updated the `split` method to handle both Unix (`\n`) and Windows (`\r\n`) newline characters using the regular expression `/\r?\n/`.

4. **TypeScript Best Practices**:
   - Added explicit type annotations for function parameters and return types.
   - Used destructuring to extract schema nodes for cleaner code.
   - Added JSDoc comments to document the purpose, parameters, and return value of the `getLineNumber` function and the reason behind choice of the indexes.

#### Detailed Changes
- **`replaceCodeWithText`**:
  - Identifies code blocks within the selected range.

- **`transformCodeBlockToParagraphs`**:
  - Transforms the code block and inserts paragraph nodes for each line of text/code.
  - Handles case of empty lines in between as well.
  - Calculates the new cursor position after transformation.
  - Dispatches the transaction and focuses the editor at the newly calculated cursor position.

- **`getLineNumber`**:
  - Splits the text content inside the code block into lines.
  - Accurately calculates the line number based on the cursor position relative to the code block's start position after calculating the code block's offset inside the editor itself.

#### Error Handling
- Added error handling to catch and log any errors that occur during the replacement process.
- Throws an error if the code block (parent) offset is invalid.