### PR TITLE
[WEB-1753] fix: padding inside the blockquotes inside list items

### DIFF
--- a/packages/editor/src/styles/editor.css
+++ b/packages/editor/src/styles/editor.css
@@ -17,6 +17,11 @@
   height: 0;
 }
 
+.ProseMirror li blockquote {
+  margin-top: 10px;
+  padding-inline-start: 1em;
+}
+
 /* block quotes */
 .ProseMirror blockquote {
   font-style: normal;


### PR DESCRIPTION
## Description

Fix the padding inside the blockquotes inside list items (task, numbered and bullet)

| Before | After |
|--------|--------|
|  <img width="157" alt="image" src="https://github.com/makeplane/plane/assets/73993394/a0c731b6-7a84-45a5-b6c7-14c600db077d"> | <img width="228" alt="image" src="https://github.com/makeplane/plane/assets/73993394/3e40c860-7a35-42f4-b0ca-3b2e418dab08"> |


