### PR TITLE
[WEB-2277] fix: project intake viewer permission validation

### DIFF
--- a/web/app/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/inbox/header.tsx
+++ b/web/app/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/inbox/header.tsx
@@ -9,8 +9,10 @@ import { Breadcrumbs, Button, Intake } from "@plane/ui";
 // components
 import { BreadcrumbLink, Logo } from "@/components/common";
 import { InboxIssueCreateEditModalRoot } from "@/components/inbox";
+// constants
+import { EUserProjectRoles } from "@/constants/project";
 // hooks
-import { useProject, useProjectInbox } from "@/hooks/store";
+import { useProject, useProjectInbox, useUser } from "@/hooks/store";
 
 export const ProjectInboxHeader: FC = observer(() => {
   // states
@@ -18,8 +20,14 @@ export const ProjectInboxHeader: FC = observer(() => {
   // router
   const { workspaceSlug, projectId } = useParams();
   // store hooks
+  const {
+    membership: { currentProjectRole },
+  } = useUser();
   const { currentProjectDetails, loader: currentProjectDetailsLoader } = useProject();
   const { loader } = useProjectInbox();
+
+  // derived value
+  const isViewer = currentProjectRole === EUserProjectRoles.VIEWER;
 
   return (
     <div className="relative z-10 flex h-[3.75rem] w-full flex-shrink-0 flex-row items-center justify-between gap-x-2 gap-y-4 bg-custom-sidebar-background-100 p-4">
@@ -58,7 +66,7 @@ export const ProjectInboxHeader: FC = observer(() => {
         </div>
       </div>
 
-      {currentProjectDetails?.inbox_view && workspaceSlug && projectId && (
+      {currentProjectDetails?.inbox_view && workspaceSlug && projectId && !isViewer && (
         <div className="flex items-center gap-2">
           <InboxIssueCreateEditModalRoot
             workspaceSlug={workspaceSlug.toString()}


### PR DESCRIPTION
### Changes:
This PR fixes the intake issue permission validation. Previously, users with viewer permissions could access the create issue modal, which was not the intended behavior.

### Reference:
[[WEB-2277]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/8d1e120e-d264-48f0-b6b3-f7b86648b061)

### Media:
| Before | After |
|--------|--------|
| ![before]() | ![after]() |