### PR TITLE
[WEB-1913] fix: handled error message for duplicate label

### DIFF
--- a/web/core/components/issues/issue-detail/label/root.tsx
+++ b/web/core/components/issues/issue-detail/label/root.tsx
@@ -64,7 +64,7 @@ export const IssueLabel: FC<TIssueLabel> = observer((props) => {
         } catch (error) {
           let errMessage = "Label creation failed";
           if (error && (error as any).error === "Label with the same name already exists in the project")
-            errMessage = "Label already exist";
+            errMessage = "Label already exists";
 
           setToast({
             title: "Error!",

--- a/web/core/components/issues/issue-detail/label/root.tsx
+++ b/web/core/components/issues/issue-detail/label/root.tsx
@@ -62,10 +62,14 @@ export const IssueLabel: FC<TIssueLabel> = observer((props) => {
             });
           return labelResponse;
         } catch (error) {
+          let errMessage = "Label creation failed";
+          if (error && (error as any).error === "Label with the same name already exists in the project")
+            errMessage = "Label already exist";
+
           setToast({
             title: "Error!",
             type: TOAST_TYPE.ERROR,
-            message: "Label creation failed",
+            message: errMessage,
           });
           throw error;
         }


### PR DESCRIPTION
**Summary**
On adding a duplicate label, the error message changed from 'Label creation failed' to 'Label already exist'

[[WEB-1913]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/168dc7d4-8e1f-426d-93f3-bc149106a5a3)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved error handling for label creation, providing clearer and more specific error messages to users.
  
- **Bug Fixes**
	- Enhanced the feedback provided when a label creation fails due to duplicate names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->