### PR TITLE
[WEB-1972] fix: persist cycle and module Issue properties on page reload in Inbox

### DIFF
--- a/web/app/[workspaceSlug]/(projects)/notifications/page.tsx
+++ b/web/app/[workspaceSlug]/(projects)/notifications/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect } from "react";
 import { observer } from "mobx-react";
+import { useParams } from "next/navigation";
 import useSWR from "swr";
 // components
 import { LogoSpinner } from "@/components/common";
@@ -14,8 +15,10 @@ import { EmptyStateType } from "@/constants/empty-state";
 import { ENotificationLoader, ENotificationQueryParamType } from "@/constants/notification";
 // hooks
 import { useIssueDetail, useUser, useWorkspace, useWorkspaceNotifications } from "@/hooks/store";
+import { useWorkspaceIssueProperties } from "@/hooks/use-workspace-issue-properties";
 
 const WorkspaceDashboardPage = observer(() => {
+  const { workspaceSlug } = useParams();
   // hooks
   const { currentWorkspace } = useWorkspace();
   const {
@@ -33,6 +36,9 @@ const WorkspaceDashboardPage = observer(() => {
   const pageTitle = currentWorkspace?.name ? `${currentWorkspace?.name} - Notifications` : undefined;
   const { workspace_slug, project_id, issue_id, is_inbox_issue } =
     notificationLiteByNotificationId(currentSelectedNotificationId);
+
+  // fetching workspace issue properties
+  useWorkspaceIssueProperties(workspaceSlug);
 
   // fetch workspace notifications
   const notificationMutation =


### PR DESCRIPTION
### Problem Statement:
In the inbox, when we preview an issue, the modules and cycles are not rendering in the issue details upon reloading the page.

### Solution:
We are retrieving workspace-level issue properties during the page load, which will resolve all persistent issues in the issue preview.

### Changes:
1. Inbox page

### Plane Issue:
[[WEB-1972]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/a53a8fcf-42b6-491a-8876-100a41d3ecac)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the Workspace Dashboard to dynamically handle different workspaces using the URL context.
	- Integrated workspace-specific issue properties for improved data responsiveness.
  
- **Improvements**
	- Improved control flow for fetching workspace issue properties, ensuring timely updates based on user navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->