### PR TITLE
[WEB-2101] fix: Visibility of empty Grouping in Kanban for Space views

### DIFF
--- a/space/core/components/issues/issue-layouts/kanban/default.tsx
+++ b/space/core/components/issues/issue-layouts/kanban/default.tsx
@@ -64,22 +64,15 @@ export const KanBan: React.FC<IKanBan> = observer((props) => {
   if (!groupList) return null;
 
   const visibilityGroupBy = (_list: IGroupByColumn): { showGroup: boolean; showIssues: boolean } => {
-    if (subGroupBy) {
-      const groupVisibility = {
-        showGroup: true,
-        showIssues: true,
-      };
-      if (!showEmptyGroup) {
-        groupVisibility.showGroup = (getGroupIssueCount(_list.id, undefined, false) ?? 0) > 0;
-      }
-      return groupVisibility;
-    } else {
-      const groupVisibility = {
-        showGroup: true,
-        showIssues: true,
-      };
-      return groupVisibility;
+    const groupVisibility = {
+      showGroup: true,
+      showIssues: true,
+    };
+
+    if (!showEmptyGroup) {
+      groupVisibility.showGroup = (getGroupIssueCount(_list.id, undefined, false) ?? 0) > 0;
     }
+    return groupVisibility;
   };
 
   return (


### PR DESCRIPTION
This PR fixes the issue in Space views for Kanban, when in empty groups were shown even when it was disabled in the view properties

<img width="1918" alt="image" src="https://github.com/user-attachments/assets/7ee55a63-f7e8-469f-8ee2-ad242d4f1754">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified the logic in the KanBan component to enhance readability while maintaining original functionality.
	- Removed redundant code related to visibility grouping, improving overall performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->