### PR TITLE
[WEB-1971] fix: remove issue from cycle while changing cycle

### DIFF
--- a/web/core/store/issue/helpers/base-issues.store.ts
+++ b/web/core/store/issue/helpers/base-issues.store.ts
@@ -892,9 +892,14 @@ export abstract class BaseIssuesStore implements IBaseIssuesStore {
 
   addCycleToIssue = async (workspaceSlug: string, projectId: string, cycleId: string, issueId: string) => {
     const issueCycleId = this.rootIssueStore.issues.getIssueById(issueId)?.cycle_id;
+
+    if (issueCycleId === cycleId) return;
+
     try {
       // Update issueIds from current store
       runInAction(() => {
+        // If cycle Id before update is the same as current cycle Id then, remove issueId from list
+        if (this.cycleId === issueCycleId) this.removeIssueFromList(issueId);
         // If cycle Id is the current cycle Id, then, add issue to list of issueIds
         if (this.cycleId === cycleId) this.addIssueToList(issueId);
         // For Each issue update cycle Id by calling current store's update Issue, without making an API call


### PR DESCRIPTION
This PR fixes the issue when updating cycle while in a cycle issues page, the issue does not get removed.


https://github.com/user-attachments/assets/f00514cd-b939-47b1-9ed1-0e3c61a164b2



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the efficiency of the issue cycle assignment by preventing unnecessary processing when the same cycle ID is used.
	- Enhanced state management by ensuring proper removal of issues from lists when reassigned to the same cycle.

These enhancements lead to a more responsive and accurate issue management experience for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->