### PR TITLE
[WEB-2035] fix: checkbox color on inbox page filters

### DIFF
--- a/web/core/components/workspace-notifications/sidebar/filters/menu/menu-option-item.tsx
+++ b/web/core/components/workspace-notifications/sidebar/filters/menu/menu-option-item.tsx
@@ -31,12 +31,12 @@ export const NotificationFilterOptionItem: FC<{ label: string; value: ENotificat
       onClick={() => handleFilterTypeChange(value, !isSelected)}
     >
       <div
-        className={cn(
-          "flex-shrink-0 w-3 h-3 flex justify-center items-center rounded-sm transition-all",
-          isSelected ? "bg-custom-primary-100" : "bg-custom-background-90"
-        )}
+        className={cn("flex-shrink-0 w-3 h-3 flex justify-center items-center rounded-sm transition-all", {
+          "bg-custom-primary text-white": isSelected,
+          "bg-custom-background-90": !isSelected,
+        })}
       >
-        {isSelected && <Check className="h-2 w-2" />}
+        {isSelected && <Check className="h-2.5 w-2.5" />}
       </div>
       <div className={cn("whitespace-nowrap text-sm", isSelected ? "text-custom-text-100" : "text-custom-text-200")}>
         {label}


### PR DESCRIPTION
### Problem:
- On the inbox page, the color of the checked filter checkbox was incorrect.

### Solution:
- Made the necessary changes to ensure the checkbox displays the correct color when checked.

### Reference:
[[WEB-2035]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/33ff0d97-8548-475e-961f-31b8756984c8)

### Media:
| Before | After |
|--------|--------|
| ![WEB-2035 Before](https://github.com/user-attachments/assets/fb049178-0931-4b7d-b818-703e28232be8) | ![WEB-2035 After](https://github.com/user-attachments/assets/d711ef02-4b26-4ab2-9afb-e79309df5ed8) |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the visual styling of notification filter options for improved user experience.
  
- **Bug Fixes**
	- Adjusted the size of the check icon for selected items to improve visibility.
  
- **Style**
	- Updated class names and text colors based on selection state for better consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->