### PR TITLE
fix: multiline copy paste

### DIFF
--- a/packages/editor/src/core/extensions/extensions.tsx
+++ b/packages/editor/src/core/extensions/extensions.tsx
@@ -125,6 +125,7 @@ export const CoreEditorExtensions = ({
   Markdown.configure({
     html: true,
     transformPastedText: true,
+    breaks: true,
   }),
   Table,
   TableHeader,


### PR DESCRIPTION
## Description

Correctly let the Markdown plugin handle parsing of multiline data except for code blocks on pasting data from external sources

| Before | After |
|--------|--------|
| <img width="792" alt="image" src="https://github.com/makeplane/plane/assets/73993394/0b6e2d8c-c729-43b8-ab98-608b0d69fb1b"> | <img width="792" alt="image" src="https://github.com/makeplane/plane/assets/73993394/dd56a327-ab90-4ff9-814a-03bffbc1e8c8"> | 

