### PR TITLE
[WEB-2243] fix: active cycle info icon overlap

### DIFF
--- a/web/core/components/cycles/list/cycles-list-item.tsx
+++ b/web/core/components/cycles/list/cycles-list-item.tsx
@@ -109,7 +109,7 @@ export const CyclesListItem: FC<TCyclesListItem> = observer((props) => {
       appendTitleElement={
         <button
           onClick={openCycleOverview}
-          className={`z-[5] flex-shrink-0 ${isMobile ? "flex" : "hidden group-hover:flex"}`}
+          className={`z-[1] flex-shrink-0 ${isMobile ? "flex" : "hidden group-hover:flex"}`}
         >
           <Info className="h-4 w-4 text-custom-text-400" />
         </button>


### PR DESCRIPTION
### Changes:
This PR fixes the overlapping of info icon with the above component which appears while hovering over the current active cycle

Current State
<img width="220" alt="Screenshot 2024-08-26 at 6 13 21 PM" src="https://github.com/user-attachments/assets/25a45a57-2a19-4bdb-8c26-d58a8d9192e1">

Previous State
<img width="272" alt="Screenshot 2024-08-26 at 6 12 47 PM" src="https://github.com/user-attachments/assets/4bd4a713-9d5a-4107-9669-e925f7411a28">


### Reference:
[[WEB-2243]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/6dbc9072-d635-4017-80ee-3ed31d710ef4/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted the z-index of the button in the Cycles List Item component to improve visibility and interaction, especially in overlapping scenarios.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->