### PR TITLE
[WEB-1948] fix: priority icons

### DIFF
--- a/web/core/components/analytics/custom-analytics/table.tsx
+++ b/web/core/components/analytics/custom-analytics/table.tsx
@@ -62,7 +62,7 @@ export const AnalyticsTable: React.FC<Props> = ({ analytics, barGraphData, param
           <tr key={`table-row-${index}`} className="divide-x divide-custom-border-200 text-xs text-custom-text-200">
             <td className="px-2.5 py-2">
               <div className="relative flex items-center gap-2 w-full overflow-hidden">
-                <div className="flex-shrink-0 h-3 w-3 rounded overflow-hidden">
+                <div className="flex-shrink-0 rounded overflow-hidden">
                   {params.x_axis === "priority" ? (
                     <PriorityIcon priority={(item.name as string).toLowerCase() as TIssuePriorities} />
                   ) : (

--- a/web/core/components/analytics/custom-analytics/table.tsx
+++ b/web/core/components/analytics/custom-analytics/table.tsx
@@ -62,9 +62,9 @@ export const AnalyticsTable: React.FC<Props> = ({ analytics, barGraphData, param
           <tr key={`table-row-${index}`} className="divide-x divide-custom-border-200 text-xs text-custom-text-200">
             <td className="px-2.5 py-2">
               <div className="relative flex items-center gap-2 w-full overflow-hidden">
-                <div className="flex-shrink-0 rounded overflow-hidden">
+                <div className="flex-shrink-0 h-3 w-3 rounded overflow-hidden">
                   {params.x_axis === "priority" ? (
-                    <PriorityIcon priority={(item.name as string).toLowerCase() as TIssuePriorities} />
+                    <PriorityIcon size={12} priority={(item.name as string).toLowerCase() as TIssuePriorities} />
                   ) : (
                     <div
                       className="w-full h-full"


### PR DESCRIPTION
Summary
Broken priority icons displayed under custom analytics

[[WEB-1948]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/5e6c7023-6641-4d90-a7e9-2b4b47ee94be)