### PR TITLE
[WEB-2133] fix : Remove inbox delete option for members

### DIFF
--- a/web/core/components/inbox/content/inbox-issue-header.tsx
+++ b/web/core/components/inbox/content/inbox-issue-header.tsx
@@ -85,7 +85,7 @@ export const InboxIssueActionsHeader: FC<TInboxIssueActionsHeader> = observer((p
   const canMarkAsDeclined = isAllowed && (inboxIssue?.status === 0 || inboxIssue?.status === -2);
   // can delete only if admin or is creator of the issue
   const canDelete =
-    (!!currentProjectRole && currentProjectRole > EUserProjectRoles.MEMBER) ||
+    (!!currentProjectRole && currentProjectRole >= EUserProjectRoles.ADMIN) ||
     inboxIssue?.created_by === currentUser?.id;
   const isAcceptedOrDeclined = inboxIssue?.status ? [-1, 1, 2].includes(inboxIssue.status) : undefined;
   // days left for snooze

--- a/web/core/components/inbox/content/inbox-issue-header.tsx
+++ b/web/core/components/inbox/content/inbox-issue-header.tsx
@@ -83,7 +83,10 @@ export const InboxIssueActionsHeader: FC<TInboxIssueActionsHeader> = observer((p
   const canMarkAsDuplicate = isAllowed && (inboxIssue?.status === 0 || inboxIssue?.status === -2);
   const canMarkAsAccepted = isAllowed && (inboxIssue?.status === 0 || inboxIssue?.status === -2);
   const canMarkAsDeclined = isAllowed && (inboxIssue?.status === 0 || inboxIssue?.status === -2);
-  const canDelete = isAllowed || inboxIssue?.created_by === currentUser?.id;
+  // can delete only if admin or is creator of the issue
+  const canDelete =
+    (!!currentProjectRole && currentProjectRole > EUserProjectRoles.MEMBER) ||
+    inboxIssue?.created_by === currentUser?.id;
   const isAcceptedOrDeclined = inboxIssue?.status ? [-1, 1, 2].includes(inboxIssue.status) : undefined;
   // days left for snooze
   const numberOfDaysLeft = findHowManyDaysLeft(inboxIssue?.snoozed_till);


### PR DESCRIPTION
This PR removes the option for deletion of issues for members if they are not the author of the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced access control for issue deletion, now allowing only users with administrative roles or the issue creator to delete issues.

- **Bug Fixes**
	- Improved permission handling ensures that only authorized users can manage issue deletions, enhancing security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->