### PR TITLE
[PWA-11] fix: pwa kanban layout block

### DIFF
--- a/web/core/components/issues/issue-layouts/kanban/block.tsx
+++ b/web/core/components/issues/issue-layouts/kanban/block.tsx
@@ -217,7 +217,7 @@ export const KanbanIssueBlock: React.FC<IssueBlockProps> = observer((props) => {
             { "bg-custom-background-80 z-[100]": isCurrentBlockDragging }
           )}
           onClick={() => handleIssuePeekOverview(issue)}
-          disabled={!!issue?.tempId || isMobile}
+          disabled={!!issue?.tempId}
         >
           <RenderIfVisible
             classNames="space-y-2 px-3 py-2"

--- a/web/core/components/issues/issue-layouts/kanban/block.tsx
+++ b/web/core/components/issues/issue-layouts/kanban/block.tsx
@@ -122,7 +122,6 @@ export const KanbanIssueBlock: React.FC<IssueBlockProps> = observer((props) => {
   const workspaceSlug = routerWorkspaceSlug?.toString();
   // hooks
   const { getIsIssuePeeked, setPeekIssue } = useIssueDetail();
-  const { isMobile } = usePlatformOS();
 
   const handleIssuePeekOverview = (issue: TIssue) =>
     workspaceSlug &&


### PR DESCRIPTION
### Changes:
This PR includes following changes:
- Improved the clickability of the Kanban layout blocks, addressing an issue where clicking on an item from the Kanban layout was not working in PWA or mobile views.

### Reference:
[[PWA-11]](https://app.plane.so/plane/projects/e4b10a8d-1a9a-458b-a546-713d122b1379/issues/b47b65e4-b296-45d9-9c04-e8b9b794d793)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- The Kanban Issue Block can now be interacted with on mobile devices unless a temporary ID is present, enhancing the user experience for mobile users. 

- **Bug Fixes**
	- Simplified the disabling logic, ensuring clearer functionality for the Kanban Issue Block.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->