### PR TITLE
[WEB-2293] fix: version history editor initialization

### DIFF
--- a/web/ce/components/pages/version/editor.tsx
+++ b/web/ce/components/pages/version/editor.tsx
@@ -92,12 +92,13 @@ export const PagesVersionEditor: React.FC<Props> = observer((props) => {
       </div>
     );
 
+  const description = isCurrentVersionActive ? currentPageDetails.description_html : versionDetails?.description_html;
+  if (description === undefined || description?.trim() === "") return null;
+
   return (
     <DocumentReadOnlyEditorWithRef
       id={activeVersion ?? ""}
-      initialValue={
-        (isCurrentVersionActive ? currentPageDetails.description_html : versionDetails?.description_html) ?? "<p></p>"
-      }
+      initialValue={description ?? "<p></p>"}
       containerClassName="p-0 pb-64 border-none"
       displayConfig={displayConfig}
       editorClassName="pl-10"


### PR DESCRIPTION
#### Bug fixes:

Initialize the version history editor only once the content is available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
	- Enhanced the `PagesVersionEditor` component for better management of initial content, improving readability and control flow.
	- Added a safeguard to prevent rendering when there is no valid content, leading to a more robust user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->