### PR TITLE
[WEB-2031] fix: display update view button even when any filters are not applied for views

### DIFF
--- a/web/core/components/issues/issue-layouts/filters/applied-filters/roots/global-view-root.tsx
+++ b/web/core/components/issues/issue-layouts/filters/applied-filters/roots/global-view-root.tsx
@@ -117,7 +117,8 @@ export const GlobalViewsAppliedFiltersRoot = observer((props: Props) => {
     });
   };
 
-  const areFiltersEqual = getAreFiltersEqual(appliedFilters, issueFilters, viewDetails);
+  // add a placeholder object instead of appliedFilters if it is undefined
+  const areFiltersEqual = getAreFiltersEqual(appliedFilters ?? {}, issueFilters, viewDetails);
 
   const isAuthorizedUser = !!currentWorkspaceRole && currentWorkspaceRole >= EUserWorkspaceRoles.MEMBER;
 

--- a/web/core/components/issues/issue-layouts/filters/applied-filters/roots/project-view-root.tsx
+++ b/web/core/components/issues/issue-layouts/filters/applied-filters/roots/project-view-root.tsx
@@ -91,7 +91,8 @@ export const ProjectViewAppliedFiltersRoot: React.FC = observer(() => {
     );
   };
 
-  const areFiltersEqual = getAreFiltersEqual(appliedFilters, issueFilters, viewDetails);
+  // add a placeholder object instead of appliedFilters if it is undefined
+  const areFiltersEqual = getAreFiltersEqual(appliedFilters ?? {}, issueFilters, viewDetails);
   const viewFilters = {
     filters: cloneDeep(appliedFilters ?? {}),
     display_filters: cloneDeep(issueFilters?.displayFilters),


### PR DESCRIPTION
This PR fixes the issue when update view button is not dislayed when no filters are applied even when display filters or properties are changed

https://github.com/user-attachments/assets/11eb3293-be19-483e-97f2-277e2db4a112



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for `appliedFilters` in the Global Views and Project View components, preventing potential runtime errors due to undefined values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->