### PR TITLE
[WEB-2029] fix: active cycle filter

### DIFF
--- a/web/core/components/cycles/active-cycle/productivity.tsx
+++ b/web/core/components/cycles/active-cycle/productivity.tsx
@@ -56,8 +56,8 @@ export const ActiveCycleProductivity: FC<ActiveCycleProductivityProps> = observe
   const completionChartDistributionData = chartDistributionData?.completion_chart || undefined;
 
   return cycle ? (
-    <div className="flex flex-col justify-center min-h-[17rem] gap-5 px-3.5 py-4 bg-custom-background-100 border border-custom-border-200 rounded-lg">
-      <div className="relative flex items-center justify-between gap-4 -mt-7">
+    <div className="flex flex-col min-h-[17rem] gap-5 px-3.5 py-4 bg-custom-background-100 border border-custom-border-200 rounded-lg">
+      <div className="relative flex items-center justify-between gap-4">
         <Link href={`/${workspaceSlug}/projects/${projectId}/cycles/${cycle?.id}`}>
           <h3 className="text-base text-custom-text-300 font-semibold">Issue burndown</h3>
         </Link>

--- a/web/core/store/cycle.store.ts
+++ b/web/core/store/cycle.store.ts
@@ -213,7 +213,9 @@ export class CycleStore implements ICycleStore {
     const projectId = this.rootStore.router.projectId;
     if (!projectId) return null;
     const activeCycle = Object.keys(this.cycleMap ?? {}).find(
-      (cycleId) => this.cycleMap?.[cycleId]?.project_id === projectId
+      (cycleId) =>
+        this.cycleMap?.[cycleId]?.project_id === projectId &&
+        this.cycleMap?.[cycleId]?.status?.toLowerCase() === "current"
     );
     return activeCycle || null;
   }


### PR DESCRIPTION
**Summary**
Project was taking the the first cycle as the active cycle

**Fix**
`currentProjectActiveCycleId` was missing the `status === 'current'` check


[[WEB-2029]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/37e2c46c-8c00-41cb-82eb-116b8a6b1093)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the alignment and visual consistency in the Active Cycle Productivity component by removing unnecessary margin styles.
  
- **New Features**
	- Enhanced the logic for retrieving the active cycle to ensure only cycles marked as "current" are considered, improving the accuracy of cycle data displayed to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->