### PR TITLE
[WEB-1807] fix: sidebar quick action overlapping

### DIFF
--- a/web/core/components/workspace/sidebar/quick-actions.tsx
+++ b/web/core/components/workspace/sidebar/quick-actions.tsx
@@ -109,9 +109,7 @@ export const SidebarQuickActions = observer(() => {
                 </button>
               )}
               {isDraftButtonOpen && (
-                <div
-                  className={`fixed left-4 mt-0 h-10 w-[203px] pt-2 ${isSidebarCollapsed ? "top-[5.5rem]" : "top-24"}`}
-                >
+                <div className="absolute  mt-0 h-10 w-[220px] pt-2 z-10 top-8 left-0">
                   <div className="h-full w-full">
                     <button
                       onClick={() => setIsDraftIssueModalOpen(true)}


### PR DESCRIPTION
#### Changes:
This PR includes a fix for the sidebar draft issue and resolves the overlapping quick action problem.

#### Issue link: [[WEB-1807]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/b605d1b1-6ed7-4b04-b855-9a7dcead02bb)

#### Media:
| Before | After |
|--------|--------|
| ![before](https://github.com/makeplane/plane/assets/121005188/b6ee2cc9-73b1-4385-97c9-042ea24fd283) | ![after](https://github.com/makeplane/plane/assets/121005188/949004e9-a7c5-465b-a96e-44b439f5868c) |