### PR TITLE
[WEB-2021] fix: mutating the inbox count on the sidebar and inbox tab when we click mark all as read

### DIFF
--- a/web/core/store/notifications/workspace-notifications.store.ts
+++ b/web/core/store/notifications/workspace-notifications.store.ts
@@ -373,6 +373,13 @@ export class WorkspaceNotificationStore implements IWorkspaceNotificationStore {
       };
       await workspaceNotificationService.markAllNotificationsAsRead(workspaceSlug, params);
       runInAction(() => {
+        update(
+          this.unreadNotificationsCount,
+          this.currentNotificationTab === ENotificationTab.ALL
+            ? "total_unread_notifications_count"
+            : "mention_unread_notifications_count",
+          () => 0
+        );
         Object.values(this.notifications).forEach((notification) =>
           notification.mutateNotification({
             read_at: new Date().toUTCString(),


### PR DESCRIPTION
### Problem Statement:
In the inbox, when we click the option `mark all as read` the notification count is not mutating in the workspace app sidebar badge and inbox tab badge

### Solution:
When we click `mark all as read` in the inbox we are mutating the store `unread notification count` observer

### Changes:
1. workspace notification store

### Plane Issue:
[[WEB-2021]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/50539af8-a720-4604-9f50-14f80a4166ee)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced notification management to accurately reflect unread counts when marking notifications as read, improving user experience.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->