### PR TITLE
[WEB-1718] style: fix spreadsheet column width when other properties are hidden.

### DIFF
--- a/web/core/components/issues/issue-layouts/spreadsheet/columns/state-column.tsx
+++ b/web/core/components/issues/issue-layouts/spreadsheet/columns/state-column.tsx
@@ -16,7 +16,7 @@ export const SpreadsheetStateColumn: React.FC<Props> = observer((props) => {
   const { issue, onChange, disabled, onClose } = props;
 
   return (
-    <div className="h-11 max-w-48 border-b-[0.5px] border-custom-border-200">
+    <div className="h-11 border-b-[0.5px] border-custom-border-200">
       <StateDropdown
         projectId={issue.project_id ?? undefined}
         value={issue.state_id}

--- a/web/core/components/issues/issue-layouts/spreadsheet/issue-column.tsx
+++ b/web/core/components/issues/issue-layouts/spreadsheet/issue-column.tsx
@@ -38,7 +38,7 @@ export const IssueColumn = observer((props: Props) => {
     >
       <td
         tabIndex={0}
-        className="h-11 w-full min-w-[8rem] text-sm after:absolute after:w-full after:bottom-[-1px] after:border after:border-custom-border-100 border-r-[1px] border-custom-border-100"
+        className="h-11 w-full min-w-36 max-w-48 text-sm after:absolute after:w-full after:bottom-[-1px] after:border after:border-custom-border-100 border-r-[1px] border-custom-border-100"
         ref={tableCellRef}
       >
         <Column

--- a/web/core/components/issues/issue-layouts/spreadsheet/spreadsheet-header-column.tsx
+++ b/web/core/components/issues/issue-layouts/spreadsheet/spreadsheet-header-column.tsx
@@ -28,7 +28,7 @@ export const SpreadsheetHeaderColumn = observer((props: Props) => {
       shouldRenderProperty={() => shouldRenderProperty}
     >
       <th
-        className="h-11 w-full min-w-[8rem] items-center bg-custom-background-90 text-sm font-medium px-4 py-1 border border-b-0 border-t-0 border-custom-border-100"
+        className="h-11 w-full min-w-36 max-w-48 items-center bg-custom-background-90 text-sm font-medium px-4 py-1 border border-b-0 border-t-0 border-custom-border-100"
         ref={tableHeaderCellRef}
         tabIndex={0}
       >


### PR DESCRIPTION
### Problem
When the user deselects all properties except "State" in the spreadsheet view, the state column does not display correctly. This issue arose from the recent fix in #4859. We added the max width for the state column and did not considered the situation when other properties are hidden, causing the table to expand to full width while the state column remains constrained by a max width, resulting in unusual white space.

### Solution
Adjusted the CSS logic to ensure the state column expands appropriately when it is the only visible column while also handling the max width.

### Media
* Before
  <img width="1258" alt="image" src="https://github.com/makeplane/plane/assets/33979846/459d60db-4de1-4b92-9e88-44242a198753">

* After
  <img width="1285" alt="image" src="https://github.com/makeplane/plane/assets/33979846/301ebd28-2b58-4268-8969-4151211da662">
  <img width="1265" alt="image" src="https://github.com/makeplane/plane/assets/33979846/f12addc8-f1f8-4d0e-b4d5-c7471fd8de21">
  
### Issue link: [WEB-1718
](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/fb6c5091-72c4-4e97-9937-12bbd6fb729d)