### PR TITLE
[WEB-647] fix: showing first issue as default inbox state

### DIFF
--- a/web/core/components/inbox/sidebar/root.tsx
+++ b/web/core/components/inbox/sidebar/root.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { FC, useCallback, useRef, useState } from "react";
+import { FC, useCallback, useEffect, useRef, useState } from "react";
 import { observer } from "mobx-react";
+import { useParams } from "next/navigation";
 import { TInboxIssueCurrentTab } from "@plane/types";
 import { Loader } from "@plane/ui";
 // components
@@ -53,6 +54,7 @@ export const InboxSidebar: FC<IInboxSidebarProps> = observer((props) => {
   } = useProjectInbox();
 
   const router = useAppRouter();
+  const { inboxIssueId } = useParams();
 
   const fetchNextPages = useCallback(() => {
     if (!workspaceSlug || !projectId) return;
@@ -61,6 +63,13 @@ export const InboxSidebar: FC<IInboxSidebarProps> = observer((props) => {
 
   // page observer
   useIntersectionObserver(containerRef, elementRef, fetchNextPages, "20%");
+
+  useEffect(() => {
+    if (inboxIssueId) return;
+    router.push(
+      `/${workspaceSlug}/projects/${projectId}/inbox?currentTab=${currentTab}&inboxIssueId=${filteredInboxIssueIds[0]}`
+    );
+  }, [filteredInboxIssueIds, currentTab, workspaceSlug, projectId, router, inboxIssueId]);
 
   return (
     <div className="bg-custom-background-100 flex-shrink-0 w-full h-full border-r border-custom-border-300 ">


### PR DESCRIPTION
Summary
Inbox - first issue is not displayed on the right panel


[[WEB-647]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/a3391ce0-c811-45c0-9d50-91908eb7187e)