### PR TITLE
[WEB-1799] fix: page breadcrumb tooltip persistence

### DIFF
--- a/web/app/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/pages/(detail)/header.tsx
+++ b/web/app/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/pages/(detail)/header.tsx
@@ -7,7 +7,7 @@ import { FileText } from "lucide-react";
 // types
 import { TLogoProps } from "@plane/types";
 // ui
-import { Breadcrumbs, Button, EmojiIconPicker, EmojiIconPickerTypes, TOAST_TYPE, setToast } from "@plane/ui";
+import { Breadcrumbs, Button, EmojiIconPicker, EmojiIconPickerTypes, TOAST_TYPE, Tooltip, setToast } from "@plane/ui";
 // components
 import { BreadcrumbLink, Logo } from "@/components/common";
 // helpers
@@ -31,7 +31,7 @@ export const PageDetailsHeader = observer(() => {
   const { currentProjectDetails, loader } = useProject();
   const { isContentEditable, isSubmitting, name, logo_props, updatePageLogo } = usePage(pageId?.toString() ?? "");
   // use platform
-  const { platform } = usePlatformOS();
+  const { isMobile, platform } = usePlatformOS();
   // derived values
   const isMac = platform === "MacOS";
 
@@ -100,49 +100,57 @@ export const PageDetailsHeader = observer(() => {
             <Breadcrumbs.BreadcrumbItem
               type="text"
               link={
-                <BreadcrumbLink
-                  label={name ?? "Page"}
-                  icon={
-                    <EmojiIconPicker
-                      isOpen={isOpen}
-                      handleToggle={(val: boolean) => setIsOpen(val)}
-                      className="flex items-center justify-center"
-                      buttonClassName="flex items-center justify-center"
-                      label={
-                        <>
-                          {logo_props?.in_use ? (
-                            <Logo logo={logo_props} size={16} type="lucide" />
-                          ) : (
-                            <FileText className="h-4 w-4 text-custom-text-300" />
-                          )}
-                        </>
-                      }
-                      onChange={(val) => {
-                        let logoValue = {};
+                <li className="flex items-center space-x-2" tabIndex={-1}>
+                  <div className="flex flex-wrap items-center gap-2.5">
+                    <div className="flex cursor-default items-center gap-1 text-sm font-medium text-custom-text-100">
+                      <div className="flex h-5 w-5 items-center justify-center overflow-hidden">
+                        <EmojiIconPicker
+                          isOpen={isOpen}
+                          handleToggle={(val: boolean) => setIsOpen(val)}
+                          className="flex items-center justify-center"
+                          buttonClassName="flex items-center justify-center"
+                          label={
+                            <>
+                              {logo_props?.in_use ? (
+                                <Logo logo={logo_props} size={16} type="lucide" />
+                              ) : (
+                                <FileText className="h-4 w-4 text-custom-text-300" />
+                              )}
+                            </>
+                          }
+                          onChange={(val) => {
+                            let logoValue = {};
 
-                        if (val?.type === "emoji")
-                          logoValue = {
-                            value: convertHexEmojiToDecimal(val.value.unified),
-                            url: val.value.imageUrl,
-                          };
-                        else if (val?.type === "icon") logoValue = val.value;
+                            if (val?.type === "emoji")
+                              logoValue = {
+                                value: convertHexEmojiToDecimal(val.value.unified),
+                                url: val.value.imageUrl,
+                              };
+                            else if (val?.type === "icon") logoValue = val.value;
 
-                        handlePageLogoUpdate({
-                          in_use: val?.type,
-                          [val?.type]: logoValue,
-                        }).finally(() => setIsOpen(false));
-                      }}
-                      defaultIconColor={
-                        logo_props?.in_use && logo_props.in_use === "icon" ? logo_props?.icon?.color : undefined
-                      }
-                      defaultOpen={
-                        logo_props?.in_use && logo_props?.in_use === "emoji"
-                          ? EmojiIconPickerTypes.EMOJI
-                          : EmojiIconPickerTypes.ICON
-                      }
-                    />
-                  }
-                />
+                            handlePageLogoUpdate({
+                              in_use: val?.type,
+                              [val?.type]: logoValue,
+                            }).finally(() => setIsOpen(false));
+                          }}
+                          defaultIconColor={
+                            logo_props?.in_use && logo_props.in_use === "icon" ? logo_props?.icon?.color : undefined
+                          }
+                          defaultOpen={
+                            logo_props?.in_use && logo_props?.in_use === "emoji"
+                              ? EmojiIconPickerTypes.EMOJI
+                              : EmojiIconPickerTypes.ICON
+                          }
+                        />
+                      </div>
+                      <Tooltip tooltipContent={name ?? "Page"} position="bottom" isMobile={isMobile}>
+                        <div className="relative line-clamp-1 block max-w-[150px] overflow-hidden truncate">
+                          {name ?? "Page"}
+                        </div>
+                      </Tooltip>
+                    </div>
+                  </div>
+                </li>
               }
             />
           </Breadcrumbs>


### PR DESCRIPTION
#### Problem:

When trying to change the icon of a Page from the breadcrumb, the page title tooltip persists even when not hovering over the title.

#### Solution:

Removed the tooltip as a wrapper to the breadcrumb item and added it only to the page title.

#### Media:

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/757f65f3-dbdd-4c2e-a9f3-919cf706192d"></video> | <video src="https://github.com/user-attachments/assets/554e75d0-2d01-4438-95aa-4404930d43a8"></video> | 

#### Plane issue: [WEB-1799](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/64ceb871-bb0a-4196-985b-116298079477)