### PR TITLE
feat(configure_instance): check mandatory variables before starting

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Meet [Plane](https://dub.sh/plane-website-readme), an open-source project manage
 
 The easiest way to get started with Plane is by creating a [Plane Cloud](https://app.plane.so) account.
 
-If you would like to self-host Plane, please see our [deployment guide](https://docs.plane.so/docker-compose).
+If you would like to self-host Plane, please see our [deployment guide](https://docs.plane.so/self-hosting/overview).
 
 | Installation methods | Docs link                                                                                                                                          |
 | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |

--- a/apiserver/plane/license/management/commands/configure_instance.py
+++ b/apiserver/plane/license/management/commands/configure_instance.py
@@ -19,7 +19,7 @@ class Command(BaseCommand):
         from plane.license.utils.instance_value import get_configuration_value
 
         mandatory_keys = [
-            {                           
+            {
                 "key": "SECRET_KEY",
                 "value": os.environ.get("SECRET_KEY", "1"),
                 "category": "CONFIGURATION",

--- a/apiserver/plane/license/management/commands/configure_instance.py
+++ b/apiserver/plane/license/management/commands/configure_instance.py
@@ -8,6 +8,9 @@ from django.core.management.base import BaseCommand
 from plane.license.models import InstanceConfiguration
 
 
+from django.core.exceptions import ObjectDoesNotExist
+
+
 class Command(BaseCommand):
     help = "Configure instance variables"
 
@@ -24,16 +27,16 @@ class Command(BaseCommand):
             }
         ]
 
-        for item in config_keys:
+        for item in mandatory_keys:
             try:
                 InstanceConfiguration.objects.get(key=item.get("key"))
             except ObjectDoesNotExist:
                 self.stdout.write(
                     self.style.ERROR(
-                        f"Either the {obj.key} or entry doesn't exist."
+                        f"Either the {item.get('key')} or entry doesn't exist."
                     )
                 )
-                return
+                exit(1)
 
         config_keys = [
             # Authentication Settings

--- a/apiserver/plane/license/management/commands/configure_instance.py
+++ b/apiserver/plane/license/management/commands/configure_instance.py
@@ -8,9 +8,6 @@ from django.core.management.base import BaseCommand
 from plane.license.models import InstanceConfiguration
 
 
-from django.core.exceptions import ObjectDoesNotExist
-
-
 class Command(BaseCommand):
     help = "Configure instance variables"
 

--- a/apiserver/plane/license/management/commands/configure_instance.py
+++ b/apiserver/plane/license/management/commands/configure_instance.py
@@ -2,7 +2,7 @@
 import os
 
 # Django imports
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 
 # Module imports
 from plane.license.models import InstanceConfiguration
@@ -19,12 +19,7 @@ class Command(BaseCommand):
 
         for item in mandatory_keys:
             if not os.environ.get(item):
-                self.stdout.write(
-                    self.style.ERROR(
-                        f"{item} env variable is required."
-                    )
-                )
-                exit(1)
+                raise CommandError(f"{item} env variable is required.")
 
         config_keys = [
             # Authentication Settings

--- a/apiserver/plane/license/management/commands/configure_instance.py
+++ b/apiserver/plane/license/management/commands/configure_instance.py
@@ -15,6 +15,26 @@ class Command(BaseCommand):
         from plane.license.utils.encryption import encrypt_data
         from plane.license.utils.instance_value import get_configuration_value
 
+        mandatory_keys = [
+            {                           
+                "key": "SECRET_KEY",
+                "value": os.environ.get("SECRET_KEY", "1"),
+                "category": "CONFIGURATION",
+                "is_encrypted": True,
+            }
+        ]
+
+        for item in config_keys:
+            try:
+                InstanceConfiguration.objects.get(key=item.get("key"))
+            except ObjectDoesNotExist:
+                self.stdout.write(
+                    self.style.ERROR(
+                        f"Either the {obj.key} or entry doesn't exist."
+                    )
+                )
+                return
+
         config_keys = [
             # Authentication Settings
             {

--- a/apiserver/plane/license/management/commands/configure_instance.py
+++ b/apiserver/plane/license/management/commands/configure_instance.py
@@ -18,22 +18,13 @@ class Command(BaseCommand):
         from plane.license.utils.encryption import encrypt_data
         from plane.license.utils.instance_value import get_configuration_value
 
-        mandatory_keys = [
-            {
-                "key": "SECRET_KEY",
-                "value": os.environ.get("SECRET_KEY", "1"),
-                "category": "CONFIGURATION",
-                "is_encrypted": True,
-            }
-        ]
+        mandatory_keys = ["SECRET_KEY"]
 
         for item in mandatory_keys:
-            try:
-                InstanceConfiguration.objects.get(key=item.get("key"))
-            except ObjectDoesNotExist:
+            if not os.environ.get(item):
                 self.stdout.write(
                     self.style.ERROR(
-                        f"Either the {item.get('key')} or entry doesn't exist."
+                        f"{item} env variable is required."
                     )
                 )
                 exit(1)


### PR DESCRIPTION
Hello guys,

To add little contexte about it, i run a self hosted plane instance and i had the case when my SECRET_KEY has not been defined which occur a lot of weird behavior such as google auth configuration dropped after a container restart or even not retrieve after a uprade.

This is a PR to check mandatory keys such as SECRET_KEY in order to prevent starting it without them.

