### PR TITLE
[WEB-1504] chore: profile picture modal improvement and mutation fix

### DIFF
--- a/web/app/profile/page.tsx
+++ b/web/app/profile/page.tsx
@@ -54,6 +54,7 @@ const ProfileSettingsPage = observer(() => {
     reset,
     watch,
     control,
+    setValue,
     formState: { errors },
   } = useForm<IUser>({ defaultValues });
   // store hooks
@@ -104,6 +105,7 @@ const ProfileSettingsPage = observer(() => {
               message: "Profile picture deleted successfully.",
             });
             setIsRemoving(false);
+            setValue("avatar", "");
           })
           .catch(() => {
             setToast({
@@ -112,7 +114,10 @@ const ProfileSettingsPage = observer(() => {
               message: "There was some error in deleting your profile picture. Please try again.",
             });
           })
-          .finally(() => setIsRemoving(false));
+          .finally(() => {
+            setIsRemoving(false);
+            setIsImageUploadModalOpen(false);
+          });
     });
   };
 


### PR DESCRIPTION
#### Changes: 
This PR includes the following changes:
- Close the profile picture modal upon image removal.
- Fix a mutation issue where the UI did not reflect image removal from the modal.

#### Issue link: [[WEB-1504]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/dfef8962-2d2e-4268-929d-ac6639be8085)

#### Media:
| Before | After |
|--------|--------|
| ![WEB-1504 Before](https://github.com/makeplane/plane/assets/121005188/286c95d5-8bcf-49f6-af24-4603d1451948) | ![WEB-1504 After](https://github.com/makeplane/plane/assets/121005188/38dd09c1-ec9b-4409-8464-bc185a2766d9) |
