### PR TITLE
[WEB-1717] fix: order by on issues not updating for custom global views

### DIFF
--- a/web/core/store/issue/workspace/filter.store.ts
+++ b/web/core/store/issue/workspace/filter.store.ts
@@ -92,7 +92,7 @@ export class WorkspaceIssuesFilter extends IssueFilterHelperStore implements IWo
     const userFilters = this.getIssueFilters(viewId);
     if (!userFilters) return undefined;
 
-    const filteredParams = handleIssueQueryParamsByLayout(userFilters?.displayFilters?.layout, "my_issues");
+    const filteredParams = handleIssueQueryParamsByLayout(EIssueLayoutTypes.SPREADSHEET, "my_issues");
     if (!filteredParams) return undefined;
 
     const filteredRouteParams: Partial<Record<TIssueParams, string | boolean>> = this.computedFilteredParams(
@@ -155,7 +155,9 @@ export class WorkspaceIssuesFilter extends IssueFilterHelperStore implements IWo
       } else {
         const _filters = await this.issueFilterService.getViewDetails(workspaceSlug, viewId);
         filters = this.computedFilters(_filters?.filters);
-        displayFilters = this.computedDisplayFilters(_filters?.display_filters);
+        displayFilters = this.computedDisplayFilters(_filters?.display_filters, {
+          layout: EIssueLayoutTypes.SPREADSHEET,
+        });
         displayProperties = this.computedDisplayProperties(_filters?.display_properties);
       }
 


### PR DESCRIPTION
[WEB-1717](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/5e2d5568-3768-48f9-9343-2f4c4e038174)

This PR fixes the order by of a custom global view when applied, by forcing to use spreadsheet as default view regardless of whichever view is stored in the view.