### PR TITLE
[WEB-1899] fix: issue attachment delete modal

### DIFF
--- a/web/core/components/issues/attachment/attachment-list-item.tsx
+++ b/web/core/components/issues/attachment/attachment-list-item.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { FC } from "react";
+import { FC, useState } from "react";
 import { observer } from "mobx-react";
 import { Trash } from "lucide-react";
 // ui
@@ -29,27 +29,31 @@ type TIssueAttachmentsListItem = {
 export const IssueAttachmentsListItem: FC<TIssueAttachmentsListItem> = observer((props) => {
   // props
   const { attachmentId, handleAttachmentOperations, disabled } = props;
+  const [isDeleteIssueAttachmentModalOpen, setIsDeleteIssueAttachmentModalOpen] = useState(false);
   // store hooks
   const { getUserDetails } = useMember();
   const {
     attachment: { getAttachmentById },
-    isDeleteAttachmentModalOpen,
     toggleDeleteAttachmentModal,
   } = useIssueDetail();
+  const { isMobile } = usePlatformOS();
+
+  const handleModalToggle = (value: boolean) => {
+    setIsDeleteIssueAttachmentModalOpen(value);
+    toggleDeleteAttachmentModal(value);
+  };
 
   // derived values
   const attachment = attachmentId ? getAttachmentById(attachmentId) : undefined;
-  // hooks
-  const { isMobile } = usePlatformOS();
 
   if (!attachment) return <></>;
 
   return (
     <>
-      {isDeleteAttachmentModalOpen && (
+      {isDeleteIssueAttachmentModalOpen && (
         <IssueAttachmentDeleteModal
-          isOpen={isDeleteAttachmentModalOpen}
-          onClose={() => toggleDeleteAttachmentModal(false)}
+          isOpen={isDeleteIssueAttachmentModalOpen}
+          onClose={() => handleModalToggle(false)}
           handleAttachmentOperations={handleAttachmentOperations}
           data={attachment}
         />
@@ -95,7 +99,7 @@ export const IssueAttachmentsListItem: FC<TIssueAttachmentsListItem> = observer(
                 onClick={(e) => {
                   e.preventDefault();
                   e.stopPropagation();
-                  toggleDeleteAttachmentModal(true);
+                  handleModalToggle(true);
                 }}
               >
                 <div className="flex items-center gap-2">


### PR DESCRIPTION
Changes:
This PR addresses the issue with the attachment delete modal. Previously, clicking on delete would close the modal without any action. I have made the necessary changes to ensure it now functions as intended.

Issue link: [[WEB-1899]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/04a4adf5-8f02-480a-aaef-09da8b18de26/)