### PR TITLE
[WEB-1666] style: emoji picker search section

### DIFF
--- a/web/styles/globals.css
+++ b/web/styles/globals.css
@@ -678,3 +678,17 @@ div.web-view-spinner div.bar12 {
 .disable-autofill-style:-webkit-autofill:active {
   -webkit-background-clip: text;
 }
+
+.epr-search-container > input {
+  background-color: rgb(var(--color-background-90)) !important;
+  color: rgb(var(--color-text-100)) !important;
+  border: none !important;
+}
+
+.epr-search-container > input::placeholder {
+  color: rgb(var(--color-text-400)) !important;
+}
+
+.epr-search-container > .epr-icn-search {
+  color: rgb(var(--color-text-400)) !important;
+}


### PR DESCRIPTION
#### Changes:
This PR addresses the issue with the emoji picker search section consistency in dark theme.

#### Issue link: [[WEB-1666]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/18d89f27-d1d3-49b4-8b92-ae40ed7841ef)

#### Media:
| Before | After |
|--------|--------|
| ![before](https://github.com/makeplane/plane/assets/121005188/bdda99de-9a51-4b68-8065-d2c5fdf5d3aa) | ![after](https://github.com/makeplane/plane/assets/121005188/ba7ee0bb-069a-4627-98d4-fabcac120ee4) |