### PR TITLE
[WEB-2087] fix: pages full width toggle seems laggy

### DIFF
--- a/web/core/components/pages/editor/editor-body.tsx
+++ b/web/core/components/pages/editor/editor-body.tsx
@@ -101,7 +101,7 @@ export const PageEditorBody: React.FC<Props> = observer((props) => {
       <div
         className={cn("sticky top-0 hidden h-full flex-shrink-0 -translate-x-full p-5 duration-200 md:block", {
           "translate-x-0": sidePeekVisible,
-          "w-40 lg:w-56": !isFullWidth,
+          "w-[10rem] lg:w-[14rem]": !isFullWidth,
           "w-[5%]": isFullWidth,
         })}
       >
@@ -113,8 +113,8 @@ export const PageEditorBody: React.FC<Props> = observer((props) => {
         )}
       </div>
       <div
-        className={cn("h-full w-full pt-5", {
-          "md:w-[calc(100%-10rem)] xl:w-[calc(100%-14rem-14rem)]": !isFullWidth,
+        className={cn("h-full w-full pt-5 duration-200", {
+          "md:w-[calc(100%-10rem)] xl:w-[calc(100%-28rem)]": !isFullWidth,
           "md:w-[90%]": isFullWidth,
         })}
       >
@@ -168,8 +168,8 @@ export const PageEditorBody: React.FC<Props> = observer((props) => {
         </div>
       </div>
       <div
-        className={cn("hidden xl:block flex-shrink-0", {
-          "w-40 lg:w-56": !isFullWidth,
+        className={cn("hidden xl:block flex-shrink-0 duration-200", {
+          "w-[10rem] lg:w-[14rem]": !isFullWidth,
           "w-[5%]": isFullWidth,
         })}
       />


### PR DESCRIPTION
#### Problem:

Full width toggle of a page lags in Safari.

#### Solution:

Add `transition-duration` to the divs with variable widths to make the transition smooth.

#### Media:

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/462ab34f-0099-46a2-8c39-577b25bf72e0"></video> | <video src="https://github.com/user-attachments/assets/959e8fcd-1517-4fa7-bd79-d5e3537c5805"></video> | 

#### Plane issue: [WEB-2087](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/d5af7e41-fe50-4bb7-b8a1-a2de0cca4609)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved responsive design for the page editor, enhancing layout flexibility across different screen sizes.
- **Bug Fixes**
	- Fixed layout issues by updating width calculations to ensure proper element sizing in various display scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->