### PR TITLE
[WEB-1492] fix: resolved issue creation error in layouts while group_by and sub_group_by filters applied in quick add

### DIFF
--- a/web/core/store/issue/cycle/issue.store.ts
+++ b/web/core/store/issue/cycle/issue.store.ts
@@ -7,7 +7,14 @@ import set from "lodash/set";
 import uniq from "lodash/uniq";
 import update from "lodash/update";
 // types
-import { TIssue,  TLoader, IssuePaginationOptions, TIssuesResponse, ViewFlags, TBulkOperationsPayload } from "@plane/types";
+import {
+  TIssue,
+  TLoader,
+  IssuePaginationOptions,
+  TIssuesResponse,
+  ViewFlags,
+  TBulkOperationsPayload,
+} from "@plane/types";
 import { IIssueRootStore } from "../root.store";
 import { BaseIssuesStore, IBaseIssuesStore } from "../helpers/base-issues.store";
 import { ICycleIssuesFilter } from "./filter.store";
@@ -391,9 +398,13 @@ export class CycleIssues extends BaseIssuesStore implements ICycleIssues {
         this.rootIssueStore.issues.removeIssue(data.id);
       });
 
-      if (data.module_ids && data.module_ids.length > 0) {
-        await this.changeModulesInIssue(workspaceSlug, projectId, response.id, data.module_ids, []);
+      const currentModuleIds =
+        data.module_ids && data.module_ids.length > 0 ? data.module_ids.filter((moduleId) => moduleId != "None") : [];
+
+      if (currentModuleIds.length > 0) {
+        await this.changeModulesInIssue(workspaceSlug, projectId, response.id, currentModuleIds, []);
       }
+
       return response;
     } catch (error) {
       throw error;

--- a/web/core/store/issue/module/issue.store.ts
+++ b/web/core/store/issue/module/issue.store.ts
@@ -234,9 +234,12 @@ export class ModuleIssues extends BaseIssuesStore implements IModuleIssues {
         this.rootIssueStore.issues.removeIssue(data.id);
       });
 
-      if (data.cycle_id && data.cycle_id !== "") {
-        await this.addCycleToIssue(workspaceSlug, projectId, data.cycle_id, response.id);
+      const currentCycleId = data.cycle_id !== "" && data.cycle_id === "None" ? undefined : data.cycle_id;
+
+      if (currentCycleId) {
+        await this.addCycleToIssue(workspaceSlug, projectId, currentCycleId, response.id);
       }
+
       return response;
     } catch (error) {
       throw error;


### PR DESCRIPTION
### Summary
This PR resolves two main issues:
1. **Quick Add Issue Error**: In all issue layouts, when creating an issue using quick add under the "None" category, an error alert is thrown, and an error appears in the request, even though the expected behavior works correctly.
2. **Issue Creation with Filters**: When creating an issue with filters applied for sub_group_by as Module and group_by as Cycle, the issue was switching between multiple filters before returning to the original position.


### Changes
1.issue base store
2. Cycle issue store
3. Module issue store


### Issue link: [[WEB-1492]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/b31f2021-62a1-43cf-aae1-aed6d432c26d)