### PR TITLE
feat: removed created_by from read_only serializer field, and ProjectMemberEndpoint updates

### DIFF
--- a/apiserver/plane/api/serializers/issue.py
+++ b/apiserver/plane/api/serializers/issue.py
@@ -53,7 +53,6 @@ class IssueSerializer(BaseSerializer):
             "id",
             "workspace",
             "project",
-            "created_by",
             "updated_by",
             "updated_at",
         ]
@@ -338,9 +337,7 @@ class IssueAttachmentSerializer(BaseSerializer):
             "workspace",
             "project",
             "issue",
-            "created_by",
             "updated_by",
-            "created_at",
             "updated_at",
         ]
 
@@ -433,3 +430,4 @@ class IssueExpandSerializer(BaseSerializer):
             "created_at",
             "updated_at",
         ]
+

--- a/apiserver/plane/api/urls/member.py
+++ b/apiserver/plane/api/urls/member.py
@@ -1,13 +1,13 @@
 from django.urls import path
 
 from plane.api.views import (
-    WorkspaceMemberAPIEndpoint,
+    ProjectMemberAPIEndpoint,
 )
 
 urlpatterns = [
     path(
-        "workspaces/<str:slug>/members/",
-        WorkspaceMemberAPIEndpoint.as_view(),
+        "workspaces/<str:slug>/projects/<str:project_id>/members/",
+        ProjectMemberAPIEndpoint.as_view(),
         name="users",
     ),
 ]

--- a/apiserver/plane/api/views/__init__.py
+++ b/apiserver/plane/api/views/__init__.py
@@ -25,6 +25,7 @@ from .module import (
     ModuleArchiveUnarchiveAPIEndpoint,
 )
 
-from .member import WorkspaceMemberAPIEndpoint
+from .member import ProjectMemberAPIEndpoint
 
 from .inbox import InboxIssueAPIEndpoint
+

--- a/apiserver/plane/api/views/cycle.py
+++ b/apiserver/plane/api/views/cycle.py
@@ -660,7 +660,6 @@ class CycleIssueAPIEndpoint(BaseAPIView):
         cycle = Cycle.objects.get(
             workspace__slug=slug, project_id=project_id, pk=cycle_id
         )
