### PR TITLE
[WEB-2263] fix: god mode wrong credentials error message banner

### DIFF
--- a/admin/core/components/authentication/auth-banner.tsx
+++ b/admin/core/components/authentication/auth-banner.tsx
@@ -1,0 +1,29 @@
+import { FC } from "react";
+import { Info, X } from "lucide-react";
+// helpers
+import { TAuthErrorInfo } from "@/helpers/authentication.helper";
+
+type TAuthBanner = {
+  bannerData: TAuthErrorInfo | undefined;
+  handleBannerData?: (bannerData: TAuthErrorInfo | undefined) => void;
+};
+
+export const AuthBanner: FC<TAuthBanner> = (props) => {
+  const { bannerData, handleBannerData } = props;
+
+  if (!bannerData) return <></>;
+  return (
+    <div className="relative flex items-center p-2 rounded-md gap-2 border border-custom-primary-100/50 bg-custom-primary-100/10">
+      <div className="w-4 h-4 flex-shrink-0 relative flex justify-center items-center">
+        <Info size={16} className="text-custom-primary-100" />
+      </div>
+      <div className="w-full text-sm font-medium text-custom-primary-100">{bannerData?.message}</div>
+      <div
+        className="relative ml-auto w-6 h-6 rounded-sm flex justify-center items-center transition-all cursor-pointer hover:bg-custom-primary-100/20 text-custom-primary-100/80"
+        onClick={() => handleBannerData && handleBannerData(undefined)}
+      >
+        <X className="w-4 h-4 flex-shrink-0" />
+      </div>
+    </div>
+  );
+};

--- a/admin/core/components/authentication/index.ts
+++ b/admin/core/components/authentication/index.ts
@@ -1,3 +1,4 @@
+export * from "./auth-banner";
 export * from "./email-config-switch";
 export * from "./password-config-switch";
 export * from "./authentication-method-card";

--- a/admin/core/components/login/sign-in-form.tsx
+++ b/admin/core/components/login/sign-in-form.tsx
@@ -102,9 +102,9 @@ export const InstanceSignInForm: FC = (props) => {
 
   useEffect(() => {
     if (errorCode) {
-      const errorhandler = authErrorHandler(errorCode?.toString() as EAuthenticationErrorCodes);
-      if (errorhandler) {
-        setErrorInfo(errorhandler);
+      const errorDetail = authErrorHandler(errorCode?.toString() as EAuthenticationErrorCodes);
+      if (errorDetail) {
+        setErrorInfo(errorDetail);
       }
     }
   }, [errorCode]);
@@ -124,11 +124,7 @@ export const InstanceSignInForm: FC = (props) => {
         {errorData.type && errorData?.message ? (
           <Banner type="error" message={errorData?.message} />
         ) : (
-          <>
-            {errorInfo && errorInfo?.type === EErrorAlertType.BANNER_ALERT && (
-              <AuthBanner bannerData={errorInfo} handleBannerData={(value) => setErrorInfo(value)} />
-            )}
-          </>
+          <>{errorInfo && <AuthBanner bannerData={errorInfo} handleBannerData={(value) => setErrorInfo(value)} />}</>
         )}
 
         <form

--- a/admin/core/components/login/sign-in-form.tsx
+++ b/admin/core/components/login/sign-in-form.tsx
@@ -8,8 +8,16 @@ import { Button, Input, Spinner } from "@plane/ui";
 // components
 import { Banner } from "@/components/common";
 // helpers
+import {
+  authErrorHandler,
+  EAuthenticationErrorCodes,
+  EErrorAlertType,
+  TAuthErrorInfo,
+} from "@/helpers/authentication.helper";
+
 import { API_BASE_URL } from "@/helpers/common.helper";
 import { AuthService } from "@/services/auth.service";
+import { AuthBanner } from "../authentication";
 // ui
 // icons
 
@@ -53,6 +61,7 @@ export const InstanceSignInForm: FC = (props) => {
   const [csrfToken, setCsrfToken] = useState<string | undefined>(undefined);
   const [formData, setFormData] = useState<TFormData>(defaultFromData);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [errorInfo, setErrorInfo] = useState<TAuthErrorInfo | undefined>(undefined);
 
   const handleFormChange = (key: keyof TFormData, value: string | boolean) =>
     setFormData((prev) => ({ ...prev, [key]: value }));
@@ -91,6 +100,15 @@ export const InstanceSignInForm: FC = (props) => {
     [formData.email, formData.password, isSubmitting]
   );
 
+  useEffect(() => {
+    if (errorCode) {
+      const errorhandler = authErrorHandler(errorCode?.toString() as EAuthenticationErrorCodes);
+      if (errorhandler) {
+        setErrorInfo(errorhandler);
+      }
+    }
+  }, [errorCode]);
+
   return (
     <div className="flex-grow container mx-auto max-w-lg px-10 lg:max-w-md lg:px-5 py-10 lg:pt-28 transition-all">
       <div className="relative flex flex-col space-y-6">
@@ -103,7 +121,15 @@ export const InstanceSignInForm: FC = (props) => {
           </p>
         </div>
 
-        {errorData.type && errorData?.message && <Banner type="error" message={errorData?.message} />}
+        {errorData.type && errorData?.message ? (
+          <Banner type="error" message={errorData?.message} />
+        ) : (
+          <>
+            {errorInfo && errorInfo?.type === EErrorAlertType.BANNER_ALERT && (
+              <AuthBanner bannerData={errorInfo} handleBannerData={(value) => setErrorInfo(value)} />
+            )}
+          </>
+        )}
 
         <form
           className="space-y-4"


### PR DESCRIPTION
### Changes:
This PR fixes the issue where the error message banner was not displayed when incorrect credentials were entered in God Mode. The necessary changes have been made to ensure the error message now appears as expected.

### Reference:
[WEB-2263]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced the `AuthBanner` component to display authentication error messages, enhancing user feedback for sign-in processes.
	- Updated the `sign-in-form` to utilize the `AuthBanner` for contextual error messaging based on authentication status.

- **Bug Fixes**
	- Improved error handling in the `sign-in-form`, ensuring relevant error messages are displayed to users when needed.

- **Chores**
	- Updated module exports to include the new `AuthBanner` component, streamlining component availability across the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->