### PR TITLE
[WEB-2238] fix: issue delete notification message updated

### DIFF
--- a/packages/types/src/workspace-notifications.d.ts
+++ b/packages/types/src/workspace-notifications.d.ts
@@ -28,7 +28,7 @@ export type TNotificationData = {
     actor: string | undefined;
     field: string | undefined;
     issue_comment: string | undefined;
-    verb: "created" | "updated";
+    verb: "created" | "updated" | "deleted";
     new_value: string | undefined;
     old_value: string | undefined;
   };

--- a/web/core/components/workspace-notifications/sidebar/notification-card/item.tsx
+++ b/web/core/components/workspace-notifications/sidebar/notification-card/item.tsx
@@ -104,29 +104,35 @@ export const NotificationItem: FC<TNotificationItem> = observer((props) => {
                       : notificationField === "None"
                         ? null
                         : replaceUnderscoreIfSnakeCase(notificationField)}{" "}
-                  {!["comment", "archived_at", "None"].includes(notificationField) ? "to" : ""}
-                  <span className="font-semibold">
-                    {" "}
-                    {notificationField !== "None" ? (
-                      notificationField !== "comment" ? (
-                        notificationField === "target_date" ? (
-                          renderFormattedDate(notification?.data?.issue_activity.new_value)
-                        ) : notificationField === "attachment" ? (
-                          "the issue"
-                        ) : notificationField === "description" ? (
-                          stripAndTruncateHTML(notification?.data?.issue_activity.new_value || "", 55)
-                        ) : notificationField === "archived_at" ? null : (
-                          notification?.data?.issue_activity.new_value
-                        )
-                      ) : (
-                        <span>
-                          {sanitizeCommentForNotification(notification?.data?.issue_activity.new_value ?? undefined)}
-                        </span>
-                      )
-                    ) : (
-                      "the issue and assigned it to you."
-                    )}
-                  </span>
+                  {notification?.data?.issue_activity.verb !== "deleted" && (
+                    <>
+                      {!["comment", "archived_at", "None"].includes(notificationField) ? "to" : ""}
+                      <span className="font-semibold">
+                        {" "}
+                        {notificationField !== "None" ? (
+                          notificationField !== "comment" ? (
+                            notificationField === "target_date" ? (
+                              renderFormattedDate(notification?.data?.issue_activity.new_value)
+                            ) : notificationField === "attachment" ? (
+                              "the issue"
+                            ) : notificationField === "description" ? (
+                              stripAndTruncateHTML(notification?.data?.issue_activity.new_value || "", 55)
+                            ) : notificationField === "archived_at" ? null : (
+                              notification?.data?.issue_activity.new_value
+                            )
+                          ) : (
+                            <span>
+                              {sanitizeCommentForNotification(
+                                notification?.data?.issue_activity.new_value ?? undefined
+                              )}
+                            </span>
+                          )
+                        ) : (
+                          "the issue and assigned it to you."
+                        )}
+                      </span>
+                    </>
+                  )}
                 </>
               ) : (
                 <span className="semi-bold">{notification.message}</span>


### PR DESCRIPTION
### Changes:
This PR resolves the issue related to the notification message when an issue is deleted.

### Reference:
[[WEB-2238]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/1341f25d-10dd-4bac-8dd8-5f5cf9e7a7e8)

### Media:
| Before | After |
|--------|--------|
| ![before](https://github.com/user-attachments/assets/30c79a0c-28ec-4485-95a1-14d06fd9b0a5) | ![after](https://github.com/user-attachments/assets/90f05ac2-8551-4910-9aa1-54c3fe6cda2f) |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for notification of deleted items, enhancing tracking capabilities.
  
- **Improvements**
	- Updated the notification display logic to ensure deleted notifications do not show irrelevant details, improving clarity for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->