### PR TITLE
[WEB-2168] fix: yjs duplicate import error

### DIFF
--- a/web/next.config.js
+++ b/web/next.config.js
@@ -1,6 +1,8 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 /** @type {import("next").NextConfig} */
 require("dotenv").config({ path: ".env" });
+const path = require("path");
+
 const { withSentryConfig } = require("@sentry/nextjs");
 const withPWA = require("next-pwa")({
   dest: "public",
@@ -33,6 +35,13 @@ const nextConfig = {
       },
     ],
     unoptimized: true,
+  },
+  webpack: (config, { isServer }) => {
+    if (!isServer) {
+      // Ensure that all imports of 'yjs' resolve to the same instance
+      config.resolve.alias["yjs"] = path.resolve(__dirname, "node_modules/yjs");
+    }
+    return config;
   },
   async redirects() {
     return [


### PR DESCRIPTION
This PR fixes the issue of duplicate Yjs import.

Reference- https://tiptap.dev/docs/editor/getting-started/install/nextjs#using-yjs-with-nextjs

#### Plane issue: [WEB-2168](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/d2dc8664-81e8-419b-85fa-ea4b2db367ee)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced Webpack configuration for improved module resolution of the `yjs` library.
	- Added support for consistent imports in client-side builds, promoting reliability.

- **Bug Fixes**
	- Addressed potential issues with module resolution that could affect application performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->