### PR TITLE
[WEB-1876] fix: "Show sub-issues" checkbox checked by default under Archives

### DIFF
--- a/web/core/store/issue/archived/filter.store.ts
+++ b/web/core/store/issue/archived/filter.store.ts
@@ -89,6 +89,10 @@ export class ArchivedIssuesFilter extends IssueFilterHelperStore implements IArc
 
     const _filters: IIssueFilters = this.computedIssueFilters(displayFilters);
 
+    if (_filters.displayFilters) {
+
+      _filters.displayFilters.sub_issue = true
+    }
     return _filters;
   }
 

--- a/web/core/store/issue/archived/filter.store.ts
+++ b/web/core/store/issue/archived/filter.store.ts
@@ -89,10 +89,6 @@ export class ArchivedIssuesFilter extends IssueFilterHelperStore implements IArc
 
     const _filters: IIssueFilters = this.computedIssueFilters(displayFilters);
 
-    if (_filters.displayFilters) {
-
-      _filters.displayFilters.sub_issue = true
-    }
     return _filters;
   }
 
@@ -137,7 +133,10 @@ export class ArchivedIssuesFilter extends IssueFilterHelperStore implements IArc
       );
 
       const filters: IIssueFilterOptions = this.computedFilters(_filters?.filters);
-      const displayFilters: IIssueDisplayFilterOptions = this.computedDisplayFilters(_filters?.display_filters);
+      const displayFilters: IIssueDisplayFilterOptions = this.computedDisplayFilters({
+        ..._filters?.display_filters,
+        sub_issue: true,
+      });
       const displayProperties: IIssueDisplayProperties = this.computedDisplayProperties(_filters?.display_properties);
       const kanbanFilters = {
         group_by: [],


### PR DESCRIPTION
### "Show sub-issues" checkbox should be checked by default under Archives

![image](https://github.com/makeplane/plane/assets/36129505/bd91d26b-63f7-4208-b319-241b1c0a013d)

[[WEB-1876]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/7efbc443-70a4-49a3-a0cc-f1278db25302)