### PR TITLE
responsive styles for recent-collborators

### DIFF
--- a/web/core/components/dashboard/widgets/recent-collaborators/root.tsx
+++ b/web/core/components/dashboard/widgets/recent-collaborators/root.tsx
@@ -15,14 +15,14 @@ export const RecentCollaboratorsWidget: React.FC<WidgetProps> = (props) => {
 
   return (
     <div className="w-full rounded-xl border-[0.5px] border-custom-border-200 bg-custom-background-100 duration-300 hover:shadow-custom-shadow-4xl">
-      <div className="flex items-start justify-between px-7 pt-6">
+      <div className="flex flex-col sm:flex-row items-start justify-between px-7 pt-6">
         <div>
           <h4 className="text-lg font-semibold text-custom-text-300">Collaborators</h4>
           <p className="mt-2 text-xs font-medium text-custom-text-300">
             View and find all members you collaborate with across projects
           </p>
         </div>
-        <div className="flex min-w-72 items-center justify-start gap-2 rounded-md border border-custom-border-200 px-2.5 py-1.5 placeholder:text-custom-text-400">
+        <div className="mt-5 sm:mt-0 flex min-w-72 items-center justify-start gap-2 rounded-md border border-custom-border-200 px-2.5 py-1.5 placeholder:text-custom-text-400">
           <Search className="h-3.5 w-3.5 text-custom-text-400" />
           <input
             className="w-full border-none bg-transparent text-sm focus:outline-none"


### PR DESCRIPTION
[issue 4947](https://github.com/makeplane/plane/issues/4937) - Dashboard collaboration card responsiveness issue

new xs screens: 
<img width="585" alt="Screenshot 2024-06-27 at 3 01 54 PM" src="https://github.com/makeplane/plane/assets/24251117/b852e93e-35ac-4358-abff-e7fd2abb8909">

screen size sm and up: 
<img width="1077" alt="Screenshot 2024-06-27 at 8 20 12 PM" src="https://github.com/makeplane/plane/assets/24251117/c3473323-ba86-4936-a6bb-4e5f3c224df4">


old small screen: 
![342854005-74ee30b7-dfba-47cf-a2d0-f484e4ff6666](https://github.com/makeplane/plane/assets/24251117/2b07e7c2-d3dc-4645-b916-7db15e1ea06d)
