### PR TITLE
[WEB-2160] fix: initial fetch filters is not being applied when we have a undefined currentTab in params

### DIFF
--- a/web/core/components/inbox/root.tsx
+++ b/web/core/components/inbox/root.tsx
@@ -34,7 +34,12 @@ export const InboxIssueRoot: FC<TInboxIssueRoot> = observer((props) => {
     if (navigationTab && navigationTab !== currentTab) {
       handleCurrentTab(workspaceSlug, projectId, navigationTab);
     } else {
-      fetchInboxIssues(workspaceSlug.toString(), projectId.toString(), undefined, navigationTab);
+      fetchInboxIssues(
+        workspaceSlug.toString(),
+        projectId.toString(),
+        undefined,
+        navigationTab || EInboxIssueCurrentTab.OPEN
+      );
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [inboxAccessible, workspaceSlug, projectId]);
@@ -77,6 +82,7 @@ export const InboxIssueRoot: FC<TInboxIssueRoot> = observer((props) => {
             setIsMobileSidebar={setIsMobileSidebar}
             workspaceSlug={workspaceSlug.toString()}
             projectId={projectId.toString()}
+            inboxIssueId={inboxIssueId}
           />
         </div>
 

--- a/web/core/components/inbox/sidebar/root.tsx
+++ b/web/core/components/inbox/sidebar/root.tsx
@@ -2,7 +2,6 @@
 
 import { FC, useCallback, useEffect, useRef, useState } from "react";
 import { observer } from "mobx-react";
-import { useParams } from "next/navigation";
 import { TInboxIssueCurrentTab } from "@plane/types";
 import { Loader } from "@plane/ui";
 // components
@@ -22,6 +21,7 @@ import { useIntersectionObserver } from "@/hooks/use-intersection-observer";
 type IInboxSidebarProps = {
   workspaceSlug: string;
   projectId: string;
+  inboxIssueId: string | undefined;
   setIsMobileSidebar: (value: boolean) => void;
 };
 
@@ -37,7 +37,7 @@ const tabNavigationOptions: { key: TInboxIssueCurrentTab; label: string }[] = [
 ];
 
 export const InboxSidebar: FC<IInboxSidebarProps> = observer((props) => {
-  const { workspaceSlug, projectId, setIsMobileSidebar } = props;
+  const { workspaceSlug, projectId, inboxIssueId, setIsMobileSidebar } = props;
   // ref
   const containerRef = useRef<HTMLDivElement>(null);
   const [elementRef, setElementRef] = useState<HTMLDivElement | null>(null);
@@ -54,7 +54,6 @@ export const InboxSidebar: FC<IInboxSidebarProps> = observer((props) => {
   } = useProjectInbox();
 
   const router = useAppRouter();
-  const { inboxIssueId } = useParams();
 
   const fetchNextPages = useCallback(() => {
     if (!workspaceSlug || !projectId) return;
@@ -65,11 +64,14 @@ export const InboxSidebar: FC<IInboxSidebarProps> = observer((props) => {
   useIntersectionObserver(containerRef, elementRef, fetchNextPages, "20%");
 
   useEffect(() => {
-    if (inboxIssueId) return;
-    router.push(
-      `/${workspaceSlug}/projects/${projectId}/inbox?currentTab=${currentTab}&inboxIssueId=${filteredInboxIssueIds[0]}`
-    );
-  }, []);
+    if (workspaceSlug && projectId && currentTab && filteredInboxIssueIds.length > 0) {
+      if (inboxIssueId === undefined) {
+        router.push(
+          `/${workspaceSlug}/projects/${projectId}/inbox?currentTab=${currentTab}&inboxIssueId=${filteredInboxIssueIds[0]}`
+        );
+      }
+    }
+  }, [currentTab, filteredInboxIssueIds, inboxIssueId, projectId, router, workspaceSlug]);
 
   return (
     <div className="bg-custom-background-100 flex-shrink-0 w-full h-full border-r border-custom-border-300 ">


### PR DESCRIPTION
### Problem Statement:
In the project intake store, the default filters are not applied based on the tab currently selected for the initial load.

### Solution:
To resolve the above problem, In this PR, We pass the current tab or the default open tab to the initial fetch function to initiate the default filters.

### Changes:
1. Project intake store
2. Intake sidebar root component

### Plane Issue:
[[WEB-2160]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/1c9352f4-7ad4-43e9-8f21-2b9b1c4e60fd)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced inbox issue fetching logic to ensure valid default values for the current tab.
	- Added support for handling specific inbox issue identifiers in the Inbox components.
  
- **Bug Fixes**
	- Improved routing logic in the sidebar to function correctly based on the presence of inbox issue IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->