### PR TITLE
[WEB-1910] fix: disable selection if no issues are present

### DIFF
--- a/web/core/components/issues/issue-layouts/list/headers/group-by-card.tsx
+++ b/web/core/components/issues/issue-layouts/list/headers/group-by-card.tsx
@@ -98,6 +98,7 @@ export const HeaderGroupByCard = observer((props: IHeaderGroupByCard) => {
               )}
               groupID={groupID}
               selectionHelpers={selectionHelpers}
+              disabled={count === 0}
             />
           </div>
         )}


### PR DESCRIPTION
#### Problem:

Users are able to select groups with no issues in them, resulting in some unwanted errors.

#### Solution:

Disabled group selection if no issues are present.

#### Media:

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/4dfd0a52-a57c-485b-aa81-c9ac15e64eb5"></video> | <video src="https://github.com/user-attachments/assets/2116ee83-f754-463e-9e25-d81e231f7e76"></video> | 

#### Plane issue: [WEB-1910](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/59a90d34-044f-41c8-891c-83d4c3d26e2e)