### PR TITLE
[WEB-1759] fix: project dropdown action

### DIFF
--- a/web/core/components/workspace/sidebar/projects-list-item.tsx
+++ b/web/core/components/workspace/sidebar/projects-list-item.tsx
@@ -337,11 +337,11 @@ export const SidebarProjectsListItem: React.FC<Props> = observer((props) => {
                     disabled={!isSidebarCollapsed}
                     isMobile={isMobile}
                   >
-                    <Link href={`/${workspaceSlug}/projects/${project.id}/issues`} className="flex-grow flex">
+                    <Link href={`/${workspaceSlug}/projects/${project.id}/issues`} className="flex-grow flex truncate">
                       <Disclosure.Button
                         as="button"
                         type="button"
-                        className={cn("flex-grow flex items-center gap-1.5 truncate text-left select-none", {
+                        className={cn("flex-grow flex items-center gap-1.5 text-left select-none w-full", {
                           "justify-center": isSidebarCollapsed,
                         })}
                       >

--- a/web/core/components/workspace/sidebar/projects-list-item.tsx
+++ b/web/core/components/workspace/sidebar/projects-list-item.tsx
@@ -317,11 +317,18 @@ export const SidebarProjectsListItem: React.FC<Props> = observer((props) => {
                 </Tooltip>
               )}
               {isSidebarCollapsed ? (
-                <Disclosure.Button as="button" className="size-8 aspect-square flex-shrink-0 grid place-items-center">
-                  <div className="size-4 grid place-items-center flex-shrink-0">
-                    <Logo logo={project.logo_props} size={16} />
-                  </div>
-                </Disclosure.Button>
+                <Link
+                  href={`/${workspaceSlug}/projects/${project.id}/issues`}
+                  className={cn("flex-grow flex items-center gap-1.5 truncate text-left select-none", {
+                    "justify-center": isSidebarCollapsed,
+                  })}
+                >
+                  <Disclosure.Button as="button" className="size-8 aspect-square flex-shrink-0 grid place-items-center">
+                    <div className="size-4 grid place-items-center flex-shrink-0">
+                      <Logo logo={project.logo_props} size={16} />
+                    </div>
+                  </Disclosure.Button>
+                </Link>
               ) : (
                 <>
                   <Tooltip
@@ -340,12 +347,11 @@ export const SidebarProjectsListItem: React.FC<Props> = observer((props) => {
                         <Logo logo={project.logo_props} size={16} />
                       </div>
                       {!isSidebarCollapsed && (
-                        <Disclosure.Button
-                          as="button"
-                          type="button"
-                          className="p-0.5 rounded"
-                        >    <p className="truncate text-sm font-medium text-custom-sidebar-text-200">{project.name}</p>
-                        </Disclosure.Button>)}
+                        <Disclosure.Button as="button" type="button" className="p-0.5 rounded">
+                          {" "}
+                          <p className="truncate text-sm font-medium text-custom-sidebar-text-200">{project.name}</p>
+                        </Disclosure.Button>
+                      )}
                     </Link>
                   </Tooltip>
                   <CustomMenu
@@ -504,9 +510,9 @@ export const SidebarProjectsListItem: React.FC<Props> = observer((props) => {
               </Disclosure.Panel>
             </Transition>
             {isLastChild && <DropIndicator isVisible={instruction === "DRAG_BELOW"} />}
-          </div >
+          </div>
         )}
-      </Disclosure >
+      </Disclosure>
     </>
   );
 });

--- a/web/core/components/workspace/sidebar/projects-list-item.tsx
+++ b/web/core/components/workspace/sidebar/projects-list-item.tsx
@@ -337,21 +337,21 @@ export const SidebarProjectsListItem: React.FC<Props> = observer((props) => {
                     disabled={!isSidebarCollapsed}
                     isMobile={isMobile}
                   >
-                    <Link
-                      href={`/${workspaceSlug}/projects/${project.id}/issues`}
-                      className={cn("flex-grow flex items-center gap-1.5 truncate text-left select-none", {
-                        "justify-center": isSidebarCollapsed,
-                      })}
-                    >
-                      <div className="size-4 grid place-items-center flex-shrink-0">
-                        <Logo logo={project.logo_props} size={16} />
-                      </div>
-                      {!isSidebarCollapsed && (
-                        <Disclosure.Button as="button" type="button" className="p-0.5 rounded">
-                          {" "}
+                    <Link href={`/${workspaceSlug}/projects/${project.id}/issues`} className="flex-grow flex">
+                      <Disclosure.Button
+                        as="button"
+                        type="button"
+                        className={cn("flex-grow flex items-center gap-1.5 truncate text-left select-none", {
+                          "justify-center": isSidebarCollapsed,
+                        })}
+                      >
+                        <div className="size-4 grid place-items-center flex-shrink-0">
+                          <Logo logo={project.logo_props} size={16} />
+                        </div>
+                        {!isSidebarCollapsed && (
                           <p className="truncate text-sm font-medium text-custom-sidebar-text-200">{project.name}</p>
-                        </Disclosure.Button>
-                      )}
+                        )}
+                      </Disclosure.Button>
                     </Link>
                   </Tooltip>
                   <CustomMenu
@@ -461,7 +461,6 @@ export const SidebarProjectsListItem: React.FC<Props> = observer((props) => {
                 </>
               )}
             </div>
-
             <Transition
               enter="transition duration-100 ease-out"
               enterFrom="transform scale-95 opacity-0"

--- a/web/core/components/workspace/sidebar/projects-list-item.tsx
+++ b/web/core/components/workspace/sidebar/projects-list-item.tsx
@@ -340,8 +340,12 @@ export const SidebarProjectsListItem: React.FC<Props> = observer((props) => {
                         <Logo logo={project.logo_props} size={16} />
                       </div>
                       {!isSidebarCollapsed && (
-                        <p className="truncate text-sm font-medium text-custom-sidebar-text-200">{project.name}</p>
-                      )}
+                        <Disclosure.Button
+                          as="button"
+                          type="button"
+                          className="p-0.5 rounded"
+                        >    <p className="truncate text-sm font-medium text-custom-sidebar-text-200">{project.name}</p>
+                        </Disclosure.Button>)}
                     </Link>
                   </Tooltip>
                   <CustomMenu
@@ -500,9 +504,9 @@ export const SidebarProjectsListItem: React.FC<Props> = observer((props) => {
               </Disclosure.Panel>
             </Transition>
             {isLastChild && <DropIndicator isVisible={instruction === "DRAG_BELOW"} />}
-          </div>
+          </div >
         )}
-      </Disclosure>
+      </Disclosure >
     </>
   );
 });

--- a/web/core/components/workspace/sidebar/projects-list-item.tsx
+++ b/web/core/components/workspace/sidebar/projects-list-item.tsx
@@ -348,9 +348,7 @@ export const SidebarProjectsListItem: React.FC<Props> = observer((props) => {
                         <div className="size-4 grid place-items-center flex-shrink-0">
                           <Logo logo={project.logo_props} size={16} />
                         </div>
-                        {!isSidebarCollapsed && (
-                          <p className="truncate text-sm font-medium text-custom-sidebar-text-200">{project.name}</p>
-                        )}
+                        <p className="truncate text-sm font-medium text-custom-sidebar-text-200">{project.name}</p>
                       </Disclosure.Button>
                     </Link>
                   </Tooltip>


### PR DESCRIPTION
### In projects dropdown action are not working as expected

Description: When clicking on the projects we get project details(issues, cycles, modules, views etc.) then if we click on the accordion dropdown closes, now if we click on the same project dropdown wont work, we have to click on the accordion only to open the project details.

[[WEB-1759]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/0ac2736a-a496-41e3-82fa-4a40aa7d9954)