### PR TITLE
[WEB-1956] fix: shortcuts

### DIFF
--- a/web/core/components/command-palette/command-modal.tsx
+++ b/web/core/components/command-palette/command-modal.tsx
@@ -46,7 +46,7 @@ export const CommandModal: React.FC = observer(() => {
   // hooks
   const { getProjectById, workspaceProjectIds } = useProject();
   const { isMobile } = usePlatformOS();
-  const { canPerformWorkspaceCreateActions } = useUser();
+  const { getProjectsWithPermissions } = useUser();
   // states
   const [placeholder, setPlaceholder] = useState("Type a command or search...");
   const [resultsCount, setResultsCount] = useState(0);
@@ -286,7 +286,8 @@ export const CommandModal: React.FC = observer(() => {
                           {workspaceSlug &&
                             workspaceProjectIds &&
                             workspaceProjectIds.length > 0 &&
-                            canPerformWorkspaceCreateActions && (
+                            getProjectsWithPermissions &&
+                            Object.keys(getProjectsWithPermissions).length > 0 && (
                               <Command.Group heading="Issue">
                                 <Command.Item
                                   onSelect={() => {

--- a/web/core/components/command-palette/command-palette.tsx
+++ b/web/core/components/command-palette/command-palette.tsx
@@ -41,7 +41,12 @@ export const CommandPalette: FC = observer(() => {
   const { toggleSidebar } = useAppTheme();
   const { setTrackElement } = useEventTracker();
   const { platform } = usePlatformOS();
-  const { data: currentUser, canPerformProjectCreateActions, canPerformWorkspaceCreateActions } = useUser();
+  const {
+    data: currentUser,
+    canPerformProjectCreateActions,
+    canPerformWorkspaceCreateActions,
+    getProjectsWithPermissions,
+  } = useUser();
   const {
     issues: { removeIssue },
   } = useIssuesStore();
@@ -118,6 +123,19 @@ export const CommandPalette: FC = observer(() => {
       return canPerformWorkspaceCreateActions;
     },
     [canPerformWorkspaceCreateActions]
+  );
+
+  const performAnyProjectCreateActions = useCallback(
+    (showToast: boolean = true) => {
+      const projectsWithPermissions = Object.keys(getProjectsWithPermissions).length;
+      if (projectsWithPermissions < 0 && showToast)
+        setToast({
+          type: TOAST_TYPE.ERROR,
+          title: "You don't have permission to perform this action.",
+        });
+      return projectsWithPermissions > 0;
+    },
+    [getProjectsWithPermissions]
   );
 
   const shortcutsList: {
@@ -222,7 +240,10 @@ export const CommandPalette: FC = observer(() => {
         }
       } else if (!isAnyModalOpen) {
         setTrackElement("Shortcut key");
-        if (Object.keys(shortcutsList.global).includes(keyPressed) && performWorkspaceCreateActions())
+        if (
+          Object.keys(shortcutsList.global).includes(keyPressed) &&
+          ((!projectId && performAnyProjectCreateActions()) || performProjectCreateActions())
+        )
           shortcutsList.global[keyPressed].action();
         // workspace authorized actions
         else if (
@@ -244,6 +265,7 @@ export const CommandPalette: FC = observer(() => {
       }
     },
     [
+      performAnyProjectCreateActions,
       performProjectCreateActions,
       performWorkspaceCreateActions,
       copyIssueUrlToClipboard,

--- a/web/core/components/issues/issue-modal/form.tsx
+++ b/web/core/components/issues/issue-modal/form.tsx
@@ -32,7 +32,7 @@ import { renderFormattedPayloadDate, getDate } from "@/helpers/date-time.helper"
 import { getChangedIssuefields, getDescriptionPlaceholder } from "@/helpers/issue.helper";
 import { shouldRenderProject } from "@/helpers/project.helper";
 // hooks
-import { useProjectEstimates, useInstance, useIssueDetail, useProject, useWorkspace } from "@/hooks/store";
+import { useProjectEstimates, useInstance, useIssueDetail, useProject, useWorkspace, useUser } from "@/hooks/store";
 import useKeypress from "@/hooks/use-keypress";
 import { useProjectIssueProperties } from "@/hooks/use-project-issue-properties";
 // services
@@ -121,6 +121,8 @@ export const IssueFormRoot: FC<IssueFormProps> = observer((props) => {
   const workspaceStore = useWorkspace();
   const workspaceId = workspaceStore.getWorkspaceBySlug(workspaceSlug?.toString())?.id as string;
   const { config } = useInstance();
+  const { getProjectsWithPermissions } = useUser();
+
   const { getProjectById } = useProject();
   const { areEstimateEnabledByProjectId } = useProjectEstimates();
 
@@ -341,20 +343,23 @@ export const IssueFormRoot: FC<IssueFormProps> = observer((props) => {
                 rules={{
                   required: true,
                 }}
-                render={({ field: { value, onChange } }) => (
-                  <div className="h-7">
-                    <ProjectDropdown
-                      value={value}
-                      onChange={(projectId) => {
-                        onChange(projectId);
-                        handleFormChange();
-                      }}
-                      buttonVariant="border-with-text"
-                      renderCondition={(project) => shouldRenderProject(project)}
-                      tabIndex={getTabIndex("project_id")}
-                    />
-                  </div>
-                )}
+                render={({ field: { value, onChange } }) =>
+                  getProjectsWithPermissions &&
+                  getProjectsWithPermissions[value!] && (
+                    <div className="h-7">
+                      <ProjectDropdown
+                        value={value}
+                        onChange={(projectId) => {
+                          onChange(projectId);
+                          handleFormChange();
+                        }}
+                        buttonVariant="border-with-text"
+                        renderCondition={(project) => shouldRenderProject(project)}
+                        tabIndex={getTabIndex("project_id")}
+                      />
+                    </div>
+                  )
+                }
               />
             )}
             <h3 className="text-xl font-medium text-custom-text-200">{data?.id ? "Update" : "Create"} Issue</h3>

--- a/web/core/store/user/index.ts
+++ b/web/core/store/user/index.ts
@@ -44,6 +44,7 @@ export interface IUserStore {
   // computed
   canPerformProjectCreateActions: boolean;
   canPerformWorkspaceCreateActions: boolean;
+  getProjectsWithPermissions: { [projectId: string]: number } | null;
 }
 
 export class UserStore implements IUserStore {
@@ -91,6 +92,7 @@ export class UserStore implements IUserStore {
       // computed
       canPerformProjectCreateActions: computed,
       canPerformWorkspaceCreateActions: computed,
+      getProjectsWithPermissions: computed,
     });
   }
 
@@ -228,6 +230,26 @@ export class UserStore implements IUserStore {
     await this.authService.signOut(API_BASE_URL);
     this.store.resetOnSignOut();
   };
+
+  /**
+   * @description returns projects where user has permissions
+   * @returns {{[projectId: string]: number} || null}
+   */
+  get getProjectsWithPermissions() {
+    const allWorkspaceRoles =
+      this.membership.workspaceProjectsRole &&
+      this.membership.workspaceProjectsRole[this.membership.router.workspaceSlug || ""];
+    return (
+      (allWorkspaceRoles &&
+        Object.keys(allWorkspaceRoles)
+          .filter((key) => allWorkspaceRoles[key] >= EUserProjectRoles.MEMBER)
+          .reduce(
+            (res: { [projectId: string]: number }, key: string) => ((res[key] = allWorkspaceRoles[key]), res),
+            {}
+          )) ||
+      null
+    );
+  }
 
   /**
    * @description tells if user has project create actions permissions

--- a/web/core/store/user/user-membership.store.ts
+++ b/web/core/store/user/user-membership.store.ts
@@ -11,6 +11,7 @@ import { ProjectMemberService } from "@/services/project";
 import { UserService } from "@/services/user.service";
 // plane web store
 import { CoreRootStore } from "../root.store";
+import { IRouterStore } from "../router.store";
 
 export interface IUserMembershipStore {
   // observables
@@ -47,6 +48,8 @@ export interface IUserMembershipStore {
   leaveWorkspace: (workspaceSlug: string) => Promise<void>;
   joinProject: (workspaceSlug: string, projectIds: string[]) => Promise<any>;
   leaveProject: (workspaceSlug: string, projectId: string) => Promise<void>;
+
+  router: IRouterStore;
 }
 
 export class UserMembershipStore implements IUserMembershipStore {


### PR DESCRIPTION
Description

The functionality of the create issue modal (accessed by the keyboard shortcut "C") is inconsistent for users with varying permission levels within a workspace and its projects.

Scenarios:





Guest/Viewer (Workspace & Project):





Expected Behavior: User cannot access the create issue modal (due to limited permissions).



Actual Behavior: User cannot access the modal (correct behavior).



Guest/Viewer (Workspace) & Member (Project):





Expected Behavior:





User can access the create issue modal (because they are a member in a project).



Project selection dropdown displays only the project where the user is a member.



Actual Behavior:





User cannot access the modal (correct).


[[WEB-1956]
](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/12ef14b0-2802-49b0-b29b-08af60e2b848)