### PR TITLE
[WEB-1671] fix: expired snooze issues fixed

### DIFF
--- a/web/core/components/inbox/inbox-issue-status.tsx
+++ b/web/core/components/inbox/inbox-issue-status.tsx
@@ -17,9 +17,9 @@ export const InboxIssueStatus: React.FC<Props> = observer((props) => {
   const { inboxIssue, iconSize = 16, showDescription = false } = props;
   // derived values
   const inboxIssueStatusDetail = INBOX_STATUS.find((s) => s.status === inboxIssue.status);
-  if (!inboxIssueStatusDetail) return <></>;
 
   const isSnoozedDatePassed = inboxIssue.status === 0 && new Date(inboxIssue.snoozed_till ?? "") < new Date();
+  if (!inboxIssueStatusDetail || isSnoozedDatePassed) return <></>;
 
   const description = inboxIssueStatusDetail.description(new Date(inboxIssue.snoozed_till ?? ""));
 

--- a/web/core/store/inbox/project-inbox.store.ts
+++ b/web/core/store/inbox/project-inbox.store.ts
@@ -158,20 +158,22 @@ export class ProjectInboxStore implements IProjectInboxStore {
     appliedFilters = appliedFilters.filter((filter) => this.inboxFilters?.status?.includes(filter));
     const currentTime = new Date().getTime();
 
-    return this.inboxIssueIds.filter((id) => {
-      if (appliedFilters.length == 2) return true;
-      if (appliedFilters.includes(EInboxIssueStatus.SNOOZED))
-        return (
-          this.inboxIssues[id].status === EInboxIssueStatus.SNOOZED &&
-          currentTime < new Date(this.inboxIssues[id].snoozed_till!).getTime()
-        );
-      if (appliedFilters.includes(EInboxIssueStatus.PENDING))
-        return (
-          appliedFilters.includes(this.inboxIssues[id].status) ||
-          (this.inboxIssues[id].status === EInboxIssueStatus.SNOOZED &&
-            currentTime > new Date(this.inboxIssues[id].snoozed_till!).getTime())
-        );
-    });
+    return this.currentTab === EInboxIssueCurrentTab.OPEN
+      ? this.inboxIssueIds.filter((id) => {
+          if (appliedFilters.length == 2) return true;
+          if (appliedFilters[0] === EInboxIssueStatus.SNOOZED)
+            return (
+              this.inboxIssues[id].status === EInboxIssueStatus.SNOOZED &&
+              currentTime < new Date(this.inboxIssues[id].snoozed_till!).getTime()
+            );
+          if (appliedFilters[0] === EInboxIssueStatus.PENDING)
+            return (
+              appliedFilters.includes(this.inboxIssues[id].status) ||
+              (this.inboxIssues[id].status === EInboxIssueStatus.SNOOZED &&
+                currentTime > new Date(this.inboxIssues[id].snoozed_till!).getTime())
+            );
+        })
+      : this.inboxIssueIds.filter((id) => appliedFilters.includes(this.inboxIssues[id].status));
   }
 
   getIssueInboxByIssueId = computedFn((issueId: string) => this.inboxIssues?.[issueId]);


### PR DESCRIPTION
**Summary**
Snoozed issues with a past due date continue to display "-x days to go" after the intended snooze date has passed. These issues should no longer be considered snoozed and should be displayed under inbox issues window and time stamp -x days should be removed

[[WEB-1671]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/a4015291-9cb7-4414-b6bd-de9b42efd177)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced filtering logic for inbox issues, improving issue visibility based on current status and snooze conditions.
	- Updated rendering logic for inbox issues to ensure only relevant information is displayed based on status and snooze state.

- **Bug Fixes**
	- Fixed empty fragment rendering for inbox issues, ensuring that inactive or snoozed issues do not clutter the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->