### PR TITLE
[WEB-2054] fix: kanban layout loader enhancements and issue count alignment

### DIFF
--- a/web/core/components/issues/issue-layouts/kanban/headers/group-by-card.tsx
+++ b/web/core/components/issues/issue-layouts/kanban/headers/group-by-card.tsx
@@ -112,7 +112,7 @@ export const HeaderGroupByCard: FC<IHeaderGroupByCard> = observer((props) => {
         </div>
 
         <div
-          className={`relative flex items-center gap-1 ${
+          className={`relative flex items-baseline gap-1 ${
             verticalAlignPosition ? `flex-col` : `w-full flex-row overflow-hidden`
           }`}
         >

--- a/web/core/components/ui/loader/layouts/kanban-layout-loader.tsx
+++ b/web/core/components/ui/loader/layouts/kanban-layout-loader.tsx
@@ -11,11 +11,10 @@ export const KanbanLayoutLoader = ({ cardsInEachColumn = [2, 3, 2, 4, 3] }: { ca
     {cardsInEachColumn.map((cardsInColumn, columnIndex) => (
       <div key={columnIndex} className="flex flex-col gap-3">
         <div className="flex items-center justify-between h-9 w-80">
-          <div className="flex item-center">
+          <div className="flex item-center gap-3 px-1.5">
             <span className="h-6 w-6 bg-custom-background-80 rounded animate-pulse" />
             <span className="h-6 w-24 bg-custom-background-80 rounded animate-pulse" />
           </div>
-          <span className="h-6 w-6 bg-custom-background-80 rounded animate-pulse" />
         </div>
         {Array.from({ length: cardsInColumn }, (_, cardIndex) => (
           <KanbanIssueBlockLoader key={cardIndex} />


### PR DESCRIPTION
### Changes:
This PR includes the following updates:
- Improved the Kanban layout loader.
- Fixed the issue count alignment in the Kanban layout.

### Media:
| Before | After |
|--------|--------|
| ![before](https://github.com/user-attachments/assets/723c4715-ac5f-461d-8f15-7b70e1ba020e) | ![after](https://github.com/user-attachments/assets/3a57ed53-6335-4110-9206-dca072ac014a) |
| ![before](https://github.com/user-attachments/assets/3bd4c07b-4a5f-4abb-ab67-afa7d9651504) | ![after](https://github.com/user-attachments/assets/ba9a426e-889e-4bbf-b14d-34d739225395) |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style Changes**
	- Improved vertical alignment of elements within the Kanban component for better visual presentation.
	- Enhanced spacing and padding around loading indicators in the Kanban layout loader for improved aesthetics.
	- Simplified the structure of the Kanban layout loader by removing redundant elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->