### PR TITLE
Fixed typo in manifest.json

### DIFF
--- a/web/public/manifest.json
+++ b/web/public/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Plane",
-  "shot_name": "Plane",
+  "short_name": "Plane",
   "icons": [
     {
       "src": "/icons/icon-192x192.png",


### PR DESCRIPTION
Changed "shot_name" to "short_name", small typo 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the manifest file to correct the key `"shot_name"` to `"short_name"` for improved clarity and standardization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->