### PR TITLE
chore: only admin can perform bulk delete operation

### DIFF
--- a/apiserver/plane/app/views/issue/base.py
+++ b/apiserver/plane/app/views/issue/base.py
@@ -622,7 +622,7 @@ class BulkDeleteIssuesEndpoint(BaseAPIView):
         if ProjectMember.objects.filter(
             workspace__slug=slug,
             member=request.user,
-            role=20,
+            role__in=[15, 10, 5],
             project_id=project_id,
             is_active=True,
         ).exists():


### PR DESCRIPTION
chore: 
- now only admins are authorized to perform bulk delete operations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced deletion criteria for project members, allowing for multiple role values (15, 10, and 5) to determine eligibility.
  
- **Bug Fixes**
	- Improved functionality related to user permissions and access control when deleting issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->