### PR TITLE
[WEB-1756] fix: unable to create new todo-list item in the lite-text editor

### DIFF
--- a/packages/editor/src/core/extensions/enter-key-extension.tsx
+++ b/packages/editor/src/core/extensions/enter-key-extension.tsx
@@ -17,6 +17,7 @@ export const EnterKeyExtension = (onEnterKeyPress?: (descriptionHTML: string) =>
           editor.commands.first(({ commands }) => [
             () => commands.newlineInCode(),
             () => commands.splitListItem("listItem"),
+            () => commands.splitListItem("taskItem"),
             () => commands.createParagraphNear(),
             () => commands.liftEmptyBlock(),
             () => commands.splitBlock(),

--- a/web/core/components/issues/issue-detail/issue-activity/comments/comment-create.tsx
+++ b/web/core/components/issues/issue-detail/issue-activity/comments/comment-create.tsx
@@ -66,7 +66,6 @@ export const IssueCommentCreate: FC<TIssueCommentCreate> = (props) => {
                 projectId={projectId}
                 workspaceSlug={workspaceSlug}
                 onEnterKeyPress={(commentHTML) => {
-                  console.log("commentHTML", commentHTML);
                   const isEmpty =
                     commentHTML?.trim() === "" ||
                     commentHTML === "<p></p>" ||


### PR DESCRIPTION
#### Problem:

Creating a new todo-list item is not possible in the lite-text editor(comments box).

#### Solution:

Added new list item creation logic on pressing `Shift + Enter` in the enter key extension.

#### Media:

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/6c78fec0-bfc4-4c50-8e47-7e8feb69208f"></video> | <video src="https://github.com/user-attachments/assets/7d88452e-ff94-4b7f-a8fb-effff49b04eb"></video> | 

#### Plane issue: [WEB-1756](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/7582dd9b-9fd4-448e-8cef-b45d2b0ef75c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced task list management by allowing the splitting of task items with the Enter key.
  
- **Bug Fixes**
	- Removed unnecessary console log from the comment creation component, improving performance and reducing console clutter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->