### PR TITLE
chore: add rate limiting in magic generate endpoint

### DIFF
--- a/apiserver/plane/authentication/views/app/magic.py
+++ b/apiserver/plane/authentication/views/app/magic.py
@@ -29,12 +29,17 @@ from plane.authentication.adapter.error import (
     AuthenticationException,
     AUTHENTICATION_ERROR_CODES,
 )
+from plane.authentication.rate_limit import AuthenticationThrottle
 
 
 class MagicGenerateEndpoint(APIView):
 
     permission_classes = [
         AllowAny,
+    ]
+
+    throttle_classes = [
+        AuthenticationThrottle,
     ]
 
     def post(self, request):


### PR DESCRIPTION
### Description
This PR adds authentication throttle to the magic generate endpoint.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced rate-limiting functionality to enhance the `MagicGenerate` endpoint, improving performance and preventing abuse.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->