### PR TITLE
fix: unable to added issues to a completed cycle

### DIFF
--- a/apiserver/plane/api/views/cycle.py
+++ b/apiserver/plane/api/views/cycle.py
@@ -672,17 +672,6 @@ class CycleIssueAPIEndpoint(BaseAPIView):
             workspace__slug=slug, project_id=project_id, pk=cycle_id
         )
 
-        if (
-            cycle.end_date is not None
-            and cycle.end_date < timezone.now().date()
-        ):
-            return Response(
-                {
-                    "error": "The Cycle has already been completed so no new issues can be added"
-                },
-                status=status.HTTP_400_BAD_REQUEST,
-            )
-
         # Get all CycleIssues already created
         cycle_issues = list(
             CycleIssue.objects.filter(


### PR DESCRIPTION
## Tasks
- Removed code that was preventing to add issues to cycle which has been completed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Users can now add new issues to cycles even after they have been marked as completed.
  
- **Bug Fixes**
	- Removed restriction that previously prevented adding issues to completed cycles, addressing the 400 Bad Request error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->