### PR TITLE
[WEB-522] fix: handling the issue and estimate point dropdown in the active cycle to render only when the estimate type is points

### DIFF
--- a/web/core/components/cycles/active-cycle/productivity.tsx
+++ b/web/core/components/cycles/active-cycle/productivity.tsx
@@ -9,6 +9,8 @@ import { EmptyState } from "@/components/empty-state";
 // constants
 import { EmptyStateType } from "@/constants/empty-state";
 import { useCycle, useProjectEstimates } from "@/hooks/store";
+// plane web constants
+import { EEstimateSystem } from "@/plane-web/constants/estimates";
 
 export type ActiveCycleProductivityProps = {
   workspaceSlug: string;
@@ -25,7 +27,7 @@ export const ActiveCycleProductivity: FC<ActiveCycleProductivityProps> = observe
   const { workspaceSlug, projectId, cycle } = props;
   // hooks
   const { getPlotTypeByCycleId, setPlotType, fetchCycleDetails } = useCycle();
-  const { areEstimateEnabledByProjectId } = useProjectEstimates();
+  const { currentActiveEstimateId, areEstimateEnabledByProjectId, estimateById } = useProjectEstimates();
   // state
   const [loader, setLoader] = useState(false);
   // derived values
@@ -44,6 +46,11 @@ export const ActiveCycleProductivity: FC<ActiveCycleProductivityProps> = observe
     }
   };
 
+  const isCurrentProjectEstimateEnabled = projectId && areEstimateEnabledByProjectId(projectId) ? true : false;
+  const estimateDetails =
+    isCurrentProjectEstimateEnabled && currentActiveEstimateId && estimateById(currentActiveEstimateId);
+  const isCurrentEstimateTypeIsPoints = estimateDetails && estimateDetails?.type === EEstimateSystem.POINTS;
+
   const chartDistributionData = plotType === "points" ? cycle?.estimate_distribution : cycle?.distribution || undefined;
   const completionChartDistributionData = chartDistributionData?.completion_chart || undefined;
 
@@ -53,7 +60,7 @@ export const ActiveCycleProductivity: FC<ActiveCycleProductivityProps> = observe
         <Link href={`/${workspaceSlug}/projects/${projectId}/cycles/${cycle?.id}`}>
           <h3 className="text-base text-custom-text-300 font-semibold">Issue burndown</h3>
         </Link>
-        {areEstimateEnabledByProjectId(projectId) && (
+        {isCurrentEstimateTypeIsPoints && (
           <div className="relative flex items-center gap-2">
             <CustomSelect
               value={plotType}

--- a/web/core/lib/wrappers/store-wrapper.tsx
+++ b/web/core/lib/wrappers/store-wrapper.tsx
@@ -14,7 +14,7 @@ type TStoreWrapper = {
 const StoreWrapper: FC<TStoreWrapper> = observer((props) => {
   const { children } = props;
   // theme
-  const { setTheme } = useTheme();
+  const { resolvedTheme, setTheme } = useTheme();
   // router
   const params = useParams();
   // store hooks
@@ -32,13 +32,13 @@ const StoreWrapper: FC<TStoreWrapper> = observer((props) => {
     const localBoolValue = localValue ? (localValue === "true" ? true : false) : false;
 
     if (localValue && sidebarCollapsed === undefined) toggleSidebar(localBoolValue);
-  }, [sidebarCollapsed, toggleSidebar]);
+  }, [sidebarCollapsed, setTheme, toggleSidebar]);
 
   /**
    * Setting up the theme of the user by fetching it from local storage
    */
   useEffect(() => {
-    setTheme(userProfile?.theme?.theme || "system");
+    setTheme(userProfile?.theme?.theme || resolvedTheme || "system");
     if (!userProfile?.theme?.theme) return;
 
     if (userProfile?.theme?.theme === "custom" && userProfile?.theme?.palette) {
@@ -50,7 +50,7 @@ const StoreWrapper: FC<TStoreWrapper> = observer((props) => {
         dom
       );
     } else unsetCustomCssVariables();
-  }, [userProfile, userProfile?.theme, userProfile?.theme?.palette, setTheme, dom]);
+  }, [userProfile, userProfile?.theme, userProfile?.theme?.palette, setTheme, dom, resolvedTheme]);
 
   useEffect(() => {
     if (dom) return;

--- a/web/core/lib/wrappers/store-wrapper.tsx
+++ b/web/core/lib/wrappers/store-wrapper.tsx
@@ -14,7 +14,7 @@ type TStoreWrapper = {
 const StoreWrapper: FC<TStoreWrapper> = observer((props) => {
   const { children } = props;
   // theme
-  const { resolvedTheme, setTheme } = useTheme();
+  const { setTheme } = useTheme();
   // router
   const params = useParams();
   // store hooks
@@ -32,13 +32,13 @@ const StoreWrapper: FC<TStoreWrapper> = observer((props) => {
     const localBoolValue = localValue ? (localValue === "true" ? true : false) : false;
 
     if (localValue && sidebarCollapsed === undefined) toggleSidebar(localBoolValue);
-  }, [sidebarCollapsed, setTheme, toggleSidebar]);
+  }, [sidebarCollapsed, toggleSidebar]);
 
   /**
    * Setting up the theme of the user by fetching it from local storage
    */
   useEffect(() => {
-    setTheme(userProfile?.theme?.theme || resolvedTheme || "system");
+    setTheme(userProfile?.theme?.theme || "system");
     if (!userProfile?.theme?.theme) return;
 
     if (userProfile?.theme?.theme === "custom" && userProfile?.theme?.palette) {
@@ -50,7 +50,7 @@ const StoreWrapper: FC<TStoreWrapper> = observer((props) => {
         dom
       );
     } else unsetCustomCssVariables();
-  }, [userProfile, userProfile?.theme, userProfile?.theme?.palette, setTheme, dom, resolvedTheme]);
+  }, [userProfile, userProfile?.theme, userProfile?.theme?.palette, setTheme, dom]);
 
   useEffect(() => {
     if (dom) return;


### PR DESCRIPTION
#### Summary
This PR handles the issue and estimate point dropdown in the active cycle to render only when the estimate type is points

#### Changes
1. Active cycles in the project

#### Issue link: [[WEB-522]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/6d658a72-0898-49c8-8989-7841ae9c3498)