### PR TITLE
[WEB-1968] fix: leave project mutation

### DIFF
--- a/web/core/store/user/user-membership.store.ts
+++ b/web/core/store/user/user-membership.store.ts
@@ -249,14 +249,10 @@ export class UserMembershipStore implements IUserMembershipStore {
    */
   leaveProject = async (workspaceSlug: string, projectId: string) =>
     await this.userService.leaveProject(workspaceSlug, projectId).then(() => {
-      const newPermissions: { [projectId: string]: boolean } = {};
-      newPermissions[projectId] = false;
-      runInAction(() => {
-        this.hasPermissionToProject = {
-          ...this.hasPermissionToProject,
-          ...newPermissions,
-        };
-      });
+      // remove the user membership for a project
+      set(this.hasPermissionToProject, [projectId], false);
+      // update the project member list with the new permissions
+      set(this.store.projectRoot.project.projectMap, [projectId, "is_member"], false);
     });
 
   /**


### PR DESCRIPTION
### Problem:
When a user leaves a project from the app sidebar, the change doesn't reflect immediately; a hard reload is required.

### Solution:
There was an issue with the store handle logic. I have made the necessary changes to ensure it works correctly.

### Issue link: [[WEB-1968]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/26279c68-c7e7-4783-8a4a-b824c2d3d006)

### Media:
| Before | After |
|--------|--------|
| ![WEB-1968 (2)](https://github.com/user-attachments/assets/7e8f9ea2-6222-460b-9ca8-922b2d879cf9) | ![WEB-1968 (1)](https://github.com/user-attachments/assets/45d33bcd-18a9-4b4c-b115-321c63449e4a) |



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Streamlined the process for users to leave a project, enhancing efficiency and clarity in permission updates. 

- **Bug Fixes**
	- Improved the reliability of updating user membership status in project listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->