### PR TITLE
[WEB-522] chore: handled maximum no of char that user can enter in estimate point create and update

### DIFF
--- a/web/ce/constants/estimates.ts
+++ b/web/ce/constants/estimates.ts
@@ -1,6 +1,8 @@
 // types
 import { TEstimateSystems } from "@plane/types";
 
+export const maxEstimatePointInputLength = 20;
+
 export enum EEstimateSystem {
   POINTS = "points",
   CATEGORIES = "categories",

--- a/web/ce/constants/estimates.ts
+++ b/web/ce/constants/estimates.ts
@@ -1,7 +1,7 @@
 // types
 import { TEstimateSystems } from "@plane/types";
 
-export const maxEstimatePointInputLength = 20;
+export const MAX_ESTIMATE_POINT_INPUT_LENGTH = 20;
 
 export enum EEstimateSystem {
   POINTS = "points",

--- a/web/core/components/estimates/points/create.tsx
+++ b/web/core/components/estimates/points/create.tsx
@@ -11,7 +11,7 @@ import { isEstimatePointValuesRepeated } from "@/helpers/estimates";
 // hooks
 import { useEstimate } from "@/hooks/store";
 // plane web constants
-import { EEstimateSystem } from "@/plane-web/constants/estimates";
+import { EEstimateSystem, maxEstimatePointInputLength } from "@/plane-web/constants/estimates";
 
 type TEstimatePointCreate = {
   workspaceSlug: string;
@@ -155,7 +155,7 @@ export const EstimatePointCreate: FC<TEstimatePointCreate> = observer((props) =>
   const inputProps = {
     type: inputFieldType,
     pattern: inputFieldType === "number" ? "[0-9]*" : undefined,
-    maxlength: inputFieldType === "number" ? undefined : 24,
+    maxlength: maxEstimatePointInputLength,
   };
 
   return (

--- a/web/core/components/estimates/points/create.tsx
+++ b/web/core/components/estimates/points/create.tsx
@@ -11,7 +11,7 @@ import { isEstimatePointValuesRepeated } from "@/helpers/estimates";
 // hooks
 import { useEstimate } from "@/hooks/store";
 // plane web constants
-import { EEstimateSystem, maxEstimatePointInputLength } from "@/plane-web/constants/estimates";
+import { EEstimateSystem, MAX_ESTIMATE_POINT_INPUT_LENGTH } from "@/plane-web/constants/estimates";
 
 type TEstimatePointCreate = {
   workspaceSlug: string;
@@ -155,7 +155,7 @@ export const EstimatePointCreate: FC<TEstimatePointCreate> = observer((props) =>
   const inputProps = {
     type: inputFieldType,
     pattern: inputFieldType === "number" ? "[0-9]*" : undefined,
-    maxlength: maxEstimatePointInputLength,
+    maxlength: MAX_ESTIMATE_POINT_INPUT_LENGTH,
   };
 
   return (

--- a/web/core/components/estimates/points/update.tsx
+++ b/web/core/components/estimates/points/update.tsx
@@ -11,7 +11,7 @@ import { isEstimatePointValuesRepeated } from "@/helpers/estimates";
 // hooks
 import { useEstimatePoint } from "@/hooks/store";
 // plane web constants
-import { EEstimateSystem } from "@/plane-web/constants/estimates";
+import { EEstimateSystem, maxEstimatePointInputLength } from "@/plane-web/constants/estimates";
 
 type TEstimatePointUpdate = {
   workspaceSlug: string;
@@ -163,7 +163,7 @@ export const EstimatePointUpdate: FC<TEstimatePointUpdate> = observer((props) =>
   const inputProps = {
     type: inputFieldType,
     pattern: inputFieldType === "number" ? "[0-9]*" : undefined,
-    maxlength: inputFieldType === "number" ? undefined : 24,
+    maxlength: maxEstimatePointInputLength,
   };
 
   return (

--- a/web/core/components/estimates/points/update.tsx
+++ b/web/core/components/estimates/points/update.tsx
@@ -11,7 +11,7 @@ import { isEstimatePointValuesRepeated } from "@/helpers/estimates";
 // hooks
 import { useEstimatePoint } from "@/hooks/store";
 // plane web constants
-import { EEstimateSystem, maxEstimatePointInputLength } from "@/plane-web/constants/estimates";
+import { EEstimateSystem, MAX_ESTIMATE_POINT_INPUT_LENGTH } from "@/plane-web/constants/estimates";
 
 type TEstimatePointUpdate = {
   workspaceSlug: string;
@@ -163,7 +163,7 @@ export const EstimatePointUpdate: FC<TEstimatePointUpdate> = observer((props) =>
   const inputProps = {
     type: inputFieldType,
     pattern: inputFieldType === "number" ? "[0-9]*" : undefined,
-    maxlength: maxEstimatePointInputLength,
+    maxlength: MAX_ESTIMATE_POINT_INPUT_LENGTH,
   };
 
   return (


### PR DESCRIPTION
#### Summary
This PR handles the maximum number of characters that a user can enter when creating or updating an estimate point, ensuring that inputs are validated and restricted appropriately.

#### Changes
1. Estimate constant
2. Estimate create and update component

#### Issue link: [[WEB-522]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/6d658a72-0898-49c8-8989-7841ae9c3498)