### PR TITLE
chore: update cache command to delete the cache entry for the cache key

### DIFF
--- a/apiserver/plane/db/management/commands/clear_cache.py
+++ b/apiserver/plane/db/management/commands/clear_cache.py
@@ -6,8 +6,23 @@ from django.core.management import BaseCommand
 class Command(BaseCommand):
     help = "Clear Cache before starting the server to remove stale values"
 
+    def add_arguments(self, parser):
+        # Positional argument
+        parser.add_argument(
+            "--key", type=str, nargs="?", help="Key to clear cache"
+        )
+
     def handle(self, *args, **options):
         try:
+            if options["key"]:
+                cache.delete(options["key"])
+                self.stdout.write(
+                    self.style.SUCCESS(
+                        f"Cache Cleared for key: {options['key']}"
+                    )
+                )
+                return
+
             cache.clear()
             self.stdout.write(self.style.SUCCESS("Cache Cleared"))
             return


### PR DESCRIPTION
### Description
This PR updates the `clear_cache` command to accept an **optional** parameter key to remove the entry for the specific cache key.
```bash
python manage.py clear_cache <key>
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new command-line option for cache clearing, allowing users to delete specific cache entries by key.
	- Enhanced flexibility in cache management for improved user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->