### PR TITLE
[WEB-2150] fix: issue selection redirect alert

### DIFF
--- a/web/core/hooks/use-multiple-select.ts
+++ b/web/core/hooks/use-multiple-select.ts
@@ -3,6 +3,8 @@
 import { useCallback, useEffect, useMemo } from "react";
 // hooks
 import { useMultipleSelectStore } from "@/hooks/store";
+//
+import useReloadConfirmations from "./use-reload-confirmation";
 
 export type TEntityDetails = {
   entityID: string;
@@ -51,6 +53,15 @@ export const useMultipleSelect = (props: Props) => {
     getIsEntityActive,
     getEntityDetailsFromEntityID,
   } = useMultipleSelectStore();
+
+  useReloadConfirmations(
+    selectedEntityIds && selectedEntityIds.length > 0,
+    "Are you sure you would want to leave the page, all the selected bulk issues will be cleared",
+    true,
+    () => {
+      clearSelection();
+    }
+  );
 
   const groups = useMemo(() => Object.keys(entities), [entities]);
 

--- a/web/core/hooks/use-multiple-select.ts
+++ b/web/core/hooks/use-multiple-select.ts
@@ -56,7 +56,7 @@ export const useMultipleSelect = (props: Props) => {
 
   useReloadConfirmations(
     selectedEntityIds && selectedEntityIds.length > 0,
-    "Are you sure you would want to leave the page, all the selected bulk issues will be cleared",
+    "Are you sure you want to leave? Your current bulk operation selections will be lost.",
     true,
     () => {
       clearSelection();

--- a/web/core/hooks/use-reload-confirmation.tsx
+++ b/web/core/hooks/use-reload-confirmation.tsx
@@ -1,8 +1,10 @@
 import { useCallback, useEffect, useState } from "react";
 
 //TODO: remove temp flag isActive later and use showAlert as the source of truth
-const useReloadConfirmations = (isActive = true) => {
-  const [showAlert, setShowAlert] = useState(false);
+const useReloadConfirmations = (isActive = true, message?: string, defaultShowAlert = false, onLeave?: () => void) => {
+  const [showAlert, setShowAlert] = useState(defaultShowAlert);
+
+  const alertMessage = message ?? "Are you sure you want to leave? Changes you made may not be saved.";
 
   const handleBeforeUnload = useCallback(
     (event: BeforeUnloadEvent) => {
@@ -28,8 +30,10 @@ const useReloadConfirmations = (isActive = true) => {
       const isAnchorTargetBlank = anchorElement.getAttribute("target") === "_blank";
       if (isAnchorTargetBlank) return;
       // show confirm dialog
-      const leave = confirm("Are you sure you want to leave? Changes you made may not be saved.");
-      if (!leave) {
+      const isLeaving = confirm(alertMessage);
+      if (isLeaving) {
+        onLeave && onLeave();
+      } else {
         event.preventDefault();
         event.stopPropagation();
       }


### PR DESCRIPTION
PR to prompt users about leaving the page when multiple issues are selected. Once the user leaves the page, issue selections are cleared

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a confirmation prompt when users attempt to leave the page with selected entity IDs, preventing accidental loss of selections.
	- Enhanced the confirmation hook to allow customizable alert messages and improved user experience during navigation. 

- **Bug Fixes**
	- Improved handling of user responses to the confirmation dialog for better flexibility and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->