### PR TITLE
[WEB-1675] fix: issue peek view label with longer title

### DIFF
--- a/web/core/components/issues/peek-overview/properties.tsx
+++ b/web/core/components/issues/peek-overview/properties.tsx
@@ -357,7 +357,7 @@ export const PeekOverviewProperties: FC<IPeekOverviewProperties> = observer((pro
             <Tag className="h-4 w-4 flex-shrink-0" />
             <span>Labels</span>
           </div>
-          <div className="flex w-full flex-col gap-3">
+          <div className="flex w-full flex-col gap-3 truncate">
             <IssueLabel workspaceSlug={workspaceSlug} projectId={projectId} issueId={issueId} disabled={disabled} />
           </div>
         </div>


### PR DESCRIPTION
#### Changes:
This PR includes a fix for the label overflow issue in the peek overview. Previously, longer labels were overflowing; I have resolved this by making the necessary adjustments.

#### Issue link: [[WEB-1675]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/cd20a726-343b-409e-8398-abc19ba5f480)

#### Media:
| Before | After |
|--------|--------|
| ![before](https://github.com/makeplane/plane/assets/121005188/82713128-bbfd-439a-981c-11a465acfdcd) | ![after](https://github.com/makeplane/plane/assets/121005188/87bbe95c-0e9d-4045-80d6-d921787a0053) |