### PR TITLE
[WEB-2325] fix: Creator unable to delete inbox issue

### DIFF
--- a/web/core/components/inbox/content/inbox-issue-header.tsx
+++ b/web/core/components/inbox/content/inbox-issue-header.tsx
@@ -85,8 +85,7 @@ export const InboxIssueActionsHeader: FC<TInboxIssueActionsHeader> = observer((p
   const canMarkAsDeclined = isAllowed && (inboxIssue?.status === 0 || inboxIssue?.status === -2);
   // can delete only if admin or is creator of the issue
   const canDelete =
-    (!!currentProjectRole && currentProjectRole >= EUserProjectRoles.ADMIN) ||
-    inboxIssue?.created_by === currentUser?.id;
+    (!!currentProjectRole && currentProjectRole >= EUserProjectRoles.ADMIN) || issue?.created_by === currentUser?.id;
   const isAcceptedOrDeclined = inboxIssue?.status ? [-1, 1, 2].includes(inboxIssue.status) : undefined;
   // days left for snooze
   const numberOfDaysLeft = findHowManyDaysLeft(inboxIssue?.snoozed_till);


### PR DESCRIPTION
fix to use the accurate created by while checking if the current user is the creator of the inbox issue, so that they have the permission to delete the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced logic for determining user permissions to delete issues, allowing for more accurate control based on issue ownership.
  
- **Bug Fixes**
	- Resolved inconsistencies in how issue deletion permissions are evaluated, improving user experience regarding issue management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->