### PR TITLE
[WEB-2189] fix: issue peek overview and issue detail unauthorised delete action

### DIFF
--- a/web/core/components/issues/delete-issue-modal.tsx
+++ b/web/core/components/issues/delete-issue-modal.tsx
@@ -55,7 +55,9 @@ export const DeleteIssueModal: React.FC<Props> = (props) => {
         message: PROJECT_ERROR_MESSAGES.permissionError.message,
       });
       onClose();
-    } else if (onSubmit)
+      return;
+    }
+    if (onSubmit)
       await onSubmit()
         .then(() => {
           setToast({

--- a/web/core/components/issues/delete-issue-modal.tsx
+++ b/web/core/components/issues/delete-issue-modal.tsx
@@ -8,7 +8,7 @@ import { AlertModalCore, TOAST_TYPE, setToast } from "@plane/ui";
 // constants
 import { PROJECT_ERROR_MESSAGES } from "@/constants/project";
 // hooks
-import { useIssues, useProject } from "@/hooks/store";
+import { useIssues, useProject, useUser } from "@/hooks/store";
 
 type Props = {
   isOpen: boolean;
@@ -26,6 +26,7 @@ export const DeleteIssueModal: React.FC<Props> = (props) => {
   // store hooks
   const { issueMap } = useIssues();
   const { getProjectById } = useProject();
+  const { data: currentUser, canPerformProjectAdminActions } = useUser();
 
   useEffect(() => {
     setIsDeleting(false);
@@ -36,6 +37,8 @@ export const DeleteIssueModal: React.FC<Props> = (props) => {
   // derived values
   const issue = data ? data : issueMap[dataId!];
   const projectDetails = getProjectById(issue?.project_id);
+  const isIssueCreator = issue?.created_by === currentUser?.id;
+  const authorized = isIssueCreator || canPerformProjectAdminActions;
 
   const onClose = () => {
     setIsDeleting(false);
@@ -44,7 +47,15 @@ export const DeleteIssueModal: React.FC<Props> = (props) => {
 
   const handleIssueDelete = async () => {
     setIsDeleting(true);
-    if (onSubmit)
+
+    if (!authorized) {
+      setToast({
+        title: PROJECT_ERROR_MESSAGES.permissionError.title,
+        type: TOAST_TYPE.ERROR,
+        message: PROJECT_ERROR_MESSAGES.permissionError.message,
+      });
+      onClose();
+    } else if (onSubmit)
       await onSubmit()
         .then(() => {
           setToast({

--- a/web/core/components/issues/issue-detail-widgets/relations/helper.tsx
+++ b/web/core/components/issues/issue-detail-widgets/relations/helper.tsx
@@ -70,11 +70,12 @@ export const useRelationOperations = (): TRelationIssueOperations => {
       },
       remove: async (workspaceSlug: string, projectId: string, issueId: string) => {
         try {
-          await removeIssue(workspaceSlug, projectId, issueId);
-          captureIssueEvent({
-            eventName: ISSUE_DELETED,
-            payload: { id: issueId, state: "SUCCESS", element: "Issue detail page" },
-            path: pathname,
+          return removeIssue(workspaceSlug, projectId, issueId).then(() => {
+            captureIssueEvent({
+              eventName: ISSUE_DELETED,
+              payload: { id: issueId, state: "SUCCESS", element: "Issue detail page" },
+              path: pathname,
+            });
           });
         } catch (error) {
           captureIssueEvent({

--- a/web/core/components/issues/issue-detail-widgets/sub-issues/helper.tsx
+++ b/web/core/components/issues/issue-detail-widgets/sub-issues/helper.tsx
@@ -150,13 +150,14 @@ export const useSubIssueOperations = (): TSubIssueOperations => {
       deleteSubIssue: async (workspaceSlug: string, projectId: string, parentIssueId: string, issueId: string) => {
         try {
           setSubIssueHelpers(parentIssueId, "issue_loader", issueId);
-          await deleteSubIssue(workspaceSlug, projectId, parentIssueId, issueId);
-          captureIssueEvent({
-            eventName: "Sub-issue deleted",
-            payload: { id: issueId, state: "SUCCESS", element: "Issue detail page" },
-            path: pathname,
+          return deleteSubIssue(workspaceSlug, projectId, parentIssueId, issueId).then(() => {
+            captureIssueEvent({
+              eventName: "Sub-issue deleted",
+              payload: { id: issueId, state: "SUCCESS", element: "Issue detail page" },
+              path: pathname,
+            });
+            setSubIssueHelpers(parentIssueId, "issue_loader", issueId);
           });
-          setSubIssueHelpers(parentIssueId, "issue_loader", issueId);
         } catch (error) {
           captureIssueEvent({
             eventName: "Sub-issue removed",

--- a/web/core/components/issues/issue-detail/issue-detail-quick-actions.tsx
+++ b/web/core/components/issues/issue-detail/issue-detail-quick-actions.tsx
@@ -78,14 +78,18 @@ export const IssueDetailQuickActions: FC<Props> = observer((props) => {
 
   const handleDeleteIssue = async () => {
     try {
-      if (issue?.archived_at) await removeArchivedIssue(workspaceSlug, projectId, issueId);
-      else await removeIssue(workspaceSlug, projectId, issueId);
-      router.push(`/${workspaceSlug}/projects/${projectId}/issues`);
-      captureIssueEvent({
-        eventName: ISSUE_DELETED,
-        payload: { id: issueId, state: "SUCCESS", element: "Issue detail page" },
-        path: pathname,
-      });
+      if (issue?.archived_at) {
+        return removeArchivedIssue(workspaceSlug, projectId, issueId).then(() => {
+          router.push(`/${workspaceSlug}/projects/${projectId}/issues`);
+          captureIssueEvent({
+            eventName: ISSUE_DELETED,
+            payload: { id: issueId, state: "SUCCESS", element: "Issue detail page" },
+            path: pathname,
+          });
+        });
+      } else {
+        return removeIssue(workspaceSlug, projectId, issueId);
+      }
     } catch (error) {
       setToast({
         title: "Error!",

--- a/web/core/components/issues/peek-overview/root.tsx
+++ b/web/core/components/issues/peek-overview/root.tsx
@@ -34,6 +34,7 @@ export const IssuePeekOverview: FC<IIssuePeekOverview> = observer((props) => {
   } = useIssues(EIssuesStoreType.ARCHIVED);
   const {
     peekIssue,
+    setPeekIssue,
     issue: { fetchIssue },
     fetchActivities,
   } = useIssueDetail();
@@ -43,6 +44,11 @@ export const IssuePeekOverview: FC<IIssuePeekOverview> = observer((props) => {
   // state
   const [loader, setLoader] = useState(true);
   const [error, setError] = useState(false);
+
+  const removeRoutePeekId = () => {
+    setPeekIssue(undefined);
+    if (embedIssue) embedRemoveCurrentNotification && embedRemoveCurrentNotification();
+  };
 
   const issueOperations: TIssueOperations = useMemo(
     () => ({
@@ -95,16 +101,13 @@ export const IssuePeekOverview: FC<IIssuePeekOverview> = observer((props) => {
       },
       remove: async (workspaceSlug: string, projectId: string, issueId: string) => {
         try {
-          issues?.removeIssue(workspaceSlug, projectId, issueId);
-          setToast({
-            title: "Success!",
-            type: TOAST_TYPE.SUCCESS,
-            message: "Issue deleted successfully",
-          });
-          captureIssueEvent({
-            eventName: ISSUE_DELETED,
-            payload: { id: issueId, state: "SUCCESS", element: "Issue peek-overview" },
-            path: pathname,
+          return issues?.removeIssue(workspaceSlug, projectId, issueId).then(() => {
+            captureIssueEvent({
+              eventName: ISSUE_DELETED,
+              payload: { id: issueId, state: "SUCCESS", element: "Issue peek-overview" },
+              path: pathname,
+            });
+            removeRoutePeekId();
           });
         } catch (error) {
           setToast({

--- a/web/core/components/issues/peek-overview/view.tsx
+++ b/web/core/components/issues/peek-overview/view.tsx
@@ -131,7 +131,7 @@ export const IssueView: FC<IIssueView> = observer((props) => {
             toggleDeleteIssueModal(null);
           }}
           data={issue}
-          onSubmit={() => issueOperations.remove(workspaceSlug, projectId, issueId).then(() => removeRoutePeekId())}
+          onSubmit={async () => issueOperations.remove(workspaceSlug, projectId, issueId)}
         />
       )}
 


### PR DESCRIPTION
### Changes:
This PR resolves an issue with unauthorized delete actions in PeekOverview and Issue Details. Previously, when an unauthorized user attempted to delete an issue, sub-issue, or relation from PeekOverview or Issue detail pages, they would receive two conflicting toast alerts—one indicating success and the other an error. I have made the necessary changes to ensure the correct toast alert is displayed, accurately reflecting the outcome of the action.

### Reference:
[[WEB-2189]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/f2d9a868-446b-4986-80cd-e85f2a6b8643)

### Media:
| Before | After |
|--------|--------|
| ![WEB-2189 Before](https://github.com/user-attachments/assets/bec57804-b238-4b2e-af91-54a5543b05c7) | ![WEB-2189 After](https://github.com/user-attachments/assets/0333508b-b834-4114-899d-b63bb4aa8a71) |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Improved asynchronous handling for issue removal processes, enhancing reliability and control flow.
	- Introduced new user permission checks in the issue deletion modal to ensure authorized actions.
	- Added functionality to determine if the user is the creator of the issue being deleted.

- **Bug Fixes**
	- Adjusted event capturing mechanisms to ensure they only occur after successful issue removals, potentially enhancing error tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->