### PR TITLE
[WEB-1836] fix: modal core onClose functionality

### DIFF
--- a/packages/ui/src/modals/modal-core.tsx
+++ b/packages/ui/src/modals/modal-core.tsx
@@ -17,7 +17,7 @@ export const ModalCore: React.FC<Props> = (props) => {
 
   return (
     <Transition.Root show={isOpen} as={Fragment}>
-      <Dialog as="div" className="relative z-20" onClose={() => handleClose && handleClose}>
+      <Dialog as="div" className="relative z-20" onClose={() => handleClose && handleClose()}>
         <Transition.Child
           as={Fragment}
           enter="ease-out duration-300"


### PR DESCRIPTION
#### Changes:
This PR includes a fix for the onClose functionality of the modal core component. Previously, clicking outside the modal did not close it, which was not the intended behavior. I have made the necessary adjustments to make it work as intended.

#### Issue link: [[WEB-1836]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/6543ee61-00c0-4c9c-bc10-ba920835989f/)