### PR TITLE
[WEB-1886] fix: mutating the total issues count in the archived issues header when we restore or remove issues from archives

### DIFF
--- a/web/app/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/archives/header.tsx
+++ b/web/app/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/archives/header.tsx
@@ -26,17 +26,13 @@ export const ProjectArchivesHeader: FC<TProps> = observer((props: TProps) => {
   const { workspaceSlug, projectId } = useParams();
   // store hooks
   const {
-    issuesFilter: { issueFilters },
+    issues: { getGroupIssueCount },
   } = useIssues(EIssuesStoreType.ARCHIVED);
   const { currentProjectDetails, loader } = useProject();
   // hooks
   const { isMobile } = usePlatformOS();
 
-  const issueCount = currentProjectDetails
-    ? !issueFilters?.displayFilters?.sub_issue && currentProjectDetails.archived_sub_issues
-      ? currentProjectDetails.archived_issues - currentProjectDetails.archived_sub_issues
-      : currentProjectDetails.archived_issues
-    : undefined;
+  const issueCount = getGroupIssueCount(undefined, undefined, false);
 
   const activeTabBreadcrumbDetail =
     PROJECT_ARCHIVES_BREADCRUMB_LIST[activeTab as keyof typeof PROJECT_ARCHIVES_BREADCRUMB_LIST];


### PR DESCRIPTION
### Problem Statement:
In the Archived issues, when we restore the issue the total issues count is not mutating in the archived issue header

### Solution:
When we restore the issues, we update the total issues count in the archived issues header.

### Changes:
1. Archived issue header

### Plane Issue:
[[WEB-1886]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/dfd3186b-f0db-4bf0-a5ea-60f313491756)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Enhanced the logic for counting issues in the Project Archives, leading to more consistent and streamlined behavior.
  - Simplified control flow in the Project Archives header, improving readability and maintainability for future modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->