### PR TITLE
[WEB-2107] fix: Default filters and sorting on the initial load, filter mutation on tab change

### DIFF
--- a/web/core/components/inbox/root.tsx
+++ b/web/core/components/inbox/root.tsx
@@ -34,7 +34,7 @@ export const InboxIssueRoot: FC<TInboxIssueRoot> = observer((props) => {
     if (navigationTab && navigationTab !== currentTab) {
       handleCurrentTab(workspaceSlug, projectId, navigationTab);
     } else {
-      fetchInboxIssues(workspaceSlug.toString(), projectId.toString());
+      fetchInboxIssues(workspaceSlug.toString(), projectId.toString(), undefined, navigationTab);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [inboxAccessible, workspaceSlug, projectId]);

--- a/web/core/store/inbox/project-inbox.store.ts
+++ b/web/core/store/inbox/project-inbox.store.ts
@@ -55,11 +55,17 @@ export interface IProjectInboxStore {
     paginationCursor: string
   ) => Partial<Record<keyof TInboxIssueFilter, string>>;
   createOrUpdateInboxIssue: (inboxIssues: TInboxIssue[], workspaceSlug: string, projectId: string) => void;
+  initializeQueryParams: (projectId: string, tab: TInboxIssueCurrentTab) => void;
   // actions
   handleCurrentTab: (workspaceSlug: string, projectId: string, tab: TInboxIssueCurrentTab) => void;
   handleInboxIssueFilters: <T extends keyof TInboxIssueFilter>(key: T, value: TInboxIssueFilter[T]) => void; // if user sends me undefined, I will remove the value from the filter key
   handleInboxIssueSorting: <T extends keyof TInboxIssueSorting>(key: T, value: TInboxIssueSorting[T]) => void; // if user sends me undefined, I will remove the value from the filter key
-  fetchInboxIssues: (workspaceSlug: string, projectId: string, loadingType?: TLoader) => Promise<void>;
+  fetchInboxIssues: (
+    workspaceSlug: string,
+    projectId: string,
+    loadingType?: TLoader,
+    tab?: TInboxIssueCurrentTab | undefined
+  ) => Promise<void>;
   fetchInboxPaginationIssues: (workspaceSlug: string, projectId: string) => Promise<void>;
   fetchInboxIssueById: (workspaceSlug: string, projectId: string, inboxIssueId: string) => Promise<TInboxIssue>;
   createInboxIssue: (
@@ -121,11 +127,7 @@ export class ProjectInboxStore implements IProjectInboxStore {
   get inboxFilters() {
     const { projectId } = this.store.router;
     if (!projectId) return {} as TInboxIssueFilter;
-    return isEmpty(this.filtersMap?.[projectId])
-      ? this.currentTab === EInboxIssueCurrentTab.OPEN
-        ? { status: [EInboxIssueStatus.PENDING] }
-        : { status: [EInboxIssueStatus.ACCEPTED, EInboxIssueStatus.DECLINED, EInboxIssueStatus.DUPLICATE] }
-      : this.filtersMap?.[projectId];
+    return this.filtersMap?.[projectId];
   }
 
   /**
@@ -134,9 +136,7 @@ export class ProjectInboxStore implements IProjectInboxStore {
   get inboxSorting() {
     const { projectId } = this.store.router;
     if (!projectId) return {} as TInboxIssueSorting;
-    return isEmpty(this.sortingMap?.[projectId])
-      ? ({ order_by: "issue__created_at", sort_by: "desc" } as TInboxIssueSorting)
-      : this.sortingMap?.[projectId];
+    return this.sortingMap?.[projectId];
   }
 
   get getAppliedFiltersCount() {
@@ -240,17 +240,21 @@ export class ProjectInboxStore implements IProjectInboxStore {
 
   // actions
   handleCurrentTab = (workspaceSlug: string, projectId: string, tab: TInboxIssueCurrentTab) => {
-    runInAction(() => {
-      set(this, "currentTab", tab);
-      set(this, ["inboxIssueIds"], []);
-      set(this, ["inboxIssuePaginationInfo"], undefined);
-      set(this, ["sorting", projectId, "order_by"], "issue__created_at");
-      set(this, ["sorting", projectId, "sort_by"], "desc");
-      set(this, "filters", undefined);
-      if (tab === "closed") set(this, ["filters", projectId, "status"], [-1, 1, 2]);
-      else set(this, ["filters", projectId, "status"], [-2]);
-    });
-    if (workspaceSlug && projectId) this.fetchInboxIssues(workspaceSlug, projectId, "filter-loading");
+    if (workspaceSlug && projectId) {
+      runInAction(() => {
+        set(this, "currentTab", tab);
+        set(this, ["inboxIssueIds"], []);
+        set(this, ["inboxIssuePaginationInfo"], undefined);
+        set(this.sortingMap, [projectId], { order_by: "issue__created_at", sort_by: "desc" });
+        set(this.filtersMap, [projectId], {
+          status:
+            tab === EInboxIssueCurrentTab.OPEN
+              ? [EInboxIssueStatus.PENDING]
+              : [EInboxIssueStatus.ACCEPTED, EInboxIssueStatus.DECLINED, EInboxIssueStatus.DUPLICATE],
+        });
+      });
+      this.fetchInboxIssues(workspaceSlug, projectId, "filter-loading");
+    }
   };
 
   handleInboxIssueFilters = <T extends keyof TInboxIssueFilter>(key: T, value: TInboxIssueFilter[T]) => {
@@ -275,13 +279,35 @@ export class ProjectInboxStore implements IProjectInboxStore {
     }
   };
 
+  initializeQueryParams = (projectId: string, tab: TInboxIssueCurrentTab) => {
+    if (!projectId || !tab) return;
+    if (isEmpty(this.inboxFilters)) {
+      set(this.filtersMap, [projectId], {
+        status:
+          tab === EInboxIssueCurrentTab.OPEN
+            ? [EInboxIssueStatus.PENDING]
+            : [EInboxIssueStatus.ACCEPTED, EInboxIssueStatus.DECLINED, EInboxIssueStatus.DUPLICATE],
+      });
+    }
+    if (isEmpty(this.inboxSorting)) {
+      set(this.sortingMap, [projectId], { order_by: "issue__created_at", sort_by: "desc" });
+    }
+  };
+
   /**
    * @description fetch intake issues with paginated data
    * @param workspaceSlug
    * @param projectId
    */
-  fetchInboxIssues = async (workspaceSlug: string, projectId: string, loadingType: TLoader = undefined) => {
+  fetchInboxIssues = async (
+    workspaceSlug: string,
+    projectId: string,
+    loadingType: TLoader = undefined,
+    tab: TInboxIssueCurrentTab | undefined = undefined
+  ) => {
     try {
+      if (loadingType === undefined && tab) this.initializeQueryParams(projectId, tab);
+
       if (this.currentInboxProjectId != projectId) {
         runInAction(() => {
           set(this, ["currentInboxProjectId"], projectId);

--- a/web/core/store/inbox/project-inbox.store.ts
+++ b/web/core/store/inbox/project-inbox.store.ts
@@ -55,7 +55,7 @@ export interface IProjectInboxStore {
     paginationCursor: string
   ) => Partial<Record<keyof TInboxIssueFilter, string>>;
   createOrUpdateInboxIssue: (inboxIssues: TInboxIssue[], workspaceSlug: string, projectId: string) => void;
-  initializeQueryParams: (projectId: string, tab: TInboxIssueCurrentTab) => void;
+  initializeDefaultFilters: (projectId: string, tab: TInboxIssueCurrentTab) => void;
   // actions
   handleCurrentTab: (workspaceSlug: string, projectId: string, tab: TInboxIssueCurrentTab) => void;
   handleInboxIssueFilters: <T extends keyof TInboxIssueFilter>(key: T, value: TInboxIssueFilter[T]) => void; // if user sends me undefined, I will remove the value from the filter key
@@ -279,7 +279,7 @@ export class ProjectInboxStore implements IProjectInboxStore {
     }
   };
 
-  initializeQueryParams = (projectId: string, tab: TInboxIssueCurrentTab) => {
+  initializeDefaultFilters = (projectId: string, tab: TInboxIssueCurrentTab) => {
     if (!projectId || !tab) return;
     if (isEmpty(this.inboxFilters)) {
       set(this.filtersMap, [projectId], {
@@ -306,7 +306,7 @@ export class ProjectInboxStore implements IProjectInboxStore {
     tab: TInboxIssueCurrentTab | undefined = undefined
   ) => {
     try {
-      if (loadingType === undefined && tab) this.initializeQueryParams(projectId, tab);
+      if (loadingType === undefined && tab) this.initializeDefaultFilters(projectId, tab);
 
       if (this.currentInboxProjectId != projectId) {
         runInAction(() => {


### PR DESCRIPTION
### Problem Statement:
In the project intake store, 
1. when we switch between the tabs in intake the default filters are not mutating based on the tab selected.
2. On initial load the default filters are not applying based on the current selected tab.

### Solution:
To resolve the above problem in this PR, 
1. Updated the `handleCurrentTab` mutation function with proper keys.
2. We pass the current tab to the initial fetch function to initiate the default filters.

### Changes:
1. Project intake store
2. Intake root component

### Plane Issue:
[[WEB-2107]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/8f20c83a-f0cf-41d6-bd36-2eb3add2e2a7)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced inbox issue fetching with improved handling for navigation tabs and default filters.
	- Introduced a method to initialize default filters based on project ID and current tab.
  
- **Bug Fixes**
	- Simplified filter and sorting retrieval logic for better performance and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->