### PR TITLE
[WEB-412] chore: estimates analytics 

### DIFF
--- a/apiserver/plane/api/views/cycle.py
+++ b/apiserver/plane/api/views/cycle.py
@@ -784,6 +784,7 @@ class TransferCycleIssueAPIEndpoint(BaseAPIView):
 
     def post(self, request, slug, project_id, cycle_id):
         new_cycle_id = request.data.get("new_cycle_id", False)
+        plot_type = request.GET.get("plot_type", "issues")
 
         if not new_cycle_id:
             return Response(
@@ -865,6 +866,7 @@ class TransferCycleIssueAPIEndpoint(BaseAPIView):
             queryset=old_cycle.first(),
             slug=slug,
             project_id=project_id,
+            plot_type=plot_type,
             cycle_id=cycle_id,
         )
 

--- a/apiserver/plane/app/serializers/module.py
+++ b/apiserver/plane/app/serializers/module.py
@@ -177,6 +177,8 @@ class ModuleSerializer(DynamicBaseSerializer):
     started_issues = serializers.IntegerField(read_only=True)
     unstarted_issues = serializers.IntegerField(read_only=True)
     backlog_issues = serializers.IntegerField(read_only=True)
+    total_estimate_points = serializers.IntegerField(read_only=True)
+    completed_estimate_points = serializers.IntegerField(read_only=True)
 
     class Meta:
         model = Module
@@ -201,6 +203,8 @@ class ModuleSerializer(DynamicBaseSerializer):
             "external_id",
             "logo_props",
             # computed fields
+            "total_estimate_points",
+            "completed_estimate_points",
             "is_favorite",
             "total_issues",
             "cancelled_issues",

--- a/apiserver/plane/app/views/cycle/archive.py
+++ b/apiserver/plane/app/views/cycle/archive.py
@@ -177,6 +177,7 @@ class CycleArchiveUnarchiveEndpoint(BaseAPIView):
         )
 
     def get(self, request, slug, project_id, pk=None):
+        plot_type = request.GET.get("plot_type", "issues")
         if pk is None:
             queryset = (
                 self.get_queryset()
@@ -375,6 +376,7 @@ class CycleArchiveUnarchiveEndpoint(BaseAPIView):
                     queryset=queryset,
                     slug=slug,
                     project_id=project_id,
+                    plot_type=plot_type,
                     cycle_id=pk,
                 )
 

--- a/apiserver/plane/app/views/cycle/base.py
+++ b/apiserver/plane/app/views/cycle/base.py
@@ -245,6 +245,7 @@ class CycleViewSet(BaseViewSet):
 
     def list(self, request, slug, project_id):
         queryset = self.get_queryset().filter(archived_at__isnull=True)
+        plot_type = request.GET.get("plot_type", "issues")
         cycle_view = request.GET.get("cycle_view", "all")
 
         # Update the order by
@@ -379,6 +380,7 @@ class CycleViewSet(BaseViewSet):
                             queryset=queryset.first(),
                             slug=slug,
                             project_id=project_id,
+                            plot_type=plot_type,
                             cycle_id=data[0]["id"],
                         )
                     )
@@ -573,6 +575,7 @@ class CycleViewSet(BaseViewSet):
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
     def retrieve(self, request, slug, project_id, pk):
+        plot_type = request.GET.get("plot_type", "issues")
         queryset = (
             self.get_queryset().filter(archived_at__isnull=True).filter(pk=pk)
         )
@@ -728,6 +731,7 @@ class CycleViewSet(BaseViewSet):
                 queryset=queryset,
                 slug=slug,
                 project_id=project_id,
+                plot_type=plot_type,
                 cycle_id=pk,
             )
 
@@ -844,6 +848,7 @@ class TransferCycleIssueEndpoint(BaseAPIView):
 
     def post(self, request, slug, project_id, cycle_id):
         new_cycle_id = request.data.get("new_cycle_id", False)
+        plot_type = request.GET.get("plot_type", "issues")
 
         if not new_cycle_id:
             return Response(
@@ -925,6 +930,7 @@ class TransferCycleIssueEndpoint(BaseAPIView):
             queryset=old_cycle.first(),
             slug=slug,
             project_id=project_id,
+            plot_type=plot_type,
             cycle_id=cycle_id,
         )
 

--- a/apiserver/plane/app/views/module/archive.py
+++ b/apiserver/plane/app/views/module/archive.py
@@ -165,6 +165,7 @@ class ModuleArchiveUnarchiveEndpoint(BaseAPIView):
         )
 
     def get(self, request, slug, project_id, pk=None):
