### PR TITLE
[WEB-2209] chore: made cursor update on created_by in issue properties pane in issue detail, and issue peek overview

### DIFF
--- a/web/core/components/issues/issue-detail/sidebar.tsx
+++ b/web/core/components/issues/issue-detail/sidebar.tsx
@@ -131,7 +131,7 @@ export const IssueDetailsSidebar: React.FC<Props> = observer((props) => {
                   <UserCircle2 className="h-4 w-4 flex-shrink-0" />
                   <span>Created by</span>
                 </div>
-                <div className="h-full flex items-center gap-1.5 rounded px-2 py-0.5 text-sm justify-between cursor-default">
+                <div className="w-full h-full flex items-center gap-1.5 rounded px-2 py-0.5 text-sm justify-between cursor-not-allowed">
                   <ButtonAvatars showTooltip userIds={createdByDetails.id} />
                   <span className="flex-grow truncate text-xs leading-5">{createdByDetails?.display_name}</span>
                 </div>

--- a/web/core/components/issues/peek-overview/properties.tsx
+++ b/web/core/components/issues/peek-overview/properties.tsx
@@ -133,7 +133,7 @@ export const PeekOverviewProperties: FC<IPeekOverviewProperties> = observer((pro
               <UserCircle2 className="h-4 w-4 flex-shrink-0" />
               <span>Created by</span>
             </div>
-            <div className="h-full flex items-center gap-1.5 rounded px-2 py-0.5 text-sm justify-between cursor-default">
+            <div className="w-full h-full flex items-center gap-1.5 rounded px-2 py-0.5 text-sm justify-between cursor-not-allowed">
               <ButtonAvatars showTooltip userIds={createdByDetails?.id} />
               <span className="flex-grow truncate text-xs leading-5">{createdByDetails?.display_name}</span>
             </div>


### PR DESCRIPTION
### Summary:
- Made cursor update from cursor-default to cursor-not-allowed on created_by in the issue properties pane in issue detail, and issue peek overview

### Plane Issue:
[[WEB-2209]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/ee178d51-3c25-46eb-925b-0ae294b45eb4)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **User Interface Enhancements**
	- Updated styling for non-interactive elements in the sidebar, improving visual cues for user interaction.
	- Ensured full-width display for user information in the sidebar, enhancing layout consistency.
	- Altered cursor styling in the Peek Overview component to indicate non-interactive areas, improving user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->