### PR TITLE
[WEB-1829] fix: stop issues query before fetching the view filters

### DIFF
--- a/web/core/components/issues/issue-layouts/roots/project-view-layout-root.tsx
+++ b/web/core/components/issues/issue-layouts/roots/project-view-layout-root.tsx
@@ -4,6 +4,7 @@ import { useParams } from "next/navigation";
 import useSWR from "swr";
 // mobx store
 // components
+import { LogoSpinner } from "@/components/common";
 import {
   IssuePeekOverview,
   ProjectViewAppliedFiltersRoot,
@@ -42,7 +43,7 @@ export const ProjectViewLayoutRoot: React.FC = observer(() => {
   // hooks
   const { issuesFilter } = useIssues(EIssuesStoreType.PROJECT_VIEW);
 
-  useSWR(
+  const { isLoading } = useSWR(
     workspaceSlug && projectId && viewId ? `PROJECT_VIEW_ISSUES_${workspaceSlug}_${projectId}_${viewId}` : null,
     async () => {
       if (workspaceSlug && projectId && viewId) {
@@ -55,6 +56,14 @@ export const ProjectViewLayoutRoot: React.FC = observer(() => {
   const activeLayout = issuesFilter?.issueFilters?.displayFilters?.layout;
 
   if (!workspaceSlug || !projectId || !viewId) return <></>;
+
+  if (isLoading) {
+    return (
+      <div className="relative flex h-screen w-full items-center justify-center">
+        <LogoSpinner />
+      </div>
+    );
+  }
 
   return (
     <IssuesStoreContext.Provider value={EIssuesStoreType.PROJECT_VIEW}>

--- a/web/core/store/project-view.store.ts
+++ b/web/core/store/project-view.store.ts
@@ -6,7 +6,7 @@ import { IProjectView, TViewFilters } from "@plane/types";
 // constants
 import { EViewAccess } from "@/constants/views";
 // helpers
-import { getViewName, orderViews, shouldFilterView } from "@/helpers/project-views.helpers";
+import { getValidatedViewFilters, getViewName, orderViews, shouldFilterView } from "@/helpers/project-views.helpers";
 // services
 import { ViewService } from "@/plane-web/services";
 // store
@@ -196,7 +196,7 @@ export class ProjectViewStore implements IProjectViewStore {
    * @returns Promise<IProjectView>
    */
   createView = async (workspaceSlug: string, projectId: string, data: Partial<IProjectView>): Promise<IProjectView> => {
-    const response = await this.viewService.createView(workspaceSlug, projectId, data);
+    const response = await this.viewService.createView(workspaceSlug, projectId, getValidatedViewFilters(data));
 
     runInAction(() => {
       set(this.viewMap, [response.id], response);

--- a/web/helpers/project-views.helpers.ts
+++ b/web/helpers/project-views.helpers.ts
@@ -1,3 +1,4 @@
+import isNil from "lodash/isNil";
 import orderBy from "lodash/orderBy";
 import { IProjectView, TViewFilterProps, TViewFiltersSortBy, TViewFiltersSortKey } from "@plane/types";
 import { getDate } from "@/helpers/date-time.helper";
@@ -73,4 +74,17 @@ export const getViewName = (name: string | undefined) => {
   if (name === undefined) return "";
   if (!name || name.trim() === "") return "Untitled";
   return name;
+};
+
+/**
+ * Adds validation for the view creation filters
+ * @param data
+ * @returns
+ */
+export const getValidatedViewFilters = (data: Partial<IProjectView>) => {
+  if (data?.display_filters && data?.display_filters?.layout === "kanban" && isNil(data.display_filters.group_by)) {
+    data.display_filters.group_by = "state";
+  }
+
+  return data;
 };


### PR DESCRIPTION
This PR is to fix issues when issues are queried before completely fetching view filters when the filters are cleared and the page is visited back.  
This also adds default group by for kanban views


https://github.com/makeplane/plane/assets/71900764/4e9d675b-5a41-472d-9142-69ad887fb466



https://github.com/makeplane/plane/assets/71900764/f9bc7aa8-7b2f-46cd-98fb-21cdd290c695


