### PR TITLE
[WEB-2228] fix: dashboard peek overview issue fetch

### DIFF
--- a/web/core/components/inbox/modals/create-edit-modal/issue-properties.tsx
+++ b/web/core/components/inbox/modals/create-edit-modal/issue-properties.tsx
@@ -179,7 +179,13 @@ export const InboxIssueProperties: FC<TInboxIssueProperties> = observer((props) 
                 <CustomMenu.MenuItem className="!p-1" onClick={() => setParentIssueModalOpen(true)}>
                   Change parent issue
                 </CustomMenu.MenuItem>
-                <CustomMenu.MenuItem className="!p-1" onClick={() => handleData("parent_id", "")}>
+                <CustomMenu.MenuItem
+                  className="!p-1"
+                  onClick={() => {
+                    handleData("parent_id", "");
+                    setSelectedParentIssue(undefined);
+                  }}
+                >
                   Remove parent issue
                 </CustomMenu.MenuItem>
               </>

--- a/web/core/components/issues/peek-overview/root.tsx
+++ b/web/core/components/issues/peek-overview/root.tsx
@@ -20,10 +20,17 @@ interface IIssuePeekOverview {
   embedRemoveCurrentNotification?: () => void;
   is_archived?: boolean;
   is_draft?: boolean;
+  shouldReplaceIssueOnFetch?: boolean;
 }
 
 export const IssuePeekOverview: FC<IIssuePeekOverview> = observer((props) => {
-  const { embedIssue = false, embedRemoveCurrentNotification, is_archived = false, is_draft = false } = props;
+  const {
+    embedIssue = false,
+    embedRemoveCurrentNotification,
+    is_archived = false,
+    is_draft = false,
+    shouldReplaceIssueOnFetch = true,
+  } = props;
   // router
   const pathname = usePathname();
   const {
@@ -60,7 +67,8 @@ export const IssuePeekOverview: FC<IIssuePeekOverview> = observer((props) => {
             workspaceSlug,
             projectId,
             issueId,
-            is_archived ? "ARCHIVED" : is_draft ? "DRAFT" : "DEFAULT"
+            is_archived ? "ARCHIVED" : is_draft ? "DRAFT" : "DEFAULT",
+            shouldReplaceIssueOnFetch
           );
           setLoader(false);
           setError(false);

--- a/web/core/components/page-views/workspace-dashboard.tsx
+++ b/web/core/components/page-views/workspace-dashboard.tsx
@@ -64,7 +64,7 @@ export const WorkspaceDashboardView = observer(() => {
         <>
           {joinedProjectIds.length > 0 || loader ? (
             <>
-              <IssuePeekOverview />
+              <IssuePeekOverview shouldReplaceIssueOnFetch={false} />
               <div
                 className={cn(
                   "space-y-7 md:p-7 p-3 bg-custom-background-90 h-full w-full flex flex-col overflow-y-auto",

--- a/web/core/store/issue/issue-details/issue.store.ts
+++ b/web/core/store/issue/issue-details/issue.store.ts
@@ -13,7 +13,8 @@ export interface IIssueStoreActions {
     workspaceSlug: string,
     projectId: string,
     issueId: string,
-    issueType?: "DEFAULT" | "DRAFT" | "ARCHIVED"
+    issueType?: "DEFAULT" | "DRAFT" | "ARCHIVED",
+    shouldReplace?: boolean
   ) => Promise<TIssue>;
   updateIssue: (workspaceSlug: string, projectId: string, issueId: string, data: Partial<TIssue>) => Promise<void>;
   removeIssue: (workspaceSlug: string, projectId: string, issueId: string) => Promise<void>;
@@ -61,7 +62,13 @@ export class IssueStore implements IIssueStore {
   });
 
   // actions
-  fetchIssue = async (workspaceSlug: string, projectId: string, issueId: string, issueType = "DEFAULT") => {
+  fetchIssue = async (
+    workspaceSlug: string,
+    projectId: string,
+    issueId: string,
+    issueType = "DEFAULT",
+    shouldReplace = true
+  ) => {
     const query = {
       expand: "issue_reactions,issue_attachment,issue_link,parent",
     };
@@ -107,7 +114,7 @@ export class IssueStore implements IIssueStore {
       is_subscribed: issue?.is_subscribed,
     };
 
-    this.rootIssueDetailStore.rootIssueStore.issues.addIssue([issuePayload], true);
+    this.rootIssueDetailStore.rootIssueStore.issues.addIssue([issuePayload], shouldReplace);
 
     // store handlers from issue detail
     // parent


### PR DESCRIPTION
### Changes:
This PR includes the following updates:
- Updated the dashboard issue peek overview fetch method. Previously, clicking on any issue from the dashboard replaced the newly fetched data. I've made the necessary adjustments to fix this.
- Fixed the intake accept issue modal, where users were unable to unselect the parent issue.

### Reference:
[[WEB-2228]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/9b7d46ac-361d-4e4d-b15d-03b9b2474e18/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new property allowing control over whether an issue should be replaced upon fetching, enhancing flexibility in issue management.
	- Updated the `IssuePeekOverview` component to maintain the current issue view during data fetching unless explicitly changed.

- **Bug Fixes**
	- Improved responsiveness of the UI by ensuring that the state associated with the selected parent issue resets correctly when removed.

- **Documentation**
	- Updated interface definitions to reflect new optional parameters for enhanced clarity and configurability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->