### PR TITLE
[WEB-2304] fix: increase z-index from z-20 to z-[21] in dropdown.tsx

### DIFF
--- a/web/core/components/workspace/sidebar/dropdown.tsx
+++ b/web/core/components/workspace/sidebar/dropdown.tsx
@@ -134,9 +134,9 @@ export const SidebarDropdown = observer(() => {
               leaveTo="transform opacity-0 scale-95"
             >
               <Menu.Items as={Fragment}>
-                <div className="fixed top-12 left-4 z-20 mt-1 flex w-full max-w-[19rem] origin-top-left flex-col divide-y divide-custom-border-100 rounded-md border-[0.5px] border-custom-sidebar-border-300 bg-custom-sidebar-background-100 shadow-custom-shadow-rg outline-none">
+                <div className="fixed top-12 left-4 z-[21] mt-1 flex w-full max-w-[19rem] origin-top-left flex-col divide-y divide-custom-border-100 rounded-md border-[0.5px] border-custom-sidebar-border-300 bg-custom-sidebar-background-100 shadow-custom-shadow-rg outline-none">
                   <div className="vertical-scrollbar scrollbar-sm mb-2 flex max-h-96 flex-col items-start justify-start gap-2 overflow-y-scroll px-4">
-                    <h6 className="sticky top-0 z-10 h-full w-full bg-custom-sidebar-background-100 pb-1 pt-3 text-sm font-medium text-custom-sidebar-text-400">
+                    <h6 className="sticky top-0 z-[21] h-full w-full bg-custom-sidebar-background-100 pb-1 pt-3 text-sm font-medium text-custom-sidebar-text-400">
                       {currentUser?.email}
                     </h6>
                     {workspacesList ? (
@@ -264,7 +264,7 @@ export const SidebarDropdown = observer(() => {
             leaveTo="transform opacity-0 scale-95"
           >
             <Menu.Items
-              className="absolute left-0 z-20 mt-1 flex w-52 origin-top-left  flex-col divide-y
+              className="absolute left-0 z-[21] mt-1 flex w-52 origin-top-left  flex-col divide-y
             divide-custom-sidebar-border-200 rounded-md border border-custom-sidebar-border-200 bg-custom-sidebar-background-100 px-1 py-2 text-xs shadow-lg outline-none"
               ref={setPopperElement as Ref<HTMLDivElement>}
               style={styles.popper}


### PR DESCRIPTION
### Changes: 

Left Side Nav Menus' scrollbar was visible in **Safari Browser** above the workspace switcher dropdown, when are opened together.
Increased z index of dropdown.tsx from z-20 to z-[21]. 

Previous State: 
<img width="421" alt="Screenshot 2024-08-28 at 3 13 17 PM" src="https://github.com/user-attachments/assets/11a7d29d-6168-465e-9c18-27cff6c4d427">

New State: 
<img width="490" alt="Screenshot 2024-08-28 at 3 13 45 PM" src="https://github.com/user-attachments/assets/67fdc34b-b568-4c3a-a939-c6c245530ed3">

### Reference: 
[[WEB-2304]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/7f4e4995-eee4-4f78-aab1-2b772f47c509/)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
	- Improved visibility and interaction within the sidebar dropdown menu by adjusting the z-index of the main dropdown container and sticky header.

These changes ensure that key elements are properly layered, enhancing the overall user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->