### PR TITLE
[WEB - 1581] fix: magic code when smtp is not configured

### DIFF
--- a/apiserver/plane/authentication/provider/credentials/magic_code.py
+++ b/apiserver/plane/authentication/provider/credentials/magic_code.py
@@ -48,7 +48,7 @@ class MagicCodeProvider(CredentialAdapter):
             raise AuthenticationException(
                 error_code=AUTHENTICATION_ERROR_CODES["SMTP_NOT_CONFIGURED"],
                 error_message="SMTP_NOT_CONFIGURED",
-                payload={"email": str(self.key)},
+                payload={"email": str(key)},
             )
 
         if ENABLE_MAGIC_LINK_LOGIN == "0":
@@ -57,7 +57,7 @@ class MagicCodeProvider(CredentialAdapter):
                     "MAGIC_LINK_LOGIN_DISABLED"
                 ],
                 error_message="MAGIC_LINK_LOGIN_DISABLED",
-                payload={"email": str(self.key)},
+                payload={"email": str(key)},
             )
 
         super().__init__(


### PR DESCRIPTION
fix: 
- error in magic code login when smtp is not configured.

**Ticket** - [[WEB - 1581]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/e60154f5-fbd8-4b4a-9336-bc5d1ab60821)