### PR TITLE
[WEB-2038] fix: error message for display name in profile settings

### DIFF
--- a/web/app/profile/page.tsx
+++ b/web/app/profile/page.tsx
@@ -369,7 +369,7 @@ const ProfileSettingsPage = observer(() => {
                     />
                   )}
                 />
-                {errors?.display_name && <span className="text-xs text-red-500">Please enter display name</span>}
+                {errors?.display_name && <span className="text-xs text-red-500">{errors?.display_name?.message}</span>}
               </div>
 
               <div className="flex flex-col gap-1">


### PR DESCRIPTION
### Problem:
- On the profile settings page, the error message for the display name was not appropriate. It was always displaying "Please enter display name" for all cases.

### Solution:
- Made necessary changes to ensure the error message displays correctly based on the specific condition.

### Reference:
[[WEB-2038]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/60ff4744-96c1-4cba-96e8-446a7b7b8665)

### Media:
| Before | After |
|--------|--------|
| ![WEB-2038 Before](https://github.com/user-attachments/assets/29a3a62b-2403-4214-8e00-232228c80678) | ![WEB-2038 After](https://github.com/user-attachments/assets/419682cd-63ae-4c34-aa1f-288ab59490d8) |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error messaging for the display name field on the Profile Settings page, providing more specific feedback to users.
  
- **Bug Fixes**
	- Improved user experience by replacing static error messages with dynamic, contextual messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->