### PR TITLE
[WEB-522] fix: Input type number validation on estimate in create and update

### DIFF
--- a/web/core/components/estimates/points/create.tsx
+++ b/web/core/components/estimates/points/create.tsx
@@ -58,8 +58,10 @@ export const EstimatePointCreate: FC<TEstimatePointCreate> = observer((props) =>
   };
 
   const handleEstimateInputValue = (value: string) => {
-    setEstimateInputValue(value);
-    handleEstimatePointError && handleEstimatePointError(value, undefined);
+    if (value.length <= MAX_ESTIMATE_POINT_INPUT_LENGTH) {
+      setEstimateInputValue(value);
+      handleEstimatePointError && handleEstimatePointError(value, undefined);
+    }
   };
 
   const handleCreate = async (event: FormEvent<HTMLFormElement>) => {

--- a/web/core/components/estimates/points/update.tsx
+++ b/web/core/components/estimates/points/update.tsx
@@ -63,8 +63,10 @@ export const EstimatePointUpdate: FC<TEstimatePointUpdate> = observer((props) =>
   };
 
   const handleEstimateInputValue = (value: string) => {
-    handleEstimatePointError && handleEstimatePointError(value, undefined);
-    setEstimateInputValue(() => value);
+    if (value.length <= MAX_ESTIMATE_POINT_INPUT_LENGTH) {
+      setEstimateInputValue(() => value);
+      handleEstimatePointError && handleEstimatePointError(value, undefined);
+    }
   };
 
   const handleUpdate = async (event: FormEvent<HTMLFormElement>) => {


### PR DESCRIPTION
#### Summary
This PR handles the maximum number of characters that a user can enter when creating or updating an estimate point, ensuring that inputs are validated and restricted appropriately.

#### Changes
1. Estimate constant
2. Estimate create and update component

#### Issue link: [[WEB-522]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/6d658a72-0898-49c8-8989-7841ae9c3498)