### PR TITLE
[WEB-1683] fix: kanban subgroup quick add validation

### DIFF
--- a/web/core/components/issues/issue-layouts/kanban/swimlanes.tsx
+++ b/web/core/components/issues/issue-layouts/kanban/swimlanes.tsx
@@ -123,6 +123,7 @@ const SubGroupSwimlane: React.FC<ISubGroupSwimlane> = observer((props) => {
     loadMoreIssues,
     showEmptyGroup,
     enableQuickIssueCreate,
+    disableIssueCreation,
     canEditProperties,
     addIssuesToView,
     quickAddCallback,
@@ -187,6 +188,7 @@ const SubGroupSwimlane: React.FC<ISubGroupSwimlane> = observer((props) => {
                     handleKanbanFilters={handleKanbanFilters}
                     showEmptyGroup={showEmptyGroup}
                     enableQuickIssueCreate={enableQuickIssueCreate}
+                    disableIssueCreation={disableIssueCreation}
                     canEditProperties={canEditProperties}
                     addIssuesToView={addIssuesToView}
                     quickAddCallback={quickAddCallback}


### PR DESCRIPTION
### Changes:
Fixed the Kanban subgroup layout quick add validation. Previously, the quick add button was being rendered in the completed cycle, which was not the intended behavior. I have made changes to ensure it works as intended.

### Issue link: [[WEB-1683]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/12e58f7a-1606-45ea-8ccb-58b56a0faa2a)

