### PR TITLE
[WEB-2099] fix: modules and cycle peek views toggle

### DIFF
--- a/web/core/components/cycles/board/cycles-board-card.tsx
+++ b/web/core/components/cycles/board/cycles-board-card.tsx
@@ -139,7 +139,7 @@ export const CyclesBoardCard: FC<ICyclesBoardCard> = observer((props) => {
     e.stopPropagation();
 
     const query = generateQueryParams(searchParams, ["peekCycle"]);
-    if (searchParams.has("peekCycle")) {
+    if (searchParams.has("peekCycle") && searchParams.get("peekCycle") === cycleId) {
       router.push(`${pathname}?${query}`);
     } else {
       router.push(`${pathname}?${query && `${query}&`}peekCycle=${cycleId}`);

--- a/web/core/components/cycles/list/cycles-list-item.tsx
+++ b/web/core/components/cycles/list/cycles-list-item.tsx
@@ -70,7 +70,7 @@ export const CyclesListItem: FC<TCyclesListItem> = observer((props) => {
     e.stopPropagation();
 
     const query = generateQueryParams(searchParams, ["peekCycle"]);
-    if (searchParams.has("peekCycle")) {
+    if (searchParams.has("peekCycle") && searchParams.get("peekCycle") === cycleId) {
       router.push(`${pathname}?${query}`);
     } else {
       router.push(`${pathname}?${query && `${query}&`}peekCycle=${cycleId}`);

--- a/web/core/components/modules/module-card-item.tsx
+++ b/web/core/components/modules/module-card-item.tsx
@@ -113,7 +113,7 @@ export const ModuleCardItem: React.FC<Props> = observer((props) => {
     e.preventDefault();
 
     const query = generateQueryParams(searchParams, ["peekModule"]);
-    if (searchParams.has("peekModule")) {
+    if (searchParams.has("peekModule") && searchParams.get("peekModule") === moduleId) {
       router.push(`${pathname}?${query}`);
     } else {
       router.push(`${pathname}?${query && `${query}&`}peekModule=${moduleId}`);

--- a/web/core/components/modules/module-list-item.tsx
+++ b/web/core/components/modules/module-list-item.tsx
@@ -67,7 +67,7 @@ export const ModuleListItem: React.FC<Props> = observer((props) => {
     e.preventDefault();
 
     const query = generateQueryParams(searchParams, ["peekModule"]);
-    if (searchParams.has("peekModule")) {
+    if (searchParams.has("peekModule") && searchParams.get("peekModule") === moduleId) {
       router.push(`${pathname}?${query}`);
     } else {
       router.push(`${pathname}?${query && `${query}&`}peekModule=${moduleId}`);


### PR DESCRIPTION
This PR fixes the issue when an peek Module and peek Cycle is toggled, it cannot be switched to other module/cylce without un toggling the opened peek view.

https://github.com/user-attachments/assets/8616b03e-0eaf-4d7e-b09b-5a9899da619e



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced navigation logic for cycle and module components to ensure routing only occurs when parameters match the current ID, preventing unintended navigations.
- **Bug Fixes**
	- Improved precision in the handling of `peekCycle` and `peekModule` parameters within their respective components, leading to a more reliable user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->