### PR TITLE
[WEB-1905] fix: sort order for workspace views

### DIFF
--- a/web/core/store/issue/workspace/filter.store.ts
+++ b/web/core/store/issue/workspace/filter.store.ts
@@ -143,6 +143,7 @@ export class WorkspaceIssuesFilter extends IssueFilterHelperStore implements IWo
       const _filters = this.handleIssuesLocalFilters.get(EIssuesStoreType.GLOBAL, workspaceSlug, undefined, viewId);
       displayFilters = this.computedDisplayFilters(_filters?.display_filters, {
         layout: EIssueLayoutTypes.SPREADSHEET,
+        order_by: "-created_at",
       });
       displayProperties = this.computedDisplayProperties(_filters?.display_properties);
       kanbanFilters = {
@@ -158,8 +159,14 @@ export class WorkspaceIssuesFilter extends IssueFilterHelperStore implements IWo
         filters = this.computedFilters(_filters?.filters);
         displayFilters = this.computedDisplayFilters(_filters?.display_filters, {
           layout: EIssueLayoutTypes.SPREADSHEET,
+          order_by: "-created_at",
         });
         displayProperties = this.computedDisplayProperties(_filters?.display_properties);
+      }
+
+      // override existing order by if ordered by manual sort_order
+      if (displayFilters.order_by === "sort_order") {
+        displayFilters.order_by = "-created_at";
       }
 
       runInAction(() => {


### PR DESCRIPTION
This PR adds the default sort order as created-at. If the order by is manual, replace it with created-at.


https://github.com/user-attachments/assets/5e8c253a-a6d9-449e-8db7-cce0a4ef63b5

