### PR TITLE
[WEB-1995] fix: searched page redirection from command palette.

### DIFF
--- a/web/core/components/command-palette/actions/search-results.tsx
+++ b/web/core/components/command-palette/actions/search-results.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Command } from "cmdk";
+import { useParams } from "next/navigation";
 // types
 import { IWorkspaceSearchResults } from "@plane/types";
 // helpers
@@ -15,8 +16,11 @@ type Props = {
 
 export const CommandPaletteSearchResults: React.FC<Props> = (props) => {
   const { closePalette, results } = props;
-
+  // router
   const router = useAppRouter();
+  const { projectId: routerProjectId } = useParams();
+  // derived values
+  const projectId = routerProjectId?.toString();
 
   return (
     <>
@@ -32,7 +36,7 @@ export const CommandPaletteSearchResults: React.FC<Props> = (props) => {
                   key={item.id}
                   onSelect={() => {
                     closePalette();
-                    router.push(currentSection.path(item));
+                    router.push(currentSection.path(item, projectId));
                   }}
                   value={`${key}-${item?.id}-${item.name}-${item.project__identifier ?? ""}-${item.sequence_id ?? ""}`}
                   className="focus:outline-none"

--- a/web/core/components/command-palette/helpers.tsx
+++ b/web/core/components/command-palette/helpers.tsx
@@ -73,8 +73,8 @@ export const commandGroups: {
         <span className="text-xs text-custom-text-300">{page.project__identifiers?.[0]}</span> {page.name}
       </h6>
     ),
-    path: (page: IWorkspaceDefaultSearchResult) =>
-      `/${page?.workspace__slug}/projects/${page?.project_id}/pages/${page?.id}`,
+    path: (page: IWorkspacePageSearchResult) =>
+      `/${page?.workspace__slug}/projects/${page?.project_ids?.[0]}/pages/${page?.id}`,
     title: "Pages",
   },
   project: {

--- a/web/core/components/command-palette/helpers.tsx
+++ b/web/core/components/command-palette/helpers.tsx
@@ -15,7 +15,7 @@ export const commandGroups: {
   [key: string]: {
     icon: JSX.Element;
     itemName: (item: any) => React.ReactNode;
-    path: (item: any) => string;
+    path: (item: any, projectId: string | undefined) => string;
     title: string;
   };
 } = {
@@ -73,8 +73,11 @@ export const commandGroups: {
         <span className="text-xs text-custom-text-300">{page.project__identifiers?.[0]}</span> {page.name}
       </h6>
     ),
-    path: (page: IWorkspacePageSearchResult) =>
-      `/${page?.workspace__slug}/projects/${page?.project_ids?.[0]}/pages/${page?.id}`,
+    path: (page: IWorkspacePageSearchResult, projectId: string | undefined) => {
+      let redirectProjectId = page?.project_ids?.[0];
+      if (!!projectId && page?.project_ids?.includes(projectId)) redirectProjectId = projectId;
+      return `/${page?.workspace__slug}/projects/${redirectProjectId}/pages/${page?.id}`;
+    },
     title: "Pages",
   },
   project: {


### PR DESCRIPTION
### Problem
When attempting to visit a page from the command palette search results, an error displays: "Project doesn't exist."

### Solution
This issue arose because the API response for page search results recently changed to return an array of project IDs instead of a single ID. However, the redirection logic has not been updated to handle this new format.

### Media
* Before

  https://github.com/user-attachments/assets/0f65a21b-49a8-4a25-91cb-c2da9e2b8211

* After

  https://github.com/user-attachments/assets/d8dea416-f290-43f9-9de3-4157c27e7e66

### Issue link: [WEB-1995](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/0c64a205-fbf6-4425-aa2c-119a858692bf)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced the command palette to support multiple project IDs associated with workspace pages, improving flexibility in handling project data.
	- Improved routing capabilities in the Command Palette Search Results component, enabling context-sensitive navigation based on selected project IDs.

- **Bug Fixes**
	- Corrected the structure of the path function to accommodate updates in workspace page data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->