### PR TITLE
[WEB-1559] chore: add page prop to the quick actions dropdown

### DIFF
--- a/web/core/components/pages/dropdowns/quick-actions.tsx
+++ b/web/core/components/pages/dropdowns/quick-actions.tsx
@@ -13,13 +13,12 @@ import { usePage } from "@/hooks/store";
 
 type Props = {
   pageId: string;
+  pageLink: string;
   parentRef: React.RefObject<HTMLElement>;
-  projectId: string;
-  workspaceSlug: string;
 };
 
 export const PageQuickActions: React.FC<Props> = observer((props) => {
-  const { pageId, parentRef, projectId, workspaceSlug } = props;
+  const { pageId, pageLink, parentRef } = props;
   // states
   const [deletePageModal, setDeletePageModal] = useState(false);
   // store hooks
@@ -35,7 +34,6 @@ export const PageQuickActions: React.FC<Props> = observer((props) => {
     canCurrentUserDeletePage,
   } = usePage(pageId);
 
-  const pageLink = `${workspaceSlug}/projects/${projectId}/pages/${pageId}`;
   const handleCopyText = () =>
     copyUrlToClipboard(pageLink).then(() => {
       setToast({

--- a/web/core/components/pages/dropdowns/quick-actions.tsx
+++ b/web/core/components/pages/dropdowns/quick-actions.tsx
@@ -8,17 +8,17 @@ import { ArchiveIcon, ContextMenu, CustomMenu, TContextMenuItem, TOAST_TYPE, set
 import { DeletePageModal } from "@/components/pages";
 // helpers
 import { copyUrlToClipboard } from "@/helpers/string.helper";
-// hooks
-import { usePage } from "@/hooks/store";
+// store
+import { IPageStore } from "@/store/pages/page.store";
 
 type Props = {
-  pageId: string;
+  page: IPageStore;
   pageLink: string;
   parentRef: React.RefObject<HTMLElement>;
 };
 
 export const PageQuickActions: React.FC<Props> = observer((props) => {
-  const { pageId, pageLink, parentRef } = props;
+  const { page, pageLink, parentRef } = props;
   // states
   const [deletePageModal, setDeletePageModal] = useState(false);
   // store hooks
@@ -32,7 +32,7 @@ export const PageQuickActions: React.FC<Props> = observer((props) => {
     canCurrentUserArchivePage,
     canCurrentUserChangeAccess,
     canCurrentUserDeletePage,
-  } = usePage(pageId);
+  } = page;
 
   const handleCopyText = () =>
     copyUrlToClipboard(pageLink).then(() => {
@@ -85,7 +85,7 @@ export const PageQuickActions: React.FC<Props> = observer((props) => {
 
   return (
     <>
-      <DeletePageModal isOpen={deletePageModal} onClose={() => setDeletePageModal(false)} pageId={pageId} />
+      <DeletePageModal isOpen={deletePageModal} onClose={() => setDeletePageModal(false)} pageId={page.id ?? ""} />
       <ContextMenu parentRef={parentRef} items={MENU_ITEMS} />
       <CustomMenu placement="bottom-end" ellipsis closeOnSelect>
         {MENU_ITEMS.map((item) => {

--- a/web/core/components/pages/list/block-item-action.tsx
+++ b/web/core/components/pages/list/block-item-action.tsx
@@ -24,8 +24,10 @@ export const BlockItemAction: FC<Props> = observer((props) => {
   const { workspaceSlug, projectId, pageId, parentRef } = props;
 
   // store hooks
-  const { access, created_at, is_favorite, owned_by, addToFavorites, removeFromFavorites } = usePage(pageId);
+  const page = usePage(pageId);
   const { getUserDetails } = useMember();
+  // derived values
+  const { access, created_at, is_favorite, owned_by, addToFavorites, removeFromFavorites } = page;
 
   // derived values
   const ownerDetails = owned_by ? getUserDetails(owned_by) : undefined;
@@ -85,7 +87,7 @@ export const BlockItemAction: FC<Props> = observer((props) => {
       {/* quick actions dropdown */}
       <PageQuickActions
         parentRef={parentRef}
-        pageId={pageId}
+        page={page}
         pageLink={`${workspaceSlug}/projects/${projectId}/pages/${pageId}`}
       />
     </>

--- a/web/core/components/pages/list/block-item-action.tsx
+++ b/web/core/components/pages/list/block-item-action.tsx
@@ -83,7 +83,11 @@ export const BlockItemAction: FC<Props> = observer((props) => {
       />
 
       {/* quick actions dropdown */}
-      <PageQuickActions parentRef={parentRef} pageId={pageId} projectId={projectId} workspaceSlug={workspaceSlug} />
+      <PageQuickActions
+        parentRef={parentRef}
+        pageId={pageId}
+        pageLink={`${workspaceSlug}/projects/${projectId}/pages/${pageId}`}
+      />
     </>
   );
 });


### PR DESCRIPTION
#### Improvements:

Add `page` prop to the page quick actions dropdown instead of accessing it via the `usePage` hook.