### PR TITLE
[WEB-1686] fix: issues incorrect filters while switching between, projects, modules etc

### DIFF
--- a/web/core/components/issues/issue-layouts/calendar/roots/project-view-root.tsx
+++ b/web/core/components/issues/issue-layouts/calendar/roots/project-view-root.tsx
@@ -1,4 +1,5 @@
 import { observer } from "mobx-react";
+import { useParams } from "next/navigation";
 // hooks
 import { ProjectIssueQuickActions } from "@/components/issues";
 // components
@@ -6,6 +7,8 @@ import { ProjectIssueQuickActions } from "@/components/issues";
 import { BaseCalendarRoot } from "../base-calendar-root";
 // constants
 
-export const ProjectViewCalendarLayout: React.FC = observer(() => (
-  <BaseCalendarRoot QuickActions={ProjectIssueQuickActions} />
-));
+export const ProjectViewCalendarLayout: React.FC = observer(() => {
+  const { viewId } = useParams();
+
+  return <BaseCalendarRoot QuickActions={ProjectIssueQuickActions} viewId={viewId.toString()} />;
+});

--- a/web/core/components/issues/issue-layouts/kanban/kanban-group.tsx
+++ b/web/core/components/issues/issue-layouts/kanban/kanban-group.tsx
@@ -91,7 +91,7 @@ export const KanbanGroup = observer((props: IKanbanGroup) => {
     loadMoreIssues(groupId, sub_group_id === "null"? undefined: sub_group_id)
   }, [loadMoreIssues, groupId, sub_group_id])
 
