### PR TITLE
[WEB-1184] fix: align checkboxes in the list layout

### DIFF
--- a/web/components/issues/issue-layouts/list/block.tsx
+++ b/web/components/issues/issue-layouts/list/block.tsx
@@ -144,7 +144,7 @@ export const IssueBlock = observer((props: IssueBlockProps) => {
     >
       <div className="flex w-full truncate">
         <div className="flex flex-grow items-center gap-1.5 truncate">
-          <div className="flex items-center gap-2" style={isSubIssue ? { marginLeft } : {}}>
+          <div className="flex items-center gap-2">
             {/* select checkbox */}
             {projectId && canEditIssueProperties && (
               <Tooltip
@@ -174,7 +174,10 @@ export const IssueBlock = observer((props: IssueBlockProps) => {
               </Tooltip>
             )}
             {displayProperties && displayProperties?.key && (
-              <div className="flex-shrink-0 text-xs font-medium text-custom-text-300">
+              <div
+                className="flex-shrink-0 text-xs font-medium text-custom-text-300"
+                style={isSubIssue ? { marginLeft } : {}}
+              >
                 {projectIdentifier}-{issue.sequence_id}
               </div>
             )}


### PR DESCRIPTION
#### Improvements:

Align the select checkboxes in the list layout.

#### Media:

| Before | After |
|--------|--------|
| <img width="700" alt="image" src="https://github.com/makeplane/plane/assets/65252264/5ea10794-99a4-4517-af63-99fa9192be45"> | <img width="700" alt="image" src="https://github.com/makeplane/plane/assets/65252264/37e47d84-747c-4118-a8c2-d23b7bf23c1d"> |

#### Plane issue: [WEB-1184](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/401246d4-bc2b-493c-8fa7-5e712cbfe5d5)