### PR TITLE
[WEB-1636] chore: handled estimation error when the input field is not empty

### DIFF
--- a/web/core/components/estimates/points/create.tsx
+++ b/web/core/components/estimates/points/create.tsx
@@ -166,7 +166,14 @@ export const EstimatePointCreate: FC<TEstimatePointCreate> = observer((props) =>
           autoFocus
         />
         {estimatePointError?.message && (
-          <Tooltip tooltipContent={estimatePointError?.message} position="bottom">
+          <Tooltip
+            tooltipContent={
+              (estimateInputValue || "")?.length >= 1
+                ? `You have some unsaved changes, Please save them before clicking on done`
+                : estimatePointError?.message
+            }
+            position="bottom"
+          >
             <div className="flex-shrink-0 w-3.5 h-3.5 overflow-hidden mr-3 relative flex justify-center items-center text-red-500">
               <Info size={14} />
             </div>

--- a/web/core/components/estimates/points/update.tsx
+++ b/web/core/components/estimates/points/update.tsx
@@ -175,7 +175,14 @@ export const EstimatePointUpdate: FC<TEstimatePointUpdate> = observer((props) =>
         />
         {estimatePointError?.message && (
           <>
-            <Tooltip tooltipContent={estimatePointError?.message} position="bottom">
+            <Tooltip
+              tooltipContent={
+                (estimateInputValue || "")?.length >= 1
+                  ? `You have some unsaved changes, Please save them before clicking on done`
+                  : estimatePointError?.message
+              }
+              position="bottom"
+            >
               <div className="flex-shrink-0 w-3.5 h-3.5 overflow-hidden mr-3 relative flex justify-center items-center text-red-500">
                 <Info size={14} />
               </div>


### PR DESCRIPTION
#### Summary
This PR handles estimation errors when the input field is not empty, ensuring proper validation and error messaging.

#### Changes
1. Estimate point `Create` component
2. Estimate point `Update` component

#### Issue link: [[WEB-1636]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/8a88fa5a-f483-4bf0-9719-ae7d07921854)