### PR TITLE
[WEB-1808] style: fix `settings` highlight on app sidebar.

### DIFF
--- a/web/core/constants/dashboard.ts
+++ b/web/core/constants/dashboard.ts
@@ -296,7 +296,7 @@ export const SIDEBAR_WORKSPACE_MENU_ITEMS: {
     label: "Settings",
     href: `/settings`,
     access: EUserWorkspaceRoles.GUEST,
-    highlight: (pathname: string, baseUrl: string) => pathname.includes(`${baseUrl}/analytics/`),
+    highlight: (pathname: string, baseUrl: string) => pathname.includes(`${baseUrl}/settings/`),
     Icon: Settings,
   },
 ];


### PR DESCRIPTION
### Media
* Before
  <img width="589" alt="image" src="https://github.com/makeplane/plane/assets/33979846/73ceceb9-6a59-424c-8eb6-77919cbc9223">
  <img width="520" alt="image" src="https://github.com/makeplane/plane/assets/33979846/20a7bedf-84b5-4c1a-be0f-d453ea6e6eab">


* After
  <img width="567" alt="image" src="https://github.com/makeplane/plane/assets/33979846/f416ae47-74b3-4623-bb0f-335b82f325c5">
  <img width="445" alt="image" src="https://github.com/makeplane/plane/assets/33979846/675cd35a-f6dd-4b81-b479-90880ec07f64">


### Issue link: [WEB-1808](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/b0928642-93e7-46cf-848d-a0d352972634)