### PR TITLE
feat: added `deleted_at` as read-only property for the label serializer

### DIFF
--- a/apiserver/plane/api/serializers/issue.py
+++ b/apiserver/plane/api/serializers/issue.py
@@ -269,6 +269,7 @@ class LabelSerializer(BaseSerializer):
             "updated_by",
             "created_at",
             "updated_at",
+            "deleted_at",
         ]
 
 
@@ -430,4 +431,3 @@ class IssueExpandSerializer(BaseSerializer):
             "created_at",
             "updated_at",
         ]
-


### PR DESCRIPTION
## Description
Getting error for `deleted_at` being a required field, modified the label serializer for adding `deleted_at` property as a read_only field for avoiding the error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new field for tracking deletion timestamps of issues, enhancing data integrity and historical tracking.
  
- **Style**
	- Minor formatting adjustment to the codebase for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->