### PR TITLE
[WEB-2066] fix: completed cycle date picker validation

### DIFF
--- a/web/core/components/cycles/analytics-sidebar/root.tsx
+++ b/web/core/components/cycles/analytics-sidebar/root.tsx
@@ -387,7 +387,7 @@ export const CycleDetailsSidebar: React.FC<Props> = observer((props) => {
                           to: "End date",
                         }}
                         required={cycleDetails.status !== "draft"}
-                        disabled={!isEditingAllowed || isArchived}
+                        disabled={!isEditingAllowed || isArchived || isCompleted}
                       />
                     )}
                   />


### PR DESCRIPTION
#### Changes:
This PR addresses a bug with the date picker validation for completed cycles. Previously, users were able to open the date range picker popover for completed cycles, which is not intended behavior. Added validation to prevent this issue.

#### Reference: 
[[WEB-2066]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/12846cc7-1995-4883-98de-560fae974b2b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the user experience by preventing interaction with completed cycles in the Cycle Details Sidebar.
  
- **Bug Fixes**
	- Improved the control flow for disabling components, ensuring users cannot edit or interact with cycles based on additional conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->