### PR TITLE
[WEB-2251] fix: workspace inbox read endpoint permission

### DIFF
--- a/apiserver/plane/app/views/notification/base.py
+++ b/apiserver/plane/app/views/notification/base.py
@@ -195,7 +195,7 @@ class NotificationViewSet(BaseViewSet, BasePaginator):
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
     @allow_permission(
-        allowed_roles=[ROLE.ADMIN, ROLE.MEMBER], level="WORKSPACE"
+        allowed_roles=[ROLE.ADMIN, ROLE.MEMBER, ROLE.VIEWER, ROLE.GUEST], level="WORKSPACE"
     )
     def mark_read(self, request, slug, pk):
         notification = Notification.objects.get(


### PR DESCRIPTION
#### Changes:
This PR resolves the issue with permission validation on the workspace inbox read endpoint for guest and viewer roles



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded the ability to mark notifications as read to users with Viewer and Guest roles, enhancing accessibility and user experience for these roles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->