### PR TITLE
[WEB-1935] dev: fix page versioning task

### DIFF
--- a/apiserver/plane/bgtasks/page_version_task.py
+++ b/apiserver/plane/bgtasks/page_version_task.py
@@ -30,7 +30,7 @@ def page_version(
             workspace_id=page.workspace_id,
             description_html=page.description_html,
             description_binary=page.description_binary,
-            ownned_by_id=user_id,
+            owned_by_id=user_id,
             last_saved_at=page.updated_at,
         )
 


### PR DESCRIPTION
dev:
-  This PR fixes the background task for creating page versions. The error was due to a misspell in creating the versions.

**Ticket** - [[WEB - 1935]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/25f303a5-78eb-431e-bde3-e25bb327df24)