### PR TITLE
[WEB-1820] fix: analytics truncate project name

### DIFF
--- a/web/core/components/analytics/custom-analytics/select/project.tsx
+++ b/web/core/components/analytics/custom-analytics/select/project.tsx
@@ -25,7 +25,7 @@ export const SelectProject: React.FC<Props> = observer((props) => {
       content: (
         <div className="flex items-center gap-2 truncate">
           <span className="text-[0.65rem] text-custom-text-200 flex-shrink-0">{projectDetails?.identifier}</span>
-          <span className="flex-grow truncate">{projectDetails?.name.substring(0, 21)}{projectDetails?.name && projectDetails.name.length > 21 && '...'}</span>
+          <span className="flex-grow w-[192px] truncate">{projectDetails?.name}</span>
         </div>
       ),
     };

--- a/web/core/components/analytics/custom-analytics/select/project.tsx
+++ b/web/core/components/analytics/custom-analytics/select/project.tsx
@@ -25,7 +25,7 @@ export const SelectProject: React.FC<Props> = observer((props) => {
       content: (
         <div className="flex items-center gap-2 truncate">
           <span className="text-[0.65rem] text-custom-text-200 flex-shrink-0">{projectDetails?.identifier}</span>
-          <span className="flex-grow truncate">{projectDetails?.name}</span>
+          <span className="flex-grow truncate">{projectDetails?.name.substring(0, 21)}{projectDetails?.name && projectDetails.name.length > 21 && '...'}</span>
         </div>
       ),
     };
@@ -39,9 +39,9 @@ export const SelectProject: React.FC<Props> = observer((props) => {
       label={
         value && value.length > 0
           ? projectIds
-              ?.filter((p) => value.includes(p))
-              .map((p) => getProjectById(p)?.name)
-              .join(", ")
+            ?.filter((p) => value.includes(p))
+            .map((p) => getProjectById(p)?.name)
+            .join(", ")
           : "All projects"
       }
       multiple

--- a/web/core/components/analytics/custom-analytics/select/project.tsx
+++ b/web/core/components/analytics/custom-analytics/select/project.tsx
@@ -44,7 +44,7 @@ export const SelectProject: React.FC<Props> = observer((props) => {
               .join(", ")
           : "All projects"
       }
-      optionsClassName={"w-52"}
+      optionsClassName={"w-48"}
       multiple
     />
   );

--- a/web/core/components/analytics/custom-analytics/select/project.tsx
+++ b/web/core/components/analytics/custom-analytics/select/project.tsx
@@ -44,7 +44,7 @@ export const SelectProject: React.FC<Props> = observer((props) => {
               .join(", ")
           : "All projects"
       }
-      optionsClassName={"w-[18vw]"}
+      optionsClassName={"w-52"}
       multiple
     />
   );

--- a/web/core/components/analytics/custom-analytics/select/project.tsx
+++ b/web/core/components/analytics/custom-analytics/select/project.tsx
@@ -23,9 +23,9 @@ export const SelectProject: React.FC<Props> = observer((props) => {
       value: projectDetails?.id,
       query: `${projectDetails?.name} ${projectDetails?.identifier}`,
       content: (
-        <div className="flex items-center gap-2 truncate">
+        <div className="flex items-center gap-2">
           <span className="text-[0.65rem] text-custom-text-200 flex-shrink-0">{projectDetails?.identifier}</span>
-          <span className="flex-grow w-[192px] truncate">{projectDetails?.name}</span>
+          <span className="flex-grow truncate">{projectDetails?.name}</span>
         </div>
       ),
     };
@@ -39,11 +39,12 @@ export const SelectProject: React.FC<Props> = observer((props) => {
       label={
         value && value.length > 0
           ? projectIds
-            ?.filter((p) => value.includes(p))
-            .map((p) => getProjectById(p)?.name)
-            .join(", ")
+              ?.filter((p) => value.includes(p))
+              .map((p) => getProjectById(p)?.name)
+              .join(", ")
           : "All projects"
       }
+      optionsClassName={"w-[18vw]"}
       multiple
     />
   );


### PR DESCRIPTION
Truncate project name under custom analytics's project selection dropdown
![image](https://github.com/makeplane/plane/assets/36129505/27bbe68f-4692-4fd2-922a-8c8c3d7f3c37)

[[WEB-1820]
](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/18d1a65e-e5c6-43ca-a9d0-45ae8f428d6f)