### PR TITLE
[WEB-1539] chore: remove clear selection logic on escape key press

### DIFF
--- a/web/hooks/use-multiple-select.ts
+++ b/web/hooks/use-multiple-select.ts
@@ -271,20 +271,6 @@ export const useMultipleSelect = (props: Props) => {
     [disabled, entitiesList, handleEntitySelection, isGroupSelected]
   );
 
-  // clear selection on escape key press
-  useEffect(() => {
-    if (disabled) return;
-
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") clearSelection();
-    };
-
-    window.addEventListener("keydown", handleKeyDown);
-    return () => {
-      window.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [clearSelection, disabled]);
-
   // select entities on shift + arrow up/down key press
   useEffect(() => {
     if (disabled) return;


### PR DESCRIPTION
#### Improvements:

Removed the logic to clear selection on pressing the Escape key to prevent unwanted de-selection on closing modals/dropdowns on pressing the Escape key.

#### Plane issue: [WEB-1539](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/57980ac7-a258-4de6-b1f4-d18135aedfcc)