### PR TITLE
[WEB-1801] improvement: open shortcut guide using `shift+/` key combination.

### DIFF
--- a/web/core/components/command-palette/command-palette.tsx
+++ b/web/core/components/command-palette/command-palette.tsx
@@ -139,11 +139,6 @@ export const CommandPalette: FC = observer(() => {
           description: "Create a new issue in the current project",
           action: () => toggleCreateIssueModal(true),
         },
-        h: {
-          title: "Show shortcuts",
-          description: "Show all the available shortcuts",
-          action: () => toggleShortcutModal(true),
-        },
       },
       workspace: {
         p: {
@@ -199,15 +194,21 @@ export const CommandPalette: FC = observer(() => {
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
-      const { key, ctrlKey, metaKey, altKey } = e;
+      const { key, ctrlKey, metaKey, altKey, shiftKey } = e;
       if (!key) return;
 
       const keyPressed = key.toLowerCase();
       const cmdClicked = ctrlKey || metaKey;
+      const shiftClicked = shiftKey;
 
       if (cmdClicked && keyPressed === "k" && !isAnyModalOpen) {
         e.preventDefault();
         toggleCommandPaletteModal(true);
+      }
+
+      if (shiftClicked && (keyPressed === "?" || keyPressed === "/") && !isAnyModalOpen) {
+        e.preventDefault();
+        toggleShortcutModal(true);
       }
       // if on input, textarea or editor, don't do anything
       if (

--- a/web/core/components/command-palette/shortcuts-modal/commands-list.tsx
+++ b/web/core/components/command-palette/shortcuts-modal/commands-list.tsx
@@ -29,7 +29,7 @@ export const ShortcutCommandsList: React.FC<Props> = (props) => {
         { keys: "V", description: "Create view" },
         { keys: "D", description: "Create page" },
         { keys: "Delete", description: "Bulk delete issues" },
-        { keys: "H", description: "Open shortcuts guide" },
+        { keys: "Shift,/", description: "Open shortcuts guide" },
         {
           keys: platform === "MacOS" ? "Ctrl,control,C" : "Ctrl,Alt,C",
           description: "Copy issue URL from the issue details page",


### PR DESCRIPTION
In this PR, I have updated the key combination to open shortcut guide to `Shift+/`. For more info please refer #1428 

Plane issue link: [WEB-1801](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/09bf1b98-e84d-4228-9890-5c2bd5b440c8)