### PR TITLE
[WEB-2013] fix: issue link modal preloading previous data

### DIFF
--- a/web/core/components/issues/issue-detail/links/create-update-link-modal.tsx
+++ b/web/core/components/issues/issue-detail/links/create-update-link-modal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { FC, useEffect, Fragment } from "react";
+import { observer } from "mobx-react";
 import { Controller, useForm } from "react-hook-form";
 import { Dialog, Transition } from "@headlessui/react";
 import type { TIssueLinkEditableFields } from "@plane/types";
@@ -27,7 +28,7 @@ const defaultValues: TIssueLinkCreateFormFieldOptions = {
   url: "",
 };
 
-export const IssueLinkCreateUpdateModal: FC<TIssueLinkCreateEditModal> = (props) => {
+export const IssueLinkCreateUpdateModal: FC<TIssueLinkCreateEditModal> = observer((props) => {
   // props
   const { isModalOpen, handleOnClose, linkOperations } = props;
 
@@ -45,6 +46,7 @@ export const IssueLinkCreateUpdateModal: FC<TIssueLinkCreateEditModal> = (props)
 
   const onClose = () => {
     setIssueLinkData(null);
+    reset(defaultValues);
     if (handleOnClose) handleOnClose();
   };
 
@@ -55,8 +57,8 @@ export const IssueLinkCreateUpdateModal: FC<TIssueLinkCreateEditModal> = (props)
   };
 
   useEffect(() => {
-    reset({ ...defaultValues, ...preloadedData });
-  }, [preloadedData, reset]);
+    if (isModalOpen) reset({ ...defaultValues, ...preloadedData });
+  }, [preloadedData, reset, isModalOpen]);
 
   return (
     <Transition.Root show={isModalOpen} as={Fragment}>
@@ -165,4 +167,4 @@ export const IssueLinkCreateUpdateModal: FC<TIssueLinkCreateEditModal> = (props)
       </Dialog>
     </Transition.Root>
   );
-};
+});


### PR DESCRIPTION
### Problem:
- The issue link modal was preloading data from the previous link.

### Solution:
- Made necessary changes to reset the data to default on submit and on close, ensuring the modal does not preload previous link data.

### Reference:
[[WEB-2013]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/0ab5d0fa-e860-4524-b698-7fa079260704)

### Media:
| Before | After |
|--------|--------|
| ![WEB-2013 Before](https://github.com/user-attachments/assets/51482b80-988d-4a1d-b3c4-94f31c0c2455) | ![WEB-2013 After](https://github.com/user-attachments/assets/8580e413-ee41-4cd5-af6e-4379e47f5b26) |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced responsiveness of the Issue Link Create/Update modal to observable state changes.
	
- **Improvements**
	- The modal now resets to its default state upon closure, improving user experience by preventing stale data.
	- Form resets are now conditionally triggered, optimizing performance when the modal is open.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->