### PR TITLE
fix: google auth integrity error

### DIFF
--- a/apiserver/plane/authentication/adapter/oauth.py
+++ b/apiserver/plane/authentication/adapter/oauth.py
@@ -100,10 +100,8 @@ class OauthAdapter(Adapter):
         account, created = Account.objects.update_or_create(
             user=user,
             provider=self.provider,
+            provider_account_id=self.user_data.get("user").get("provider_id"),
             defaults={
-                "provider_account_id": self.user_data.get("user").get(
-                    "provider_id"
-                ),
                 "access_token": self.token_data.get("access_token"),
                 "refresh_token": self.token_data.get("refresh_token", None),
                 "access_token_expired_at": self.token_data.get(


### PR DESCRIPTION
### Description
This PR fixes the integrity error encountered during authenticating with google by adding another parameter while fetching accounts from database.
```python
Account.objects.update_or_create(
            user=user,
            provider=self.provider,
            provider_account_id=self.user_data.get("user").get("provider_id"),
            ...
```