### PR TITLE
[WEB-2177] fix: handling the archived module ids in the issue list and issue detail endpoints

### DIFF
--- a/apiserver/plane/app/views/inbox/base.py
+++ b/apiserver/plane/app/views/inbox/base.py
@@ -160,7 +160,8 @@ class InboxIssueViewSet(BaseViewSet):
                     ArrayAgg(
                         "issue_module__module_id",
                         distinct=True,
-                        filter=~Q(issue_module__module_id__isnull=True),
+                        filter=~Q(issue_module__module_id__isnull=True)
+                        & Q(issue_module__module__archived_at__isnull=True),
                     ),
                     Value([], output_field=ArrayField(UUIDField())),
                 ),

--- a/apiserver/plane/app/views/issue/base.py
+++ b/apiserver/plane/app/views/issue/base.py
@@ -64,7 +64,6 @@ from plane.utils.user_timezone_converter import user_timezone_converter
 
 
 class IssueListEndpoint(BaseAPIView):
-
     permission_classes = [
         ProjectEntityPermission,
     ]
@@ -438,7 +437,8 @@ class IssueViewSet(BaseViewSet):
                     ArrayAgg(
                         "issue_module__module_id",
                         distinct=True,
-                        filter=~Q(issue_module__module_id__isnull=True),
+                        filter=~Q(issue_module__module_id__isnull=True)
+                        & Q(issue_module__module__archived_at__isnull=True),
                     ),
                     Value([], output_field=ArrayField(UUIDField())),
                 ),
@@ -626,7 +626,6 @@ class BulkDeleteIssuesEndpoint(BaseAPIView):
             project_id=project_id,
             is_active=True,
         ).exists():
-
             return Response(
                 {"error": "Only admin can perform this action"},
                 status=status.HTTP_403_FORBIDDEN,

--- a/apiserver/plane/app/views/view/base.py
+++ b/apiserver/plane/app/views/view/base.py
@@ -223,7 +223,8 @@ class WorkspaceViewIssuesViewSet(BaseViewSet):
                     ArrayAgg(
                         "issue_module__module_id",
                         distinct=True,
-                        filter=~Q(issue_module__module_id__isnull=True),
+                        filter=~Q(issue_module__module_id__isnull=True)
+                        & Q(issue_module__module__archived_at__isnull=True),
                     ),
                     Value([], output_field=ArrayField(UUIDField())),
                 ),

--- a/apiserver/plane/utils/grouper.py
+++ b/apiserver/plane/utils/grouper.py
@@ -18,7 +18,6 @@ from plane.db.models import (
 
 
 def issue_queryset_grouper(queryset, group_by, sub_group_by):
-
     FIELD_MAPPER = {
         "label_ids": "labels__id",
         "assignee_ids": "assignees__id",
@@ -30,7 +29,10 @@ def issue_queryset_grouper(queryset, group_by, sub_group_by):
         "label_ids": ("labels__id", ~Q(labels__id__isnull=True)),
         "module_ids": (
             "issue_module__module_id",
-            ~Q(issue_module__module_id__isnull=True),
+            (
+                ~Q(issue_module__module_id__isnull=True)
+                & Q(issue_module__module__archived_at__isnull=True)
+            ),
         ),
     }
     default_annotations = {
@@ -51,7 +53,6 @@ def issue_queryset_grouper(queryset, group_by, sub_group_by):
 
 
 def issue_on_results(issues, group_by, sub_group_by):
-
     FIELD_MAPPER = {
         "labels__id": "label_ids",
         "assignees__id": "assignee_ids",


### PR DESCRIPTION
### Summary
This pull request removes the module_ids which are archived from the issue, module, and cycle issues endpoint and issue detail endpoint

### Plane Issue:
[[WEB-2177]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/2cfe07a0-381a-466c-ab58-ec518c4fab61)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced filtering logic to exclude archived modules from dataset queries.
	- Improved data integrity by ensuring only relevant, non-archived modules are included in responses.

- **Bug Fixes**
	- Resolved issues related to outdated filtering conditions that included archived modules in results.

- **Style**
	- Minor formatting adjustments for cleaner code, including the removal of unnecessary blank lines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->