### PR TITLE
[WEB-1757] chore: rename deploy to publish

### DIFF
--- a/space/app/issues/[anchor]/layout.tsx
+++ b/space/app/issues/[anchor]/layout.tsx
@@ -63,7 +63,7 @@ const IssuesLayout = observer((props: Props) => {
           <Image src={planeLogo} alt="Plane logo" className="h-6 w-6" height="24" width="24" />
         </div>
         <div className="text-xs">
-          Powered by <span className="font-semibold">Plane Deploy</span>
+          Powered by <span className="font-semibold">Plane Pubish</span>
         </div>
       </a>
     </div>

--- a/space/app/layout.tsx
+++ b/space/app/layout.tsx
@@ -9,11 +9,11 @@ import "@/styles/globals.css";
 import { ToastProvider } from "@/lib/toast-provider";
 
 export const metadata: Metadata = {
-  title: "Plane Deploy | Make your Plane boards public with one-click",
-  description: "Plane Deploy is a customer feedback management tool built on top of plane.so",
+  title: "Plane Publish | Make your Plane boards public with one-click",
+  description: "Plane Publish is a customer feedback management tool built on top of plane.so",
   openGraph: {
-    title: "Plane Deploy | Make your Plane boards public with one-click",
-    description: "Plane Deploy is a customer feedback management tool built on top of plane.so",
+    title: "Plane Publish | Make your Plane boards public with one-click",
+    description: "Plane Publish is a customer feedback management tool built on top of plane.so",
     url: "https://sites.plane.so/",
   },
   keywords:

--- a/space/core/constants/seo.ts
+++ b/space/core/constants/seo.ts
@@ -1,6 +1,6 @@
-export const SITE_NAME = "Plane Deploy | Make your Plane boards and roadmaps pubic with just one-click. ";
-export const SITE_TITLE = "Plane Deploy | Make your Plane boards public with one-click";
-export const SITE_DESCRIPTION = "Plane Deploy is a customer feedback management tool built on top of plane.so";
+export const SITE_NAME = "Plane Publish | Make your Plane boards and roadmaps pubic with just one-click. ";
+export const SITE_TITLE = "Plane Publish | Make your Plane boards public with one-click";
+export const SITE_DESCRIPTION = "Plane Publish is a customer feedback management tool built on top of plane.so";
 export const SITE_KEYWORDS =
   "software development, customer feedback, software, accelerate, code management, release management, project management, issue tracking, agile, scrum, kanban, collaboration";
 export const SITE_URL = "https://app.plane.so/";


### PR DESCRIPTION
#### Improvements:

Replaced the keyword `Deploy` with `Publish` across the space app.