### PR TITLE
[WEB-1638] fix: updated the ui in-consistancy in active cycle estimate dropdown

### DIFF
--- a/web/core/components/cycles/active-cycle/productivity.tsx
+++ b/web/core/components/cycles/active-cycle/productivity.tsx
@@ -54,13 +54,12 @@ export const ActiveCycleProductivity: FC<ActiveCycleProductivityProps> = observe
           <h3 className="text-base text-custom-text-300 font-semibold">Issue burndown</h3>
         </Link>
         {areEstimateEnabledByProjectId(projectId) && (
-          <>
+          <div className="relative flex items-center gap-2">
             <CustomSelect
               value={plotType}
               label={<span>{cycleBurnDownChartOptions.find((v) => v.value === plotType)?.label ?? "None"}</span>}
               onChange={onChange}
               maxHeight="lg"
-              className="m-0 p-0"
             >
               {cycleBurnDownChartOptions.map((item) => (
                 <CustomSelect.Option key={item.value} value={item.value}>
@@ -69,7 +68,7 @@ export const ActiveCycleProductivity: FC<ActiveCycleProductivityProps> = observe
               ))}
             </CustomSelect>
             {loader && <Spinner className="h-3 w-3" />}
-          </>
+          </div>
         )}
       </div>
 


### PR DESCRIPTION
### Summary
This PR fixes UI inconsistencies in the active cycle estimate dropdown, ensuring a consistent and user-friendly interface.

### Changes
1. Active cycle product (issue burndown) component

### Issue link: [[WEB-1638]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/54a48c78-c7c5-4e70-b2f8-a16506f781a5)