### PR TITLE
[WEB-1599] chore: auth email input one password extenction improvement

### DIFF
--- a/space/components/account/auth-forms/email.tsx
+++ b/space/components/account/auth-forms/email.tsx
@@ -66,9 +66,10 @@ export const AuthEmailForm: FC<TAuthEmailForm> = observer((props) => {
             autoFocus
           />
           {email.length > 0 && (
-            <div className="flex-shrink-0 h-5 w-5 mr-2 bg-onboarding-background-200 hover:cursor-pointer">
-              <XCircle className="h-5 w-5 stroke-custom-text-400" onClick={() => setEmail("")} />
-            </div>
+            <XCircle
+              className="absolute right-3 h-5 w-5 stroke-custom-text-400 hover:cursor-pointer"
+              onClick={() => setEmail("")}
+            />
           )}
         </div>
         {emailError?.email && !isFocused && (

--- a/space/components/account/auth-forms/password.tsx
+++ b/space/components/account/auth-forms/password.tsx
@@ -117,9 +117,10 @@ export const AuthPasswordForm: React.FC<Props> = observer((props: Props) => {
             disabled
           />
           {passwordFormData.email.length > 0 && (
-            <div className="flex-shrink-0 h-5 w-5 mr-2 bg-onboarding-background-200 hover:cursor-pointer">
-              <XCircle className="h-5 w-5 stroke-custom-text-400" onClick={handleEmailClear} />
-            </div>
+            <XCircle
+              className="absolute right-3 h-5 w-5 stroke-custom-text-400 hover:cursor-pointer"
+              onClick={handleEmailClear}
+            />
           )}
         </div>
       </div>

--- a/space/components/account/auth-forms/unique-code.tsx
+++ b/space/components/account/auth-forms/unique-code.tsx
@@ -101,9 +101,10 @@ export const AuthUniqueCodeForm: React.FC<TAuthUniqueCodeForm> = (props) => {
             disabled
           />
           {uniqueCodeFormData.email.length > 0 && (
-            <div className="flex-shrink-0 h-5 w-5 mr-2 bg-onboarding-background-200 hover:cursor-pointer">
-              <XCircle className="h-5 w-5 stroke-custom-text-400" onClick={handleEmailClear} />
-            </div>
+            <XCircle
+              className="absolute right-3 h-5 w-5 stroke-custom-text-400 hover:cursor-pointer"
+              onClick={handleEmailClear}
+            />
           )}
         </div>
       </div>

--- a/web/core/components/account/auth-forms/email.tsx
+++ b/web/core/components/account/auth-forms/email.tsx
@@ -66,9 +66,10 @@ export const AuthEmailForm: FC<TAuthEmailForm> = observer((props) => {
             autoFocus
           />
           {email.length > 0 && (
-            <div className="flex-shrink-0 h-5 w-5 mr-2 bg-onboarding-background-200 hover:cursor-pointer">
-              <XCircle className="h-5 w-5 stroke-custom-text-400" onClick={() => setEmail("")} />
-            </div>
+            <XCircle
+              className="absolute right-3 h-5 w-5 stroke-custom-text-400 hover:cursor-pointer"
+              onClick={() => setEmail("")}
+            />
           )}
         </div>
         {emailError?.email && !isFocused && (

--- a/web/core/components/account/auth-forms/password.tsx
+++ b/web/core/components/account/auth-forms/password.tsx
@@ -140,9 +140,10 @@ export const AuthPasswordForm: React.FC<Props> = observer((props: Props) => {
             disabled
           />
           {passwordFormData.email.length > 0 && (
-            <div className="flex-shrink-0 h-5 w-5 mr-2 bg-onboarding-background-200 hover:cursor-pointer">
-              <XCircle className="h-5 w-5 stroke-custom-text-400" onClick={handleEmailClear} />
-            </div>
+            <XCircle
+              className="absolute right-3 h-5 w-5 stroke-custom-text-400 hover:cursor-pointer"
+              onClick={handleEmailClear}
+            />
           )}
         </div>
       </div>

--- a/web/core/components/account/auth-forms/unique-code.tsx
+++ b/web/core/components/account/auth-forms/unique-code.tsx
@@ -100,9 +100,10 @@ export const AuthUniqueCodeForm: React.FC<TAuthUniqueCodeForm> = (props) => {
             disabled
           />
           {uniqueCodeFormData.email.length > 0 && (
-            <div className="flex-shrink-0 h-5 w-5 mr-2 bg-onboarding-background-200 hover:cursor-pointer">
-              <XCircle className="h-5 w-5 stroke-custom-text-400" onClick={handleEmailClear} />
-            </div>
+            <XCircle
+              className="absolute right-3 h-5 w-5 stroke-custom-text-400 hover:cursor-pointer"
+              onClick={handleEmailClear}
+            />
           )}
         </div>
       </div>


### PR DESCRIPTION
#### Changes:
This PR includes the following changes:
- Improved the email input field on authentication pages. Previously, when using the 1Password Chrome extension to input an email, the field behaved unpredictably. This issue has been resolved with the necessary adjustments.

#### Issue link: [WEB-1599]

#### Media:
| Before | After |
|--------|--------|
| ![Screen Recording 2024-06-12 at 8 (1)](https://github.com/makeplane/plane/assets/121005188/f14a76d9-92eb-4192-b311-2ed4204d62fc) |  ![Screen Recording 2024-06-12 at 8](https://github.com/makeplane/plane/assets/121005188/2902f286-d9b3-406b-b4b7-97fc76fdb9a9) | 


