### PR TITLE
[WEB-1907] Fix/favorite move out of folder

### DIFF
--- a/web/core/components/workspace/sidebar/favorites/favorite-folder.tsx
+++ b/web/core/components/workspace/sidebar/favorites/favorite-folder.tsx
@@ -93,12 +93,12 @@ export const FavoriteFolder: React.FC<Props> = (props) => {
     const element = elementRef.current;
 
     if (!element) return;
-    const initialData = { type: "PARENT", id: favorite.id };
+    const initialData = { type: "PARENT", id: favorite.id, is_folder: favorite.is_folder };
 
     return combine(
       draggable({
         element,
-        // getInitialData: () => initialData,
+        getInitialData: () => initialData,
         onDragStart: () => setIsDragging(true),
         onDrop: (data) => {
           setIsDraggedOver(false);
@@ -109,7 +109,7 @@ export const FavoriteFolder: React.FC<Props> = (props) => {
             const edge = extractClosestEdge(destinationData) || undefined;
             const payload = {
               id: favorite.id,
-              sequence: getDestinationStateSequence(favoriteMap, destinationData.id as string, edge),
+              sequence: Math.round(getDestinationStateSequence(favoriteMap, destinationData.id as string, edge) || 0),
             };
 
             handleOnDropFolder(payload);
@@ -127,7 +127,7 @@ export const FavoriteFolder: React.FC<Props> = (props) => {
         onDragEnter: (args) => {
           setIsDragging(true);
           setIsDraggedOver(true);
-          setClosestEdge(extractClosestEdge(args.self.data));
+          args.source.data.is_folder && setClosestEdge(extractClosestEdge(args.self.data));
         },
         onDragLeave: () => {
           setIsDragging(false);
@@ -142,7 +142,7 @@ export const FavoriteFolder: React.FC<Props> = (props) => {
           setIsDraggedOver(false);
           const sourceId = source?.data?.id as string | undefined;
           const destinationId = self?.data?.id as string | undefined;
-
+          if (source.data.is_folder) return;
           if (sourceId === destinationId) return;
           if (!sourceId || !destinationId) return;
           if (favoriteMap[sourceId].parent === destinationId) return;

--- a/web/core/components/workspace/sidebar/favorites/favorite-folder.tsx
+++ b/web/core/components/workspace/sidebar/favorites/favorite-folder.tsx
@@ -28,10 +28,11 @@ type Props = {
   isLastChild: boolean;
   favorite: IFavorite;
   handleRemoveFromFavorites: (favorite: IFavorite) => void;
+  handleRemoveFromFavoritesFolder: (favoriteId: string) => void;
 };
 
 export const FavoriteFolder: React.FC<Props> = (props) => {
-  const { favorite, handleRemoveFromFavorites } = props;
+  const { favorite, handleRemoveFromFavorites, handleRemoveFromFavoritesFolder } = props;
   // store hooks
   const { sidebarCollapsed: isSidebarCollapsed } = useAppTheme();
 
@@ -312,6 +313,8 @@ export const FavoriteFolder: React.FC<Props> = (props) => {
                       key={child.id}
                       favorite={child}
                       handleRemoveFromFavorites={handleRemoveFromFavorites}
+                      handleRemoveFromFavoritesFolder={handleRemoveFromFavoritesFolder}
+                      favoriteMap={favoriteMap}
                     />
                   ))}
                 </Disclosure.Panel>

--- a/web/core/components/workspace/sidebar/favorites/favorite-item.tsx
+++ b/web/core/components/workspace/sidebar/favorites/favorite-item.tsx
@@ -139,7 +139,7 @@ export const FavoriteItem = observer(
             {getIcon()}
 
             {!sidebarCollapsed && (
-              <Link href={getLink()} className="text-sm leading-5 font-medium flex-1">
+              <Link href={getLink()} className="text-sm leading-5 font-medium flex-1 truncate">
                 {favorite.entity_data ? favorite.entity_data.name : favorite.name}
               </Link>
             )}

--- a/web/core/components/workspace/sidebar/favorites/favorite-item.tsx
+++ b/web/core/components/workspace/sidebar/favorites/favorite-item.tsx
@@ -118,10 +118,8 @@ export const FavoriteItem = observer(
             setIsDragging(false);
           },
           onDrop: ({ source }) => {
-            console.log(source);
             setIsDragging(false);
             const sourceId = source?.data?.id as string | undefined;
-            console.log({ sourceId });
             if (!sourceId || !favoriteMap[sourceId].parent) return;
             handleRemoveFromFavoritesFolder(sourceId);
           },

--- a/web/core/components/workspace/sidebar/favorites/favorite-item.tsx
+++ b/web/core/components/workspace/sidebar/favorites/favorite-item.tsx
@@ -2,7 +2,7 @@
 
 import React, { useEffect, useRef, useState } from "react";
 import { combine } from "@atlaskit/pragmatic-drag-and-drop/combine";
-import { draggable } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
+import { draggable, dropTargetForElements } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
 import { observer } from "mobx-react";
 import Link from "next/link";
 import { useParams } from "next/navigation";
@@ -22,11 +22,15 @@ import { usePlatformOS } from "@/hooks/use-platform-os";
 
 export const FavoriteItem = observer(
   ({
+    favoriteMap,
     favorite,
     handleRemoveFromFavorites,
+    handleRemoveFromFavoritesFolder,
   }: {
     favorite: IFavorite;
+    favoriteMap: Record<string, IFavorite>;
     handleRemoveFromFavorites: (favorite: IFavorite) => void;
+    handleRemoveFromFavoritesFolder: (favoriteId: string) => void;
   }) => {
     // store hooks
     const { sidebarCollapsed } = useAppTheme();
@@ -100,6 +104,26 @@ export const FavoriteItem = observer(
           },
           onDrop: () => {
             setIsDragging(false);
+          },
+        }),
+        dropTargetForElements({
+          element,
+          onDragStart: () => {
+            setIsDragging(true);
+          },
+          onDragEnter: () => {
+            setIsDragging(true);
+          },
+          onDragLeave: () => {
+            setIsDragging(false);
+          },
+          onDrop: ({ source }) => {
+            console.log(source);
+            setIsDragging(false);
+            const sourceId = source?.data?.id as string | undefined;
+            console.log({ sourceId });
+            if (!sourceId || !favoriteMap[sourceId].parent) return;
+            handleRemoveFromFavoritesFolder(sourceId);
           },
         })
       );

--- a/web/core/components/workspace/sidebar/favorites/favorites-menu.tsx
+++ b/web/core/components/workspace/sidebar/favorites/favorites-menu.tsx
@@ -3,7 +3,7 @@
 import React, { useEffect, useRef, useState } from "react";
 import { combine } from "@atlaskit/pragmatic-drag-and-drop/combine";
 import { dropTargetForElements } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
-import { orderBy } from "lodash";
+import { orderBy, uniqBy } from "lodash";
 import { observer } from "mobx-react";
 import { useParams } from "next/navigation";
 import { ChevronRight, FolderPlus } from "lucide-react";
@@ -131,7 +131,7 @@ export const SidebarFavoritesMenu = observer(() => {
             )}
           >
             <span onClick={() => toggleFavoriteMenu(!isFavoriteMenuOpen)} className="flex-1 text-start">
-              MY FAVORITES
+              YOUR FAVORITES
             </span>
             <span className="flex gap-2 flex-shrink-0 opacity-0 pointer-events-none group-hover/workspace-button:opacity-100 group-hover/workspace-button:pointer-events-auto rounded p-0.5 ">
               <FolderPlus
@@ -168,7 +168,7 @@ export const SidebarFavoritesMenu = observer(() => {
               static
             >
               {createNewFolder && <NewFavoriteFolder setCreateNewFolder={setCreateNewFolder} actionType="create" />}
-              {orderBy(Object.values(favoriteMap), "sequence", "desc")
+              {uniqBy(orderBy(Object.values(favoriteMap), "sequence", "desc"), "id")
                 .filter((fav) => !fav.parent)
                 .map((fav, index) => (
                   <Tooltip

--- a/web/core/components/workspace/sidebar/favorites/favorites-menu.tsx
+++ b/web/core/components/workspace/sidebar/favorites/favorites-menu.tsx
@@ -184,9 +184,15 @@ export const SidebarFavoritesMenu = observer(() => {
                         favorite={fav}
                         isLastChild={index === favoriteIds.length - 1}
                         handleRemoveFromFavorites={handleRemoveFromFavorites}
+                        handleRemoveFromFavoritesFolder={handleRemoveFromFavoritesFolder}
                       />
                     ) : (
-                      <FavoriteItem favorite={fav} handleRemoveFromFavorites={handleRemoveFromFavorites} />
+                      <FavoriteItem
+                        favorite={fav}
+                        handleRemoveFromFavorites={handleRemoveFromFavorites}
+                        handleRemoveFromFavoritesFolder={handleRemoveFromFavoritesFolder}
+                        favoriteMap={favoriteMap}
+                      />
                     )}
                   </Tooltip>
                 ))}

--- a/web/core/store/cycle.store.ts
+++ b/web/core/store/cycle.store.ts
@@ -551,6 +551,7 @@ export class CycleStore implements ICycleStore {
   deleteCycle = async (workspaceSlug: string, projectId: string, cycleId: string) =>
     await this.cycleService.deleteCycle(workspaceSlug, projectId, cycleId).then(() => {
       runInAction(() => {
+        this.rootStore.favorite.removeFavoriteFromStore(cycleId);
         delete this.cycleMap[cycleId];
         delete this.activeCycleIdMap[cycleId];
       });

--- a/web/core/store/module.store.ts
+++ b/web/core/store/module.store.ts
@@ -405,6 +405,7 @@ export class ModulesStore implements IModuleStore {
     await this.moduleService.deleteModule(workspaceSlug, projectId, moduleId).then(() => {
       runInAction(() => {
         delete this.moduleMap[moduleId];
+        this.rootStore.favorite.removeFavoriteFromStore(moduleId);
       });
     });
   };

--- a/web/core/store/project-view.store.ts
+++ b/web/core/store/project-view.store.ts
@@ -271,6 +271,7 @@ export class ProjectViewStore implements IProjectViewStore {
     await this.viewService.deleteView(workspaceSlug, projectId, viewId).then(() => {
       runInAction(() => {
         delete this.viewMap[viewId];
+        this.rootStore.favorite.removeFavoriteFromStore(viewId);
       });
     });
   };

--- a/web/core/store/project/project.store.ts
+++ b/web/core/store/project/project.store.ts
@@ -401,6 +401,7 @@ export class ProjectStore implements IProjectStore {
       await this.projectService.deleteProject(workspaceSlug, projectId);
       runInAction(() => {
         delete this.projectMap[projectId];
+        this.rootStore.favorite.removeFavoriteFromStore(projectId);
       });
     } catch (error) {
       console.log("Failed to delete project from project store");


### PR DESCRIPTION
Summary
Users can now hover on a item to move it out of favorite

[[WEB-1907]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/d820a165-b857-47dc-86c5-a6bf05caccd8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced drag-and-drop functionality for favorite items and folders, allowing users to easily manage their favorites.
	- Introduced a method for removing favorites directly from folders via drag-and-drop actions.

- **User Interface Updates**
	- Updated the label from "MY FAVORITES" to "YOUR FAVORITES" for improved user engagement.
	- Improved rendering logic to prevent duplicate favorite items based on IDs.

- **Bug Fixes**
	- Enhanced error handling during updates and deletions of favorites, ensuring data integrity and rollback on failure.

- **Chores**
	- Refined internal logic for managing favorites and modules to ensure consistency across the application during deletions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->