### PR TITLE
[WEB-1550] fix: editor focus after mentioning a user

### DIFF
--- a/packages/editor/src/core/extensions/mentions/mentions-list.tsx
+++ b/packages/editor/src/core/extensions/mentions/mentions-list.tsx
@@ -146,10 +146,11 @@ export const MentionList = forwardRef((props: MentionListProps, ref) => {
         <div className="text-center text-custom-text-400">Loading...</div>
       ) : items.length ? (
         items.map((item, index) => (
-          <div
+          <button
             key={item.id}
+            type="button"
             className={cn(
-              "flex cursor-pointer items-center gap-2 rounded px-1 py-1.5 hover:bg-custom-background-80 text-custom-text-200",
+              "w-full text-left flex cursor-pointer items-center gap-2 rounded px-1 py-1.5 hover:bg-custom-background-80 text-custom-text-200",
               {
                 "bg-custom-background-80": index === selectedIndex,
               }
@@ -158,7 +159,7 @@ export const MentionList = forwardRef((props: MentionListProps, ref) => {
           >
             <Avatar name={item?.title} src={item?.avatar} />
             <span className="flex-grow truncate">{item.title}</span>
-          </div>
+          </button>
         ))
       ) : (
         <div className="text-center text-custom-text-400">No results</div>


### PR DESCRIPTION
#### Problem:

When mentioning a user by clicking on their name from the mentions' list, the focus shifts to the next line.

#### Solution:

Replaced the mention item HTML element from `div` to `button` to handle click events in a better way.

#### Media:

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/1ac50b22-7aaf-435e-985b-e177179880c6"></video> | <video src="https://github.com/user-attachments/assets/3ef2f8a1-9b1d-4bc7-a200-73b62f3d64dd"></video> | 

#### Plane issue: [WEB-1550](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/19e8db25-7b06-402b-85d6-792495140383)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the interactivity of the mention list items by changing them from `<div>` elements to `<button>` elements.
	- Improved accessibility and functionality of the mention list component.
- **Style**
	- Adjusted class names for proper styling and layout, ensuring visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->