### PR TITLE
[WEB-2256] fix: empty state comic button responsiveness

### DIFF
--- a/web/core/components/empty-state/comic-box-button.tsx
+++ b/web/core/components/empty-state/comic-box-button.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Ref, useState } from "react";
+import { Fragment, Ref, useState } from "react";
 import { usePopper } from "react-popper";
 import { Popover } from "@headlessui/react";
 // popper
@@ -43,33 +43,35 @@ export const ComicBoxButton: React.FC<Props> = (props) => {
   });
 
   return (
-    <Popover>
-      <Popover.Button ref={setReferenceElement} onClick={onClick} disabled={disabled}>
-        <div className={`flex items-center gap-2.5 ${getButtonStyling("primary", "lg", disabled)}`}>
-          {icon}
-          <span className="leading-4">{label}</span>
-          <span className="relative h-2 w-2">
-            <div
-              onMouseEnter={handleMouseEnter}
-              onMouseLeave={handleMouseLeave}
-              className={`absolute bg-blue-300 right-0 z-10 h-2.5 w-2.5 animate-ping rounded-full`}
-            />
-            <div className={`absolute bg-blue-400/40 right-0 h-1.5 w-1.5 mt-0.5 mr-0.5 rounded-full`} />
-          </span>
-        </div>
+    <Popover as="div" className="relative">
+      <Popover.Button as={Fragment}>
+        <button type="button" ref={setReferenceElement} onClick={onClick} disabled={disabled}>
+          <div className={`flex items-center gap-2.5 ${getButtonStyling("primary", "lg", disabled)}`}>
+            {icon}
+            <span className="leading-4">{label}</span>
+            <span className="relative h-2 w-2">
+              <div
+                onMouseEnter={handleMouseEnter}
+                onMouseLeave={handleMouseLeave}
+                className={`absolute bg-blue-300 right-0 z-10 h-2.5 w-2.5 animate-ping rounded-full`}
+              />
+              <div className={`absolute bg-blue-400/40 right-0 h-1.5 w-1.5 mt-0.5 mr-0.5 rounded-full`} />
+            </span>
+          </div>
+        </button>
       </Popover.Button>
       {isHovered && (
-        <Popover.Panel
-          as="div"
-          className="flex flex-col rounded border border-custom-border-200 bg-custom-background-100 p-5 relative min-w-80"
-          ref={setPopperElement as Ref<HTMLDivElement>}
-          style={styles.popper}
-          {...attributes.popper}
-          static
-        >
-          <div className="absolute w-2 h-2 bg-custom-background-100 border rounded-lb-sm  border-custom-border-200 border-r-0 border-t-0 transform rotate-45 bottom-2 -left-[5px]" />
-          <h3 className="text-lg font-semibold w-full">{title}</h3>
-          <h4 className="mt-1 text-sm">{description}</h4>
+        <Popover.Panel className="fixed z-10" static>
+          <div
+            className="flex flex-col rounded border border-custom-border-200 bg-custom-background-100 p-5 relative w-52 lg:w-60 xl:w-80"
+            ref={setPopperElement as Ref<HTMLDivElement>}
+            style={styles.popper}
+            {...attributes.popper}
+          >
+            <div className="absolute w-2 h-2 bg-custom-background-100 border rounded-lb-sm  border-custom-border-200 border-r-0 border-t-0 transform rotate-45 bottom-2 -left-[5px]" />
+            <h3 className="text-lg font-semibold w-full">{title}</h3>
+            <h4 className="mt-1 text-sm">{description}</h4>
+          </div>
         </Popover.Panel>
       )}
     </Popover>


### PR DESCRIPTION
### Changes:
This PR improves the responsiveness of the empty state comic button.

### Reference:
[[WEB-2256]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/bfac164d-af77-457a-8e2c-dc57a1b7ad05/)

### Media:
| Before | After |
|--------|--------|
| ![before](https://github.com/user-attachments/assets/71533b3d-0440-4bc4-90e7-12556e6eab07) | ![after](https://github.com/user-attachments/assets/a85d5909-fce3-4a9b-ab8c-1083d65afa89) |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved the structure and functionality of the ComicBoxButton, enhancing accessibility and responsiveness.
	- Updated the Popover to ensure it overlays other elements correctly, providing a better user experience.
  
- **Bug Fixes**
	- Resolved layout inconsistencies for the Popover component across different screen sizes. 

- **Style**
	- Enhanced visual presentation of the ComicBoxButton component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->