### PR TITLE
[WEB-2026] fix:  avatar visibility on project list after user leaves project

### DIFF
--- a/web/core/store/user/user-membership.store.ts
+++ b/web/core/store/user/user-membership.store.ts
@@ -1,7 +1,7 @@
-import { set } from "lodash";
+import { set, update } from "lodash";
 import { action, observable, runInAction, makeObservable, computed } from "mobx";
 // types
-import { IWorkspaceMemberMe, IProjectMember, IUserProjectsRole } from "@plane/types";
+import { IWorkspaceMemberMe, IProjectMember, IUserProjectsRole, IProjectMemberLite } from "@plane/types";
 // constants
 import { EUserProjectRoles } from "@/constants/project";
 import { EUserWorkspaceRoles } from "@/constants/workspace";
@@ -253,6 +253,15 @@ export class UserMembershipStore implements IUserMembershipStore {
       set(this.hasPermissionToProject, [projectId], false);
       // update the project member list with the new permissions
       set(this.store.projectRoot.project.projectMap, [projectId, "is_member"], false);
+      // remove user from project members list
+      update(this.store.projectRoot.project.projectMap, projectId, (project) => {
+        if (project) {
+          project.members = project.members.filter(
+            (member: IProjectMemberLite) => member.member_id !== this.store.user?.data?.id
+          );
+        }
+        return project;
+      });
     });
 
   /**

--- a/web/core/store/user/user-membership.store.ts
+++ b/web/core/store/user/user-membership.store.ts
@@ -1,4 +1,5 @@
-import { set, update } from "lodash";
+import set from "lodash/set";
+import update from "lodash/update";
 import { action, observable, runInAction, makeObservable, computed } from "mobx";
 // types
 import { IWorkspaceMemberMe, IProjectMember, IUserProjectsRole, IProjectMemberLite } from "@plane/types";


### PR DESCRIPTION
### Problem:
- When a user leaves a project, their avatar is still visible on the project card on the project list page due to a mutation issue.

### Solution:
- Implemented necessary changes to ensure the user's avatar is removed from the project card upon leaving the project.

### Reference:
[[WEB-2026]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/7ac339b2-94d5-4253-abad-7ed1bd052b78)

### Media:
| Before | After |
|--------|--------|
| ![WEB-2026 Before](https://github.com/user-attachments/assets/334858c9-547f-4127-a0fd-f58ccce8c1f0) | ![WEB-2026 After (1)](https://github.com/user-attachments/assets/cb75526f-080f-4741-be85-f31a7e38711d) |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced user permissions management, ensuring users are automatically removed from project member lists when permissions are revoked.
  
- **Bug Fixes**
	- Improved accuracy of project membership states by implementing additional checks and updates to user roles.

- **Documentation**
	- Updated import statements to include new types for better clarity and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->