### PR TITLE
[WEB-1544] fix: don't add issue as a sub-issue if parent has been removed

### DIFF
--- a/web/components/issues/sub-issues/root.tsx
+++ b/web/components/issues/sub-issues/root.tsx
@@ -462,7 +462,9 @@ export const SubIssuesRoot: FC<ISubIssuesRoot> = observer((props) => {
                 toggleCreateIssueModal(false);
               }}
               onSubmit={async (_issue: TIssue) => {
-                await subIssueOperations.addSubIssue(workspaceSlug, projectId, parentIssueId, [_issue.id]);
+                if (_issue.parent_id) {
+                  await subIssueOperations.addSubIssue(workspaceSlug, projectId, parentIssueId, [_issue.id]);
+                }
               }}
             />
           )}


### PR DESCRIPTION
#### Problem:

When trying to create a new issue as a sub-issue, if the user removes the parent issue from the create issue modal, the issue still gets created as the sub-issue.

#### Solution:

Added an extra condition to only add the issue as a sub-issue if `parent_id` is present in the response.

#### Media:

| Before | After |
|--------|--------|
| <video src="https://github.com/makeplane/plane/assets/65252264/fdb8a94e-641a-4b7e-a82d-5f163c17c318"></video> | <video src="https://github.com/makeplane/plane/assets/65252264/29f6d56b-41d9-4399-9b16-d6866060809d"></video> | 

#### Plane issue: [WEB-1544](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/9ecd7473-24d2-46b0-b232-15c79cc8de22)