### PR TITLE
[WEB-2110] fix: broken link while trying to copy page link

### DIFF
--- a/web/core/components/pages/editor/header/options-dropdown.tsx
+++ b/web/core/components/pages/editor/header/options-dropdown.tsx
@@ -108,7 +108,10 @@ export const PageOptionsDropdown: React.FC<Props> = observer((props) => {
     {
       key: "copy-page-link",
       action: () => {
-        copyUrlToClipboard(`${workspaceSlug?.toString()}/projects/${projectId?.toString()}/pages/${id}`).then(() =>
+        const pageLink = projectId
+          ? `${workspaceSlug?.toString()}/projects/${projectId?.toString()}/pages/${id}`
+          : `${workspaceSlug?.toString()}/pages/${id}`;
+        copyUrlToClipboard(pageLink).then(() =>
           setToast({
             type: TOAST_TYPE.SUCCESS,
             title: "Success!",


### PR DESCRIPTION
#### Problem:

When trying to copy a page link from the options dropdown inside a page, projectId comes as `undefined`.

#### Solution:

Add project information to the page link only if the `projectId` is present in the params.

#### Plane issue: [WEB-2110](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/d5b38ae4-c178-4a5e-9324-e0ea085afb36)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the Page Options Dropdown to generate valid URLs for copying page links, accommodating scenarios without a project ID.
- **Bug Fixes**
	- Improved the logic for URL construction to ensure proper handling of undefined project IDs, thus enhancing the overall user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->