### PR TITLE
[WEB-1908] chore: update input type number validation to type text in estimate input form

### DIFF
--- a/web/core/components/estimates/points/create.tsx
+++ b/web/core/components/estimates/points/create.tsx
@@ -154,7 +154,6 @@ export const EstimatePointCreate: FC<TEstimatePointCreate> = observer((props) =>
   // derived values
   const inputProps = {
     type: "text",
-    pattern: undefined,
     maxlength: MAX_ESTIMATE_POINT_INPUT_LENGTH,
   };
 

--- a/web/core/components/estimates/points/create.tsx
+++ b/web/core/components/estimates/points/create.tsx
@@ -152,11 +152,9 @@ export const EstimatePointCreate: FC<TEstimatePointCreate> = observer((props) =>
   };
 
   // derived values
-  const inputFieldType =
-    estimateType && [(EEstimateSystem.TIME, EEstimateSystem.POINTS)].includes(estimateType) ? "number" : "text";
   const inputProps = {
-    type: inputFieldType,
-    pattern: inputFieldType === "number" ? "[0-9]*" : undefined,
+    type: "text",
+    pattern: undefined,
     maxlength: MAX_ESTIMATE_POINT_INPUT_LENGTH,
   };
 

--- a/web/core/components/estimates/points/update.tsx
+++ b/web/core/components/estimates/points/update.tsx
@@ -160,11 +160,9 @@ export const EstimatePointUpdate: FC<TEstimatePointUpdate> = observer((props) =>
   };
 
   // derived values
-  const inputFieldType =
-    estimateType && [(EEstimateSystem.TIME, EEstimateSystem.POINTS)].includes(estimateType) ? "number" : "text";
   const inputProps = {
-    type: inputFieldType,
-    pattern: inputFieldType === "number" ? "[0-9]*" : undefined,
+    type: "text",
+    pattern: undefined,
     maxlength: MAX_ESTIMATE_POINT_INPUT_LENGTH,
   };
 

--- a/web/core/components/estimates/points/update.tsx
+++ b/web/core/components/estimates/points/update.tsx
@@ -162,7 +162,6 @@ export const EstimatePointUpdate: FC<TEstimatePointUpdate> = observer((props) =>
   // derived values
   const inputProps = {
     type: "text",
-    pattern: undefined,
     maxlength: MAX_ESTIMATE_POINT_INPUT_LENGTH,
   };
 


### PR DESCRIPTION
#### Summary
This PR updates the validation of the estimate input form by changing the input type from number to text, allowing for more flexible validation and input handling.

#### Changes
1. Estimate create component
2. Estimate update component

#### Issue link: [[WEB-1908]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/4fee001f-37af-4ed0-aa08-226fb04e1709)