-        print("cycle name", cycle.name)
 
         if (
             cycle.end_date is not None

--- a/apiserver/plane/api/views/cycle.py
+++ b/apiserver/plane/api/views/cycle.py
@@ -26,7 +26,7 @@ from plane.api.serializers import (
     CycleSerializer,
 )
 from plane.app.permissions import ProjectEntityPermission
-from plane.bgtasks.issue_activities_task import issue_activity
+from plane.bgtasks.issue_activites_task import issue_activity
 from plane.db.models import (
     Cycle,
     CycleIssue,
@@ -1192,4 +1192,3 @@ class TransferCycleIssueAPIEndpoint(BaseAPIView):
         )
 
         return Response({"message": "Success"}, status=status.HTTP_200_OK)
-

--- a/apiserver/plane/api/views/cycle.py
+++ b/apiserver/plane/api/views/cycle.py
@@ -26,7 +26,7 @@ from plane.api.serializers import (
     CycleSerializer,
 )
 from plane.app.permissions import ProjectEntityPermission
-from plane.bgtasks.issue_activites_task import issue_activity
+from plane.bgtasks.issue_activities_task import issue_activity
 from plane.db.models import (
     Cycle,
     CycleIssue,
@@ -660,62 +660,76 @@ class CycleIssueAPIEndpoint(BaseAPIView):
         cycle = Cycle.objects.get(
             workspace__slug=slug, project_id=project_id, pk=cycle_id
         )
+        print("cycle name", cycle.name)
 
-        issues = Issue.objects.filter(
-            pk__in=issues, workspace__slug=slug, project_id=project_id
-        ).values_list("id", flat=True)
+        if (
+            cycle.end_date is not None
+            and cycle.end_date < timezone.now().date()
+        ):
+            return Response(
+                {
+                    "error": "The Cycle has already been completed so no new issues can be added"
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
 
         # Get all CycleIssues already created
-        cycle_issues = list(CycleIssue.objects.filter(issue_id__in=issues))
-        update_cycle_issue_activity = []
-        record_to_create = []
-        records_to_update = []
-
-        for issue in issues:
-            cycle_issue = [
-                cycle_issue
-                for cycle_issue in cycle_issues
-                if str(cycle_issue.issue_id) in issues
-            ]
-            # Update only when cycle changes
-            if len(cycle_issue):
-                if cycle_issue[0].cycle_id != cycle_id:
-                    update_cycle_issue_activity.append(
-                        {
-                            "old_cycle_id": str(cycle_issue[0].cycle_id),
-                            "new_cycle_id": str(cycle_id),
-                            "issue_id": str(cycle_issue[0].issue_id),
-                        }
-                    )
-                    cycle_issue[0].cycle_id = cycle_id
-                    records_to_update.append(cycle_issue[0])
-            else:
-                record_to_create.append(
-                    CycleIssue(
-                        project_id=project_id,
-                        workspace=cycle.workspace,
-                        created_by=request.user,
-                        updated_by=request.user,
-                        cycle=cycle,
-                        issue_id=issue,
-                    )
-                )
-
-        CycleIssue.objects.bulk_create(
-            record_to_create,
-            batch_size=10,
-            ignore_conflicts=True,
+        cycle_issues = list(
+            CycleIssue.objects.filter(
+                ~Q(cycle_id=cycle_id), issue_id__in=issues
+            )
         )
-        CycleIssue.objects.bulk_update(
-            records_to_update,
-            ["cycle"],
+
+        existing_issues = [
+            str(cycle_issue.issue_id)
+            for cycle_issue in cycle_issues
+            if str(cycle_issue.issue_id) in issues
+        ]
+        new_issues = list(set(issues) - set(existing_issues))
+
+        # New issues to create
+        created_records = CycleIssue.objects.bulk_create(
+            [
+                CycleIssue(
+                    project_id=project_id,
+                    workspace_id=cycle.workspace_id,
+                    cycle_id=cycle_id,
+                    issue_id=issue,
+                )
+                for issue in new_issues
+            ],
+            ignore_conflicts=True,
             batch_size=10,
+        )
+
+        # Updated Issues
+        updated_records = []
+        update_cycle_issue_activity = []
+        # Iterate over each cycle_issue in cycle_issues
+        for cycle_issue in cycle_issues:
+            old_cycle_id = cycle_issue.cycle_id
+            # Update the cycle_issue's cycle_id
+            cycle_issue.cycle_id = cycle_id
+            # Add the modified cycle_issue to the records_to_update list
+            updated_records.append(cycle_issue)
+            # Record the update activity
+            update_cycle_issue_activity.append(
+                {
+                    "old_cycle_id": str(old_cycle_id),
+                    "new_cycle_id": str(cycle_id),
+                    "issue_id": str(cycle_issue.issue_id),
+                }
+            )
+
+        # Update the cycle issues
+        CycleIssue.objects.bulk_update(
+            updated_records, ["cycle_id"], batch_size=100
         )
 
         # Capture Issue Activity
         issue_activity.delay(
             type="cycle.activity.created",
-            requested_data=json.dumps({"cycles_list": str(issues)}),
+            requested_data=json.dumps({"cycles_list": issues}),
             actor_id=str(self.request.user.id),
             issue_id=None,
             project_id=str(self.kwargs.get("project_id", None)),
@@ -723,13 +737,14 @@ class CycleIssueAPIEndpoint(BaseAPIView):
                 {
                     "updated_cycle_issues": update_cycle_issue_activity,
                     "created_cycle_issues": serializers.serialize(
-                        "json", record_to_create
+                        "json", created_records
                     ),
                 }
             ),
             epoch=int(timezone.now().timestamp()),
+            notification=True,
+            origin=request.META.get("HTTP_ORIGIN"),
         )
-
         # Return all Cycle Issues
         return Response(
             CycleIssueSerializer(self.get_queryset(), many=True).data,
@@ -1178,3 +1193,4 @@ class TransferCycleIssueAPIEndpoint(BaseAPIView):
         )
 
         return Response({"message": "Success"}, status=status.HTTP_200_OK)
+

--- a/apiserver/plane/api/views/issue.py
+++ b/apiserver/plane/api/views/issue.py
@@ -38,7 +38,7 @@ from plane.app.permissions import (
     ProjectLitePermission,
     ProjectMemberPermission,
 )
-from plane.bgtasks.issue_activities_task import issue_activity
+from plane.bgtasks.issue_activites_task import issue_activity
 from plane.db.models import (
     Issue,
     IssueActivity,
@@ -1017,4 +1017,3 @@ class IssueAttachmentEndpoint(BaseAPIView):
         )
         serializer = IssueAttachmentSerializer(issue_attachments, many=True)
         return Response(serializer.data, status=status.HTTP_200_OK)
-

--- a/apiserver/plane/api/views/issue.py
+++ b/apiserver/plane/api/views/issue.py
@@ -334,7 +334,7 @@ class IssueAPIEndpoint(BaseAPIView):
                 project_id=project_id,
                 pk=serializer.data["id"],
             ).first()
-            issue.created_at = request.data.get("created_at")
+            issue.created_at = request.data.get("created_at", timezone.now())
             issue.created_by_id = request.data.get(
                 "created_by", request.user.id
             )
@@ -803,7 +803,9 @@ class IssueCommentAPIEndpoint(BaseAPIView):
                 pk=serializer.data.get("id")
             )
             # Update the created_at and the created_by and save the comment
-            issue_comment.created_at = request.data.get("created_at")
+            issue_comment.created_at = request.data.get(
+                "created_at", timezone.now()
+            )
             issue_comment.created_by_id = request.data.get(
                 "created_by", request.user.id
             )

--- a/apiserver/plane/api/views/issue.py
+++ b/apiserver/plane/api/views/issue.py
@@ -156,32 +156,20 @@ class IssueAPIEndpoint(BaseAPIView):
         external_source = request.GET.get("external_source")
 
         if external_id and external_source:
-            try:
-                issue = Issue.objects.get(
-                    external_id=external_id,
-                    external_source=external_source,
-                    workspace__slug=slug,
-                    project_id=project_id,
-                )
-                return Response(
-                    IssueSerializer(
-                        issue,
-                        fields=self.fields,
-                        expand=self.expand,
-                    ).data,
-                    status=status.HTTP_200_OK,
-                )
-            except ObjectDoesNotExist:
-                return Response(
-                    {"detail": "Issue not found."},
-                    status=status.HTTP_404_NOT_FOUND,
-                )
-            except MultipleObjectsReturned:
-                return Response(
-                    {"detail": "Multiple issues found."},
-                    status=status.HTTP_400_BAD_REQUEST,
-                )
-
+            issue = Issue.objects.get(
+                external_id=external_id,
+                external_source=external_source,
+                workspace__slug=slug,
+                project_id=project_id,
+            )
+            return Response(
+                IssueSerializer(
+                    issue,
+                    fields=self.fields,
+                    expand=self.expand,
+                ).data,
+                status=status.HTTP_200_OK,
+            )
         if pk:
             issue = Issue.issue_objects.annotate(
                 sub_issues_count=Issue.issue_objects.filter(

--- a/apiserver/plane/api/views/issue.py
+++ b/apiserver/plane/api/views/issue.py
@@ -4,7 +4,6 @@ import json
 from django.core.serializers.json import DjangoJSONEncoder
 
 # Django imports
-from django.core.exceptions import ObjectDoesNotExist, MultipleObjectsReturned
 from django.db import IntegrityError
 from django.db.models import (
     Case,

--- a/apiserver/plane/api/views/member.py
+++ b/apiserver/plane/api/views/member.py
@@ -33,17 +33,15 @@ class ProjectMemberAPIEndpoint(BaseAPIView):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        workspace = Workspace.objects.filter(slug=slug).first()
-
         # Get the workspace members that are present inside the workspace
         project_members = ProjectMember.objects.filter(
-            project_id=project_id, workspace_id=workspace.id
-        )
+            project_id=project_id, workspace__slug=slug
+        ).values_list("member_id", flat=True)
 
         # Get all the users that are present inside the workspace
         users = UserLiteSerializer(
             User.objects.filter(
-                id__in=project_members.values_list("member_id", flat=True)
+                id__in=project_members,
             ),
             many=True,
         ).data

--- a/apiserver/plane/api/views/member.py
+++ b/apiserver/plane/api/views/member.py
@@ -21,9 +21,17 @@ from plane.db.models import (
     ProjectMember,
 )
 
+from plane.app.permissions import (
+    ProjectMemberPermission,
+)
+
 
 # API endpoint to get and insert users inside the workspace
 class ProjectMemberAPIEndpoint(BaseAPIView):
+    permission_classes = [
+        ProjectMemberPermission,
+    ]
+
     # Get all the users that are present inside the workspace
     def get(self, request, slug, project_id):
         # Check if the workspace exists

--- a/apiserver/plane/bgtasks/issue_activites_task.py
+++ b/apiserver/plane/bgtasks/issue_activites_task.py
@@ -593,7 +593,8 @@ def create_issue_activity(
         epoch=epoch,
     )
     issue_activity.created_at = issue.created_at
-    issue_activity.save(update_fields=["created_at"])
+    issue_activity.actor_id = issue.created_by_id
+    issue_activity.save(update_fields=["created_at", "actor_id"])
     requested_data = (
         json.loads(requested_data) if requested_data is not None else None
     )
@@ -1773,3 +1774,4 @@ def issue_activity(
     except Exception as e:
         log_exception(e)
         return
+


### PR DESCRIPTION
## Tasks
- Modified `WorkspaceMemberEndpoint` to `ProjectMemberEndpoint` for fetching and creating new users
- Added Parameters for getting the issues based on external_id and external_source
- Fixed broken logic for migrating one cycle issue to other cycle issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced API functionality to retrieve issues by `external_id` and `external_source`.
	- Updated API endpoints to reflect project-specific member operations.

- **Improvements**
	- Streamlined serialization by removing unnecessary fields, potentially boosting performance.
	- Improved validation and logic handling for cycle management to prevent issues being added to completed cycles.

- **Bug Fixes**
	- Corrected import errors and ensured consistency in function calls related to issue activities.

- **Refactor**
	- Renamed API endpoints to reflect project context, enhancing clarity in operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->