### PR TITLE
[WEB-1874] fix: issue link error toast alert

### DIFF
--- a/web/core/components/issues/issue-detail-widgets/links/helper.tsx
+++ b/web/core/components/issues/issue-detail-widgets/links/helper.tsx
@@ -21,9 +21,9 @@ export const useLinkOperations = (workspaceSlug: string, projectId: string, issu
             type: TOAST_TYPE.SUCCESS,
             title: "Link created",
           });
-        } catch (error) {
+        } catch (error: any) {
           setToast({
-            message: "The link could not be created",
+            message: error?.data?.error ?? "The link could not be created",
             type: TOAST_TYPE.ERROR,
             title: "Link not created",
           });

--- a/web/core/components/issues/issue-detail/links/root.tsx
+++ b/web/core/components/issues/issue-detail/links/root.tsx
@@ -52,9 +52,9 @@ export const IssueLinkRoot: FC<TIssueLinkRoot> = (props) => {
             title: "Link created",
           });
           toggleIssueLinkModal(false);
-        } catch (error) {
+        } catch (error: any) {
           setToast({
-            message: "The link could not be created",
+            message: error?.data?.error ?? "The link could not be created",
             type: TOAST_TYPE.ERROR,
             title: "Link not created",
           });


### PR DESCRIPTION
#### Changes:
This PR includes an improvement for the issue link toast alert message. Previously, when a user tried to add an existing link, the message "The link could not be created" was rendered, which was not very descriptive. I have now added a more detailed response message.

#### Issue link: [[WEB-1874]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/ad7f918b-4bd0-4429-b9a4-6f14e056c829)