### PR TITLE
[WEB-1635] style: fix vertical section tabs highlights.

### DIFF
--- a/web/core/components/archives/archive-tabs-list.tsx
+++ b/web/core/components/archives/archive-tabs-list.tsx
@@ -11,7 +11,6 @@ export const ArchiveTabsList: FC = observer(() => {
   // router
   const { workspaceSlug, projectId } = useParams();
   const pathname = usePathname();
-  const activeTab = pathname.split("/").pop();
   // store hooks
   const { getProjectById } = useProject();
 
@@ -28,7 +27,7 @@ export const ArchiveTabsList: FC = observer(() => {
             <Link key={tab.key} href={`/${workspaceSlug}/projects/${projectId}/archives/${tab.key}`}>
               <span
                 className={`flex min-w-min flex-shrink-0 whitespace-nowrap border-b-2 py-3 px-4 text-sm font-medium outline-none ${
-                  tab.key === activeTab
+                  pathname.includes(tab.key)
                     ? "border-custom-primary-100 text-custom-primary-100"
                     : "border-transparent hover:border-custom-border-200 text-custom-text-300 hover:text-custom-text-400"
                 }`}

--- a/web/core/constants/dashboard.ts
+++ b/web/core/constants/dashboard.ts
@@ -264,7 +264,7 @@ export const SIDEBAR_MENU_ITEMS: {
     label: "Home",
     href: ``,
     access: EUserWorkspaceRoles.GUEST,
-    highlight: (pathname: string, baseUrl: string) => pathname === `${baseUrl}`,
+    highlight: (pathname: string, baseUrl: string) => pathname === `${baseUrl}/`,
     Icon: Home,
   },
   {
@@ -272,7 +272,7 @@ export const SIDEBAR_MENU_ITEMS: {
     label: "Analytics",
     href: `/analytics`,
     access: EUserWorkspaceRoles.MEMBER,
-    highlight: (pathname: string, baseUrl: string) => pathname.includes(`${baseUrl}/analytics`),
+    highlight: (pathname: string, baseUrl: string) => pathname.includes(`${baseUrl}/analytics/`),
     Icon: BarChart2,
   },
   {
@@ -280,7 +280,7 @@ export const SIDEBAR_MENU_ITEMS: {
     label: "Projects",
     href: `/projects`,
     access: EUserWorkspaceRoles.GUEST,
-    highlight: (pathname: string, baseUrl: string) => pathname === `${baseUrl}/projects`,
+    highlight: (pathname: string, baseUrl: string) => pathname === `${baseUrl}/projects/`,
     Icon: Briefcase,
   },
   {
@@ -288,7 +288,7 @@ export const SIDEBAR_MENU_ITEMS: {
     label: "All Issues",
     href: `/workspace-views/all-issues`,
     access: EUserWorkspaceRoles.GUEST,
-    highlight: (pathname: string, baseUrl: string) => pathname.includes(`${baseUrl}/workspace-views`),
+    highlight: (pathname: string, baseUrl: string) => pathname.includes(`${baseUrl}/workspace-views/`),
     Icon: CheckCircle,
   },
   {
@@ -296,7 +296,7 @@ export const SIDEBAR_MENU_ITEMS: {
     label: "Active Cycles",
     href: `/active-cycles`,
     access: EUserWorkspaceRoles.GUEST,
-    highlight: (pathname: string, baseUrl: string) => pathname === `${baseUrl}/active-cycles`,
+    highlight: (pathname: string, baseUrl: string) => pathname === `${baseUrl}/active-cycles/`,
     Icon: ContrastIcon,
   },
 ];

--- a/web/core/constants/profile.ts
+++ b/web/core/constants/profile.ts
@@ -13,21 +13,21 @@ export const PROFILE_ACTION_LINKS: {
     key: "profile",
     label: "Profile",
     href: `/profile`,
-    highlight: (pathname: string) => pathname === "/profile",
+    highlight: (pathname: string) => pathname === "/profile/",
     Icon: CircleUser,
   },
   {
     key: "security",
     label: "Security",
     href: `/profile/security`,
-    highlight: (pathname: string) => pathname === "/profile/security",
+    highlight: (pathname: string) => pathname === "/profile/security/",
     Icon: KeyRound,
   },
   {
     key: "activity",
     label: "Activity",
     href: `/profile/activity`,
-    highlight: (pathname: string) => pathname === "/profile/activity",
+    highlight: (pathname: string) => pathname === "/profile/activity/",
     Icon: Activity,
   },
   {
@@ -41,7 +41,7 @@ export const PROFILE_ACTION_LINKS: {
       key: "notifications",
       label: "Notifications",
       href: `/profile/notifications`,
-      highlight: (pathname: string) => pathname === "/profile/notifications",
+      highlight: (pathname: string) => pathname === "/profile/notifications/",
       Icon: Bell,
     },
 ];

--- a/web/core/constants/project.ts
+++ b/web/core/constants/project.ts
@@ -80,7 +80,7 @@ export const PROJECT_SETTINGS_LINKS: {
     label: "General",
     href: `/settings`,
     access: EUserProjectRoles.MEMBER,
-    highlight: (pathname: string, baseUrl: string) => pathname === `${baseUrl}/settings`,
+    highlight: (pathname: string, baseUrl: string) => pathname === `${baseUrl}/settings/`,
     Icon: SettingIcon,
   },
   {
@@ -88,7 +88,7 @@ export const PROJECT_SETTINGS_LINKS: {
     label: "Members",
     href: `/settings/members`,
     access: EUserProjectRoles.MEMBER,
-    highlight: (pathname: string, baseUrl: string) => pathname === `${baseUrl}/settings/members`,
+    highlight: (pathname: string, baseUrl: string) => pathname === `${baseUrl}/settings/members/`,
     Icon: SettingIcon,
   },
   {
@@ -96,7 +96,7 @@ export const PROJECT_SETTINGS_LINKS: {
     label: "Features",
     href: `/settings/features`,
     access: EUserProjectRoles.ADMIN,
-    highlight: (pathname: string, baseUrl: string) => pathname === `${baseUrl}/settings/features`,
+    highlight: (pathname: string, baseUrl: string) => pathname === `${baseUrl}/settings/features/`,
     Icon: SettingIcon,
   },
   {
@@ -104,7 +104,7 @@ export const PROJECT_SETTINGS_LINKS: {
     label: "States",
     href: `/settings/states`,
     access: EUserProjectRoles.MEMBER,
-    highlight: (pathname: string, baseUrl: string) => pathname === `${baseUrl}/settings/states`,
+    highlight: (pathname: string, baseUrl: string) => pathname === `${baseUrl}/settings/states/`,
     Icon: SettingIcon,
   },
   {
@@ -112,7 +112,7 @@ export const PROJECT_SETTINGS_LINKS: {
     label: "Labels",
     href: `/settings/labels`,
     access: EUserProjectRoles.MEMBER,
-    highlight: (pathname: string, baseUrl: string) => pathname === `${baseUrl}/settings/labels`,
+    highlight: (pathname: string, baseUrl: string) => pathname === `${baseUrl}/settings/labels/`,
     Icon: SettingIcon,
   },
   {
@@ -120,7 +120,7 @@ export const PROJECT_SETTINGS_LINKS: {
     label: "Estimates",
     href: `/settings/estimates`,
     access: EUserProjectRoles.ADMIN,
-    highlight: (pathname: string, baseUrl: string) => pathname === `${baseUrl}/settings/estimates`,
+    highlight: (pathname: string, baseUrl: string) => pathname === `${baseUrl}/settings/estimates/`,
     Icon: SettingIcon,
   },
   {
@@ -128,7 +128,7 @@ export const PROJECT_SETTINGS_LINKS: {
     label: "Automations",
     href: `/settings/automations`,
     access: EUserProjectRoles.ADMIN,
-    highlight: (pathname: string, baseUrl: string) => pathname === `${baseUrl}/settings/automations`,
+    highlight: (pathname: string, baseUrl: string) => pathname === `${baseUrl}/settings/automations/`,
     Icon: SettingIcon,
   },
 ];

--- a/web/core/constants/workspace.ts
+++ b/web/core/constants/workspace.ts
@@ -149,7 +149,7 @@ export const WORKSPACE_SETTINGS_LINKS: {
     label: "General",
     href: `/settings`,
     access: EUserWorkspaceRoles.GUEST,
-    highlight: (pathname: string, baseUrl: string) => pathname === `${baseUrl}/settings`,
+    highlight: (pathname: string, baseUrl: string) => pathname === `${baseUrl}/settings/`,
     Icon: SettingIcon,
   },
   {
@@ -157,7 +157,7 @@ export const WORKSPACE_SETTINGS_LINKS: {
     label: "Members",
     href: `/settings/members`,
     access: EUserWorkspaceRoles.GUEST,
-    highlight: (pathname: string, baseUrl: string) => pathname === `${baseUrl}/settings/members`,
+    highlight: (pathname: string, baseUrl: string) => pathname === `${baseUrl}/settings/members/`,
     Icon: SettingIcon,
   },
   {
@@ -165,7 +165,7 @@ export const WORKSPACE_SETTINGS_LINKS: {
     label: "Billing and plans",
     href: `/settings/billing`,
     access: EUserWorkspaceRoles.ADMIN,
-    highlight: (pathname: string, baseUrl: string) => pathname === `${baseUrl}/settings/billing`,
+    highlight: (pathname: string, baseUrl: string) => pathname === `${baseUrl}/settings/billing/`,
     Icon: SettingIcon,
   },
   {
@@ -173,7 +173,7 @@ export const WORKSPACE_SETTINGS_LINKS: {
     label: "Exports",
     href: `/settings/exports`,
     access: EUserWorkspaceRoles.MEMBER,
-    highlight: (pathname: string, baseUrl: string) => pathname === `${baseUrl}/settings/exports`,
+    highlight: (pathname: string, baseUrl: string) => pathname === `${baseUrl}/settings/exports/`,
     Icon: SettingIcon,
   },
   {
@@ -181,7 +181,7 @@ export const WORKSPACE_SETTINGS_LINKS: {
     label: "Webhooks",
     href: `/settings/webhooks`,
     access: EUserWorkspaceRoles.ADMIN,
-    highlight: (pathname: string, baseUrl: string) => pathname === `${baseUrl}/settings/webhooks`,
+    highlight: (pathname: string, baseUrl: string) => pathname === `${baseUrl}/settings/webhooks/`,
     Icon: SettingIcon,
   },
   {
@@ -189,7 +189,7 @@ export const WORKSPACE_SETTINGS_LINKS: {
     label: "API tokens",
     href: `/settings/api-tokens`,
     access: EUserWorkspaceRoles.ADMIN,
-    highlight: (pathname: string, baseUrl: string) => pathname === `${baseUrl}/settings/api-tokens`,
+    highlight: (pathname: string, baseUrl: string) => pathname === `${baseUrl}/settings/api-tokens/`,
     Icon: SettingIcon,
   },
 ];


### PR DESCRIPTION
### Problem
Active tab highlights is not working for dashboard/ workspace/ project and profile tabs.

### Solution
This problem occurred due the the recent changes in `next.config` file where we added `trailingSlash: true` in the configuration. But the highlight logic was checking for the URL pathname without that trailing `/`. 

### Issue link: [WEB-1635](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/eb107144-4641-4b48-9731-8d3be6fbf2b4)