### PR TITLE
[WEB-1997] chore: changed the table name of workspace user property model

### DIFF
--- a/apiserver/plane/db/migrations/0052_auto_20231220_1141.py
+++ b/apiserver/plane/db/migrations/0052_auto_20231220_1141.py
@@ -161,7 +161,7 @@ class Migration(migrations.Migration):
             options={
                 "verbose_name": "Workspace User Property",
                 "verbose_name_plural": "Workspace User Property",
-                "db_table": "Workspace_user_properties",
+                "db_table": "workspace_user_properties",
                 "ordering": ("-created_at",),
                 "unique_together": {("workspace", "user")},
             },


### PR DESCRIPTION
chore:

- changed the table name of workspace user property model

Issue Link: [WEB-1997](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/db1a2abe-300b-4496-9660-e502d95f0a90/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the database table name for Workspace User Properties to follow a lowercase naming convention, enhancing consistency and avoiding potential case sensitivity issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->