### PR TITLE
[WEB-1920] fix: project intake disabled validation

### DIFF
--- a/web/core/components/workspace/sidebar/projects-list-item.tsx
+++ b/web/core/components/workspace/sidebar/projects-list-item.tsx
@@ -470,7 +470,7 @@ export const SidebarProjectsListItem: React.FC<Props> = observer((props) => {
                     (item.name === "Modules" && !project.module_view) ||
                     (item.name === "Views" && !project.issue_views_view) ||
                     (item.name === "Pages" && !project.page_view) ||
-                    (item.name === "Inbox" && !project.inbox_view)
+                    (item.name === "Intake" && !project.inbox_view)
                   )
                     return;
 


### PR DESCRIPTION
#### Changes:
This PR includes following changes:
- Fixed the app sidebar project intake feature toggle. Previously, the intake feature was still visible in the app sidebar even when it was toggled off.

#### Issue link: [[WEB-1920]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/cc64b6d3-2f87-42d1-b6e3-5af1d7026e95)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Renamed the sidebar item from "Inbox" to "Intake" for better alignment with project views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->