### PR TITLE
[WEB-2334] fix: home button borderline misalignment

### DIFF
--- a/web/app/[workspaceSlug]/(projects)/sidebar.tsx
+++ b/web/app/[workspaceSlug]/(projects)/sidebar.tsx
@@ -74,7 +74,7 @@ export const AppSidebar: FC<IAppSidebar> = observer(() => {
           })}
         />
         <div
-          className={cn("overflow-x-hidden scrollbar-sm h-full w-full overflow-y-auto px-2", {
+          className={cn("overflow-x-hidden scrollbar-sm h-full w-full overflow-y-auto px-2 py-0.5", {
             "vertical-scrollbar px-4": !sidebarCollapsed,
           })}
         >


### PR DESCRIPTION
### Changes 

- The borderline that appears around the Home button on the sidebar when navigated using the 'tab' button on the keyboard now has a py-0.5 class, which fixes the misalignment.

Previous Selected State
<img width="248" alt="previous" src="https://github.com/user-attachments/assets/39c0fbe9-dd43-4cb1-8995-6b2c9ed0be3b">

Current Selected State
<img width="247" alt="current" src="https://github.com/user-attachments/assets/2d767240-1f40-42d5-9082-c9f157b0cff6">

Previous Unselected State: 
<img width="249" alt="prevUn" src="https://github.com/user-attachments/assets/b5aedc70-725d-43b0-a455-9318ba91aa68">

Current Selected State: 
<img width="253" alt="currUn" src="https://github.com/user-attachments/assets/18965cc0-f44d-4d56-bacd-d4a65cefd671">

### Reference:
[[WEB-2334]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/1fd458ca-d3e4-4bae-9264-f7a7d7351b04/)
