### PR TITLE
[WEB-1937] fix: issue detail widgets permission validation

### DIFF
--- a/web/core/components/issues/issue-detail-widgets/action-buttons.tsx
+++ b/web/core/components/issues/issue-detail-widgets/action-buttons.tsx
@@ -23,30 +23,35 @@ export const IssueDetailWidgetActionButtons: FC<Props> = (props) => {
     <div className="flex items-center flex-wrap gap-2">
       <SubIssuesActionButton
         issueId={issueId}
-        disabled={disabled}
         customButton={
           <IssueDetailWidgetButton
             title="Add sub-issues"
-            icon={<Layers className="h-3.5 w-3.5 flex-shrink-0 text-custom-text-300" strokeWidth={2} />}
+            icon={<Layers className="h-3.5 w-3.5 flex-shrink-0" strokeWidth={2} />}
+            disabled={disabled}
           />
         }
+        disabled={disabled}
       />
       <RelationActionButton
         issueId={issueId}
         customButton={
           <IssueDetailWidgetButton
             title="Add Relation"
-            icon={<Waypoints className="h-3.5 w-3.5 flex-shrink-0 text-custom-text-300" strokeWidth={2} />}
+            icon={<Waypoints className="h-3.5 w-3.5 flex-shrink-0" strokeWidth={2} />}
+            disabled={disabled}
           />
         }
+        disabled={disabled}
       />
       <IssueLinksActionButton
         customButton={
           <IssueDetailWidgetButton
             title="Add Links"
-            icon={<Link className="h-3.5 w-3.5 flex-shrink-0 text-custom-text-300" strokeWidth={2} />}
+            icon={<Link className="h-3.5 w-3.5 flex-shrink-0" strokeWidth={2} />}
+            disabled={disabled}
           />
         }
+        disabled={disabled}
       />
       <IssueAttachmentActionButton
         workspaceSlug={workspaceSlug}
@@ -55,9 +60,11 @@ export const IssueDetailWidgetActionButtons: FC<Props> = (props) => {
         customButton={
           <IssueDetailWidgetButton
             title="Attach"
-            icon={<Paperclip className="h-3.5 w-3.5 flex-shrink-0 text-custom-text-300" strokeWidth={2} />}
+            icon={<Paperclip className="h-3.5 w-3.5 flex-shrink-0" strokeWidth={2} />}
+            disabled={disabled}
           />
         }
+        disabled={disabled}
       />
     </div>
   );

--- a/web/core/components/issues/issue-detail-widgets/attachments/title.tsx
+++ b/web/core/components/issues/issue-detail-widgets/attachments/title.tsx
@@ -42,12 +42,14 @@ export const IssueAttachmentsCollapsibleTitle: FC<Props> = observer((props) => {
       title="Attachments"
       indicatorElement={indicatorElement}
       actionItemElement={
-        <IssueAttachmentActionButton
-          workspaceSlug={workspaceSlug}
-          projectId={projectId}
-          issueId={issueId}
-          disabled={disabled}
-        />
+        !disabled && (
+          <IssueAttachmentActionButton
+            workspaceSlug={workspaceSlug}
+            projectId={projectId}
+            issueId={issueId}
+            disabled={disabled}
+          />
+        )
       }
     />
   );

--- a/web/core/components/issues/issue-detail-widgets/links/title.tsx
+++ b/web/core/components/issues/issue-detail-widgets/links/title.tsx
@@ -40,7 +40,7 @@ export const IssueLinksCollapsibleTitle: FC<Props> = observer((props) => {
       isOpen={isOpen}
       title="Links"
       indicatorElement={indicatorElement}
-      actionItemElement={<IssueLinksActionButton disabled={disabled} />}
+      actionItemElement={!disabled && <IssueLinksActionButton disabled={disabled} />}
     />
   );
 });

--- a/web/core/components/issues/issue-detail-widgets/relations/title.tsx
+++ b/web/core/components/issues/issue-detail-widgets/relations/title.tsx
@@ -39,7 +39,7 @@ export const RelationsCollapsibleTitle: FC<Props> = observer((props) => {
       isOpen={isOpen}
       title="Relations"
       indicatorElement={indicatorElement}
-      actionItemElement={<RelationActionButton issueId={issueId} disabled={disabled} />}
+      actionItemElement={!disabled && <RelationActionButton issueId={issueId} disabled={disabled} />}
     />
   );
 });

--- a/web/core/components/issues/issue-detail-widgets/sub-issues/title.tsx
+++ b/web/core/components/issues/issue-detail-widgets/sub-issues/title.tsx
@@ -50,7 +50,7 @@ export const SubIssuesCollapsibleTitle: FC<Props> = observer((props) => {
       isOpen={isOpen}
       title="Sub-issues"
       indicatorElement={indicatorElement}
-      actionItemElement={<SubIssuesActionButton issueId={parentIssueId} disabled={disabled} />}
+      actionItemElement={!disabled && <SubIssuesActionButton issueId={parentIssueId} disabled={disabled} />}
     />
   );
 });

--- a/web/core/components/issues/issue-detail-widgets/widget-button.tsx
+++ b/web/core/components/issues/issue-detail-widgets/widget-button.tsx
@@ -1,17 +1,28 @@
 "use client";
 import React, { FC } from "react";
+// helpers
+import { cn } from "@/helpers/common.helper";
 
 type Props = {
   icon: JSX.Element;
   title: string;
+  disabled?: boolean;
 };
 
 export const IssueDetailWidgetButton: FC<Props> = (props) => {
-  const { icon, title } = props;
+  const { icon, title, disabled = false } = props;
   return (
-    <div className="h-full w-min whitespace-nowrap flex items-center gap-2 border border-custom-border-200 hover:bg-custom-background-80 rounded px-3 py-1.5">
+    <div
+      className={cn(
+        "h-full w-min whitespace-nowrap flex items-center gap-2 border border-custom-border-200 rounded px-3 py-1.5",
+        {
+          "cursor-not-allowed text-custom-text-400 bg-custom-background-90": disabled,
+          "cursor-pointer text-custom-text-300 hover:bg-custom-background-80": !disabled,
+        }
+      )}
+    >
       {icon && icon}
-      <span className="text-sm font-medium text-custom-text-300">{title}</span>
+      <span className="text-sm font-medium">{title}</span>
     </div>
   );
 };


### PR DESCRIPTION
#### Changes:
This PR includes following changes:
- Added Guest/Viewer role permissions for issue detail widgets. Previously, users with the Guest/Viewer role could open the issue detail widgets modal and access the quick action menu.

#### Issue link: [[WEB-1937]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/152827b8-ab67-4286-86e2-7b6226b50ef1)

#### Media:
| Before | After |
|--------|--------|
| ![WEB-1937 BEFORE](https://github.com/user-attachments/assets/89e63e76-0a88-4681-a938-67824944fd25) | ![WEB-1937 AFTER](https://github.com/user-attachments/assets/bdc2a160-81f2-4911-a467-ca736dd45bf7) |
