### PR TITLE
[WEB-2083] fix: error message for duplicate label creation in project

### DIFF
--- a/web/core/components/labels/create-update-label-inline.tsx
+++ b/web/core/components/labels/create-update-label-inline.tsx
@@ -66,7 +66,7 @@ export const CreateUpdateLabelInline = observer(
           setToast({
             title: "Error!",
             type: TOAST_TYPE.ERROR,
-            message: error?.detail ?? "Something went wrong. Please try again later.",
+            message: error?.detail ?? error.error ?? "Something went wrong. Please try again later.",
           });
           reset(formData);
         });


### PR DESCRIPTION
**Summary**
Fixed the error message on duplicate error creation
 
[[WEB-2083]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/4491bc00-d2db-4433-9f7f-1f8fec5f8b49)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced error messaging in the CreateUpdateLabelInline component for better user feedback during error scenarios. Users will now see more informative toast notifications when an error occurs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->