### PR TITLE
[WEB-1565] fix: total onboarding steps logic.

### DIFF
--- a/web/app/onboarding/page.tsx
+++ b/web/app/onboarding/page.tsx
@@ -37,14 +37,14 @@ const OnboardingPage = observer(() => {
   const router = useRouter();
   // store hooks
   const { captureEvent } = useEventTracker();
-  const { data: user, updateCurrentUser } = useUser();
+  const { isLoading: userLoader, data: user, updateCurrentUser } = useUser();
   const { data: profile, updateUserOnBoard, updateUserProfile } = useUserProfile();
   const { workspaces, fetchWorkspaces } = useWorkspace();
 
   // computed values
   const workspacesList = Object.values(workspaces ?? {});
   // fetching workspaces list
-  useSWR(USER_WORKSPACES_LIST, () => fetchWorkspaces(), {
+  const { isLoading: workspaceListLoader } = useSWR(USER_WORKSPACES_LIST, () => fetchWorkspaces(), {
     shouldRetryOnError: false,
   });
   // fetching user workspace invitations
@@ -99,18 +99,21 @@ const OnboardingPage = observer(() => {
   };
 
   useEffect(() => {
-    // If user is already invited to a workspace, only show profile setup steps.
-    if (workspacesList && workspacesList?.length > 0) {
-      // If password is auto set then show two different steps for profile setup, else merge them.
-      if (user?.is_password_autoset) setTotalSteps(2);
-      else setTotalSteps(1);
-    } else {
-      // If password is auto set then total steps will increase to 4 due to extra step at profile setup stage.
-      if (user?.is_password_autoset) setTotalSteps(4);
-      else setTotalSteps(3);
+    // Never update the total steps if it's already set.
+    if (!totalSteps && userLoader === false && workspaceListLoader === false) {
+      // If user is already invited to a workspace, only show profile setup steps.
+      if (workspacesList && workspacesList?.length > 0) {
+        // If password is auto set then show two different steps for profile setup, else merge them.
+        if (user?.is_password_autoset) setTotalSteps(2);
+        else setTotalSteps(1);
+      } else {
+        // If password is auto set then total steps will increase to 4 due to extra step at profile setup stage.
+        if (user?.is_password_autoset) setTotalSteps(4);
+        else setTotalSteps(3);
+      }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [userLoader, workspaceListLoader]);
 
   useEffect(() => {
     const handleStepChange = async () => {


### PR DESCRIPTION
### Problem
The onboarding workflow required users to create a new workspace, even if they were already part of one.

### Solution
The issue stemmed from not waiting for the users and workspace lists API responses to determine the onboarding steps. To rectify, I implemented checks to ensure the API responded before calculating total steps. Additionally, I enforced consistency in step count to prevent fluctuations.

### Issue link: [WEB-1565](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/27d506cf-3224-46fa-9d8a-332966f5a955)
