### PR TITLE
[WEB-1951] fix: spreadsheet layout issue quick action event propagation

### DIFF
--- a/web/core/components/issues/issue-layouts/spreadsheet/issue-row.tsx
+++ b/web/core/components/issues/issue-layouts/spreadsheet/issue-row.tsx
@@ -30,9 +30,7 @@ interface Props {
   isEstimateEnabled: boolean;
   quickActions: TRenderQuickActions;
   canEditProperties: (projectId: string | undefined) => boolean;
-  updateIssue:
-    | ((projectId: string | null, issueId: string, data: Partial<TIssue>) => Promise<void>)
-    | undefined;
+  updateIssue: ((projectId: string | null, issueId: string, data: Partial<TIssue>) => Promise<void>) | undefined;
   portalElement: React.MutableRefObject<HTMLDivElement | null>;
   nestingLevel: number;
   issueId: string;
@@ -133,9 +131,7 @@ interface IssueRowDetailsProps {
   isEstimateEnabled: boolean;
   quickActions: TRenderQuickActions;
   canEditProperties: (projectId: string | undefined) => boolean;
-  updateIssue:
-    | ((projectId: string | null, issueId: string, data: Partial<TIssue>) => Promise<void>)
-    | undefined;
+  updateIssue: ((projectId: string | null, issueId: string, data: Partial<TIssue>) => Promise<void>) | undefined;
   portalElement: React.MutableRefObject<HTMLDivElement | null>;
   nestingLevel: number;
   issueId: string;
@@ -328,7 +324,10 @@ const IssueRowDetails = observer((props: IssueRowDetailsProps) => {
                 </Tooltip>
               </div>
             </div>
-            <div className={`hidden group-hover:block ${isMenuActive ? "!block" : ""}`}>
+            <div
+              className={`hidden group-hover:block ${isMenuActive ? "!block" : ""}`}
+              onClick={(e) => e.stopPropagation()}
+            >
               {quickActions({
                 issue: issueDetail,
                 parentRef: cellRef,


### PR DESCRIPTION
#### Changes:
This PR includes following changes:
- Resolved spreadsheet layout issue quick action event propagation. Previously, clicking outside the delete issue modal triggered the issue peek view.

#### Issue link: [[WEB-1951]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/3c8910d9-0756-4c35-9782-9508dd373b65)

#### Media:
| Before | After |
|--------|--------|
| ![WEB-1951 BEFORE](https://github.com/user-attachments/assets/20102c4c-12db-4727-a347-940b814c0194) | ![WEB-1951 AFTER](https://github.com/user-attachments/assets/0c30554e-7abd-4c2c-b862-b16c6985cb83) |