### PR TITLE
[WEB-1726] fix: password strength banner validation

### DIFF
--- a/web/core/components/account/auth-forms/password.tsx
+++ b/web/core/components/account/auth-forms/password.tsx
@@ -117,7 +117,7 @@ export const AuthPasswordForm: React.FC<Props> = observer((props: Props) => {
 
   return (
     <>
-      {isBannerMessage && (
+      {isBannerMessage && mode === EAuthModes.SIGN_UP && (
         <div className="relative flex items-center p-2 rounded-md gap-2 border border-red-500/50 bg-red-500/10">
           <div className="w-4 h-4 flex-shrink-0 relative flex justify-center items-center">
             <Info size={16} className="text-red-500" />


### PR DESCRIPTION
#### Changes:
This PR includes a fix for the password strength banner. Previously, it was also appearing on the sign-in screen. I've added validation to ensure it only renders during the sign-up flow.

#### Issue link: [[WEB-1726]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/a86bc9ff-9985-4729-abee-9d89e8e99858)