### PR TITLE
[WEB-1762] fix: incorrectly placed image resize outline

### DIFF
--- a/packages/editor/src/core/extensions/image/image-resize.tsx
+++ b/packages/editor/src/core/extensions/image/image-resize.tsx
@@ -30,7 +30,7 @@ export const ImageResizer = ({ editor }: { editor: Editor }) => {
   return (
     <>
       <Moveable
-        target={document.querySelector(".ProseMirror-selectednode") as HTMLElement}
+        target={document.querySelector(".active-editor .ProseMirror-selectednode") as HTMLElement}
         container={null}
         origin={false}
         edge={false}
@@ -39,7 +39,7 @@ export const ImageResizer = ({ editor }: { editor: Editor }) => {
         resizable
         throttleResize={0}
         onResizeStart={() => {
-          const imageInfo = document.querySelector(".ProseMirror-selectednode") as HTMLImageElement;
+          const imageInfo = document.querySelector(".active-editor .ProseMirror-selectednode") as HTMLImageElement;
           if (imageInfo) {
             const originalWidth = Number(imageInfo.width);
             const originalHeight = Number(imageInfo.height);


### PR DESCRIPTION
#### Problem:

On opening an issue in the peek overview, image gets selected by default with an incorrectly placed resize outline.

#### Solution:

Add resize outline only if the editor is focused on.

#### Media:

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/f36567ed-789d-46ed-bb46-6e83fcefd3ac"></video> | <video src="https://github.com/user-attachments/assets/dc2ac0f5-1036-4605-8ca0-e95acf363a1b"></video> | 

#### Plane issue: [WEB-1762](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/3495513b-9efc-4b84-b656-1dbd9f816de6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved image resizing functionality by refining the element selection process, ensuring accurate targeting of images in active editor contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->