### PR TITLE
[WEB-1797] fix: headings 4, 5 and 6 all triggering heading 3

### DIFF
--- a/packages/editor/src/core/extensions/slash-commands.tsx
+++ b/packages/editor/src/core/extensions/slash-commands.tsx
@@ -32,6 +32,9 @@ import {
   toggleHeadingOne,
   toggleHeadingTwo,
   toggleHeadingThree,
+  toggleHeadingFour,
+  toggleHeadingFive,
+  toggleHeadingSix,
 } from "@/helpers/editor-commands";
 // types
 import { CommandProps, ISlashCommandItem, UploadImage } from "@/types";
@@ -139,7 +142,7 @@ const getSuggestionItems =
         searchTerms: ["subtitle", "small"],
         icon: <Heading4 className="size-3.5" />,
         command: ({ editor, range }: CommandProps) => {
-          toggleHeadingThree(editor, range);
+          toggleHeadingFour(editor, range);
         },
       },
       {
@@ -149,7 +152,7 @@ const getSuggestionItems =
         searchTerms: ["subtitle", "small"],
         icon: <Heading5 className="size-3.5" />,
         command: ({ editor, range }: CommandProps) => {
-          toggleHeadingThree(editor, range);
+          toggleHeadingFive(editor, range);
         },
       },
       {
@@ -159,7 +162,7 @@ const getSuggestionItems =
         searchTerms: ["subtitle", "small"],
         icon: <Heading6 className="size-3.5" />,
         command: ({ editor, range }: CommandProps) => {
-          toggleHeadingThree(editor, range);
+          toggleHeadingSix(editor, range);
         },
       },
       {


### PR DESCRIPTION
#### Problem:

In the slash command, headings 4, 5 and 6 all trigger heading 3.

#### Solution:

Updated the action of slash command heading items.