### PR TITLE
[WEB-2183] fix: delete action mutation

### DIFF
--- a/web/core/store/cycle.store.ts
+++ b/web/core/store/cycle.store.ts
@@ -551,9 +551,9 @@ export class CycleStore implements ICycleStore {
   deleteCycle = async (workspaceSlug: string, projectId: string, cycleId: string) =>
     await this.cycleService.deleteCycle(workspaceSlug, projectId, cycleId).then(() => {
       runInAction(() => {
-        this.rootStore.favorite.removeFavoriteFromStore(cycleId);
         delete this.cycleMap[cycleId];
         delete this.activeCycleIdMap[cycleId];
+        if (this.rootStore.favorite.entityMap[cycleId]) this.rootStore.favorite.removeFavoriteFromStore(cycleId);
       });
     });
 

--- a/web/core/store/module.store.ts
+++ b/web/core/store/module.store.ts
@@ -405,7 +405,7 @@ export class ModulesStore implements IModuleStore {
     await this.moduleService.deleteModule(workspaceSlug, projectId, moduleId).then(() => {
       runInAction(() => {
         delete this.moduleMap[moduleId];
-        this.rootStore.favorite.removeFavoriteFromStore(moduleId);
+        if (this.rootStore.favorite.entityMap[moduleId]) this.rootStore.favorite.removeFavoriteFromStore(moduleId);
       });
     });
   };

--- a/web/core/store/pages/project-page.store.ts
+++ b/web/core/store/pages/project-page.store.ts
@@ -261,7 +261,7 @@ export class ProjectPageStore implements IProjectPageStore {
       await this.service.remove(workspaceSlug, projectId, pageId);
       runInAction(() => {
         unset(this.data, [pageId]);
-        this.rootStore.favorite.removeFavoriteFromStore(pageId);
+        if (this.rootStore.favorite.entityMap[pageId]) this.rootStore.favorite.removeFavoriteFromStore(pageId);
       });
     } catch (error) {
       runInAction(() => {

--- a/web/core/store/project-view.store.ts
+++ b/web/core/store/project-view.store.ts
@@ -271,7 +271,7 @@ export class ProjectViewStore implements IProjectViewStore {
     await this.viewService.deleteView(workspaceSlug, projectId, viewId).then(() => {
       runInAction(() => {
         delete this.viewMap[viewId];
-        this.rootStore.favorite.removeFavoriteFromStore(viewId);
+        if (this.rootStore.favorite.entityMap[viewId]) this.rootStore.favorite.removeFavoriteFromStore(viewId);
       });
     });
   };

--- a/web/core/store/project/project.store.ts
+++ b/web/core/store/project/project.store.ts
@@ -401,7 +401,7 @@ export class ProjectStore implements IProjectStore {
       await this.projectService.deleteProject(workspaceSlug, projectId);
       runInAction(() => {
         delete this.projectMap[projectId];
-        this.rootStore.favorite.removeFavoriteFromStore(projectId);
+        if (this.rootStore.favorite.entityMap[projectId]) this.rootStore.favorite.removeFavoriteFromStore(projectId);
       });
     } catch (error) {
       console.log("Failed to delete project from project store");


### PR DESCRIPTION
### Problem:
When deleting a cycle, module, view, or page, a "failed to delete" toast message appears, even though the item is successfully deleted upon reloading. This behavior is inconsistent and confusing for users.

### Solution:
The issue was caused by the "removeFavoriteFromStore" function, which lacked a check to see if the current item existed in the favorite store before attempting to delete it. I have added the necessary validation to ensure the item is present in the store before deletion, resolving the problem.

### Reference:
[[WEB-2183]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/22640805-07c2-485e-8ea7-1938349a1d82)

### Media:
| Before | After |
|--------|--------|
| ![WEB-2183 Before](https://github.com/user-attachments/assets/2efaaae3-a430-4a00-a1d6-8c6b987ced6d) | ![WEB-2183 After](https://github.com/user-attachments/assets/5f4e3d56-48ba-4ba8-9020-d732c4f773b4) |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced logic to prevent unnecessary removal of favorites from the store when the corresponding IDs do not exist, improving application robustness and performance across multiple stores (CycleStore, ModulesStore, ProjectPageStore, ProjectViewStore, and ProjectStore).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->