### PR TITLE
feat: added endpoint for creating service tokens 

### DIFF
--- a/apiserver/plane/app/urls/api.py
+++ b/apiserver/plane/app/urls/api.py
@@ -1,5 +1,5 @@
 from django.urls import path
-from plane.app.views import ApiTokenEndpoint
+from plane.app.views import ApiTokenEndpoint, ServiceApiTokenEndpoint
 
 urlpatterns = [
     # API Tokens
@@ -12,6 +12,11 @@ urlpatterns = [
         "workspaces/<str:slug>/api-tokens/<uuid:pk>/",
         ApiTokenEndpoint.as_view(),
         name="api-tokens",
+    ),
+    path(
+        "workspaces/<str:slug>/service-api-tokens/",
+        ServiceApiTokenEndpoint.as_view(),
+        name="service-api-tokens",
     ),
     ## End API Tokens
 ]

--- a/apiserver/plane/app/views/__init__.py
+++ b/apiserver/plane/app/views/__init__.py
@@ -174,8 +174,10 @@ from .module.archive import (
     ModuleArchiveUnarchiveEndpoint,
 )
 
-from .api import ApiTokenEndpoint
-
+from .api import (
+    ApiTokenEndpoint,
+    ServiceApiTokenEndpoint,
+)
 
 from .page.base import (
     PageViewSet,

--- a/apiserver/plane/app/views/api.py
+++ b/apiserver/plane/app/views/api.py
@@ -45,7 +45,7 @@ class ApiTokenEndpoint(BaseAPIView):
     def get(self, request, slug, pk=None):
         if pk is None:
             api_tokens = APIToken.objects.filter(
-                user=request.user, workspace__slug=slug
+                user=request.user, workspace__slug=slug, is_service=False
             )
             serializer = APITokenReadSerializer(api_tokens, many=True)
             return Response(serializer.data, status=status.HTTP_200_OK)
@@ -113,7 +113,6 @@ class ServiceApiTokenEndpoint(BaseAPIView):
                 user_type=user_type,
                 is_service=True,
             )
-            # Token will be only visible while creating
             return Response(
                 {
                     "token": str(api_token.token),

--- a/apiserver/plane/app/views/api.py
+++ b/apiserver/plane/app/views/api.py
@@ -61,6 +61,7 @@ class ApiTokenEndpoint(BaseAPIView):
             workspace__slug=slug,
             user=request.user,
             pk=pk,
+            is_service=False,
         )
         api_token.delete()
         return Response(status=status.HTTP_204_NO_CONTENT)
@@ -78,3 +79,45 @@ class ApiTokenEndpoint(BaseAPIView):
             serializer.save()
             return Response(serializer.data, status=status.HTTP_200_OK)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+
+class ServiceApiTokenEndpoint(BaseAPIView):
+    permission_classes = [
+        WorkspaceOwnerPermission,
+    ]
+
+    def post(self, request, slug):
+        workspace = Workspace.objects.get(slug=slug)
+
+        api_token = APIToken.objects.filter(
+            workspace=workspace,
+            is_service=True,
+        ).first()
+
+        if api_token:
+            return Response(
+                {
+                    "token": str(api_token.token),
+                },
+                status=status.HTTP_200_OK,
+            )
+        else:
+            # Check the user type
+            user_type = 1 if request.user.is_bot else 0
+
+            api_token = APIToken.objects.create(
+                label=str(uuid4().hex),
+                description="Service Token",
+                user=request.user,
+                workspace=workspace,
+                user_type=user_type,
+                is_service=True,
+            )
+            # Token will be only visible while creating
+            return Response(
+                {
+                    "token": str(api_token.token),
+                },
+                status=status.HTTP_201_CREATED,
+            )
+


### PR DESCRIPTION
## Description
- Added new service token endpoint for plane's internal Apis, with `/api/workspaces/<str:slug>/service-api-tokens/` endpoint.
- Removed deletion of service tokens from APIToken deletion endpoint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new API endpoint for managing service API tokens specific to workspaces.
	- Added functionality to create and retrieve service API tokens based on workspace identification.

- **Improvements**
	- Enhanced API organization for more granular access control to tokens.
	- Updated import structure for better clarity and maintenance. 

- **Bug Fixes**
	- Modified existing delete method to accommodate service-specific token handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->