+        plot_type = request.GET.get("plot_type", "issues")
         if pk is None:
             queryset = self.get_queryset()
             modules = queryset.values(  # Required fields
@@ -323,6 +324,7 @@ class ModuleArchiveUnarchiveEndpoint(BaseAPIView):
                     queryset=modules,
                     slug=slug,
                     project_id=project_id,
+                    plot_type=plot_type,
                     module_id=pk,
                 )
 

--- a/apiserver/plane/app/views/module/base.py
+++ b/apiserver/plane/app/views/module/base.py
@@ -16,8 +16,9 @@ from django.db.models import (
     Subquery,
     UUIDField,
     Value,
+    Sum,
 )
-from django.db.models.functions import Coalesce
+from django.db.models.functions import Coalesce, Cast
 from django.core.serializers.json import DjangoJSONEncoder
 from django.utils import timezone
 
@@ -128,6 +129,34 @@ class ModuleViewSet(BaseViewSet):
             .annotate(cnt=Count("pk"))
             .values("cnt")
         )
+        completed_estimate_point = (
+            Issue.issue_objects.filter(
+                estimate_point__estimate__type="points",
+                state__group="completed",
+                issue_module__module_id=OuterRef("pk"),
+            )
+            .values("issue_module__module_id")
+            .annotate(
+                completed_estimate_points=Sum(
+                    Cast("estimate_point__value", IntegerField())
+                )
+            )
+            .values("completed_estimate_points")[:1]
+        )
+
+        total_estimate_point = (
+            Issue.issue_objects.filter(
+                estimate_point__estimate__type="points",
+                issue_module__module_id=OuterRef("pk"),
+            )
+            .values("issue_module__module_id")
+            .annotate(
+                total_estimate_points=Sum(
+                    Cast("estimate_point__value", IntegerField())
+                )
+            )
+            .values("total_estimate_points")[:1]
+        )
         return (
             super()
             .get_queryset()
@@ -183,6 +212,18 @@ class ModuleViewSet(BaseViewSet):
                 )
             )
             .annotate(
+                completed_estimate_points=Coalesce(
+                    Subquery(completed_estimate_point),
+                    Value(0, output_field=IntegerField()),
+                ),
+            )
+            .annotate(
+                total_estimate_points=Coalesce(
+                    Subquery(total_estimate_point),
+                    Value(0, output_field=IntegerField()),
+                ),
+            )
+            .annotate(
                 member_ids=Coalesce(
                     ArrayAgg(
                         "members__id",
@@ -233,6 +274,8 @@ class ModuleViewSet(BaseViewSet):
                     "total_issues",
                     "started_issues",
                     "unstarted_issues",
+                    "completed_estimate_points",
+                    "total_estimate_points",
                     "backlog_issues",
                     "created_at",
                     "updated_at",
@@ -284,6 +327,8 @@ class ModuleViewSet(BaseViewSet):
                 "external_id",
                 "logo_props",
                 # computed fields
+                "completed_estimate_points",
+                "total_estimate_points",
                 "total_issues",
                 "is_favorite",
                 "cancelled_issues",
@@ -469,6 +514,8 @@ class ModuleViewSet(BaseViewSet):
                 "external_id",
                 "logo_props",
                 # computed fields
+                "completed_estimate_points",
+                "total_estimate_points",
                 "is_favorite",
                 "cancelled_issues",
                 "completed_issues",

--- a/apiserver/plane/app/views/module/base.py
+++ b/apiserver/plane/app/views/module/base.py
@@ -346,6 +346,7 @@ class ModuleViewSet(BaseViewSet):
         return Response(modules, status=status.HTTP_200_OK)
 
     def retrieve(self, request, slug, project_id, pk):
+        plot_type = request.GET.get("plot_type", "burndown")
         queryset = (
             self.get_queryset()
             .filter(archived_at__isnull=True)
@@ -468,6 +469,7 @@ class ModuleViewSet(BaseViewSet):
                 queryset=modules,
                 slug=slug,
                 project_id=project_id,
+                plot_type=plot_type,
                 module_id=pk,
             )
 

--- a/apiserver/plane/utils/analytics_plot.py
+++ b/apiserver/plane/utils/analytics_plot.py
@@ -231,8 +231,8 @@ def burndown_plot(
         if plot_type == "points":
             cumulative_pending_issues = total_estimate_points
             total_completed = 0
-            total_completed = Sum(
-                Cast(item["estimate_point__value"], IntegerField())
+            total_completed = sum(
+                int(item["estimate_point__value"])
                 for item in completed_issues_estimate_point_distribution
                 if item["date"] is not None and item["date"] <= date
             )

--- a/apiserver/plane/utils/analytics_plot.py
+++ b/apiserver/plane/utils/analytics_plot.py
@@ -25,7 +25,7 @@ from django.db.models.functions import (
 from django.utils import timezone
 
 # Module imports
-from plane.db.models import Issue
+from plane.db.models import Issue, Estimate
 
 
 def annotate_with_monthly_dimension(queryset, field_name, attribute):
@@ -120,9 +120,30 @@ def build_graph_plot(queryset, x_axis, y_axis, segment=None):
     return sort_data(grouped_data, temp_axis)
 
 
-def burndown_plot(queryset, slug, project_id, cycle_id=None, module_id=None):
+def burndown_plot(
+    queryset,
+    slug,
+    project_id,
+    plot_type,
+    cycle_id=None,
+    module_id=None,
+):
     # Total Issues in Cycle or Module
     total_issues = queryset.total_issues
+    # check whether the estimate is a point or not
+    estimate_type = Estimate.objects.filter(
+        workspace__slug=slug, project_id=project_id, type="points"
+    ).exists()
+    if estimate_type and plot_type == "points":
+        issue_estimates = Issue.objects.filter(
+            workspace__slug=slug,
+            project_id=project_id,
+            issue_cycle__cycle_id=cycle_id,
+            estimate_point__isnull=False,
+        ).values_list("estimate_point__value", flat=True)
+
+        issue_estimates = [int(value) for value in issue_estimates]
+        total_estimate_points = sum(issue_estimates)
 
     if cycle_id:
         if queryset.end_date and queryset.start_date:
@@ -138,18 +159,32 @@ def burndown_plot(queryset, slug, project_id, cycle_id=None, module_id=None):
 
         chart_data = {str(date): 0 for date in date_range}
 
-        completed_issues_distribution = (
-            Issue.issue_objects.filter(
-                workspace__slug=slug,
-                project_id=project_id,
-                issue_cycle__cycle_id=cycle_id,
+        if plot_type == "issues":
+            completed_issues_distribution = (
+                Issue.issue_objects.filter(
+                    workspace__slug=slug,
+                    project_id=project_id,
+                    issue_cycle__cycle_id=cycle_id,
+                )
+                .annotate(date=TruncDate("completed_at"))
+                .values("date")
+                .annotate(total_completed=Count("id"))
+                .values("date", "total_completed")
+                .order_by("date")
             )
-            .annotate(date=TruncDate("completed_at"))
-            .values("date")
-            .annotate(total_completed=Count("id"))
-            .values("date", "total_completed")
-            .order_by("date")
-        )
+        else:
+            completed_issues_estimate_point_distribution = (
+                Issue.issue_objects.filter(
+                    workspace__slug=slug,
+                    project_id=project_id,
+                    issue_cycle__cycle_id=cycle_id,
+                    estimate_point__isnull=False,
+                )
+                .annotate(date=TruncDate("completed_at"))
+                .values("date")
+                .values("date", "estimate_point__value")
+                .order_by("date")
+            )
 
     if module_id:
         # Get all dates between the two dates
@@ -162,31 +197,59 @@ def burndown_plot(queryset, slug, project_id, cycle_id=None, module_id=None):
 
         chart_data = {str(date): 0 for date in date_range}
 
-        completed_issues_distribution = (
-            Issue.issue_objects.filter(
-                workspace__slug=slug,
-                project_id=project_id,
-                issue_module__module_id=module_id,
+        if plot_type == "issues":
+            completed_issues_distribution = (
+                Issue.issue_objects.filter(
+                    workspace__slug=slug,
+                    project_id=project_id,
+                    issue_module__module_id=module_id,
+                )
+                .annotate(date=TruncDate("completed_at"))
+                .values("date")
+                .annotate(total_completed=Count("id"))
+                .values("date", "total_completed")
+                .order_by("date")
             )
-            .annotate(date=TruncDate("completed_at"))
-            .values("date")
-            .annotate(total_completed=Count("id"))
-            .values("date", "total_completed")
-            .order_by("date")
-        )
+        else:
+            completed_issues_estimate_point_distribution = (
+                Issue.issue_objects.filter(
+                    workspace__slug=slug,
+                    project_id=project_id,
+                    issue_module__module_id=module_id,
+                    estimate_point__isnull=False,
+                )
+                .annotate(date=TruncDate("completed_at"))
+                .values("date")
+                .values("date", "estimate_point__value")
+                .order_by("date")
+            )
 
     for date in date_range:
-        cumulative_pending_issues = total_issues
-        total_completed = 0
-        total_completed = sum(
-            item["total_completed"]
-            for item in completed_issues_distribution
-            if item["date"] is not None and item["date"] <= date
-        )
-        cumulative_pending_issues -= total_completed
-        if date > timezone.now().date():
-            chart_data[str(date)] = None
+        if plot_type == "issues":
+            cumulative_pending_issues = total_issues
+            total_completed = 0
+            total_completed = sum(
+                item["total_completed"]
+                for item in completed_issues_distribution
+                if item["date"] is not None and item["date"] <= date
+            )
+            cumulative_pending_issues -= total_completed
+            if date > timezone.now().date():
+                chart_data[str(date)] = None
+            else:
+                chart_data[str(date)] = cumulative_pending_issues
         else:
-            chart_data[str(date)] = cumulative_pending_issues
+            cumulative_pending_issues = total_estimate_points
+            total_completed = 0
+            total_completed = sum(
+                int(item["estimate_point__value"])
+                for item in completed_issues_estimate_point_distribution
+                if item["date"] is not None and item["date"] <= date
+            )
+            cumulative_pending_issues -= total_completed
+            if date > timezone.now().date():
+                chart_data[str(date)] = None
+            else:
+                chart_data[str(date)] = cumulative_pending_issues
 
     return chart_data

--- a/apiserver/plane/utils/analytics_plot.py
+++ b/apiserver/plane/utils/analytics_plot.py
@@ -4,13 +4,23 @@ from itertools import groupby
 
 # Django import
 from django.db import models
-from django.db.models import Case, CharField, Count, F, Sum, Value, When
+from django.db.models import (
+    Case,
+    CharField,
+    Count,
+    F,
+    Sum,
+    Value,
+    When,
+    IntegerField,
+)
 from django.db.models.functions import (
     Coalesce,
     Concat,
     ExtractMonth,
     ExtractYear,
     TruncDate,
+    Cast,
 )
 from django.utils import timezone
 
@@ -87,9 +97,9 @@ def build_graph_plot(queryset, x_axis, y_axis, segment=None):
 
     # Estimate
     else:
-        queryset = queryset.annotate(estimate=Sum("estimate_point")).order_by(
-            x_axis
-        )
+        queryset = queryset.annotate(
+            estimate=Sum(Cast("estimate_point__value", IntegerField()))
+        ).order_by(x_axis)
         queryset = (
             queryset.annotate(segment=F(segment)) if segment else queryset
         )

--- a/packages/types/src/module/modules.d.ts
+++ b/packages/types/src/module/modules.d.ts
@@ -44,6 +44,8 @@ export interface IModule {
   target_date: string | null;
   total_issues: number;
   unstarted_issues: number;
+  total_estimate_points?: number;
+  completed_estimate_points?: number;
   updated_at: string;
   updated_by?: string;
   archived_at: string | null;

--- a/web/components/analytics/custom-analytics/select/y-axis.tsx
+++ b/web/components/analytics/custom-analytics/select/y-axis.tsx
@@ -1,26 +1,54 @@
-// ui
+import { observer } from "mobx-react";
 import { TYAxisValues } from "@plane/types";
 import { CustomSelect } from "@plane/ui";
-// types
-import { ANALYTICS_Y_AXIS_VALUES } from "@/constants/analytics";
 // constants
+import { ANALYTICS_Y_AXIS_VALUES } from "@/constants/analytics";
+import { EEstimateSystem } from "@/constants/estimates";
+// hooks
+import { useAppRouter, useProjectEstimates } from "@/hooks/store";
 
 type Props = {
   value: TYAxisValues;
   onChange: () => void;
 };
 
-export const SelectYAxis: React.FC<Props> = ({ value, onChange }) => (
-  <CustomSelect
-    value={value}
-    label={<span>{ANALYTICS_Y_AXIS_VALUES.find((v) => v.value === value)?.label ?? "None"}</span>}
-    onChange={onChange}
-    maxHeight="lg"
-  >
-    {ANALYTICS_Y_AXIS_VALUES.map((item) => (
-      <CustomSelect.Option key={item.value} value={item.value}>
-        {item.label}
-      </CustomSelect.Option>
-    ))}
-  </CustomSelect>
-);
+export const SelectYAxis: React.FC<Props> = observer(({ value, onChange }) => {
+  // hooks
+  const { projectId } = useAppRouter();
+  const { areEstimateEnabledByProjectId, currentActiveEstimateId, estimateById } = useProjectEstimates();
+
+  const isEstimateEnabled = (analyticsOption: string) => {
+    if (analyticsOption === "estimate") {
+      if (
+        projectId &&
+        currentActiveEstimateId &&
+        areEstimateEnabledByProjectId(projectId) &&
+        estimateById(currentActiveEstimateId)?.type === EEstimateSystem.POINTS
+      ) {
+        return true;
+      } else {
+        return false;
+      }
+    }
+
+    return true;
+  };
+
+  return (
+    <CustomSelect
+      value={value}
+      label={<span>{ANALYTICS_Y_AXIS_VALUES.find((v) => v.value === value)?.label ?? "None"}</span>}
+      onChange={onChange}
+      maxHeight="lg"
+    >
+      {ANALYTICS_Y_AXIS_VALUES.map(
+        (item) =>
+          isEstimateEnabled(item.value) && (
+            <CustomSelect.Option key={item.value} value={item.value}>
+              {item.label}
+            </CustomSelect.Option>
+          )
+      )}
+    </CustomSelect>
+  );
+});

--- a/web/components/estimates/points/create.tsx
+++ b/web/components/estimates/points/create.tsx
@@ -1,4 +1,4 @@
-import { FC, FormEvent, useState } from "react";
+import { FC, MouseEvent, FocusEvent, useState } from "react";
 import { observer } from "mobx-react";
 import { Check, Info, X } from "lucide-react";
 import { TEstimatePointsObject, TEstimateSystemKeys } from "@plane/types";
@@ -49,7 +49,7 @@ export const EstimatePointCreate: FC<TEstimatePointCreate> = observer((props) =>
     closeCallBack();
   };
 
-  const handleCreate = async (event: FormEvent<HTMLFormElement>) => {
+  const handleCreate = async (event: MouseEvent<HTMLButtonElement> | FocusEvent<HTMLInputElement, Element>) => {
     event.preventDefault();
 
     if (!workspaceSlug || !projectId) return;
@@ -122,10 +122,10 @@ export const EstimatePointCreate: FC<TEstimatePointCreate> = observer((props) =>
   };
 
   return (
-    <form onSubmit={handleCreate} className="relative flex items-center gap-2 text-base">
+    <form className="relative flex items-center gap-2 text-base">
       <div
         className={cn(
-          "relative w-full border rounded flex items-center",
+          "relative w-full border rounded flex items-center my-1",
           error ? `border-red-500` : `border-custom-border-200`
         )}
       >
@@ -136,6 +136,7 @@ export const EstimatePointCreate: FC<TEstimatePointCreate> = observer((props) =>
           className="border-none focus:ring-0 focus:border-0 focus:outline-none p-2.5 w-full bg-transparent"
           placeholder="Enter estimate point"
           autoFocus
+          onBlur={(e) => !estimateId && handleCreate(e)}
         />
         {error && (
           <>
@@ -148,20 +149,25 @@ export const EstimatePointCreate: FC<TEstimatePointCreate> = observer((props) =>
         )}
       </div>
 
-      <button
-        type="submit"
-        className="rounded-sm w-6 h-6 flex-shrink-0 relative flex justify-center items-center hover:bg-custom-background-80 transition-colors cursor-pointer text-green-500"
-        disabled={loader}
-      >
-        {loader ? <Spinner className="w-4 h-4" /> : <Check size={14} />}
-      </button>
-      <button
-        className="rounded-sm w-6 h-6 flex-shrink-0 relative flex justify-center items-center hover:bg-custom-background-80 transition-colors cursor-pointer"
-        onClick={handleClose}
-        disabled={loader}
-      >
-        <X size={14} className="text-custom-text-200" />
-      </button>
+      {estimateId && (
+        <>
+          <button
+            type="submit"
+            className="rounded-sm w-6 h-6 flex-shrink-0 relative flex justify-center items-center hover:bg-custom-background-80 transition-colors cursor-pointer text-green-500"
+            disabled={loader}
+            onClick={handleCreate}
+          >
+            {loader ? <Spinner className="w-4 h-4" /> : <Check size={14} />}
+          </button>
+          <button
+            className="rounded-sm w-6 h-6 flex-shrink-0 relative flex justify-center items-center hover:bg-custom-background-80 transition-colors cursor-pointer"
+            onClick={handleClose}
+            disabled={loader}
+          >
+            <X size={14} className="text-custom-text-200" />
+          </button>
+        </>
+      )}
     </form>
   );
 });

--- a/web/components/estimates/points/update.tsx
+++ b/web/components/estimates/points/update.tsx
@@ -1,4 +1,4 @@
-import { FC, FormEvent, useEffect, useState } from "react";
+import { FC, MouseEvent, useEffect, FocusEvent, useState } from "react";
 import { observer } from "mobx-react";
 import { Check, Info, X } from "lucide-react";
 import { TEstimatePointsObject, TEstimateSystemKeys } from "@plane/types";
@@ -57,7 +57,7 @@ export const EstimatePointUpdate: FC<TEstimatePointUpdate> = observer((props) =>
     closeCallBack();
   };
 
-  const handleUpdate = async (event: FormEvent<HTMLFormElement>) => {
+  const handleUpdate = async (event: MouseEvent<HTMLButtonElement> | FocusEvent<HTMLInputElement, Element>) => {
     event.preventDefault();
 
     if (!workspaceSlug || !projectId) return;
@@ -134,10 +134,10 @@ export const EstimatePointUpdate: FC<TEstimatePointUpdate> = observer((props) =>
   };
 
   return (
-    <form onSubmit={handleUpdate} className="relative flex items-center gap-2 text-base">
+    <form className="relative flex items-center gap-2 text-base">
       <div
         className={cn(
-          "relative w-full border rounded flex items-center",
+          "relative w-full border rounded flex items-center my-1",
           error ? `border-red-500` : `border-custom-border-200`
         )}
       >
@@ -147,6 +147,7 @@ export const EstimatePointUpdate: FC<TEstimatePointUpdate> = observer((props) =>
           onChange={(e) => setEstimateInputValue(e.target.value)}
           className="border-none focus:ring-0 focus:border-0 focus:outline-none p-2.5 w-full bg-transparent"
           placeholder="Enter estimate point"
+          onBlur={(e) => !estimateId && handleUpdate(e)}
           autoFocus
         />
         {error && (
@@ -159,21 +160,25 @@ export const EstimatePointUpdate: FC<TEstimatePointUpdate> = observer((props) =>
           </>
         )}
       </div>
-
-      <button
-        type="submit"
-        className="rounded-sm w-6 h-6 flex-shrink-0 relative flex justify-center items-center hover:bg-custom-background-80 transition-colors cursor-pointer text-green-500"
-        disabled={loader}
-      >
-        {loader ? <Spinner className="w-4 h-4" /> : <Check size={14} />}
-      </button>
-      <button
-        className="rounded-sm w-6 h-6 flex-shrink-0 relative flex justify-center items-center hover:bg-custom-background-80 transition-colors cursor-pointer"
-        onClick={handleClose}
-        disabled={loader}
-      >
-        <X size={14} className="text-custom-text-200" />
-      </button>
+      {estimateId && (
+        <>
+          <button
+            type="submit"
+            className="rounded-sm w-6 h-6 flex-shrink-0 relative flex justify-center items-center hover:bg-custom-background-80 transition-colors cursor-pointer text-green-500"
+            disabled={loader}
+            onClick={handleUpdate}
+          >
+            {loader ? <Spinner className="w-4 h-4" /> : <Check size={14} />}
+          </button>
+          <button
+            className="rounded-sm w-6 h-6 flex-shrink-0 relative flex justify-center items-center hover:bg-custom-background-80 transition-colors cursor-pointer"
+            onClick={handleClose}
+            disabled={loader}
+          >
+            <X size={14} className="text-custom-text-200" />
+          </button>
+        </>
+      )}
     </form>
   );
 });


### PR DESCRIPTION
chore: 

- This pull request fixes the issue with the estimates in the analytics.
- The burn-down chart in the cycles and modules can now be plotted based on the `estimate points` only when the estimate type is points.
- In the grid layout, the estimate point percentage is now shown based on the number of estimates completed.
- The estimate point values will now be shown on the x-axis of the custom analytics.

Issue Link: [WEB-412](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/bb16c5ca-dddf-4888-9b5a-574b4cefc3db)