### PR TITLE
[WEB-1766] fix: relations not rendering for child-issues

### DIFF
--- a/web/core/store/issue/issue-details/issue.store.ts
+++ b/web/core/store/issue/issue-details/issue.store.ts
@@ -62,94 +62,91 @@ export class IssueStore implements IIssueStore {
 
   // actions
   fetchIssue = async (workspaceSlug: string, projectId: string, issueId: string, issueType = "DEFAULT") => {
-    try {
-      const query = {
-        expand: "issue_reactions,issue_attachment,issue_link,parent",
-      };
+    const query = {
+      expand: "issue_reactions,issue_attachment,issue_link,parent",
+    };
 
-      let issue: TIssue;
+    let issue: TIssue;
 
-      if (issueType === "ARCHIVED")
-        issue = await this.issueArchiveService.retrieveArchivedIssue(workspaceSlug, projectId, issueId, query);
-      else if (issueType === "DRAFT")
-        issue = await this.issueDraftService.getDraftIssueById(workspaceSlug, projectId, issueId, query);
-      else issue = await this.issueService.retrieve(workspaceSlug, projectId, issueId, query);
+    if (issueType === "ARCHIVED")
+      issue = await this.issueArchiveService.retrieveArchivedIssue(workspaceSlug, projectId, issueId, query);
+    else if (issueType === "DRAFT")
+      issue = await this.issueDraftService.getDraftIssueById(workspaceSlug, projectId, issueId, query);
+    else issue = await this.issueService.retrieve(workspaceSlug, projectId, issueId, query);
 
-      if (!issue) throw new Error("Issue not found");
+    if (!issue) throw new Error("Issue not found");
 
-      const issuePayload: TIssue = {
-        id: issue?.id,
-        sequence_id: issue?.sequence_id,
-        name: issue?.name,
-        description_html: issue?.description_html,
-        sort_order: issue?.sort_order,
-        state_id: issue?.state_id,
-        priority: issue?.priority,
-        label_ids: issue?.label_ids,
-        assignee_ids: issue?.assignee_ids,
-        estimate_point: issue?.estimate_point,
-        sub_issues_count: issue?.sub_issues_count,
-        attachment_count: issue?.attachment_count,
-        link_count: issue?.link_count,
-        project_id: issue?.project_id,
-        parent_id: issue?.parent_id,
-        cycle_id: issue?.cycle_id,
-        module_ids: issue?.module_ids,
-        created_at: issue?.created_at,
-        updated_at: issue?.updated_at,
-        start_date: issue?.start_date,
-        target_date: issue?.target_date,
-        completed_at: issue?.completed_at,
-        archived_at: issue?.archived_at,
-        created_by: issue?.created_by,
-        updated_by: issue?.updated_by,
-        is_draft: issue?.is_draft,
-        is_subscribed: issue?.is_subscribed,
-      };
+    const issuePayload: TIssue = {
+      id: issue?.id,
+      sequence_id: issue?.sequence_id,
+      name: issue?.name,
+      description_html: issue?.description_html,
+      sort_order: issue?.sort_order,
+      state_id: issue?.state_id,
+      priority: issue?.priority,
+      label_ids: issue?.label_ids,
+      assignee_ids: issue?.assignee_ids,
+      estimate_point: issue?.estimate_point,
+      sub_issues_count: issue?.sub_issues_count,
+      attachment_count: issue?.attachment_count,
+      link_count: issue?.link_count,
+      project_id: issue?.project_id,
+      parent_id: issue?.parent_id,
+      cycle_id: issue?.cycle_id,
+      module_ids: issue?.module_ids,
+      created_at: issue?.created_at,
+      updated_at: issue?.updated_at,
+      start_date: issue?.start_date,
+      target_date: issue?.target_date,
+      completed_at: issue?.completed_at,
+      archived_at: issue?.archived_at,
+      created_by: issue?.created_by,
+      updated_by: issue?.updated_by,
+      is_draft: issue?.is_draft,
+      is_subscribed: issue?.is_subscribed,
+    };
 
-      this.rootIssueDetailStore.rootIssueStore.issues.addIssue([issuePayload], true);
+    this.rootIssueDetailStore.rootIssueStore.issues.addIssue([issuePayload], true);
 
-      // store handlers from issue detail
-      // parent
-      if (issue && issue?.parent && issue?.parent?.id && issue?.parent?.project_id) {
-        const parentIssue = await this.issueService.retrieve(workspaceSlug, issue.parent.project_id, issue?.parent?.id);
-        this.rootIssueDetailStore.rootIssueStore.issues.addIssue([parentIssue]);
-      }
-      // assignees
-      // labels
-      // state
-
-      // issue reactions
-      if (issue.issue_reactions) this.rootIssueDetailStore.addReactions(issueId, issue.issue_reactions);
-
-      // fetch issue links
-      if (issue.issue_link) this.rootIssueDetailStore.addLinks(issueId, issue.issue_link);
-
-      // fetch issue attachments
-      if (issue.issue_attachment) this.rootIssueDetailStore.addAttachments(issueId, issue.issue_attachment);
-
-      this.rootIssueDetailStore.addSubscription(issueId, issue.is_subscribed);
-
-      // fetch issue activity
-      this.rootIssueDetailStore.activity.fetchActivities(workspaceSlug, projectId, issueId);
-
-      // fetch issue comments
-      this.rootIssueDetailStore.comment.fetchComments(workspaceSlug, projectId, issueId);
-
-      // fetch sub issues
-      this.rootIssueDetailStore.subIssues.fetchSubIssues(workspaceSlug, projectId, issueId);
-
-      // fetch issue relations
-      this.rootIssueDetailStore.relation.fetchRelations(workspaceSlug, projectId, issueId);
-
-      // fetching states
-      // TODO: check if this function is required
-      this.rootIssueDetailStore.rootIssueStore.state.fetchProjectStates(workspaceSlug, projectId);
-
-      return issue;
-    } catch (error) {
-      throw error;
+    // store handlers from issue detail
+    // parent
+    if (issue && issue?.parent && issue?.parent?.id && issue?.parent?.project_id) {
+      this.issueService.retrieve(workspaceSlug, issue.parent.project_id, issue?.parent?.id).then((res) => {
+        this.rootIssueDetailStore.rootIssueStore.issues.addIssue([res]);
+      });
     }
+    // assignees
+    // labels
+    // state
+
+    // issue reactions
+    if (issue.issue_reactions) this.rootIssueDetailStore.addReactions(issueId, issue.issue_reactions);
+
+    // fetch issue links
+    if (issue.issue_link) this.rootIssueDetailStore.addLinks(issueId, issue.issue_link);
+
+    // fetch issue attachments
+    if (issue.issue_attachment) this.rootIssueDetailStore.addAttachments(issueId, issue.issue_attachment);
+
+    this.rootIssueDetailStore.addSubscription(issueId, issue.is_subscribed);
+
+    // fetch issue activity
+    this.rootIssueDetailStore.activity.fetchActivities(workspaceSlug, projectId, issueId);
+
+    // fetch issue comments
+    this.rootIssueDetailStore.comment.fetchComments(workspaceSlug, projectId, issueId);
+
+    // fetch sub issues
+    this.rootIssueDetailStore.subIssues.fetchSubIssues(workspaceSlug, projectId, issueId);
+
+    // fetch issue relations
+    this.rootIssueDetailStore.relation.fetchRelations(workspaceSlug, projectId, issueId);
+
+    // fetching states
+    // TODO: check if this function is required
+    this.rootIssueDetailStore.rootIssueStore.state.fetchProjectStates(workspaceSlug, projectId);
+
+    return issue;
   };
 
   updateIssue = async (workspaceSlug: string, projectId: string, issueId: string, data: Partial<TIssue>) => {


### PR DESCRIPTION
#### Problems:

On archiving the parent issue, following problems can be seen in the child issues-

1. The issue details page renders a 404 error despite of the issue being present.
2. Issue relations don't render on the peek overview.

#### Solution:

Removed `await` from the parent issue details request, so that error on fetching the parent issue details is not caught by the catch block.