### PR TITLE
[WEB - 1593] fix: pagination grouping when grouping by created_by

### DIFF
--- a/apiserver/plane/utils/grouper.py
+++ b/apiserver/plane/utils/grouper.py
@@ -188,4 +188,17 @@ def issue_group_values(field, slug, project_id=None, filters=dict):
             return list(queryset.filter(project_id=project_id))
         else:
             return list(queryset)
+
+    if field == "created_by":
+        queryset = (
+            Issue.issue_objects.filter(workspace__slug=slug)
+            .filter(**filters)
+            .values_list("created_by", flat=True)
+            .distinct()
+        )
+        if project_id:
+            return list(queryset.filter(project_id=project_id))
+        else:
+            return list(queryset)
+
     return []

--- a/apiserver/plane/utils/paginator.py
+++ b/apiserver/plane/utils/paginator.py
@@ -393,16 +393,9 @@ class GroupedOffsetPaginator(OffsetPaginator):
         # Grouping for single values
         processed_results = self.__get_field_dict()
         for result in results:
-            (
-                print(result["created_at"].date(), result["priority"])
-                if str(result[self.group_by_field_name])
-                == "c88dfd3b-e97e-4948-851b-a5fe1e36ffd0"
-                else None
-            )
             group_value = str(result.get(self.group_by_field_name))
             if group_value in processed_results:
                 processed_results[str(group_value)]["results"].append(result)
-
         return processed_results
 
     def process_results(self, results):


### PR DESCRIPTION
fix: 
- pagination grouping when grouping by created_by.
Description: When display is set to created by then all the issues created by the user are not displayed.

Steps to recreate: 
- Create multiple issues 
- Now set display as Created by 
- Now we can observe that issues are not displayed

**Ticket** - [[WEB - 1593]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/db04f3a1-3948-4145-9efe-67b642f3d207)