### PR TITLE
[WEB-2178] fix: empty folder title

### DIFF
--- a/packages/ui/src/collapsible/collapsible.tsx
+++ b/packages/ui/src/collapsible/collapsible.tsx
@@ -38,7 +38,6 @@ export const Collapsible: FC<TCollapsibleProps> = (props) => {
       </Disclosure.Button>
       <Transition
         show={localIsOpen}
-        className="overflow-hidden"
         enter="transition-max-height duration-400 ease-in-out"
         enterFrom="max-h-0"
         enterTo="max-h-screen"

--- a/web/core/components/workspace/sidebar/favorites/new-fav-folder.tsx
+++ b/web/core/components/workspace/sidebar/favorites/new-fav-folder.tsx
@@ -45,10 +45,18 @@ export const NewFavoriteFolder = observer((props: TProps) => {
     formData = {
       entity_type: "folder",
       is_folder: true,
-      name: formData.name,
+      name: formData.name.trim(),
       parent: null,
       project_id: null,
     };
+
+    if (formData.name === "")
+      return setToast({
+        type: TOAST_TYPE.ERROR,
+        title: "Error!",
+        message: "Folder name cannot be empty",
+      });
+
     addFavorite(workspaceSlug.toString(), formData)
       .then(() => {
         setToast({
@@ -77,15 +85,31 @@ export const NewFavoriteFolder = observer((props: TProps) => {
         message: "Folder already exists",
       });
     const payload = {
-      name: formData.name,
+      name: formData.name.trim(),
     };
-    updateFavorite(workspaceSlug.toString(), favoriteId, payload).then(() => {
-      setToast({
-        type: TOAST_TYPE.SUCCESS,
-        title: "Success!",
-        message: "Favorite updated successfully.",
+
+    if (formData.name.trim() === "")
+      return setToast({
+        type: TOAST_TYPE.ERROR,
+        title: "Error!",
+        message: "Folder name cannot be empty",
       });
-    });
+
+    updateFavorite(workspaceSlug.toString(), favoriteId, payload)
+      .then(() => {
+        setToast({
+          type: TOAST_TYPE.SUCCESS,
+          title: "Success!",
+          message: "Favorite updated successfully.",
+        });
+      })
+      .catch(() => {
+        setToast({
+          type: TOAST_TYPE.ERROR,
+          title: "Error!",
+          message: "Something went wrong!",
+        });
+      });
     setCreateNewFolder(false);
     setValue("name", "");
   };


### PR DESCRIPTION
### Changes:
This PR includes following changes:
- Users are now restricted from creating or renaming a favorite folder with an empty title.
- An error toast alert has been added to notify users when the favorite folder endpoint encounters an error.
- Resolved the issue with collapsible overflow.


### Reference:
[[WEB-2178]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/f63a64f4-f3a1-4bd8-9e06-d534b9eced24)
[[WEB-2199]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/277d8abb-34ee-4b8b-b00f-1fa3459a6327)

### Media:
| Before | After |
|--------|--------|
| ![WEB-2178 Before (1)](https://github.com/user-attachments/assets/90cf6488-74a2-4c9a-9744-2c3877eeeaaa) | ![WEB-2178 After (2)](https://github.com/user-attachments/assets/c8b85d11-4530-45b5-bee6-caa11bbcee8c) |
| ![WEB-2178 Bedore (2)](https://github.com/user-attachments/assets/4a5aff21-8875-4882-be94-5a764d8884ca) | ![WEB-2178 After (1)](https://github.com/user-attachments/assets/0f1619fb-231d-42a4-bf55-91d36db7f251) |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced validation for folder names, preventing the creation of empty or whitespace-only folders.
	- Added user notifications for invalid folder name submissions.

- **Bug Fixes**
	- Improved error handling for empty folder name scenarios during both creation and updates.

- **Improvements**
	- Modified the behavior of the collapsible component for a more fluid display of content during transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->