### PR TITLE
[WEB-1955] fix: data types and css fixes

### DIFF
--- a/packages/types/src/issues/issue.d.ts
+++ b/packages/types/src/issues/issue.d.ts
@@ -1,7 +1,7 @@
-import { TIssuePriorities } from "../issues";
-import { TIssueAttachment } from "./issue_attachment";
-import { TIssueLink } from "./issue_link";
-import { TIssueReaction } from "./issue_reaction";
+import {TIssuePriorities} from "../issues";
+import {TIssueAttachment} from "./issue_attachment";
+import {TIssueLink} from "./issue_link";
+import {TIssueReaction} from "./issue_reaction";
 
 // new issue structure types
 
@@ -42,13 +42,10 @@ export type TBaseIssue = {
 export type TIssue = TBaseIssue & {
   description_html?: string;
   is_subscribed?: boolean;
-
-  parent?: partial<TIssue>;
-
+  parent?: Partial<TIssue>;
   issue_reactions?: TIssueReaction[];
   issue_attachment?: TIssueAttachment[];
   issue_link?: TIssueLink[];
-
   // tempId is used for optimistic updates. It is not a part of the API response.
   tempId?: string;
 };
@@ -94,6 +91,9 @@ export type TBulkIssueProperties = Pick<
   | "assignee_ids"
   | "start_date"
   | "target_date"
+  | "module_ids"
+  | "cycle_ids"
+  | "estimate_points"
 >;
 
 export type TBulkOperationsPayload = {

--- a/web/core/components/dropdowns/module/index.tsx
+++ b/web/core/components/dropdowns/module/index.tsx
@@ -36,7 +36,7 @@ type Props = TDropdownProps & {
     | {
         multiple: true;
         onChange: (val: string[]) => void;
-        value: string[];
+        value: string[] | null;
       }
   );
 
@@ -139,7 +139,9 @@ const ButtonContent: React.FC<ButtonContentProps> = (props) => {
     return (
       <>
         {!hideIcon && <DiceIcon className="h-3 w-3 flex-shrink-0" />}
-        {!hideText && <span className="flex-grow truncate text-left">{value ?? placeholder}</span>}
+        {!hideText && (
+          <span className="flex-grow truncate text-left">{value ? getModuleById(value)?.name : placeholder}</span>
+        )}
         {dropdownArrow && (
           <ChevronDown className={cn("h-2.5 w-2.5 flex-shrink-0", dropdownArrowClassName)} aria-hidden="true" />
         )}

--- a/web/core/components/ui/labels-list.tsx
+++ b/web/core/components/ui/labels-list.tsx
@@ -29,7 +29,8 @@ export const IssueLabelsList: FC<IssueLabelsListProps> = (props) => {
           >
             <div className="h-full flex items-center gap-1 rounded border-[0.5px] border-custom-border-300 px-2 py-1 text-xs text-custom-text-200">
               <span className="h-2 w-2 flex-shrink-0 rounded-full bg-custom-primary" />
-              {`${labels.length} Labels`}
+              <span>{labels.length}</span>
+              <span> Labels</span>
             </div>
           </Tooltip>
         </>


### PR DESCRIPTION
**Summary**

1. Additional properties added to the data types for bulk ops
3. Fixed some css

[[WEB-1955]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/922514a3-c798-4482-87c1-22656d2e33f7) 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `Props` type in the Dropdown component to accept `null` values, improving flexibility.
	- Added new properties to the bulk operations payload type for better data handling.

- **Improvements**
	- Refined display logic in the Dropdown component for better error handling and user experience.
	- Improved semantic structure of the label count display in the Issue Labels List component for better accessibility and styling.

- **Bug Fixes**
	- Corrected a typographical error in type definitions to ensure accurate type checking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->