### PR TITLE
[WEB - 1879] fix: remove user workspace cache on account deactivation

### DIFF
--- a/apiserver/plane/app/views/user/base.py
+++ b/apiserver/plane/app/views/user/base.py
@@ -79,6 +79,9 @@ class UserEndpoint(BaseViewSet):
         return super().partial_update(request, *args, **kwargs)
 
     @invalidate_cache(path="/api/users/me/")
+    @invalidate_cache(
+        path="/api/users/me/workspaces/", multiple=True, user=False
+    )
     def deactivate(self, request):
         # Check all workspace user is active
         user = self.get_object()


### PR DESCRIPTION
fix: 
- This PR fixes the old workspace still visible on re-login after account deactivation.

**Ticket** - [[WEB - 1879]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/13d8b69e-1467-482f-8b94-2dee03daa7a1)