### PR TITLE
[WEB-2055] fix: enable admins to change role of other admins and add missing observers

### DIFF
--- a/web/core/components/project/settings/member-columns.tsx
+++ b/web/core/components/project/settings/member-columns.tsx
@@ -1,3 +1,4 @@
+import { observer } from "mobx-react";
 import Link from "next/link";
 import { Controller, useForm } from "react-hook-form";
 import { Trash2 } from "lucide-react";
@@ -6,7 +7,7 @@ import { IUser, IWorkspaceMember } from "@plane/types";
 import { CustomSelect, PopoverMenu, TOAST_TYPE, setToast } from "@plane/ui";
 import { EUserProjectRoles } from "@/constants/project";
 import { EUserWorkspaceRoles, ROLE } from "@/constants/workspace";
-import { useMember } from "@/hooks/store";
+import { useMember, useUser } from "@/hooks/store";
 
 export interface RowData {
   member: IWorkspaceMember;
@@ -80,62 +81,74 @@ export const NameColumn: React.FC<NameProps> = (props) => {
   );
 };
 
-export const AccountTypeColumn: React.FC<AccountTypeProps> = (props) => {
+export const AccountTypeColumn: React.FC<AccountTypeProps> = observer((props) => {
   const { rowData, currentProjectRole, projectId, workspaceSlug } = props;
   // form info
   const {
     control,
     formState: { errors },
   } = useForm();
+  // store hooks
   const {
     project: { updateMember },
   } = useMember();
-  return rowData.role === EUserWorkspaceRoles.ADMIN || currentProjectRole !== EUserProjectRoles.ADMIN ? (
-    <div className="w-32 flex ">
-      <span>{ROLE[rowData.role as keyof typeof ROLE]}</span>
-    </div>
-  ) : (
-    <Controller
-      name="role"
-      control={control}
-      rules={{ required: "Role is required." }}
-      render={({ field: { value } }) => (
-        <CustomSelect
-          value={value}
-          onChange={(value: EUserProjectRoles) => {
-            if (!workspaceSlug) return;
+  const { data: currentUser } = useUser();
 
-            updateMember(workspaceSlug.toString(), projectId.toString(), rowData.member.id, {
-              role: value as unknown as EUserProjectRoles, // Cast value to unknown first, then to EUserWorkspaceRoles
-            }).catch((err) => {
-              console.log(err, "err");
-              const error = err.error;
-              const errorString = Array.isArray(error) ? error[0] : error;
+  // derived values
+  const isCurrentUser = currentUser?.id === rowData.member.id;
+  const isAdminRole = currentProjectRole === EUserProjectRoles.ADMIN;
+  const isRoleEditable = isCurrentUser && isAdminRole;
 
-              setToast({
-                type: TOAST_TYPE.ERROR,
-                title: "Error!",
-                message: errorString ?? "An error occurred while updating member role. Please try again.",
-              });
-            });
-          }}
-          label={
-            <div className="flex ">
-              <span>{ROLE[rowData.role as keyof typeof ROLE]}</span>
-            </div>
-          }
-          buttonClassName={`!px-0 !justify-start hover:bg-custom-background-100 ${errors.role ? "border-red-500" : "border-none"}`}
-          className="rounded-md p-0 w-32"
-          optionsClassName="w-full"
-          input
-        >
-          {Object.keys(ROLE).map((item) => (
-            <CustomSelect.Option key={item} value={item as unknown as EUserProjectRoles}>
-              {ROLE[item as unknown as keyof typeof ROLE]}
-            </CustomSelect.Option>
-          ))}
-        </CustomSelect>
+  return (
+    <>
+      {isRoleEditable ? (
+        <div className="w-32 flex ">
+          <span>{ROLE[rowData.role as keyof typeof ROLE]}</span>
+        </div>
+      ) : (
+        <Controller
+          name="role"
+          control={control}
+          rules={{ required: "Role is required." }}
+          render={({ field: { value } }) => (
+            <CustomSelect
+              value={value}
+              onChange={(value: EUserProjectRoles) => {
+                if (!workspaceSlug) return;
+
+                updateMember(workspaceSlug.toString(), projectId.toString(), rowData.member.id, {
+                  role: value as unknown as EUserProjectRoles, // Cast value to unknown first, then to EUserWorkspaceRoles
+                }).catch((err) => {
+                  console.log(err, "err");
+                  const error = err.error;
+                  const errorString = Array.isArray(error) ? error[0] : error;
+
+                  setToast({
+                    type: TOAST_TYPE.ERROR,
+                    title: "Error!",
+                    message: errorString ?? "An error occurred while updating member role. Please try again.",
+                  });
+                });
+              }}
+              label={
+                <div className="flex ">
+                  <span>{ROLE[rowData.role as keyof typeof ROLE]}</span>
+                </div>
+              }
+              buttonClassName={`!px-0 !justify-start hover:bg-custom-background-100 ${errors.role ? "border-red-500" : "border-none"}`}
+              className="rounded-md p-0 w-32"
+              optionsClassName="w-full"
+              input
+            >
+              {Object.keys(ROLE).map((item) => (
+                <CustomSelect.Option key={item} value={item as unknown as EUserProjectRoles}>
+                  {ROLE[item as unknown as keyof typeof ROLE]}
+                </CustomSelect.Option>
+              ))}
+            </CustomSelect>
+          )}
+        />
       )}
-    />
+    </>
   );
-};
+});


### PR DESCRIPTION
### Problem:
- Previously, users with the admin role were unable to change the roles of other admins.

### Solution:
- Added the necessary validation to allow admin users to change admin roles as intended.
- Included missing observers in the component to ensure proper functionality.

### Reference: 
[[WEB-2055]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/5b39006c-e928-431a-aaa9-6298f6d34c62)

### Media:
| Before | After |
|--------|--------|
| ![WEB-2055 Before (1)](https://github.com/user-attachments/assets/44b1e3b6-7847-4410-a0e5-abe37827e2bf) | ![WEB-2055 After (1)](https://github.com/user-attachments/assets/6d4acda8-a30a-4133-b0d3-4954540941c7) |
| ![WEB-2055 Before (2)](https://github.com/user-attachments/assets/3034269f-70b7-495f-ba30-5a736a420541) | ![WEB-2055 After (2)](https://github.com/user-attachments/assets/33c2ce0e-93fa-4e54-a082-f09281403149) |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - Enhanced the responsiveness of the Account Type Column component, allowing it to reactively reflect changes in user roles and permissions.
    - Introduced conditional rendering for role editing based on the current user's status (admin or member).

- **Bug Fixes**
    - Improved clarity and maintainability of rendering logic within the Account Type Column, reducing nested conditional statements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->