### PR TITLE
[WEB-2043] chore: updated permissions for delete operation

### DIFF
--- a/apiserver/plane/api/views/cycle.py
+++ b/apiserver/plane/api/views/cycle.py
@@ -34,6 +34,7 @@ from plane.db.models import (
     Project,
     IssueAttachment,
     IssueLink,
+    ProjectMember,
 )
 from plane.utils.analytics_plot import burndown_plot
 
@@ -363,13 +364,28 @@ class CycleAPIEndpoint(BaseAPIView):
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
     def delete(self, request, slug, project_id, pk):
+        cycle = Cycle.objects.get(
+            workspace__slug=slug, project_id=project_id, pk=pk
+        )
+        if (
+            ProjectMember.objects.filter(
+                workspace__slug=slug,
+                member=request.user,
+                role__in=[15, 10, 5],
+                project_id=project_id,
+                is_active=True,
+            ).exists()
+            and cycle.owned_by != request.user
+        ):
+            return Response(
+                {"error": "Only admin or creator can delete the issue"},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
         cycle_issues = list(
             CycleIssue.objects.filter(
                 cycle_id=self.kwargs.get("pk")
             ).values_list("issue", flat=True)
-        )
-        cycle = Cycle.objects.get(
-            workspace__slug=slug, project_id=project_id, pk=pk
         )
 
         issue_activity.delay(

--- a/apiserver/plane/api/views/cycle.py
+++ b/apiserver/plane/api/views/cycle.py
@@ -367,18 +367,17 @@ class CycleAPIEndpoint(BaseAPIView):
         cycle = Cycle.objects.get(
             workspace__slug=slug, project_id=project_id, pk=pk
         )
-        if (
-            ProjectMember.objects.filter(
+        if cycle.owned_by_id != request.user.id and (
+            not ProjectMember.objects.filter(
                 workspace__slug=slug,
                 member=request.user,
-                role__in=[15, 10, 5],
+                role=20,
                 project_id=project_id,
                 is_active=True,
             ).exists()
-            and cycle.owned_by != request.user
         ):
             return Response(
-                {"error": "Only admin or creator can delete the issue"},
+                {"error": "Only admin or creator can delete the cycle"},
                 status=status.HTTP_403_FORBIDDEN,
             )
 

--- a/apiserver/plane/api/views/inbox.py
+++ b/apiserver/plane/api/views/inbox.py
@@ -396,15 +396,14 @@ class InboxIssueAPIEndpoint(BaseAPIView):
             issue = Issue.objects.filter(
                 workspace__slug=slug, project_id=project_id, pk=issue_id
             ).first()
-            if (
-                ProjectMember.objects.filter(
+            if issue.created_by_id != request.user.id and (
+                not ProjectMember.objects.filter(
                     workspace__slug=slug,
                     member=request.user,
-                    role__in=[15, 10, 5],
+                    role=20,
                     project_id=project_id,
                     is_active=True,
                 ).exists()
-                and issue.created_by != request.user
             ):
                 return Response(
                     {"error": "Only admin or creator can delete the issue"},

--- a/apiserver/plane/api/views/inbox.py
+++ b/apiserver/plane/api/views/inbox.py
@@ -390,29 +390,27 @@ class InboxIssueAPIEndpoint(BaseAPIView):
             inbox_id=inbox.id,
         )
 
-        # Get the project member
-        project_member = ProjectMember.objects.get(
-            workspace__slug=slug,
-            project_id=project_id,
-            member=request.user,
-            is_active=True,
-        )
-
-        # Check the inbox issue created
-        if project_member.role <= 10 and str(inbox_issue.created_by_id) != str(
-            request.user.id
-        ):
-            return Response(
-                {"error": "You cannot delete inbox issue"},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
-
         # Check the issue status
         if inbox_issue.status in [-2, -1, 0, 2]:
             # Delete the issue also
-            Issue.objects.filter(
+            issue = Issue.objects.filter(
                 workspace__slug=slug, project_id=project_id, pk=issue_id
-            ).delete()
+            ).first()
+            if (
+                ProjectMember.objects.filter(
+                    workspace__slug=slug,
+                    member=request.user,
+                    role__in=[15, 10, 5],
+                    project_id=project_id,
+                    is_active=True,
+                ).exists()
+                and issue.created_by != request.user
+            ):
+                return Response(
+                    {"error": "Only admin or creator can delete the issue"},
+                    status=status.HTTP_403_FORBIDDEN,
+                )
+            issue.delete()
 
         inbox_issue.delete()
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/apiserver/plane/api/views/issue.py
+++ b/apiserver/plane/api/views/issue.py
@@ -389,9 +389,6 @@ class IssueAPIEndpoint(BaseAPIView):
         issue = Issue.objects.get(
             workspace__slug=slug, project_id=project_id, pk=pk
         )
-        current_instance = json.dumps(
-            IssueSerializer(issue).data, cls=DjangoJSONEncoder
-        )
         if (
             ProjectMember.objects.filter(
                 workspace__slug=slug,
@@ -406,6 +403,9 @@ class IssueAPIEndpoint(BaseAPIView):
                 {"error": "Only admin or creator can delete the issue"},
                 status=status.HTTP_403_FORBIDDEN,
             )
+        current_instance = json.dumps(
+            IssueSerializer(issue).data, cls=DjangoJSONEncoder
+        )
         issue.delete()
         issue_activity.delay(
             type="issue.activity.deleted",

--- a/apiserver/plane/api/views/issue.py
+++ b/apiserver/plane/api/views/issue.py
@@ -389,15 +389,14 @@ class IssueAPIEndpoint(BaseAPIView):
         issue = Issue.objects.get(
             workspace__slug=slug, project_id=project_id, pk=pk
         )
-        if (
-            ProjectMember.objects.filter(
+        if issue.created_by_id != request.user.id and (
+            not ProjectMember.objects.filter(
                 workspace__slug=slug,
                 member=request.user,
-                role__in=[15, 10, 5],
+                role=20,
                 project_id=project_id,
                 is_active=True,
             ).exists()
-            and issue.created_by != request.user
         ):
             return Response(
                 {"error": "Only admin or creator can delete the issue"},

--- a/apiserver/plane/api/views/module.py
+++ b/apiserver/plane/api/views/module.py
@@ -266,18 +266,17 @@ class ModuleAPIEndpoint(BaseAPIView):
         module = Module.objects.get(
             workspace__slug=slug, project_id=project_id, pk=pk
         )
-        if (
-            ProjectMember.objects.filter(
+        if module.created_by_id != request.user.id and (
+            not ProjectMember.objects.filter(
                 workspace__slug=slug,
                 member=request.user,
-                role__in=[15, 10, 5],
+                role=20,
                 project_id=project_id,
                 is_active=True,
             ).exists()
-            and module.created_by != request.user
         ):
             return Response(
-                {"error": "Only admin or creator can delete the issue"},
+                {"error": "Only admin or creator can delete the module"},
                 status=status.HTTP_403_FORBIDDEN,
             )
 

--- a/apiserver/plane/app/views/cycle/base.py
+++ b/apiserver/plane/app/views/cycle/base.py
@@ -1043,18 +1043,17 @@ class CycleViewSet(BaseViewSet):
         cycle = Cycle.objects.get(
             workspace__slug=slug, project_id=project_id, pk=pk
         )
-        if (
+        if cycle.owned_by_id != request.user.id and not (
             ProjectMember.objects.filter(
                 workspace__slug=slug,
                 member=request.user,
-                role__in=[15, 10, 5],
+                role=20,
                 project_id=project_id,
                 is_active=True,
             ).exists()
-            and cycle.owned_by != request.user
         ):
             return Response(
-                {"error": "Only admin or owner can delete the view"},
+                {"error": "Only admin or owner can delete the cycle"},
                 status=status.HTTP_403_FORBIDDEN,
             )
 

--- a/apiserver/plane/app/views/cycle/base.py
+++ b/apiserver/plane/app/views/cycle/base.py
@@ -47,6 +47,7 @@ from plane.db.models import (
     Label,
     User,
     Project,
+    ProjectMember,
 )
 from plane.utils.analytics_plot import burndown_plot
 
@@ -1039,13 +1040,28 @@ class CycleViewSet(BaseViewSet):
         )
 
     def destroy(self, request, slug, project_id, pk):
+        cycle = Cycle.objects.get(
+            workspace__slug=slug, project_id=project_id, pk=pk
+        )
+        if (
+            ProjectMember.objects.filter(
+                workspace__slug=slug,
+                member=request.user,
+                role__in=[15, 10, 5],
+                project_id=project_id,
+                is_active=True,
+            ).exists()
+            and cycle.owned_by != request.user
+        ):
+            return Response(
+                {"error": "Only admin or owner can delete the view"},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
         cycle_issues = list(
             CycleIssue.objects.filter(
                 cycle_id=self.kwargs.get("pk")
             ).values_list("issue", flat=True)
-        )
-        cycle = Cycle.objects.get(
-            workspace__slug=slug, project_id=project_id, pk=pk
         )
 
         issue_activity.delay(

--- a/apiserver/plane/app/views/inbox/base.py
+++ b/apiserver/plane/app/views/inbox/base.py
@@ -553,28 +553,28 @@ class InboxIssueViewSet(BaseViewSet):
             project_id=project_id,
             inbox_id=inbox_id,
         )
-        # Get the project member
-        project_member = ProjectMember.objects.get(
-            workspace__slug=slug,
-            project_id=project_id,
-            member=request.user,
-            is_active=True,
-        )
-
-        if project_member.role <= 10 and str(inbox_issue.created_by_id) != str(
-            request.user.id
-        ):
-            return Response(
-                {"error": "You cannot delete inbox issue"},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
 
         # Check the issue status
         if inbox_issue.status in [-2, -1, 0, 2]:
             # Delete the issue also
-            Issue.objects.filter(
+            issue = Issue.objects.filter(
                 workspace__slug=slug, project_id=project_id, pk=issue_id
-            ).delete()
+            ).first()
+            if (
+                ProjectMember.objects.filter(
+                    workspace__slug=slug,
+                    member=request.user,
+                    role__in=[15, 10, 5],
+                    project_id=project_id,
+                    is_active=True,
+                ).exists()
+                and issue.created_by != request.user
+            ):
+                return Response(
+                    {"error": "Only admin or creator can delete the issue"},
+                    status=status.HTTP_403_FORBIDDEN,
+                )
+            issue.delete()
 
         inbox_issue.delete()
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/apiserver/plane/app/views/inbox/base.py
+++ b/apiserver/plane/app/views/inbox/base.py
@@ -560,15 +560,14 @@ class InboxIssueViewSet(BaseViewSet):
             issue = Issue.objects.filter(
                 workspace__slug=slug, project_id=project_id, pk=issue_id
             ).first()
-            if (
-                ProjectMember.objects.filter(
+            if issue.created_by_id != request.user.id and (
+                not ProjectMember.objects.filter(
                     workspace__slug=slug,
                     member=request.user,
-                    role__in=[15, 10, 5],
+                    role=20,
                     project_id=project_id,
                     is_active=True,
                 ).exists()
-                and issue.created_by != request.user
             ):
                 return Response(
                     {"error": "Only admin or creator can delete the issue"},

--- a/apiserver/plane/app/views/issue/base.py
+++ b/apiserver/plane/app/views/issue/base.py
@@ -550,15 +550,14 @@ class IssueViewSet(BaseViewSet):
         issue = Issue.objects.get(
             workspace__slug=slug, project_id=project_id, pk=pk
         )
-        if (
-            ProjectMember.objects.filter(
+        if issue.created_by_id != request.user.id and (
+            not ProjectMember.objects.filter(
                 workspace__slug=slug,
                 member=request.user,
-                role__in=[15, 10, 5],
+                role=20,
                 project_id=project_id,
                 is_active=True,
             ).exists()
-            and issue.created_by != request.user
         ):
             return Response(
                 {"error": "Only admin or creator can delete the issue"},

--- a/apiserver/plane/app/views/issue/base.py
+++ b/apiserver/plane/app/views/issue/base.py
@@ -44,6 +44,7 @@ from plane.db.models import (
     IssueReaction,
     IssueSubscriber,
     Project,
+    ProjectMember,
 )
 from plane.utils.grouper import (
     issue_group_values,
@@ -549,6 +550,21 @@ class IssueViewSet(BaseViewSet):
         issue = Issue.objects.get(
             workspace__slug=slug, project_id=project_id, pk=pk
         )
+        if (
+            ProjectMember.objects.filter(
+                workspace__slug=slug,
+                member=request.user,
+                role__in=[15, 10, 5],
+                project_id=project_id,
+                is_active=True,
+            ).exists()
+            and issue.created_by != request.user
+        ):
+            return Response(
+                {"error": "Only admin or creator can delete the issue"},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
         issue.delete()
         issue_activity.delay(
             type="issue.activity.deleted",
@@ -602,6 +618,19 @@ class BulkDeleteIssuesEndpoint(BaseAPIView):
     ]
 
     def delete(self, request, slug, project_id):
+        if ProjectMember.objects.filter(
+            workspace__slug=slug,
+            member=request.user,
+            role=20,
+            project_id=project_id,
+            is_active=True,
+        ).exists():
+
+            return Response(
+                {"error": "Only admin can perform this action"},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
         issue_ids = request.data.get("issue_ids", [])
 
         if not len(issue_ids):

--- a/apiserver/plane/app/views/issue/draft.py
+++ b/apiserver/plane/app/views/issue/draft.py
@@ -381,15 +381,14 @@ class IssueDraftViewSet(BaseViewSet):
         issue = Issue.objects.get(
             workspace__slug=slug, project_id=project_id, pk=pk
         )
-        if (
-            ProjectMember.objects.filter(
+        if issue.created_by_id != request.user.id and (
+            not ProjectMember.objects.filter(
                 workspace__slug=slug,
                 member=request.user,
-                role__in=[15, 10, 5],
+                role=20,
                 project_id=project_id,
                 is_active=True,
             ).exists()
-            and issue.created_by != request.user
         ):
             return Response(
                 {"error": "Only admin or creator can delete the issue"},

--- a/apiserver/plane/app/views/module/base.py
+++ b/apiserver/plane/app/views/module/base.py
@@ -739,15 +739,14 @@ class ModuleViewSet(BaseViewSet):
             workspace__slug=slug, project_id=project_id, pk=pk
         )
 
-        if (
-            ProjectMember.objects.filter(
+        if module.created_by_id != request.user.id and (
+            not ProjectMember.objects.filter(
                 workspace__slug=slug,
                 member=request.user,
-                role__in=[15, 10, 5],
+                role=20,
                 project_id=project_id,
                 is_active=True,
             ).exists()
-            and module.created_by != request.user
         ):
             return Response(
                 {"error": "Only admin or creator can delete the module"},

--- a/apiserver/plane/app/views/module/base.py
+++ b/apiserver/plane/app/views/module/base.py
@@ -48,6 +48,7 @@ from plane.db.models import (
     ModuleLink,
     ModuleUserProperties,
     Project,
+    ProjectMember,
 )
 from plane.utils.analytics_plot import burndown_plot
 from plane.utils.user_timezone_converter import user_timezone_converter
@@ -737,6 +738,22 @@ class ModuleViewSet(BaseViewSet):
         module = Module.objects.get(
             workspace__slug=slug, project_id=project_id, pk=pk
         )
+
+        if (
+            ProjectMember.objects.filter(
+                workspace__slug=slug,
+                member=request.user,
+                role__in=[15, 10, 5],
+                project_id=project_id,
+                is_active=True,
+            ).exists()
+            and module.created_by != request.user
+        ):
+            return Response(
+                {"error": "Only admin or creator can delete the module"},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
         module_issues = list(
             ModuleIssue.objects.filter(module_id=pk).values_list(
                 "issue", flat=True

--- a/apiserver/plane/app/views/page/base.py
+++ b/apiserver/plane/app/views/page/base.py
@@ -333,15 +333,14 @@ class PageViewSet(BaseViewSet):
             pk=pk, workspace__slug=slug, projects__id=project_id
         )
 
-        if (
+        if not page.owned_by_id != request.user.id and not (
             ProjectMember.objects.filter(
                 workspace__slug=slug,
                 member=request.user,
-                role__in=[15, 10, 5],
+                role=20,
                 project_id=project_id,
                 is_active=True,
             ).exists()
-            and page.owned_by != request.user
         ):
             return Response(
                 {"error": "Only admin or owner can delete the page"},

--- a/apiserver/plane/app/views/page/base.py
+++ b/apiserver/plane/app/views/page/base.py
@@ -333,6 +333,21 @@ class PageViewSet(BaseViewSet):
             pk=pk, workspace__slug=slug, projects__id=project_id
         )
 
+        if (
+            ProjectMember.objects.filter(
+                workspace__slug=slug,
+                member=request.user,
+                role__in=[15, 10, 5],
+                project_id=project_id,
+                is_active=True,
+            ).exists()
+            and page.owned_by != request.user
+        ):
+            return Response(
+                {"error": "Only admin or owner can delete the page"},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
         # only the owner and admin can delete the page
         if (
             ProjectMember.objects.filter(

--- a/apiserver/plane/app/views/view/base.py
+++ b/apiserver/plane/app/views/view/base.py
@@ -116,14 +116,14 @@ class WorkspaceViewViewSet(BaseViewSet):
             pk=pk,
             workspace__slug=slug,
         )
-        if (
+        if not (
             WorkspaceMember.objects.filter(
                 workspace__slug=slug,
                 member=request.user,
-                role__in=[15, 10, 5],
+                role=20,
                 is_active=True,
             ).exists()
-            and workspace_view.owned_by != request.user
+            and workspace_view.owned_by_id != request.user.id
         ):
             return Response(
                 {"error": "You do not have permission to delete this view"},
@@ -434,7 +434,7 @@ class IssueViewViewSet(BaseViewSet):
                 role=20,
                 is_active=True,
             ).exists()
-            or project_view.owned_by == request.user
+            or project_view.owned_by_id == request.user.id
         ):
             project_view.delete()
         else:

--- a/apiserver/plane/app/views/view/base.py
+++ b/apiserver/plane/app/views/view/base.py
@@ -116,6 +116,20 @@ class WorkspaceViewViewSet(BaseViewSet):
             pk=pk,
             workspace__slug=slug,
         )
+        if (
+            WorkspaceMember.objects.filter(
+                workspace__slug=slug,
+                member=request.user,
+                role__in=[15, 10, 5],
+                is_active=True,
+            ).exists()
+            and workspace_view.owned_by != request.user
+        ):
+            return Response(
+                {"error": "You do not have permission to delete this view"},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
         workspace_member = WorkspaceMember.objects.filter(
             workspace__slug=slug,
             member=request.user,
@@ -412,14 +426,16 @@ class IssueViewViewSet(BaseViewSet):
             project_id=project_id,
             workspace__slug=slug,
         )
-        project_member = ProjectMember.objects.filter(
-            workspace__slug=slug,
-            project_id=project_id,
-            member=request.user,
-            role=20,
-            is_active=True,
-        )
-        if project_member.exists() or project_view.owned_by == request.user:
+        if (
+            ProjectMember.objects.filter(
+                workspace__slug=slug,
+                project_id=project_id,
+                member=request.user,
+                role=20,
+                is_active=True,
+            ).exists()
+            or project_view.owned_by == request.user
+        ):
             project_view.delete()
         else:
             return Response(


### PR DESCRIPTION
chore: 

- now only admins or the creator of the `issue`, `cycle`, `module`,`view`, `page` can perform the delete operation.

Issue Link: [WEB-2043](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/bf888b6f-0576-4feb-a2b1-ae3f3adf2cec/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced access control for the deletion of cycles, inbox issues, modules, issues, and views, restricting permissions to admins and creators.
	- Implemented role-based checks for deleting pages, ensuring only authorized users can perform deletions.

- **Bug Fixes**
	- Resolved issues where unauthorized users could delete cycles, inbox issues, modules, issues, and views.

- **Documentation**
	- Updated import statements to include `ProjectMember` and `WorkspaceMember` for permission checks across various views.

- **Refactor**
	- Streamlined deletion logic for improved readability and maintainability across multiple components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->