### PR TITLE
[WEB-1833] fix: editor bold text color

### DIFF
--- a/packages/tailwind-config-custom/tailwind.config.js
+++ b/packages/tailwind-config-custom/tailwind.config.js
@@ -270,7 +270,7 @@ module.exports = {
             "--tw-prose-headings": convertToRGB("--color-text-100"),
             "--tw-prose-lead": convertToRGB("--color-text-100"),
             "--tw-prose-links": convertToRGB("--color-primary-100"),
-            "--tw-prose-bold": convertToRGB("--color-text-100"),
+            "--tw-prose-bold": "inherit",
             "--tw-prose-counters": convertToRGB("--color-text-100"),
             "--tw-prose-bullets": convertToRGB("--color-text-100"),
             "--tw-prose-hr": convertToRGB("--color-text-100"),


### PR DESCRIPTION
#### Problem:

When making a table content bold when background color is applied to the row/column, the text color changes to invert mode making it impossible to read.

#### Solution:

Updated the bold text color from primary text to inherit the parent's text color.

#### Media:

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/da456b55-daaf-44af-bb83-7c466afeaa46"></video> | <video src="https://github.com/user-attachments/assets/7bf9cd6e-e6ca-438b-b52d-8e63925c0c29"></video> | 

#### Plane issue: [WEB-1833](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/802a830e-6741-4aaf-90f9-3998723e05ce)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced styling flexibility for bold text in prose elements by allowing it to inherit color from its parent, improving design consistency.
  
- **Bug Fixes**
	- Resolved styling inconsistency by updating the bold text color property in Tailwind CSS configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->