### PR TITLE
[WEB-1693] chore: added details in cycle detail endpoint

### DIFF
--- a/apiserver/plane/app/views/cycle/base.py
+++ b/apiserver/plane/app/views/cycle/base.py
@@ -645,6 +645,8 @@ class CycleViewSet(BaseViewSet):
                         "progress_snapshot",
                         "logo_props",
                         # meta fields
+                        "completed_estimate_points",
+                        "total_estimate_points",
                         "is_favorite",
                         "cancelled_issues",
                         "total_issues",
@@ -654,6 +656,7 @@ class CycleViewSet(BaseViewSet):
                         "backlog_issues",
                         "assignee_ids",
                         "status",
+                        "created_by",
                     )
                     .first()
                 )
@@ -739,6 +742,8 @@ class CycleViewSet(BaseViewSet):
                 "progress_snapshot",
                 "logo_props",
                 # meta fields
+                "completed_estimate_points",
+                "total_estimate_points",
                 "is_favorite",
                 "total_issues",
                 "cancelled_issues",
@@ -748,6 +753,7 @@ class CycleViewSet(BaseViewSet):
                 "backlog_issues",
                 "assignee_ids",
                 "status",
+                "created_by",
             ).first()
 
             # Send the model activity
@@ -800,6 +806,8 @@ class CycleViewSet(BaseViewSet):
                 "sub_issues",
                 "logo_props",
                 # meta fields
+                "completed_estimate_points",
+                "total_estimate_points",
                 "is_favorite",
                 "total_issues",
                 "cancelled_issues",


### PR DESCRIPTION
chore: 
- added `completed_estimate_points` , `total_estimate_points` and `created_by` detail in the cycle detail endpoint.

Issue Link: [WEB-1693](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/be2cb5b6-9671-43ba-b1ae-d6f868779b02/)