-  const isPaginating = !!getIssueLoader(groupId);
+  const isPaginating = !!getIssueLoader(groupId, sub_group_id);
 
   useIntersectionObserver(
     containerRef,

--- a/web/core/components/issues/issue-layouts/kanban/roots/project-view-root.tsx
+++ b/web/core/components/issues/issue-layouts/kanban/roots/project-view-root.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { observer } from "mobx-react";
+import { useParams } from "next/navigation";
 // hooks
 // constant
 // types
@@ -7,6 +8,8 @@ import { ProjectIssueQuickActions } from "../../quick-action-dropdowns";
 // components
 import { BaseKanBanRoot } from "../base-kanban-root";
 
-export const ProjectViewKanBanLayout: React.FC = observer(() => (
-  <BaseKanBanRoot QuickActions={ProjectIssueQuickActions} />
-));
+export const ProjectViewKanBanLayout: React.FC = observer(() => {
+  const { viewId } = useParams();
+
+  return <BaseKanBanRoot QuickActions={ProjectIssueQuickActions} viewId={viewId.toString()} />;
+});

--- a/web/core/components/issues/issue-layouts/list/roots/project-view-root.tsx
+++ b/web/core/components/issues/issue-layouts/list/roots/project-view-root.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { observer } from "mobx-react";
+import { useParams } from "next/navigation";
 // store
 // constants
 // types
@@ -7,4 +8,8 @@ import { ProjectIssueQuickActions } from "../../quick-action-dropdowns";
 // components
 import { BaseListRoot } from "../base-list-root";
 
-export const ProjectViewListLayout: React.FC = observer(() => <BaseListRoot QuickActions={ProjectIssueQuickActions} />);
+export const ProjectViewListLayout: React.FC = observer(() => {
+  const { viewId } = useParams();
+
+  return <BaseListRoot QuickActions={ProjectIssueQuickActions} viewId={viewId.toString()} />;
+});

--- a/web/core/components/issues/issue-layouts/roots/project-view-layout-root.tsx
+++ b/web/core/components/issues/issue-layouts/roots/project-view-layout-root.tsx
@@ -19,7 +19,7 @@ import { useIssues } from "@/hooks/store";
 import { IssuesStoreContext } from "@/hooks/use-issue-layout-store";
 // types
 
-const ProjectViewIssueLayout = (props: { activeLayout: EIssueLayoutTypes | undefined }) => {
+const ProjectViewIssueLayout = (props: { activeLayout: EIssueLayoutTypes | undefined; viewId: string }) => {
   switch (props.activeLayout) {
     case EIssueLayoutTypes.LIST:
       return <ProjectViewListLayout />;
@@ -61,7 +61,7 @@ export const ProjectViewLayoutRoot: React.FC = observer(() => {
       <div className="relative flex h-full w-full flex-col overflow-hidden">
         <ProjectViewAppliedFiltersRoot />
         <div className="relative h-full w-full overflow-auto">
-          <ProjectViewIssueLayout activeLayout={activeLayout} />
+          <ProjectViewIssueLayout activeLayout={activeLayout} viewId={viewId.toString()} />
         </div>
 
         {/* peek overview */}

--- a/web/core/components/issues/issue-layouts/spreadsheet/roots/project-view-root.tsx
+++ b/web/core/components/issues/issue-layouts/spreadsheet/roots/project-view-root.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { observer } from "mobx-react";
+import { useParams } from "next/navigation";
 // mobx store
 // components
 import { ProjectIssueQuickActions } from "../../quick-action-dropdowns";
@@ -7,6 +8,8 @@ import { BaseSpreadsheetRoot } from "../base-spreadsheet-root";
 // types
 // constants
 
-export const ProjectViewSpreadsheetLayout: React.FC = observer(() => (
-  <BaseSpreadsheetRoot QuickActions={ProjectIssueQuickActions} />
-));
+export const ProjectViewSpreadsheetLayout: React.FC = observer(() => {
+  const { viewId } = useParams();
+
+  return <BaseSpreadsheetRoot QuickActions={ProjectIssueQuickActions} viewId={viewId.toString()} />;
+});

--- a/web/core/hooks/use-issues-actions.tsx
+++ b/web/core/hooks/use-issues-actions.tsx
@@ -459,16 +459,16 @@ const useProjectViewIssueActions = () => {
   const { issues, issuesFilter } = useIssues(EIssuesStoreType.PROJECT_VIEW);
 
   const fetchIssues = useCallback(
-    async (loadType: TLoader, options: IssuePaginationOptions) => {
-      if (!workspaceSlug || !projectId) return;
-      return issues.fetchIssues(workspaceSlug.toString(), projectId.toString(), loadType, options);
+    async (loadType: TLoader, options: IssuePaginationOptions, viewId?: string) => {
+      if (!workspaceSlug || !projectId || !viewId) return;
+      return issues.fetchIssues(workspaceSlug.toString(), projectId.toString(), viewId, loadType, options);
     },
     [issues.fetchIssues, workspaceSlug, projectId]
   );
   const fetchNextIssues = useCallback(
     async (groupId?: string, subGroupId?: string) => {
-      if (!workspaceSlug || !projectId) return;
-      return issues.fetchNextIssues(workspaceSlug.toString(), projectId.toString(), groupId, subGroupId);
+      if (!workspaceSlug || !projectId || !viewId) return;
+      return issues.fetchNextIssues(workspaceSlug.toString(), projectId.toString(), viewId, groupId, subGroupId);
     },
     [issues.fetchIssues, workspaceSlug, projectId]
   );

--- a/web/core/store/issue/archived/issue.store.ts
+++ b/web/core/store/issue/archived/issue.store.ts
@@ -94,7 +94,7 @@ export class ArchivedIssues extends BaseIssuesStore implements IArchivedIssues {
       this.clear(!isExistingPaginationOptions);
 
       // get params from pagination options
-      const params = this.issueFilterStore?.getFilterParams(options, undefined, undefined, undefined);
+      const params = this.issueFilterStore?.getFilterParams(options, projectId, undefined, undefined, undefined);
       // call the fetch issues API with the params
       const response = await this.issueArchiveService.getArchivedIssues(workspaceSlug, projectId, params, {
         signal: this.controller.signal,
@@ -131,6 +131,7 @@ export class ArchivedIssues extends BaseIssuesStore implements IArchivedIssues {
       // get params from stored pagination options
       const params = this.issueFilterStore?.getFilterParams(
         this.paginationOptions,
+        projectId,
         this.getNextCursor(groupId, subGroupId),
         groupId,
         subGroupId

--- a/web/core/store/issue/cycle/issue.store.ts
+++ b/web/core/store/issue/cycle/issue.store.ts
@@ -161,7 +161,7 @@ export class CycleIssues extends BaseIssuesStore implements ICycleIssues {
       this.clear(!isExistingPaginationOptions);
 
       // get params from pagination options
-      const params = this.issueFilterStore?.getFilterParams(options, undefined, undefined, undefined);
+      const params = this.issueFilterStore?.getFilterParams(options, cycleId, undefined, undefined, undefined);
       // call the fetch issues API with the params
       const response = await this.cycleService.getCycleIssues(workspaceSlug, projectId, cycleId, params, {
         signal: this.controller.signal,
@@ -205,6 +205,7 @@ export class CycleIssues extends BaseIssuesStore implements ICycleIssues {
       // get params from stored pagination options
       const params = this.issueFilterStore?.getFilterParams(
         this.paginationOptions,
+        cycleId,
         this.getNextCursor(groupId, subGroupId),
         groupId,
         subGroupId

--- a/web/core/store/issue/draft/issue.store.ts
+++ b/web/core/store/issue/draft/issue.store.ts
@@ -92,7 +92,7 @@ export class DraftIssues extends BaseIssuesStore implements IDraftIssues {
       this.clear(!isExistingPaginationOptions);
 
       // get params from pagination options
-      const params = this.issueFilterStore?.getFilterParams(options, undefined, undefined, undefined);
+      const params = this.issueFilterStore?.getFilterParams(options, projectId, undefined, undefined, undefined);
       // call the fetch issues API with the params
       const response = await this.issueDraftService.getDraftIssues(workspaceSlug, projectId, params, {
         signal: this.controller.signal,
@@ -129,6 +129,7 @@ export class DraftIssues extends BaseIssuesStore implements IDraftIssues {
       // get params from stored pagination options
       const params = this.issueFilterStore?.getFilterParams(
         this.paginationOptions,
+        projectId,
         this.getNextCursor(groupId, subGroupId),
         groupId,
         subGroupId

--- a/web/core/store/issue/helpers/issue-filter-helper.store.ts
+++ b/web/core/store/issue/helpers/issue-filter-helper.store.ts
@@ -290,7 +290,7 @@ export class IssueFilterHelperStore implements IIssueFilterHelperStore {
    * @param displayFilters
    * @returns
    */
-  requiresServerUpdate = (displayFilters: IIssueDisplayFilterOptions) => {
+  getShouldReFetchIssues = (displayFilters: IIssueDisplayFilterOptions) => {
     const NON_SERVER_DISPLAY_FILTERS = ["order_by", "sub_issue", "type"];
     const displayFilterKeys = Object.keys(displayFilters);
 

--- a/web/core/store/issue/module/issue.store.ts
+++ b/web/core/store/issue/module/issue.store.ts
@@ -116,7 +116,7 @@ export class ModuleIssues extends BaseIssuesStore implements IModuleIssues {
       this.clear(!isExistingPaginationOptions);
 
       // get params from pagination options
-      const params = this.issueFilterStore?.getFilterParams(options, undefined, undefined, undefined);
+      const params = this.issueFilterStore?.getFilterParams(options, moduleId, undefined, undefined, undefined);
       // call the fetch issues API with the params
       const response = await this.moduleService.getModuleIssues(workspaceSlug, projectId, moduleId, params, {
         signal: this.controller.signal,
@@ -160,6 +160,7 @@ export class ModuleIssues extends BaseIssuesStore implements IModuleIssues {
       // get params from stored pagination options
       const params = this.issueFilterStore?.getFilterParams(
         this.paginationOptions,
+        moduleId,
         this.getNextCursor(groupId, subGroupId),
         groupId,
         subGroupId

--- a/web/core/store/issue/profile/filter.store.ts
+++ b/web/core/store/issue/profile/filter.store.ts
@@ -30,6 +30,7 @@ export interface IProfileIssuesFilter extends IBaseIssueFilterStore {
   //helper actions
   getFilterParams: (
     options: IssuePaginationOptions,
+    userId: string,
     cursor: string | undefined,
     groupId: string | undefined,
     subGroupId: string | undefined
@@ -77,6 +78,17 @@ export class ProfileIssuesFilter extends IssueFilterHelperStore implements IProf
     const userId = this.rootIssueStore.userId;
     if (!userId) return undefined;
 
+    return this.getIssueFilters(userId);
+  }
+
+  get appliedFilters() {
+    const userId = this.rootIssueStore.userId;
+    if (!userId) return undefined;
+
+    return this.getAppliedFilters(userId);
+  }
+
+  getIssueFilters(userId: string) {
     const displayFilters = this.filters[userId] || undefined;
     if (isEmpty(displayFilters)) return undefined;
 
@@ -85,8 +97,8 @@ export class ProfileIssuesFilter extends IssueFilterHelperStore implements IProf
     return _filters;
   }
 
-  get appliedFilters() {
-    const userFilters = this.issueFilters;
+  getAppliedFilters(userId: string) {
+    const userFilters = this.getIssueFilters(userId);
     if (!userFilters) return undefined;
 
     const filteredParams = handleIssueQueryParamsByLayout(userFilters?.displayFilters?.layout, "profile_issues");
@@ -104,11 +116,12 @@ export class ProfileIssuesFilter extends IssueFilterHelperStore implements IProf
   getFilterParams = computedFn(
     (
       options: IssuePaginationOptions,
+      userId: string,
       cursor: string | undefined,
       groupId: string | undefined,
       subGroupId: string | undefined
     ) => {
-      const filterParams = this.appliedFilters;
+      const filterParams = this.getAppliedFilters(userId);
 
       const paginationParams = this.getPaginationParams(filterParams, options, cursor, groupId, subGroupId);
       return paginationParams;

--- a/web/core/store/issue/profile/issue.store.ts
+++ b/web/core/store/issue/profile/issue.store.ts
@@ -119,7 +119,7 @@ export class ProfileIssues extends BaseIssuesStore implements IProfileIssues {
       this.setViewId(view);
 
       // get params from pagination options
-      let params = this.issueFilterStore?.getFilterParams(options, undefined, undefined, undefined);
+      let params = this.issueFilterStore?.getFilterParams(options, userId, undefined, undefined, undefined);
       params = {
         ...params,
         assignees: undefined,
@@ -167,6 +167,7 @@ export class ProfileIssues extends BaseIssuesStore implements IProfileIssues {
       // get params from stored pagination options
       let params = this.issueFilterStore?.getFilterParams(
         this.paginationOptions,
+        userId,
         this.getNextCursor(groupId, subGroupId),
         groupId,
         subGroupId

--- a/web/core/store/issue/project-views/issue.store.ts
+++ b/web/core/store/issue/project-views/issue.store.ts
@@ -20,17 +20,20 @@ export interface IProjectViewIssues extends IBaseIssuesStore {
   fetchIssues: (
     workspaceSlug: string,
     projectId: string,
+    viewId: string,
     loadType: TLoader,
     options: IssuePaginationOptions
   ) => Promise<TIssuesResponse | undefined>;
   fetchIssuesWithExistingPagination: (
     workspaceSlug: string,
     projectId: string,
+    viewId: string,
     loadType: TLoader
   ) => Promise<TIssuesResponse | undefined>;
   fetchNextIssues: (
     workspaceSlug: string,
     projectId: string,
+    viewId: string,
     groupId?: string,
     subGroupId?: string
   ) => Promise<TIssuesResponse | undefined>;
@@ -78,6 +81,7 @@ export class ProjectViewIssues extends BaseIssuesStore implements IProjectViewIs
   fetchIssues = async (
     workspaceSlug: string,
     projectId: string,
+    viewId: string,
     loadType: TLoader,
     options: IssuePaginationOptions,
     isExistingPaginationOptions: boolean = false
@@ -90,7 +94,7 @@ export class ProjectViewIssues extends BaseIssuesStore implements IProjectViewIs
       this.clear(!isExistingPaginationOptions);
 
       // get params from pagination options
-      const params = this.issueFilterStore?.getFilterParams(options, undefined, undefined, undefined);
+      const params = this.issueFilterStore?.getFilterParams(options, viewId, undefined, undefined, undefined);
       // call the fetch issues API with the params
       const response = await this.issueService.getIssues(workspaceSlug, projectId, params, {
         signal: this.controller.signal,
@@ -116,7 +120,13 @@ export class ProjectViewIssues extends BaseIssuesStore implements IProjectViewIs
    * @param subGroupId
    * @returns
    */
-  fetchNextIssues = async (workspaceSlug: string, projectId: string, groupId?: string, subGroupId?: string) => {
+  fetchNextIssues = async (
+    workspaceSlug: string,
+    projectId: string,
+    viewId: string,
+    groupId?: string,
+    subGroupId?: string
+  ) => {
     const cursorObject = this.getPaginationData(groupId, subGroupId);
     // if there are no pagination options and the next page results do not exist the return
     if (!this.paginationOptions || (cursorObject && !cursorObject?.nextPageResults)) return;
@@ -127,6 +137,7 @@ export class ProjectViewIssues extends BaseIssuesStore implements IProjectViewIs
       // get params from stored pagination options
       const params = this.issueFilterStore?.getFilterParams(
         this.paginationOptions,
+        viewId,
         this.getNextCursor(groupId, subGroupId),
         groupId,
         subGroupId
@@ -152,9 +163,14 @@ export class ProjectViewIssues extends BaseIssuesStore implements IProjectViewIs
    * @param loadType
    * @returns
    */
-  fetchIssuesWithExistingPagination = async (workspaceSlug: string, projectId: string, loadType: TLoader) => {
+  fetchIssuesWithExistingPagination = async (
+    workspaceSlug: string,
+    projectId: string,
+    viewId: string,
+    loadType: TLoader
+  ) => {
     if (!this.paginationOptions) return;
-    return await this.fetchIssues(workspaceSlug, projectId, loadType, this.paginationOptions, true);
+    return await this.fetchIssues(workspaceSlug, projectId, viewId, loadType, this.paginationOptions, true);
   };
 
   archiveBulkIssues = this.bulkArchiveIssues;

--- a/web/core/store/issue/project/issue.store.ts
+++ b/web/core/store/issue/project/issue.store.ts
@@ -93,7 +93,7 @@ export class ProjectIssues extends BaseIssuesStore implements IProjectIssues {
       this.clear(!isExistingPaginationOptions);
 
       // get params from pagination options
-      const params = this.issueFilterStore?.getFilterParams(options, undefined, undefined, undefined);
+      const params = this.issueFilterStore?.getFilterParams(options, projectId, undefined, undefined, undefined);
       // call the fetch issues API with the params
       const response = await this.issueService.getIssues(workspaceSlug, projectId, params, {
         signal: this.controller.signal,
@@ -130,6 +130,7 @@ export class ProjectIssues extends BaseIssuesStore implements IProjectIssues {
       // get params from stored pagination options
       const params = this.issueFilterStore?.getFilterParams(
         this.paginationOptions,
+        projectId,
         this.getNextCursor(groupId, subGroupId),
         groupId,
         subGroupId

--- a/web/core/store/issue/workspace/filter.store.ts
+++ b/web/core/store/issue/workspace/filter.store.ts
@@ -41,8 +41,8 @@ export interface IWorkspaceIssuesFilter extends IBaseIssueFilterStore {
   getIssueFilters: (viewId: string | undefined) => IIssueFilters | undefined;
   getAppliedFilters: (viewId: string) => Partial<Record<TIssueParams, string | boolean>> | undefined;
   getFilterParams: (
-    viewId: string,
     options: IssuePaginationOptions,
+    viewId: string,
     cursor: string | undefined,
     groupId: string | undefined,
     subGroupId: string | undefined
@@ -104,10 +104,20 @@ export class WorkspaceIssuesFilter extends IssueFilterHelperStore implements IWo
     return filteredRouteParams;
   };
 
+  get issueFilters() {
+    const viewId = this.rootIssueStore.globalViewId;
+    return this.getIssueFilters(viewId);
+  }
+
+  get appliedFilters() {
+    const viewId = this.rootIssueStore.globalViewId;
+    return this.getAppliedFilters(viewId);
+  }
+
   getFilterParams = computedFn(
     (
-      viewId: string,
       options: IssuePaginationOptions,
+      viewId: string,
       cursor: string | undefined,
       groupId: string | undefined,
       subGroupId: string | undefined
@@ -118,16 +128,6 @@ export class WorkspaceIssuesFilter extends IssueFilterHelperStore implements IWo
       return paginationParams;
     }
   );
-
-  get issueFilters() {
-    const viewId = this.rootIssueStore.globalViewId;
-    return this.getIssueFilters(viewId);
-  }
-
-  get appliedFilters() {
-    const viewId = this.rootIssueStore.globalViewId;
-    return this.getAppliedFilters(viewId);
-  }
 
   fetchFilters = async (workspaceSlug: string, viewId: TWorkspaceFilters) => {
     try {

--- a/web/core/store/issue/workspace/issue.store.ts
+++ b/web/core/store/issue/workspace/issue.store.ts
@@ -92,7 +92,7 @@ export class WorkspaceIssues extends BaseIssuesStore implements IWorkspaceIssues
       this.clear(!isExistingPaginationOptions);
 
       // get params from pagination options
-      const params = this.issueFilterStore?.getFilterParams(viewId, options, undefined, undefined, undefined);
+      const params = this.issueFilterStore?.getFilterParams(options, viewId, undefined, undefined, undefined);
       // call the fetch issues API with the params
       const response = await this.workspaceService.getViewIssues(workspaceSlug, params, {
         signal: this.controller.signal,
@@ -128,8 +128,8 @@ export class WorkspaceIssues extends BaseIssuesStore implements IWorkspaceIssues
 
       // get params from stored pagination options
       const params = this.issueFilterStore?.getFilterParams(
-        viewId,
         this.paginationOptions,
+        viewId,
         this.getNextCursor(groupId, subGroupId),
         groupId,
         subGroupId


### PR DESCRIPTION
[WEB-1686](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/a530813d-6465-425d-a093-86968b757174)

This PR fixes the issue where incorrect filters were being applied while switching between projects, modules, cycles etc. This was due to the delayed update of store's Approuter parameters. To solve this, all the API calls are made to rely on the value being passed on rather than reading it from the store.