### PR TITLE
[WEB-1872] fix: completed cycle gantt layout quick add issue validation

### DIFF
--- a/web/core/components/issues/issue-layouts/gantt/base-gantt-root.tsx
+++ b/web/core/components/issues/issue-layouts/gantt/base-gantt-root.tsx
@@ -85,6 +85,11 @@ export const BaseGanttRoot: React.FC<IBaseGanttRoot> = observer((props: IBaseGan
 
   const isAllowed = !!currentProjectRole && currentProjectRole >= EUserProjectRoles.MEMBER;
 
+  const quickAdd =
+    enableIssueCreation && isAllowed && !isCompletedCycle ? (
+      <GanttQuickAddIssueForm quickAddCallback={quickAddIssue} />
+    ) : undefined;
+
   return (
     <IssueLayoutHOC layout={EIssueLayoutTypes.GANTT}>
       <div className="h-full w-full">
@@ -103,11 +108,7 @@ export const BaseGanttRoot: React.FC<IBaseGanttRoot> = observer((props: IBaseGan
           enableReorder={appliedDisplayFilters?.order_by === "sort_order" && isAllowed}
           enableAddBlock={isAllowed}
           enableSelection={isBulkOperationsEnabled && isAllowed}
-          quickAdd={
-            enableIssueCreation && isAllowed && !isCompletedCycle ? (
-              <GanttQuickAddIssueForm quickAddCallback={quickAddIssue} />
-            ) : undefined
-          }
+          quickAdd={quickAdd}
           loadMoreBlocks={loadMoreIssues}
           canLoadMoreBlocks={nextPageResults}
           showAllBlocks

--- a/web/core/components/issues/issue-layouts/gantt/base-gantt-root.tsx
+++ b/web/core/components/issues/issue-layouts/gantt/base-gantt-root.tsx
@@ -21,6 +21,7 @@ import { IssueLayoutHOC } from "../issue-layout-HOC";
 
 interface IBaseGanttRoot {
   viewId?: string | undefined;
+  isCompletedCycle?: boolean;
 }
 
 type GanttStoreType =
@@ -30,7 +31,7 @@ type GanttStoreType =
   | EIssuesStoreType.PROJECT_VIEW;
 
 export const BaseGanttRoot: React.FC<IBaseGanttRoot> = observer((props: IBaseGanttRoot) => {
-  const { viewId } = props;
+  const { viewId, isCompletedCycle = false } = props;
   // router
   const { workspaceSlug } = useParams();
 
@@ -103,7 +104,9 @@ export const BaseGanttRoot: React.FC<IBaseGanttRoot> = observer((props: IBaseGan
           enableAddBlock={isAllowed}
           enableSelection={isBulkOperationsEnabled && isAllowed}
           quickAdd={
-            enableIssueCreation && isAllowed ? <GanttQuickAddIssueForm quickAddCallback={quickAddIssue} /> : undefined
+            enableIssueCreation && isAllowed && !isCompletedCycle ? (
+              <GanttQuickAddIssueForm quickAddCallback={quickAddIssue} />
+            ) : undefined
           }
           loadMoreBlocks={loadMoreIssues}
           canLoadMoreBlocks={nextPageResults}

--- a/web/core/components/issues/issue-layouts/roots/cycle-layout-root.tsx
+++ b/web/core/components/issues/issue-layouts/roots/cycle-layout-root.tsx
@@ -21,7 +21,11 @@ import { EIssueLayoutTypes, EIssuesStoreType } from "@/constants/issue";
 import { useCycle, useIssues } from "@/hooks/store";
 import { IssuesStoreContext } from "@/hooks/use-issue-layout-store";
 
-const CycleIssueLayout = (props: { activeLayout: EIssueLayoutTypes | undefined; cycleId: string }) => {
+const CycleIssueLayout = (props: {
+  activeLayout: EIssueLayoutTypes | undefined;
+  cycleId: string;
+  isCompletedCycle: boolean;
+}) => {
   switch (props.activeLayout) {
     case EIssueLayoutTypes.LIST:
       return <CycleListLayout />;
@@ -30,7 +34,7 @@ const CycleIssueLayout = (props: { activeLayout: EIssueLayoutTypes | undefined; 
     case EIssueLayoutTypes.CALENDAR:
       return <CycleCalendarLayout />;
     case EIssueLayoutTypes.GANTT:
-      return <BaseGanttRoot viewId={props.cycleId} />;
+      return <BaseGanttRoot viewId={props.cycleId} isCompletedCycle={props.isCompletedCycle} />;
     case EIssueLayoutTypes.SPREADSHEET:
       return <CycleSpreadsheetLayout />;
     default:
@@ -62,6 +66,7 @@ export const CycleLayoutRoot: React.FC = observer(() => {
 
   const cycleDetails = cycleId ? getCycleById(cycleId.toString()) : undefined;
   const cycleStatus = cycleDetails?.status?.toLocaleLowerCase() ?? "draft";
+  const isCompletedCycle = cycleStatus === "completed";
 
   if (!workspaceSlug || !projectId || !cycleId) return <></>;
 
@@ -78,7 +83,11 @@ export const CycleLayoutRoot: React.FC = observer(() => {
         <CycleAppliedFiltersRoot />
 
         <div className="h-full w-full overflow-auto">
-          <CycleIssueLayout activeLayout={activeLayout} cycleId={cycleId?.toString()} />
+          <CycleIssueLayout
+            activeLayout={activeLayout}
+            cycleId={cycleId?.toString()}
+            isCompletedCycle={isCompletedCycle}
+          />
         </div>
         {/* peek overview */}
         <IssuePeekOverview />


### PR DESCRIPTION
#### Changes:
This PR includes a fix for the issue with the Gantt layout's quick add button validation for completed cycles. Previously, the quick add button was rendered for completed cycles, which was not the intended behavior.

#### Issue link: [[WEB-1872]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/5b1b369e-feaa-4734-bb6c-015f0688246c)
