### PR TITLE
[WEB-1597] fix: toast themes.

### DIFF
--- a/web/app/provider.tsx
+++ b/web/app/provider.tsx
@@ -1,4 +1,5 @@
 "use client";
+
 import { FC, ReactNode } from "react";
 import dynamic from "next/dynamic";
 import { AppProgressBar } from "next-nprogress-bar";
@@ -23,16 +24,20 @@ export interface IAppProvider {
   children: ReactNode;
 }
 
+const ToastWithTheme = () => {
+  const { resolvedTheme } = useTheme();
+  return <Toast theme={resolveGeneralTheme(resolvedTheme)} />;
+};
+
 export const AppProvider: FC<IAppProvider> = (props) => {
   const { children } = props;
   // themes
-  const { resolvedTheme } = useTheme();
   return (
     <>
       <AppProgressBar height="4px" color="#3F76FF" options={{ showSpinner: false }} shallowRouting />
-      <Toast theme={resolveGeneralTheme(resolvedTheme)} />
       <StoreProvider>
         <ThemeProvider themes={["light", "dark", "light-contrast", "dark-contrast", "custom"]} defaultTheme="system">
+          <ToastWithTheme />
           <InstanceWrapper>
             <StoreWrapper>
               <CrispWrapper>


### PR DESCRIPTION
### Problem
The theme for the toast component was not changing as expected.

### Solution
The issue stemmed from defining the `resolvedTheme` from `next/theme` before the `ThemeProvider` was utilized. This caused the toast component to not receive the resolved theme properly. To address this, I adjusted the structure by placing the `Theme` component within the `ThemeProvider` and utilized the resolved theme from there.

By doing this, the toast component now correctly receives the updated theme, allowing for seamless theme changes without any issues.


### Issue link [WEB-1597](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/05580408-754b-4c8d-b22f-e8d5b0a959d6)