### PR TITLE
[WEB-1580] chore: drag handler and sidebar improvement

### DIFF
--- a/web/app/[workspaceSlug]/(projects)/sidebar.tsx
+++ b/web/app/[workspaceSlug]/(projects)/sidebar.tsx
@@ -32,10 +32,9 @@ export const AppSidebar: FC<IAppSidebar> = observer(() => {
     <div
       className={`fixed inset-y-0 z-20 flex h-full flex-shrink-0 flex-grow-0 flex-col border-r border-custom-sidebar-border-200 bg-custom-sidebar-background-100
         duration-300 md:relative
-        ${sidebarCollapsed ? "-ml-[280px]" : ""}
-        sm:${sidebarCollapsed ? "-ml-[280px]" : ""}
-        md:ml-0 ${sidebarCollapsed ? "w-[80px]" : "w-[280px]"}
-        lg:ml-0 ${sidebarCollapsed ? "w-[80px]" : "w-[280px]"}
+        ${sidebarCollapsed ? "-ml-[250px]" : ""}
+        sm:${sidebarCollapsed ? "-ml-[250px]" : ""}
+        md:ml-0 ${sidebarCollapsed ? "w-[70px]" : "w-[250px]"}
       `}
     >
       <div ref={ref} className="flex h-full w-full flex-1 flex-col">

--- a/web/app/profile/sidebar.tsx
+++ b/web/app/profile/sidebar.tsx
@@ -95,10 +95,9 @@ export const ProfileLayoutSidebar = observer(() => {
   return (
     <div
       className={`fixed inset-y-0 z-20 flex h-full flex-shrink-0 flex-grow-0 flex-col border-r border-custom-sidebar-border-200 bg-custom-sidebar-background-100 duration-300 md:relative 
-        ${sidebarCollapsed ? "-ml-[280px]" : ""}
-        sm:${sidebarCollapsed ? "-ml-[280px]" : ""}
-        md:ml-0 ${sidebarCollapsed ? "w-[80px]" : "w-[280px]"}
-        lg:ml-0 ${sidebarCollapsed ? "w-[80px]" : "w-[280px]"}
+        ${sidebarCollapsed ? "-ml-[250px]" : ""}
+        sm:${sidebarCollapsed ? "-ml-[250px]" : ""}
+        md:ml-0 ${sidebarCollapsed ? "w-[70px]" : "w-[250px]"}
       `}
     >
       <div ref={ref} className="flex h-full w-full flex-col gap-y-4">

--- a/web/core/components/labels/label-block/label-item-block.tsx
+++ b/web/core/components/labels/label-block/label-item-block.tsx
@@ -27,10 +27,11 @@ interface ILabelItemBlock {
   customMenuItems: ICustomMenuItem[];
   handleLabelDelete: (label: IIssueLabel) => void;
   isLabelGroup?: boolean;
+  dragHandleRef: MutableRefObject<HTMLButtonElement | null>;
 }
 
 export const LabelItemBlock = (props: ILabelItemBlock) => {
-  const { label, customMenuItems, handleLabelDelete, isLabelGroup } = props;
+  const { label, isDragging, customMenuItems, handleLabelDelete, isLabelGroup, dragHandleRef } = props;
   // states
   const [isMenuActive, setIsMenuActive] = useState(false);
   // refs
@@ -41,6 +42,12 @@ export const LabelItemBlock = (props: ILabelItemBlock) => {
   return (
     <div className="group flex items-center">
       <div className="flex items-center">
+        <DragHandle
+          className={cn("opacity-0 group-hover:opacity-100", {
+            "opacity-100": isDragging,
+          })}
+          ref={dragHandleRef}
+        />
         <LabelName color={label.color} name={label.name} isGroup={isLabelGroup ?? false} />
       </div>
 

--- a/web/core/components/labels/label-block/label-name.tsx
+++ b/web/core/components/labels/label-block/label-name.tsx
@@ -10,7 +10,7 @@ export const LabelName = (props: ILabelName) => {
   const { name, color, isGroup } = props;
 
   return (
-    <div className="flex items-center gap-3 pl-2">
+    <div className="flex items-center gap-3">
       {isGroup ? (
         <Component className="h-3.5 w-3.5" color={color} />
       ) : (

--- a/web/core/components/labels/project-setting-label-group.tsx
+++ b/web/core/components/labels/project-setting-label-group.tsx
@@ -55,13 +55,13 @@ export const ProjectSettingLabelGroup: React.FC<Props> = observer((props) => {
 
   return (
     <LabelDndHOC label={label} isGroup isChild={false} isLastChild={isLastChild} onDrop={onDrop}>
-      {(isDragging, isDroppingInLabel) => (
+      {(isDragging, isDroppingInLabel, dragHandleRef) => (
         <div
           className={`rounded ${isDroppingInLabel ? "border-[2px] border-custom-primary-100" : "border-[1.5px] border-transparent"}`}
         >
           <Disclosure
             as="div"
-            className={`rounded  text-custom-text-100 cursor-grab ${
+            className={`rounded  text-custom-text-100 ${
               !isDroppingInLabel ? "border-[0.5px] border-custom-border-200" : ""
             } ${isDragging ? "bg-custom-background-80" : "bg-custom-background-100"}`}
             defaultOpen
@@ -89,6 +89,7 @@ export const ProjectSettingLabelGroup: React.FC<Props> = observer((props) => {
                           customMenuItems={customMenuItems}
                           handleLabelDelete={handleLabelDelete}
                           isLabelGroup
+                          dragHandleRef={dragHandleRef}
                         />
                       )}
 

--- a/web/core/components/labels/project-setting-label-item.tsx
+++ b/web/core/components/labels/project-setting-label-item.tsx
@@ -64,9 +64,9 @@ export const ProjectSettingLabelItem: React.FC<Props> = (props) => {
 
   return (
     <LabelDndHOC label={label} isGroup={false} isChild={isChild} isLastChild={isLastChild} onDrop={onDrop}>
-      {(isDragging, isDroppingInLabel) => (
+      {(isDragging, isDroppingInLabel, dragHandleRef) => (
         <div
-          className={`rounded cursor-grab ${isDroppingInLabel ? "border-[2px] border-custom-primary-100" : "border-[1.5px] border-transparent"}`}
+          className={`rounded ${isDroppingInLabel ? "border-[2px] border-custom-primary-100" : "border-[1.5px] border-transparent"}`}
         >
           <div
             className={`py-3 px-1 group relative flex items-center justify-between gap-2 space-y-3 rounded  ${
@@ -90,6 +90,7 @@ export const ProjectSettingLabelItem: React.FC<Props> = (props) => {
                 isDragging={isDragging}
                 customMenuItems={customMenuItems}
                 handleLabelDelete={handleLabelDelete}
+                dragHandleRef={dragHandleRef}
               />
             )}
           </div>

--- a/web/core/components/project/sidebar-list.tsx
+++ b/web/core/components/project/sidebar-list.tsx
@@ -207,7 +207,7 @@ export const ProjectSidebarList: FC = observer(() => {
                   leaveTo="transform scale-95 opacity-0"
                 >
                   {isFavoriteProjectsListOpen && (
-                    <Disclosure.Panel as="div" className={`space-y-2 pl-2`} static>
+                    <Disclosure.Panel as="div" static>
                       {favoriteProjects.map((projectId, index) => (
                         <ProjectSidebarListItem
                           key={projectId}
@@ -269,7 +269,7 @@ export const ProjectSidebarList: FC = observer(() => {
                   leaveTo="transform scale-95 opacity-0"
                 >
                   {isAllProjectsListOpen && (
-                    <Disclosure.Panel as="div" className="pl-2" static>
+                    <Disclosure.Panel as="div" static>
                       {joinedProjects.map((projectId, index) => (
                         <ProjectSidebarListItem
                           key={projectId}


### PR DESCRIPTION
#### Changes:
This PR include following changes:
- Restored the drag handler for projects and labels.
- Improved the sidebar:
   - Reduced sidebar width.
   - Aligned icons and adjusted spacing.

#### Issue link: [[WEB-1580]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/1e5ce385-9e0b-4fc2-8bd6-238e89fb8a89)

#### Media:
| Before | After |
|--------|--------|
| ![before](https://github.com/makeplane/plane/assets/121005188/dde244b1-ce80-4e39-9b1a-0a04f814e28e) | ![after](https://github.com/makeplane/plane/assets/121005188/4521dc80-23de-4142-823b-120361c93ed4) |
| ![before](https://github.com/makeplane/plane/assets/121005188/d295b6c4-b7d8-4326-ae21-001e0f76572f) | ![after](https://github.com/makeplane/plane/assets/121005188/e0a430cc-3ecd-4c25-9225-060c31c2fafc) |
