### PR TITLE
[WEB-1847] chore: handled project id on the issue creation modal toast when the issue creation is happening on the home page

### DIFF
--- a/web/core/components/issues/issue-modal/modal.tsx
+++ b/web/core/components/issues/issue-modal/modal.tsx
@@ -190,10 +190,10 @@ export const CreateUpdateIssueModal: React.FC<IssuesModalProps> = observer((prop
         type: TOAST_TYPE.SUCCESS,
         title: "Success!",
         message: `${is_draft_issue ? "Draft issue" : "Issue"} created successfully.`,
-        actionItems: !is_draft_issue && (
+        actionItems: !is_draft_issue && response?.project_id && (
           <CreateIssueToastActionItems
             workspaceSlug={workspaceSlug.toString()}
-            projectId={projectId.toString()}
+            projectId={projectId ? projectId?.toString() : response?.project_id?.toString()}
             issueId={response.id}
           />
         ),

--- a/web/core/components/issues/issue-modal/modal.tsx
+++ b/web/core/components/issues/issue-modal/modal.tsx
@@ -193,7 +193,7 @@ export const CreateUpdateIssueModal: React.FC<IssuesModalProps> = observer((prop
         actionItems: !is_draft_issue && response?.project_id && (
           <CreateIssueToastActionItems
             workspaceSlug={workspaceSlug.toString()}
-            projectId={projectId ? projectId?.toString() : response?.project_id?.toString()}
+            projectId={response?.project_id}
             issueId={response.id}
           />
         ),


### PR DESCRIPTION
#### Summary
This PR handles the display of the issue redirection and copy link buttons on the issue creation modal toast when an issue is created from the home page.

#### Changes
1. Issue modal root

#### Issue link: [[WEB-1847]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/fdc46a53-a157-4430-acf2-28cf41ecc637)