### PR TITLE
[WEB-1510] chore: project active cycle progress state group color updated

### DIFF
--- a/web/core/constants/cycle.ts
+++ b/web/core/constants/cycle.ts
@@ -95,22 +95,22 @@ export const CYCLE_STATE_GROUPS_DETAILS = [
   {
     key: "completed_issues",
     title: "Completed",
-    color: "#6490FE",
+    color: "#16A34A",
   },
   {
     key: "started_issues",
     title: "Started",
-    color: "#FDD97F",
+    color: "#F59E0B",
   },
   {
     key: "unstarted_issues",
     title: "Unstarted",
-    color: "#FEB055",
+    color: "#3A3A3A",
   },
   {
     key: "backlog_issues",
     title: "Backlog",
-    color: "#F0F0F3",
+    color: "#A3A3A3",
   },
 ];
 


### PR DESCRIPTION
#### Changes:
This PR includes following changes:
- Updated the color of the project active cycle progress state group.

#### Issue link: [[WEB-1510]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/d58c48ce-ab0d-4874-8d4a-57a2bbf283e8)

#### Media:
| Before | After |
|--------|--------|
| ![before](https://github.com/makeplane/plane/assets/121005188/ed2e7cd6-7f01-4863-9f23-4de98f99ba00) | ![after](https://github.com/makeplane/plane/assets/121005188/9ba1d64f-8bf4-4a2a-b99b-dbe182875ede) |