### PR TITLE
[WEB-1791] fix: issue delete redirection

### DIFF
--- a/web/core/components/issues/issue-detail/issue-detail-quick-actions.tsx
+++ b/web/core/components/issues/issue-detail/issue-detail-quick-actions.tsx
@@ -80,6 +80,7 @@ export const IssueDetailQuickActions: FC<Props> = observer((props) => {
     try {
       if (issue?.archived_at) await removeArchivedIssue(workspaceSlug, projectId, issueId);
       else await removeIssue(workspaceSlug, projectId, issueId);
+      router.push(`/${workspaceSlug}/projects/${projectId}/issues`);
       setToast({
         title: "Success!",
         type: TOAST_TYPE.SUCCESS,

--- a/web/core/components/issues/issue-detail/issue-detail-quick-actions.tsx
+++ b/web/core/components/issues/issue-detail/issue-detail-quick-actions.tsx
@@ -81,11 +81,6 @@ export const IssueDetailQuickActions: FC<Props> = observer((props) => {
       if (issue?.archived_at) await removeArchivedIssue(workspaceSlug, projectId, issueId);
       else await removeIssue(workspaceSlug, projectId, issueId);
       router.push(`/${workspaceSlug}/projects/${projectId}/issues`);
-      setToast({
-        title: "Success!",
-        type: TOAST_TYPE.SUCCESS,
-        message: "Issue deleted successfully",
-      });
       captureIssueEvent({
         eventName: ISSUE_DELETED,
         payload: { id: issueId, state: "SUCCESS", element: "Issue detail page" },


### PR DESCRIPTION
#### Changes:
This PR includes a fix for the issue with delete redirection. Previously, deleting an issue from the issue detail page did not redirect to the issue link page. Additionally, deleting an issue was triggering two toast alerts. I have made the necessary changes to ensure it works as intended.

#### Issue link: [[WEB-1791]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/8342a062-2846-428c-b844-66760b3ea8f2)

#### Media:
| Before | After |
|--------|--------|
| ![before](https://github.com/makeplane/plane/assets/121005188/bbf5958b-5d60-4635-bede-c386369052a5) | ![after](https://github.com/makeplane/plane/assets/121005188/ec6157d2-a9f1-4cd4-9ca5-a03173e77ce6) |
