### PR TITLE
[WEB-2004] fix: empty issue title indicator

### DIFF
--- a/web/core/components/issues/title-input.tsx
+++ b/web/core/components/issues/title-input.tsx
@@ -110,7 +110,7 @@ export const IssueTitleInput: FC<IssueTitleInputProps> = observer((props) => {
           className={cn(
             "block w-full resize-none overflow-hidden rounded border-none bg-transparent px-3 py-0 text-2xl font-medium outline-none ring-0",
             {
-              "ring-1 ring-red-400 mx-3": title.length && title.length === 0,
+              "ring-1 ring-red-400 mx-2.5": title?.length === 0,
             },
             className
           )}
@@ -134,7 +134,7 @@ export const IssueTitleInput: FC<IssueTitleInputProps> = observer((props) => {
           /255
         </div>
       </div>
-      {title.length && title.length === 0 && <span className="text-sm text-red-500">Title is required</span>}
+      {title?.length === 0 && <span className="text-sm text-red-500">Title is required</span>}
     </div>
   );
 });


### PR DESCRIPTION
### Problem Statement:
When removing the title from an issue, the error indicator is not working.

### Solution:
I made the necessary adjustments to fix the error indicator and also adjusted the margin.

### Issue link: [[WEB-2004]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/d4118f06-fe72-47b2-b32d-c3e1f0b21516)

### Media:
| Before | After |
|--------|--------|
| ![WEB-2004 Before](https://github.com/user-attachments/assets/968b928a-a98e-43c6-840c-da0e7ac3b8c2) | ![WEB-2004 After](https://github.com/user-attachments/assets/e4acbf91-8418-47c7-92c0-18bb2158be9c) |





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved error handling for the title input field, preventing runtime errors if the title is undefined.

- **Style**
	- Adjusted input field margin for empty titles, resulting in a more compact appearance.

- **Bug Fixes**
	- Simplified error message rendering for missing titles, enhancing clarity and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->