### PR TITLE
[WEB-1674] chore: views access control

### DIFF
--- a/apiserver/plane/app/serializers/view.py
+++ b/apiserver/plane/app/serializers/view.py
@@ -3,18 +3,12 @@ from rest_framework import serializers
 
 # Module imports
 from .base import DynamicBaseSerializer
-from .workspace import WorkspaceLiteSerializer
-from .project import ProjectLiteSerializer
 from plane.db.models import IssueView
 from plane.utils.issue_filters import issue_filters
 
 
 class IssueViewSerializer(DynamicBaseSerializer):
     is_favorite = serializers.BooleanField(read_only=True)
-    project_detail = ProjectLiteSerializer(source="project", read_only=True)
-    workspace_detail = WorkspaceLiteSerializer(
-        source="workspace", read_only=True
-    )
 
     class Meta:
         model = IssueView

--- a/apiserver/plane/app/serializers/view.py
+++ b/apiserver/plane/app/serializers/view.py
@@ -24,6 +24,8 @@ class IssueViewSerializer(DynamicBaseSerializer):
             "project",
             "query",
             "owned_by",
+            "access",
+            "is_locked",
         ]
 
     def create(self, validated_data):


### PR DESCRIPTION
chore: 
- Added validation to ensure that only the owner can update a view at both the workspace and project levels.
Issue Link: [WEB-1674](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/9bfcbaaf-6abb-46ef-8c9d-487b9ae8fb5b)