### PR TITLE
chore: deploy board publish validation

### DIFF
--- a/apiserver/plane/space/views/project.py
+++ b/apiserver/plane/space/views/project.py
@@ -69,7 +69,7 @@ class WorkspaceProjectAnchorEndpoint(BaseAPIView):
 
     def get(self, request, slug, project_id):
         project_deploy_board = DeployBoard.objects.get(
-            workspace__slug=slug, project_id=project_id
+            workspace__slug=slug, project_id=project_id, entity_name="project"
         )
         serializer = DeployBoardSerializer(project_deploy_board)
         return Response(serializer.data, status=status.HTTP_200_OK)


### PR DESCRIPTION
chore: 
- The publish board API was returning two boards when the view was also published. This pull request resolves the issue by ensuring that only one board is returned.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved data retrieval for the DeployBoard instance by adding an additional filter criterion, enhancing specificity in the API response.
  
- **Bug Fixes**
	- Resolved potential issues with fetching irrelevant DeployBoard entries by refining the query logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->