### PR TITLE
[WEB-2285] chore: removed permission for user notification

### DIFF
--- a/apiserver/plane/app/views/notification/base.py
+++ b/apiserver/plane/app/views/notification/base.py
@@ -373,9 +373,6 @@ class UserNotificationPreferenceEndpoint(BaseAPIView):
     serializer_class = UserNotificationPreferenceSerializer
 
     # request the object
-    @allow_permission(
-        allowed_roles=[ROLE.ADMIN, ROLE.MEMBER, ROLE.GUEST], level="WORKSPACE"
-    )
     def get(self, request):
         user_notification_preference = UserNotificationPreference.objects.get(
             user=request.user
@@ -386,9 +383,6 @@ class UserNotificationPreferenceEndpoint(BaseAPIView):
         return Response(serializer.data, status=status.HTTP_200_OK)
 
     # update the object
-    @allow_permission(
-        allowed_roles=[ROLE.ADMIN, ROLE.MEMBER, ROLE.GUEST], level="WORKSPACE"
-    )
     def patch(self, request):
         user_notification_preference = UserNotificationPreference.objects.get(
             user=request.user


### PR DESCRIPTION
chore: 
- removed permission for user notification

Issue Link: [WEB-2285](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/d1de5cbc-1a13-4e29-b3f7-e44bac6a52a2)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Notification preferences can now be accessed and modified without role-based restrictions.

- **Security Update**
	- Removed permission checks for accessing user notification preferences, allowing all users to interact with this data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->