### PR TITLE
[WEB-1624] chore: add un-snooze option and minor fixes in inbox issue

### DIFF
--- a/packages/types/src/inbox.d.ts
+++ b/packages/types/src/inbox.d.ts
@@ -81,7 +81,7 @@ export type TInboxDuplicateIssueDetails = {
 export type TInboxIssue = {
   id: string;
   status: TInboxIssueStatus;
-  snoozed_till: Date | undefined;
+  snoozed_till: Date | null;
   duplicate_to: string | undefined;
   source: string;
   issue: TIssue;

--- a/web/core/components/inbox/content/inbox-issue-header.tsx
+++ b/web/core/components/inbox/content/inbox-issue-header.tsx
@@ -109,7 +109,7 @@ export const InboxIssueActionsHeader: FC<TInboxIssueActionsHeader> = observer((p
     handleRedirection(nextOrPreviousIssueId);
   };
 
-  const handleInboxSIssueSnooze = async (date: Date) => {
+  const handleInboxIssueSnooze = async (date: Date) => {
     const nextOrPreviousIssueId = redirectIssue();
     await inboxIssue?.updateInboxIssueSnoozeTill(date);
     setIsSnoozeDateModalOpen(false);
@@ -125,6 +125,16 @@ export const InboxIssueActionsHeader: FC<TInboxIssueActionsHeader> = observer((p
     await deleteInboxIssue(workspaceSlug, projectId, currentInboxIssueId).finally(() => {
       router.push(`/${workspaceSlug}/projects/${projectId}/inbox`);
     });
+  };
+
+  const handleIssueSnoozeAction = async () => {
+    if (!inboxIssue?.snoozed_till) {
+      setIsSnoozeDateModalOpen(true);
+    } else {
+      const nextOrPreviousIssueId = redirectIssue();
+      await inboxIssue?.updateInboxIssueSnoozeTill(null);
+      handleRedirection(nextOrPreviousIssueId);
+    }
   };
 
   const handleCopyIssueLink = () =>
@@ -209,7 +219,7 @@ export const InboxIssueActionsHeader: FC<TInboxIssueActionsHeader> = observer((p
           isOpen={isSnoozeDateModalOpen}
           handleClose={() => setIsSnoozeDateModalOpen(false)}
           value={inboxIssue?.snoozed_till}
-          onConfirm={handleInboxSIssueSnooze}
+          onConfirm={handleInboxIssueSnooze}
         />
       </>
 
@@ -299,10 +309,10 @@ export const InboxIssueActionsHeader: FC<TInboxIssueActionsHeader> = observer((p
                 {isAllowed && (
                   <CustomMenu verticalEllipsis placement="bottom-start">
                     {canMarkAsAccepted && (
-                      <CustomMenu.MenuItem onClick={() => setIsSnoozeDateModalOpen(true)}>
+                        <CustomMenu.MenuItem onClick={handleIssueSnoozeAction}>
                         <div className="flex items-center gap-2">
                           <Clock size={14} strokeWidth={2} />
-                          Snooze
+                            {inboxIssue.snoozed_till ? "Un-snooze" : "Snooze"}
                         </div>
                       </CustomMenu.MenuItem>
                     )}
@@ -337,7 +347,7 @@ export const InboxIssueActionsHeader: FC<TInboxIssueActionsHeader> = observer((p
           handleCopyIssueLink={handleCopyIssueLink}
           setAcceptIssueModal={setAcceptIssueModal}
           setDeclineIssueModal={setDeclineIssueModal}
-          setIsSnoozeDateModalOpen={setIsSnoozeDateModalOpen}
+          handleIssueSnoozeAction={handleIssueSnoozeAction}
           setSelectDuplicateIssue={setSelectDuplicateIssue}
           setDeleteIssueModal={setDeleteIssueModal}
           canMarkAsAccepted={canMarkAsAccepted}

--- a/web/core/components/inbox/content/inbox-issue-header.tsx
+++ b/web/core/components/inbox/content/inbox-issue-header.tsx
@@ -28,6 +28,7 @@ import { IssueUpdateStatus } from "@/components/issues";
 // constants
 import { EUserProjectRoles } from "@/constants/project";
 // helpers
+import { findHowManyDaysLeft } from "@/helpers/date-time.helper";
 import { EInboxIssueStatus } from "@/helpers/inbox.helper";
 import { copyUrlToClipboard } from "@/helpers/string.helper";
 // hooks
@@ -71,6 +72,8 @@ export const InboxIssueActionsHeader: FC<TInboxIssueActionsHeader> = observer((p
   const canMarkAsDeclined = isAllowed && (inboxIssue?.status === 0 || inboxIssue?.status === -2);
   const canDelete = isAllowed || inboxIssue?.created_by === currentUser?.id;
   const isAcceptedOrDeclined = inboxIssue?.status ? [-1, 1, 2].includes(inboxIssue.status) : undefined;
+  // days left for snooze
+  const numberOfDaysLeft = findHowManyDaysLeft(inboxIssue?.snoozed_till);
 
   const currentInboxIssueId = inboxIssue?.issue?.id;
 
@@ -128,12 +131,12 @@ export const InboxIssueActionsHeader: FC<TInboxIssueActionsHeader> = observer((p
   };
 
   const handleIssueSnoozeAction = async () => {
-    if (!inboxIssue?.snoozed_till) {
-      setIsSnoozeDateModalOpen(true);
-    } else {
+    if (inboxIssue?.snoozed_till && numberOfDaysLeft && numberOfDaysLeft > 0) {
       const nextOrPreviousIssueId = redirectIssue();
-      await inboxIssue?.updateInboxIssueSnoozeTill(null);
+      await inboxIssue?.updateInboxIssueSnoozeTill(undefined);
       handleRedirection(nextOrPreviousIssueId);
+    } else {
+      setIsSnoozeDateModalOpen(true);
     }
   };
 
@@ -312,7 +315,9 @@ export const InboxIssueActionsHeader: FC<TInboxIssueActionsHeader> = observer((p
                         <CustomMenu.MenuItem onClick={handleIssueSnoozeAction}>
                         <div className="flex items-center gap-2">
                           <Clock size={14} strokeWidth={2} />
-                            {inboxIssue.snoozed_till ? "Un-snooze" : "Snooze"}
+                            {inboxIssue?.snoozed_till && numberOfDaysLeft && numberOfDaysLeft > 0
+                              ? "Un-snooze"
+                              : "Snooze"}
                         </div>
                       </CustomMenu.MenuItem>
                     )}

--- a/web/core/components/inbox/content/inbox-issue-mobile-header.tsx
+++ b/web/core/components/inbox/content/inbox-issue-mobile-header.tsx
@@ -20,6 +20,7 @@ import { InboxIssueStatus } from "@/components/inbox";
 import { IssueUpdateStatus } from "@/components/issues";
 // helpers
 import { cn } from "@/helpers/common.helper";
+import { findHowManyDaysLeft } from "@/helpers/date-time.helper";
 // hooks
 import { useAppRouter } from "@/hooks/use-app-router";
 // store types
@@ -68,6 +69,8 @@ export const InboxIssueActionsMobileHeader: React.FC<Props> = observer((props) =
   const router = useAppRouter();
   const issue = inboxIssue?.issue;
   const currentInboxIssueId = issue?.id;
+  // days left for snooze
+  const numberOfDaysLeft = findHowManyDaysLeft(inboxIssue?.snoozed_till);
 
   if (!issue || !inboxIssue) return null;
 
@@ -129,7 +132,7 @@ export const InboxIssueActionsMobileHeader: React.FC<Props> = observer((props) =
               <CustomMenu.MenuItem onClick={handleIssueSnoozeAction}>
                 <div className="flex items-center gap-2">
                   <Clock size={14} strokeWidth={2} />
-                  {inboxIssue.snoozed_till ? "Un-snooze" : "Snooze"}
+                  {inboxIssue?.snoozed_till && numberOfDaysLeft && numberOfDaysLeft > 0 ? "Un-snooze" : "Snooze"}
                 </div>
               </CustomMenu.MenuItem>
             )}

--- a/web/core/components/inbox/content/inbox-issue-mobile-header.tsx
+++ b/web/core/components/inbox/content/inbox-issue-mobile-header.tsx
@@ -38,7 +38,7 @@ type Props = {
   setAcceptIssueModal: (value: boolean) => void;
   setDeclineIssueModal: (value: boolean) => void;
   setDeleteIssueModal: (value: boolean) => void;
-  setIsSnoozeDateModalOpen: (value: boolean) => void;
+  handleIssueSnoozeAction: () => Promise<void>;
   setSelectDuplicateIssue: (value: boolean) => void;
   handleCopyIssueLink: () => void;
   isMobileSidebar: boolean;
@@ -59,7 +59,7 @@ export const InboxIssueActionsMobileHeader: React.FC<Props> = observer((props) =
     setAcceptIssueModal,
     setDeclineIssueModal,
     setDeleteIssueModal,
-    setIsSnoozeDateModalOpen,
+    handleIssueSnoozeAction,
     setSelectDuplicateIssue,
     handleCopyIssueLink,
     isMobileSidebar,
@@ -126,10 +126,10 @@ export const InboxIssueActionsMobileHeader: React.FC<Props> = observer((props) =
               </CustomMenu.MenuItem>
             )}
             {canMarkAsAccepted && !isAcceptedOrDeclined && (
-              <CustomMenu.MenuItem onClick={() => setIsSnoozeDateModalOpen(true)}>
+              <CustomMenu.MenuItem onClick={handleIssueSnoozeAction}>
                 <div className="flex items-center gap-2">
                   <Clock size={14} strokeWidth={2} />
-                  Snooze
+                  {inboxIssue.snoozed_till ? "Un-snooze" : "Snooze"}
                 </div>
               </CustomMenu.MenuItem>
             )}

--- a/web/core/store/inbox/inbox-issue.store.ts
+++ b/web/core/store/inbox/inbox-issue.store.ts
@@ -22,7 +22,7 @@ export interface IInboxIssueStore {
   // actions
   updateInboxIssueStatus: (status: TInboxIssueStatus) => Promise<void>; // accept, decline
   updateInboxIssueDuplicateTo: (issueId: string) => Promise<void>; // connecting the inbox issue to the project existing issue
-  updateInboxIssueSnoozeTill: (date: Date | null) => Promise<void>; // snooze the issue
+  updateInboxIssueSnoozeTill: (date: Date | undefined) => Promise<void>; // snooze the issue
   updateIssue: (issue: Partial<TIssue>) => Promise<void>; // updating the issue
   updateProjectIssue: (issue: Partial<TIssue>) => Promise<void>; // updating the issue
   fetchIssueActivity: () => Promise<void>; // fetching the issue activity
@@ -124,7 +124,7 @@ export class InboxIssueStore implements IInboxIssueStore {
     }
   };
 
-  updateInboxIssueSnoozeTill = async (date: Date | null) => {
+  updateInboxIssueSnoozeTill = async (date: Date | undefined) => {
     const inboxStatus = date ? EInboxIssueStatus.SNOOZED : EInboxIssueStatus.PENDING;
     const previousData: Partial<TInboxIssue> = {
       status: this.status,

--- a/web/core/store/inbox/inbox-issue.store.ts
+++ b/web/core/store/inbox/inbox-issue.store.ts
@@ -53,7 +53,7 @@ export class InboxIssueStore implements IInboxIssueStore {
     this.id = data.id;
     this.status = data.status;
     this.issue = data?.issue;
-    this.snoozed_till = data?.snoozed_till ? new Date(data.snoozed_till) : undefined;
+    this.snoozed_till = data?.snoozed_till || undefined;
     this.duplicate_to = data?.duplicate_to || undefined;
     this.created_by = data?.created_by || undefined;
     this.duplicate_issue_detail = data?.duplicate_issue_detail || undefined;

--- a/web/core/store/inbox/inbox-issue.store.ts
+++ b/web/core/store/inbox/inbox-issue.store.ts
@@ -22,7 +22,7 @@ export interface IInboxIssueStore {
   // actions
   updateInboxIssueStatus: (status: TInboxIssueStatus) => Promise<void>; // accept, decline
   updateInboxIssueDuplicateTo: (issueId: string) => Promise<void>; // connecting the inbox issue to the project existing issue
-  updateInboxIssueSnoozeTill: (date: Date) => Promise<void>; // snooze the issue
+  updateInboxIssueSnoozeTill: (date: Date | null) => Promise<void>; // snooze the issue
   updateIssue: (issue: Partial<TIssue>) => Promise<void>; // updating the issue
   updateProjectIssue: (issue: Partial<TIssue>) => Promise<void>; // updating the issue
   fetchIssueActivity: () => Promise<void>; // fetching the issue activity
@@ -124,8 +124,8 @@ export class InboxIssueStore implements IInboxIssueStore {
     }
   };
 
-  updateInboxIssueSnoozeTill = async (date: Date) => {
-    const inboxStatus = EInboxIssueStatus.SNOOZED;
+  updateInboxIssueSnoozeTill = async (date: Date | null) => {
+    const inboxStatus = date ? EInboxIssueStatus.SNOOZED : EInboxIssueStatus.PENDING;
     const previousData: Partial<TInboxIssue> = {
       status: this.status,
       snoozed_till: this.snoozed_till,
@@ -134,7 +134,7 @@ export class InboxIssueStore implements IInboxIssueStore {
       if (!this.issue.id) return;
       const inboxIssue = await this.inboxIssueService.update(this.workspaceSlug, this.projectId, this.issue.id, {
         status: inboxStatus,
-        snoozed_till: new Date(date),
+        snoozed_till: date ? new Date(date) : null,
       });
       runInAction(() => {
         set(this, "status", inboxIssue?.status);


### PR DESCRIPTION
### Problems
1. There was no option to un-snooze an issue if it has been snoozed. 
2. Inbox issue snooze till data was inconsistent on initial load and when we go to issue detail.

### Solution
1. Added option to un-snooze the inbox issue.
2. This inconsistency was because we were updating the `snooze_till` property to date object from date string at the store initialization phase.

### Media
  https://github.com/makeplane/plane/assets/33979846/77a9c27f-ea83-43d6-b3bd-a0c82acd210c


### Issue link: [WEB-1624](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/306e68b9-7bc6-48f6-93f2-e1f094990342) and [WEB-1605](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/6002c700-c9c1-4cb1-8409-36198f88a21f)