### PR TITLE
[WEB-1409] fix: border flicker on issue title

### DIFF
--- a/web/components/issues/title-input.tsx
+++ b/web/components/issues/title-input.tsx
@@ -108,7 +108,7 @@ export const IssueTitleInput: FC<IssueTitleInputProps> = observer((props) => {
           className={cn(
             "block w-full resize-none overflow-hidden rounded border-none bg-transparent px-3 py-0 text-2xl font-medium outline-none ring-0",
             {
-              "ring-1 ring-red-400 mx-3": title.length === 0,
+              "ring-1 ring-red-400 mx-3": title.length && title.length === 0,
             },
             className
           )}


### PR DESCRIPTION
#### Changes:
This PR include following changes:
- Resolved red border flicker on title during initial load.

#### Issue link: [[WEB-1409]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/96ba2e8a-843f-4136-b431-c2ad2901ce0c)

#### Media: 
| Before | After |
|--------|--------|
| ![WEB-1409-Before](https://github.com/makeplane/plane/assets/121005188/10fe3f7c-f297-494d-9ca5-512b97333bb5) | ![WEB-1409-After](https://github.com/makeplane/plane/assets/121005188/b2b39346-4bc7-4ba1-b315-39e08f77cd66) |
