### PR TITLE
[WEB-1632] fix: validating and showing proper alert estimate point has to be taken greater than 0 in create and update

### DIFF
--- a/web/core/components/estimates/points/create.tsx
+++ b/web/core/components/estimates/points/create.tsx
@@ -82,8 +82,8 @@ export const EstimatePointCreate: FC<TEstimatePointCreate> = observer((props) =>
 
       if (!isRepeated) {
         if (currentEstimateType && [(EEstimateSystem.TIME, EEstimateSystem.POINTS)].includes(currentEstimateType)) {
-          if (estimateInputValue && Number(estimateInputValue) >= 0) {
-            if (Number(estimateInputValue) === 0) {
+          if (estimateInputValue && !isNaN(Number(estimateInputValue))) {
+            if (Number(estimateInputValue) <= 0) {
               handleEstimatePointError &&
                 handleEstimatePointError(estimateInputValue, "Estimate point should be greater than 0.");
               return;

--- a/web/core/components/estimates/points/create.tsx
+++ b/web/core/components/estimates/points/create.tsx
@@ -82,8 +82,14 @@ export const EstimatePointCreate: FC<TEstimatePointCreate> = observer((props) =>
 
       if (!isRepeated) {
         if (currentEstimateType && [(EEstimateSystem.TIME, EEstimateSystem.POINTS)].includes(currentEstimateType)) {
-          if (estimateInputValue && Number(estimateInputValue) && Number(estimateInputValue) >= 0) {
-            isEstimateValid = true;
+          if (estimateInputValue && Number(estimateInputValue) >= 0) {
+            if (Number(estimateInputValue) === 0) {
+              handleEstimatePointError &&
+                handleEstimatePointError(estimateInputValue, "Estimate point should be greater than 0.");
+              return;
+            } else {
+              isEstimateValid = true;
+            }
           }
         } else if (currentEstimateType && currentEstimateType === EEstimateSystem.CATEGORIES) {
           if (estimateInputValue && estimateInputValue.length > 0 && isNaN(Number(estimateInputValue))) {

--- a/web/core/components/estimates/points/update.tsx
+++ b/web/core/components/estimates/points/update.tsx
@@ -87,8 +87,8 @@ export const EstimatePointUpdate: FC<TEstimatePointUpdate> = observer((props) =>
 
       if (!isRepeated) {
         if (currentEstimateType && [(EEstimateSystem.TIME, EEstimateSystem.POINTS)].includes(currentEstimateType)) {
-          if (estimateInputValue && Number(estimateInputValue) >= 0) {
-            if (Number(estimateInputValue) === 0) {
+          if (estimateInputValue && !isNaN(Number(estimateInputValue))) {
+            if (Number(estimateInputValue) <= 0) {
               handleEstimatePointError &&
                 handleEstimatePointError(estimateInputValue, "Estimate point should be greater than 0.");
               return;

--- a/web/core/components/estimates/points/update.tsx
+++ b/web/core/components/estimates/points/update.tsx
@@ -87,8 +87,14 @@ export const EstimatePointUpdate: FC<TEstimatePointUpdate> = observer((props) =>
 
       if (!isRepeated) {
         if (currentEstimateType && [(EEstimateSystem.TIME, EEstimateSystem.POINTS)].includes(currentEstimateType)) {
-          if (estimateInputValue && Number(estimateInputValue) && Number(estimateInputValue) >= 0) {
-            isEstimateValid = true;
+          if (estimateInputValue && Number(estimateInputValue) >= 0) {
+            if (Number(estimateInputValue) === 0) {
+              handleEstimatePointError &&
+                handleEstimatePointError(estimateInputValue, "Estimate point should be greater than 0.");
+              return;
+            } else {
+              isEstimateValid = true;
+            }
           }
         } else if (currentEstimateType && currentEstimateType === EEstimateSystem.CATEGORIES) {
           if (estimateInputValue && estimateInputValue.length > 0 && isNaN(Number(estimateInputValue))) {


### PR DESCRIPTION
### Summary
This PR fixes the validation logic and alerts for estimate points in the create and update issue modals, ensuring that the estimate points must be greater than 0.

### Changes
1. Estimate create component
2. Estimate update component

### Issue link: [[WEB-1632]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/86c7a78d-098f-4c7b-8e22-0200048689f2)