### PR TITLE
[WEB-1936] fix: flicker issue while viewing sub issues

### DIFF
--- a/web/core/components/issues/issue-layouts/list/block-root.tsx
+++ b/web/core/components/issues/issue-layouts/list/block-root.tsx
@@ -122,7 +122,7 @@ export const IssueBlockRoot: FC<Props> = observer((props) => {
       <DropIndicator classNames={"absolute top-0 z-[2]"} isVisible={instruction === "DRAG_OVER"} />
       <RenderIfVisible
         key={`${issueId}`}
-        defaultHeight="3rem"
+        defaultHeight="inherit"
         root={containerRef}
         classNames={`relative ${isLastChild && !isExpanded ? "" : "border-b border-b-custom-border-200"}`}
         verticalOffset={100}


### PR DESCRIPTION
**Summary**
While viewing the sub issues, there was an unintended flickering due to a specific height. Fixed it by inheriting the height from the parent

[[WEB-1936]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/254be45f-b022-4eb7-aeca-9d8487eab994)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced layout flexibility by allowing the height of components to adapt to their parent container's size.
  
- **Bug Fixes**
	- Improved responsiveness and adaptability of the `IssueBlockRoot` component for varying content sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->