### PR TITLE
fix: extra indexed db update on mount (reload) causing repeated popups of unsaved changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Meet [Plane](https://dub.sh/plane-website-readme), an open-source project manage
 
 The easiest way to get started with Plane is by creating a [Plane Cloud](https://app.plane.so) account.
 
-If you would like to self-host Plane, please see our [deployment guide](https://docs.plane.so/docker-compose).
+If you would like to self-host Plane, please see our [deployment guide](https://docs.plane.so/self-hosting/overview).
 
 | Installation methods | Docs link                                                                                                                                          |
 | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Meet [Plane](https://dub.sh/plane-website-readme), an open-source project manage
 
 The easiest way to get started with Plane is by creating a [Plane Cloud](https://app.plane.so) account.
 
-If you would like to self-host Plane, please see our [deployment guide](https://docs.plane.so/self-hosting/overview).
+If you would like to self-host Plane, please see our [deployment guide](https://docs.plane.so/docker-compose).
 
 | Installation methods | Docs link                                                                                                                                          |
 | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |

--- a/packages/editor/document-editor/src/hooks/use-document-editor.ts
+++ b/packages/editor/document-editor/src/hooks/use-document-editor.ts
@@ -59,6 +59,9 @@ export const useDocumentEditor = ({
   // indexedDB provider
   useLayoutEffect(() => {
     const localProvider = new IndexeddbPersistence(id, provider.document);
+    localProvider.on("synced", () => {
+      provider.setHasIndexedDBSynced(true);
+    });
     return () => {
       localProvider?.destroy();
     };

--- a/packages/editor/document-editor/src/providers/collaboration-provider.ts
+++ b/packages/editor/document-editor/src/providers/collaboration-provider.ts
@@ -13,6 +13,10 @@ export interface CompleteCollaboratorProviderConfiguration {
    * onChange callback
    */
   onChange: (updates: Uint8Array) => void;
+  /**
+   * Whether connection to the database has been established and all available content has been loaded or not.
+   */
+  hasIndexedDBSynced: boolean;
 }
 
 export type CollaborationProviderConfiguration = Required<Pick<CompleteCollaboratorProviderConfiguration, "name">> &
@@ -24,6 +28,7 @@ export class CollaborationProvider {
     // @ts-expect-error cannot be undefined
     document: undefined,
     onChange: () => {},
+    hasIndexedDBSynced: false,
   };
 
   constructor(configuration: CollaborationProviderConfiguration) {
@@ -45,7 +50,12 @@ export class CollaborationProvider {
     return this.configuration.document;
   }
 
+  setHasIndexedDBSynced(hasIndexedDBSynced: boolean) {
+    this.configuration.hasIndexedDBSynced = hasIndexedDBSynced;
+  }
+
   documentUpdateHandler(update: Uint8Array, origin: any) {
+    if (!this.configuration.hasIndexedDBSynced) return;
     // return if the update is from the provider itself
     if (origin === this) return;
 


### PR DESCRIPTION
## Description

`y-indexeddb` adds a new update to the local database every time you reload the editor creating one unmerged/unapplied update that's unnecessary. In order to solve this, we now wait for the provider to finish indexeddb sync and only then start listening in to the document updates.