### PR TITLE
[WEB - 1998] fix: profile creation on user signup

### DIFF
--- a/apiserver/plane/authentication/utils/redirection_path.py
+++ b/apiserver/plane/authentication/utils/redirection_path.py
@@ -3,7 +3,7 @@ from plane.db.models import Profile, Workspace, WorkspaceMemberInvite
 
 def get_redirection_path(user):
     # Handle redirections
-    profile = Profile.objects.get_or_create(user=user)
+    profile, _ = Profile.objects.get_or_create(user=user)
 
     # Redirect to onboarding if the user is not onboarded yet
     if not profile.is_onboarded:

--- a/apiserver/plane/authentication/utils/redirection_path.py
+++ b/apiserver/plane/authentication/utils/redirection_path.py
@@ -3,7 +3,7 @@ from plane.db.models import Profile, Workspace, WorkspaceMemberInvite
 
 def get_redirection_path(user):
     # Handle redirections
-    profile = Profile.objects.get(user=user)
+    profile = Profile.objects.get_or_create(user=user)
 
     # Redirect to onboarding if the user is not onboarded yet
     if not profile.is_onboarded:

--- a/apiserver/plane/authentication/views/app/magic.py
+++ b/apiserver/plane/authentication/views/app/magic.py
@@ -120,7 +120,7 @@ class MagicSignInEndpoint(View):
                 callback=post_user_auth_workflow,
             )
             user = provider.authenticate()
-            profile = Profile.objects.get_or_create(user=user)
+            profile, _ = Profile.objects.get_or_create(user=user)
             # Login the user and record his device info
             user_login(request=request, user=user, is_app=True)
             if user.is_password_autoset and profile.is_onboarded:

--- a/apiserver/plane/authentication/views/app/magic.py
+++ b/apiserver/plane/authentication/views/app/magic.py
@@ -120,7 +120,7 @@ class MagicSignInEndpoint(View):
                 callback=post_user_auth_workflow,
             )
             user = provider.authenticate()
-            profile = Profile.objects.get(user=user)
+            profile = Profile.objects.get_or_create(user=user)
             # Login the user and record his device info
             user_login(request=request, user=user, is_app=True)
             if user.is_password_autoset and profile.is_onboarded:


### PR DESCRIPTION
### Summary
This PR changes the plane `get` method of django with the `get_or_create` method which creates the object if it does not exists with the default values provided in the model.

```python
profile, _ = Profile.objects.get_or_create(user=user)
```

This will remove potential cases where the user is created but the profile isn't causing an error when the user tries logging in next time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced user authentication process by ensuring that a user profile is always available, either by retrieving or creating it as needed.
	- Improved the control flow to handle user logins more gracefully without errors related to missing profiles.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->