### PR TITLE
[WEB-2229] fix: Fixed Toast Message Display for Issue Attachment

### DIFF
--- a/web/core/components/issues/attachment/attachment-item-list.tsx
+++ b/web/core/components/issues/attachment/attachment-item-list.tsx
@@ -12,7 +12,7 @@ import { IssueAttachmentsListItem } from "./attachment-list-item";
 // types
 import { IssueAttachmentDeleteModal } from "./delete-attachment-modal";
 import { TAttachmentOperations } from "./root";
-
+//yeh meri original state hai
 
 type TAttachmentOperationsRemoveModal = Exclude<TAttachmentOperations, "create">;
 
@@ -39,11 +39,29 @@ export const IssueAttachmentItemList: FC<TIssueAttachmentItemList> = observer((p
 
   const onDrop = useCallback(
     (acceptedFiles: File[], rejectedFiles:FileRejection[] ) => {
-      const acc = acceptedFiles.length;
-      const rej = rejectedFiles.length;
-        if(rej===0 && acc ===1){
-          const currentFile: File = acceptedFiles[0];
+      const totalAcceptedFiles = acceptedFiles.length;
+      const totalRejectedFiles = rejectedFiles.length;
+      console.log(`acc: ${totalAcceptedFiles} rej: ${totalRejectedFiles}`)
+      const totalUploadedFiles = totalAcceptedFiles + totalRejectedFiles;
+      if(totalUploadedFiles>1){
+        setToast({
+          type: TOAST_TYPE.ERROR,
+          title: "Error!",
+          message: "Only one file can be uploaded at a time.",
+        })
+        return;
+      }
+      if(totalRejectedFiles>0){
+        setToast({
+          type: TOAST_TYPE.ERROR,
+          title: "Error!",
+          message: "File size too large. Max file size: 5MB.",
+        })
+        return;
+      }
+      const currentFile: File = acceptedFiles[0];
           if (!currentFile || !workspaceSlug) return;
+
           const uploadedFile: File = new File([currentFile], generateFileName(currentFile.name), {
             type: currentFile.type,
           });
@@ -58,27 +76,14 @@ export const IssueAttachmentItemList: FC<TIssueAttachmentItemList> = observer((p
           );
           setIsLoading(true);
           handleAttachmentOperations.create(formData)
-            .catch(()=>{
-              setToast({
-                type: TOAST_TYPE.ERROR,
-                title: "Error!",
-                message: "File could not be attached. Try uploading again.",
-              })
+          .catch(()=>{
+            setToast({
+              type: TOAST_TYPE.ERROR,
+              title: "Error!",
+              message: "File could not be attached. Try uploading again.",
             })
-            .finally(() => setIsLoading(false));
-        } else if(rej==1 && acc==0){
-          setToast({
-            type: TOAST_TYPE.ERROR,
-            title: "Error!",
-            message: "File size too large. Max file size: 5MB.",
           })
-        } else{
-          setToast({
-            type: TOAST_TYPE.ERROR,
-            title: "Error!",
-            message: "Only one file can be uploaded at a time.",
-          })
-        }
+          .finally(() => setIsLoading(false));
     },
     [handleAttachmentOperations, workspaceSlug]
   );

--- a/web/core/components/issues/attachment/attachment-item-list.tsx
+++ b/web/core/components/issues/attachment/attachment-item-list.tsx
@@ -39,51 +39,45 @@ export const IssueAttachmentItemList: FC<TIssueAttachmentItemList> = observer((p
 
   const onDrop = useCallback(
     (acceptedFiles: File[], rejectedFiles:FileRejection[] ) => {
-      const totalAcceptedFiles = acceptedFiles.length;
-      const totalRejectedFiles = rejectedFiles.length;
-      console.log(`acc: ${totalAcceptedFiles} rej: ${totalRejectedFiles}`)
-      const totalUploadedFiles = totalAcceptedFiles + totalRejectedFiles;
-      if(totalUploadedFiles>1){
-        setToast({
-          type: TOAST_TYPE.ERROR,
-          title: "Error!",
-          message: "Only one file can be uploaded at a time.",
-        })
-        return;
-      }
-      if(totalRejectedFiles>0){
-        setToast({
-          type: TOAST_TYPE.ERROR,
-          title: "Error!",
-          message: "File size too large. Max file size: 5MB.",
-        })
-        return;
-      }
-      const currentFile: File = acceptedFiles[0];
-          if (!currentFile || !workspaceSlug) return;
+      const totalAttachedFiles = acceptedFiles.length +  rejectedFiles.length;
 
-          const uploadedFile: File = new File([currentFile], generateFileName(currentFile.name), {
-            type: currentFile.type,
-          });
-          const formData = new FormData();
-          formData.append("asset", uploadedFile);
-          formData.append(
-            "attributes",
-            JSON.stringify({
-              name: uploadedFile.name,
-              size: uploadedFile.size,
-            })
-          );
-          setIsLoading(true);
-          handleAttachmentOperations.create(formData)
-          .catch(()=>{
-            setToast({
-              type: TOAST_TYPE.ERROR,
-              title: "Error!",
-              message: "File could not be attached. Try uploading again.",
-            })
+      if(rejectedFiles.length===0){
+        const currentFile: File = acceptedFiles[0];
+        if (!currentFile || !workspaceSlug) return;
+
+        const uploadedFile: File = new File([currentFile], generateFileName(currentFile.name), {
+          type: currentFile.type,
+        });
+        const formData = new FormData();
+        formData.append("asset", uploadedFile);
+        formData.append(
+          "attributes",
+          JSON.stringify({
+            name: uploadedFile.name,
+            size: uploadedFile.size,
           })
-          .finally(() => setIsLoading(false));
+        );
+        setIsLoading(true);
+        handleAttachmentOperations.create(formData)
+        .catch(()=>{
+          setToast({
+            type: TOAST_TYPE.ERROR,
+            title: "Error!",
+            message: "File could not be attached. Try uploading again.",
+          })
+        })
+        .finally(() => setIsLoading(false));
+        return;
+      }
+
+      setToast({
+            type: TOAST_TYPE.ERROR,
+            title: "Error!",
+            message: (totalAttachedFiles>1)?
+            "Only one file can be uploaded at a time." :
+            "File size too large. Max file size: 5MB.",
+      })
+      return;
     },
     [handleAttachmentOperations, workspaceSlug]
   );

--- a/web/core/components/issues/attachment/attachment-item-list.tsx
+++ b/web/core/components/issues/attachment/attachment-item-list.tsx
@@ -1,8 +1,9 @@
 import { FC, useCallback, useState } from "react";
 import { observer } from "mobx-react";
-import { useDropzone } from "react-dropzone";
+import { FileRejection, useDropzone } from "react-dropzone";
 import { UploadCloud } from "lucide-react";
 // hooks
+import {TOAST_TYPE, setToast } from "@plane/ui";
 import { MAX_FILE_SIZE } from "@/constants/common";
 import { generateFileName } from "@/helpers/attachment.helper";
 import { useInstance, useIssueDetail } from "@/hooks/store";
@@ -11,6 +12,7 @@ import { IssueAttachmentsListItem } from "./attachment-list-item";
 // types
 import { IssueAttachmentDeleteModal } from "./delete-attachment-modal";
 import { TAttachmentOperations } from "./root";
+
 
 type TAttachmentOperationsRemoveModal = Exclude<TAttachmentOperations, "create">;
 
@@ -36,24 +38,47 @@ export const IssueAttachmentItemList: FC<TIssueAttachmentItemList> = observer((p
   const issueAttachments = getAttachmentsByIssueId(issueId);
 
   const onDrop = useCallback(
-    (acceptedFiles: File[]) => {
-      const currentFile: File = acceptedFiles[0];
-      if (!currentFile || !workspaceSlug) return;
-
-      const uploadedFile: File = new File([currentFile], generateFileName(currentFile.name), {
-        type: currentFile.type,
-      });
-      const formData = new FormData();
-      formData.append("asset", uploadedFile);
-      formData.append(
-        "attributes",
-        JSON.stringify({
-          name: uploadedFile.name,
-          size: uploadedFile.size,
-        })
-      );
-      setIsLoading(true);
-      handleAttachmentOperations.create(formData).finally(() => setIsLoading(false));
+    (acceptedFiles: File[], rejectedFiles:FileRejection[] ) => {
+      const acc = acceptedFiles.length;
+      const rej = rejectedFiles.length;
+        if(rej===0 && acc ===1){
+          const currentFile: File = acceptedFiles[0];
+          if (!currentFile || !workspaceSlug) return;
+          const uploadedFile: File = new File([currentFile], generateFileName(currentFile.name), {
+            type: currentFile.type,
+          });
+          const formData = new FormData();
+          formData.append("asset", uploadedFile);
+          formData.append(
+            "attributes",
+            JSON.stringify({
+              name: uploadedFile.name,
+              size: uploadedFile.size,
+            })
+          );
+          setIsLoading(true);
+          handleAttachmentOperations.create(formData)
+            .catch(()=>{
+              setToast({
+                type: TOAST_TYPE.ERROR,
+                title: "Error!",
+                message: "File could not be attached. Try uploading again.",
+              })
+            })
+            .finally(() => setIsLoading(false));
+        } else if(rej==1 && acc==0){
+          setToast({
+            type: TOAST_TYPE.ERROR,
+            title: "Error!",
+            message: "File size too large. Max file size: 5MB.",
+          })
+        } else{
+          setToast({
+            type: TOAST_TYPE.ERROR,
+            title: "Error!",
+            message: "Only one file can be uploaded at a time.",
+          })
+        }
     },
     [handleAttachmentOperations, workspaceSlug]
   );

--- a/web/core/components/issues/attachment/attachment-item-list.tsx
+++ b/web/core/components/issues/attachment/attachment-item-list.tsx
@@ -12,7 +12,6 @@ import { IssueAttachmentsListItem } from "./attachment-list-item";
 // types
 import { IssueAttachmentDeleteModal } from "./delete-attachment-modal";
 import { TAttachmentOperations } from "./root";
-//yeh meri original state hai
 
 type TAttachmentOperationsRemoveModal = Exclude<TAttachmentOperations, "create">;
 
@@ -75,7 +74,7 @@ export const IssueAttachmentItemList: FC<TIssueAttachmentItemList> = observer((p
             title: "Error!",
             message: (totalAttachedFiles>1)?
             "Only one file can be uploaded at a time." :
-            "File size too large. Max file size: 5MB.",
+            "The file must be 5MB or less.",
       })
       return;
     },

--- a/web/core/components/issues/issue-detail-widgets/attachments/quick-action-button.tsx
+++ b/web/core/components/issues/issue-detail-widgets/attachments/quick-action-button.tsx
@@ -35,27 +35,9 @@ export const IssueAttachmentActionButton: FC<Props> = observer((props) => {
   // handlers
   const onDrop = useCallback(
     (acceptedFiles: File[], rejectedFiles:FileRejection[] ) => {
-      const totalAcceptedFiles = acceptedFiles.length;
-      const totalRejectedFiles = rejectedFiles.length;
-      const totalUploadedFiles = totalAcceptedFiles + totalRejectedFiles;
-      if(totalUploadedFiles>1){
-        setToast({
-          type: TOAST_TYPE.ERROR,
-          title: "Error!",
-          message: "Only one file can be uploaded at a time.",
-        })
-        return;
-      }
-      if(totalRejectedFiles>0){
-        setToast({
-          type: TOAST_TYPE.ERROR,
-          title: "Error!",
-          message: "File size too large. Max file size: 5MB.",
-        })
-        return;
-      }
+      const totalAttachedFiles = acceptedFiles.length + rejectedFiles.length;
 
-
+      if(rejectedFiles.length===0){
         const currentFile: File = acceptedFiles[0];
         if (!currentFile || !workspaceSlug) return;
 
@@ -84,6 +66,17 @@ export const IssueAttachmentActionButton: FC<Props> = observer((props) => {
           setLastWidgetAction("attachments");
           setIsLoading(false);
       });
+      return;
+      }
+
+      setToast({
+        type: TOAST_TYPE.ERROR,
+        title: "Error!",
+        message: (totalAttachedFiles>1)?
+        "Only one file can be uploaded at a time." :
+        "File size too large. Max file size: 5MB.",
+      })
+      return;
     },
     [handleAttachmentOperations, workspaceSlug]
   );

--- a/web/core/components/issues/issue-detail-widgets/attachments/quick-action-button.tsx
+++ b/web/core/components/issues/issue-detail-widgets/attachments/quick-action-button.tsx
@@ -74,7 +74,7 @@ export const IssueAttachmentActionButton: FC<Props> = observer((props) => {
         title: "Error!",
         message: (totalAttachedFiles>1)?
         "Only one file can be uploaded at a time." :
-        "File size too large. Max file size: 5MB.",
+        "The file must be 5MB or less.",
       })
       return;
     },

--- a/web/core/components/issues/issue-detail-widgets/attachments/quick-action-button.tsx
+++ b/web/core/components/issues/issue-detail-widgets/attachments/quick-action-button.tsx
@@ -1,7 +1,7 @@
 "use client";
 import React, { FC, useCallback, useState } from "react";
 import { observer } from "mobx-react";
-import { useDropzone } from "react-dropzone";
+import { FileRejection, useDropzone } from "react-dropzone";
 import { Plus } from "lucide-react";
 import {TOAST_TYPE, setToast } from "@plane/ui";
 // constants
@@ -34,7 +34,28 @@ export const IssueAttachmentActionButton: FC<Props> = observer((props) => {
 
   // handlers
   const onDrop = useCallback(
-    (acceptedFiles: File[]) => {
+    (acceptedFiles: File[], rejectedFiles:FileRejection[] ) => {
+      const totalAcceptedFiles = acceptedFiles.length;
+      const totalRejectedFiles = rejectedFiles.length;
+      const totalUploadedFiles = totalAcceptedFiles + totalRejectedFiles;
+      if(totalUploadedFiles>1){
+        setToast({
+          type: TOAST_TYPE.ERROR,
+          title: "Error!",
+          message: "Only one file can be uploaded at a time.",
+        })
+        return;
+      }
+      if(totalRejectedFiles>0){
+        setToast({
+          type: TOAST_TYPE.ERROR,
+          title: "Error!",
+          message: "File size too large. Max file size: 5MB.",
+        })
+        return;
+      }
+
+
         const currentFile: File = acceptedFiles[0];
         if (!currentFile || !workspaceSlug) return;
 
@@ -66,29 +87,13 @@ export const IssueAttachmentActionButton: FC<Props> = observer((props) => {
     },
     [handleAttachmentOperations, workspaceSlug]
   );
-  const handleFileRejection = useCallback(() => {
-    setToast({
-      type: TOAST_TYPE.ERROR,
-      title: "Error!",
-      message: "File size too large. Max file size: 5MB.",
-    })
-  }, []);
 
-  const handleError = useCallback(()=>{
-    setToast({
-      type: TOAST_TYPE.ERROR,
-      title: "Error!",
-      message: "Some error occurred. Try uploading the file again.",
-    })
-  },[]);
 
   const { getRootProps, getInputProps } = useDropzone({
     onDrop,
     maxSize: config?.file_size_limit ?? MAX_FILE_SIZE,
     multiple: false,
     disabled: isLoading || disabled,
-    onDropRejected: handleFileRejection,
-    onError: handleError,
   });
 
   return (

--- a/web/core/components/issues/issue-detail-widgets/attachments/quick-action-button.tsx
+++ b/web/core/components/issues/issue-detail-widgets/attachments/quick-action-button.tsx
@@ -3,6 +3,7 @@ import React, { FC, useCallback, useState } from "react";
 import { observer } from "mobx-react";
 import { useDropzone } from "react-dropzone";
 import { Plus } from "lucide-react";
+import {TOAST_TYPE, setToast } from "@plane/ui";
 // constants
 import { MAX_FILE_SIZE } from "@/constants/common";
 // helper
@@ -34,35 +35,60 @@ export const IssueAttachmentActionButton: FC<Props> = observer((props) => {
   // handlers
   const onDrop = useCallback(
     (acceptedFiles: File[]) => {
-      const currentFile: File = acceptedFiles[0];
-      if (!currentFile || !workspaceSlug) return;
+        const currentFile: File = acceptedFiles[0];
+        if (!currentFile || !workspaceSlug) return;
 
-      const uploadedFile: File = new File([currentFile], generateFileName(currentFile.name), {
-        type: currentFile.type,
-      });
-      const formData = new FormData();
-      formData.append("asset", uploadedFile);
-      formData.append(
-        "attributes",
-        JSON.stringify({
-          name: uploadedFile.name,
-          size: uploadedFile.size,
+        const uploadedFile: File = new File([currentFile], generateFileName(currentFile.name), {
+          type: currentFile.type,
+        });
+        const formData = new FormData();
+        formData.append("asset", uploadedFile);
+        formData.append(
+          "attributes",
+          JSON.stringify({
+            name: uploadedFile.name,
+            size: uploadedFile.size,
+          })
+        );
+        setIsLoading(true);
+        handleAttachmentOperations.create(formData)
+        .catch(()=>{
+          setToast({
+            type: TOAST_TYPE.ERROR,
+            title: "Error!",
+            message: "File could not be attached. Try uploading again.",
+          })
         })
-      );
-      setIsLoading(true);
-      handleAttachmentOperations.create(formData).finally(() => {
-        setLastWidgetAction("attachments");
-        setIsLoading(false);
+        .finally(() => {
+          setLastWidgetAction("attachments");
+          setIsLoading(false);
       });
     },
     [handleAttachmentOperations, workspaceSlug]
   );
+  const handleFileRejection = useCallback(() => {
+    setToast({
+      type: TOAST_TYPE.ERROR,
+      title: "Error!",
+      message: "File size too large. Max file size: 5MB.",
+    })
+  }, []);
+
+  const handleError = useCallback(()=>{
+    setToast({
+      type: TOAST_TYPE.ERROR,
+      title: "Error!",
+      message: "Some error occurred. Try uploading the file again.",
+    })
+  },[]);
 
   const { getRootProps, getInputProps } = useDropzone({
     onDrop,
     maxSize: config?.file_size_limit ?? MAX_FILE_SIZE,
     multiple: false,
     disabled: isLoading || disabled,
+    onDropRejected: handleFileRejection,
+    onError: handleError,
   });
 
   return (


### PR DESCRIPTION
### Fixed Toast Message Display for Issue Attachment [Displaying Errors on Toast]

Action Button and DragNDrop are implemented separately in the code, so they are addressed separately.

1. Action Button allows only one file to be selected, if the file is larger than 5MB, toast should should display a related error.
<img width="715" alt="actionButtonSizeError" src="https://github.com/user-attachments/assets/614a230b-4102-4d52-9d3f-2747ebcd9893">

2. While dragging and dropping, if a file is larger than 5MB is dropped, toast should should display a related error.
<img width="728" alt="dragDropSizeError" src="https://github.com/user-attachments/assets/11bc2985-89d5-47b0-a008-3c034f316301">

3.  Only one file is allowed to be uploaded, if multiple files are dropped toast should display a related error.
<img width="719" alt="dragDropMultipleError" src="https://github.com/user-attachments/assets/25f1b239-4816-4ce4-9bc7-9b73f71430fb">





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **New Features**
	- Enhanced file upload handling with improved error feedback for accepted and rejected files.
	- Integrated toast notifications for real-time user feedback during file upload processes.

- **Bug Fixes**
	- Addressed issues with file rejection handling, ensuring users are informed when uploads fail due to size constraints.

- **Refactor**
	- Updated component logic for handling file uploads to streamline user experience and feedback mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai --> 

### Issue link: [WEB-2229](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/883634b1-a221-4a81-bef4-564853b40b0f)