### PR TITLE
[WEB-2253] chore: removed continuous loading when accessing a wrong page

### DIFF
--- a/apiserver/plane/app/permissions/base.py
+++ b/apiserver/plane/app/permissions/base.py
@@ -53,7 +53,7 @@ def allow_permission(allowed_roles, level="PROJECT", creator=False, model=None):
             # Return permission denied if no conditions are met
             return Response(
                 {"error": "You don't have the required permissions."},
-                status=status.HTTP_401_UNAUTHORIZED,
+                status=status.HTTP_403_FORBIDDEN,
             )
 
         return _wrapped_view

--- a/apiserver/plane/app/views/exporter/base.py
+++ b/apiserver/plane/app/views/exporter/base.py
@@ -15,7 +15,7 @@ class ExportIssuesEndpoint(BaseAPIView):
     model = ExporterHistory
     serializer_class = ExporterHistorySerializer
 
-    @allow_permission(allowed_roles=[ROLE.ADMIN], level="WORKSPACE")
+    @allow_permission(allowed_roles=[ROLE.ADMIN, ROLE.MEMBER], level="WORKSPACE")
     def post(self, request, slug):
         # Get the workspace
         workspace = Workspace.objects.get(slug=slug)
@@ -62,7 +62,9 @@ class ExportIssuesEndpoint(BaseAPIView):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-    @allow_permission(allowed_roles=[ROLE.ADMIN], level="WORKSPACE")
+    @allow_permission(
+        allowed_roles=[ROLE.ADMIN, ROLE.MEMBER], level="WORKSPACE"
+    )
     def get(self, request, slug):
         exporter_history = ExporterHistory.objects.filter(
             workspace__slug=slug,


### PR DESCRIPTION
chore:
- Fixes an issue where accessing an incorrect page caused continuous loading. Now, users are properly redirected or shown an error message

Issue Link: [WEB-2253](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/df2fa2f3-19b1-4d2f-9bc9-cb76737dcc41/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated permission settings to allow users with the `MEMBER` role to access export functionalities.
  
- **Bug Fixes**
  - Modified response status for denied permissions to `403 Forbidden`, improving clarity on permission errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->