### PR TITLE
[WEB-2229] fix: issue attachments toast error

### DIFF
--- a/web/core/components/issues/attachment/attachment-item-list.tsx
+++ b/web/core/components/issues/attachment/attachment-item-list.tsx
@@ -1,8 +1,9 @@
 import { FC, useCallback, useState } from "react";
 import { observer } from "mobx-react";
-import { useDropzone } from "react-dropzone";
+import { FileRejection, useDropzone } from "react-dropzone";
 import { UploadCloud } from "lucide-react";
 // hooks
+import {TOAST_TYPE, setToast } from "@plane/ui";
 import { MAX_FILE_SIZE } from "@/constants/common";
 import { generateFileName } from "@/helpers/attachment.helper";
 import { useInstance, useIssueDetail } from "@/hooks/store";
@@ -36,24 +37,46 @@ export const IssueAttachmentItemList: FC<TIssueAttachmentItemList> = observer((p
   const issueAttachments = getAttachmentsByIssueId(issueId);
 
   const onDrop = useCallback(
-    (acceptedFiles: File[]) => {
-      const currentFile: File = acceptedFiles[0];
-      if (!currentFile || !workspaceSlug) return;
+    (acceptedFiles: File[], rejectedFiles:FileRejection[] ) => {
+      const totalAttachedFiles = acceptedFiles.length +  rejectedFiles.length;
 
-      const uploadedFile: File = new File([currentFile], generateFileName(currentFile.name), {
-        type: currentFile.type,
-      });
-      const formData = new FormData();
-      formData.append("asset", uploadedFile);
-      formData.append(
-        "attributes",
-        JSON.stringify({
-          name: uploadedFile.name,
-          size: uploadedFile.size,
+      if(rejectedFiles.length===0){
+        const currentFile: File = acceptedFiles[0];
+        if (!currentFile || !workspaceSlug) return;
+
+        const uploadedFile: File = new File([currentFile], generateFileName(currentFile.name), {
+          type: currentFile.type,
+        });
+        const formData = new FormData();
+        formData.append("asset", uploadedFile);
+        formData.append(
+          "attributes",
+          JSON.stringify({
+            name: uploadedFile.name,
+            size: uploadedFile.size,
+          })
+        );
+        setIsLoading(true);
+        handleAttachmentOperations.create(formData)
+        .catch(()=>{
+          setToast({
+            type: TOAST_TYPE.ERROR,
+            title: "Error!",
+            message: "File could not be attached. Try uploading again.",
+          })
         })
-      );
-      setIsLoading(true);
-      handleAttachmentOperations.create(formData).finally(() => setIsLoading(false));
+        .finally(() => setIsLoading(false));
+        return;
+      }
+
+      setToast({
+            type: TOAST_TYPE.ERROR,
+            title: "Error!",
+            message: (totalAttachedFiles>1)?
+            "Only one file can be uploaded at a time." :
+            "File must be 5MB or less.",
+      })
+      return;
     },
     [handleAttachmentOperations, workspaceSlug]
   );


### PR DESCRIPTION
#### Changes:

This PR fixes the toast behaviour when an attachment to an issue is rejected.
Action Button and DragNDrop are implemented separately in the code, so they are addressed separately.
1. Action Button allows only one file to be selected, if the file is larger than 5MB, toast should should display a related error.
<img width="702" alt="Screenshot 2024-08-26 at 3 37 19 PM" src="https://github.com/user-attachments/assets/3f832055-efb2-4b26-853a-abbbe7261071">

2. While dragging and dropping, if a file is larger than 5MB is dropped, toast should should display a related error.
<img width="702" alt="Screenshot 2024-08-26 at 3 37 19 PM" src="https://github.com/user-attachments/assets/3f832055-efb2-4b26-853a-abbbe7261071">

3. Only one file is allowed to be uploaded, if multiple files are dropped toast should display a related error.
<img width="710" alt="Screenshot 2024-08-26 at 3 28 24 PM" src="https://github.com/user-attachments/assets/d53ae8be-8579-4ecd-8442-5e1f16c96bdf">

#### Reference
[[WEB-2229]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/883634b1-a221-4a81-bef4-564853b40b0f/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced file upload functionality with improved error handling for rejected files.
	- Introduced user feedback mechanisms via toast notifications for upload status and restrictions.
	- Implemented loading states during file upload processes.
- **Bug Fixes**
	- Resolved issues related to multiple file uploads and size limitations, ensuring adherence to specified constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->