### PR TITLE
[WEB-2341] feat: Add display filters and display properties to create/update view dialog

### DIFF
--- a/web/core/components/issues/issue-layouts/filters/header/display-filters/display-filters-selection.tsx
+++ b/web/core/components/issues/issue-layouts/filters/header/display-filters/display-filters-selection.tsx
@@ -78,20 +78,22 @@ export const DisplayFiltersSelection: React.FC<Props> = observer((props) => {
       )}
 
       {/* sub-group by */}
-      {isDisplayFilterEnabled("sub_group_by") && displayFilters?.layout === "kanban" && (
-        <div className="py-2">
-          <FilterSubGroupBy
-            displayFilters={displayFilters}
-            handleUpdate={(val) =>
-              handleDisplayFiltersUpdate({
-                sub_group_by: val,
-              })
-            }
-            subGroupByOptions={layoutDisplayFiltersOptions?.display_filters.sub_group_by ?? []}
-            ignoreGroupedFilters={[...ignoreGroupedFilters, ...computedIgnoreGroupedFilters]}
-          />
-        </div>
-      )}
+      {isDisplayFilterEnabled("sub_group_by") &&
+        displayFilters?.group_by !== null &&
+        displayFilters?.layout === "kanban" && (
+          <div className="py-2">
+            <FilterSubGroupBy
+              displayFilters={displayFilters}
+              handleUpdate={(val) =>
+                handleDisplayFiltersUpdate({
+                  sub_group_by: val,
+                })
+              }
+              subGroupByOptions={layoutDisplayFiltersOptions?.display_filters.sub_group_by ?? []}
+              ignoreGroupedFilters={[...ignoreGroupedFilters, ...computedIgnoreGroupedFilters]}
+            />
+          </div>
+        )}
 
       {/* order by */}
       {isDisplayFilterEnabled("order_by") && !isEmpty(layoutDisplayFiltersOptions?.display_filters?.order_by) && (

--- a/web/core/components/issues/issue-layouts/filters/header/display-filters/display-filters-selection.tsx
+++ b/web/core/components/issues/issue-layouts/filters/header/display-filters/display-filters-selection.tsx
@@ -78,22 +78,20 @@ export const DisplayFiltersSelection: React.FC<Props> = observer((props) => {
       )}
 
       {/* sub-group by */}
-      {isDisplayFilterEnabled("sub_group_by") &&
-        displayFilters?.group_by !== null &&
-        displayFilters?.layout === "kanban" && (
-          <div className="py-2">
-            <FilterSubGroupBy
-              displayFilters={displayFilters}
-              handleUpdate={(val) =>
-                handleDisplayFiltersUpdate({
-                  sub_group_by: val,
-                })
-              }
-              subGroupByOptions={layoutDisplayFiltersOptions?.display_filters.sub_group_by ?? []}
-              ignoreGroupedFilters={[...ignoreGroupedFilters, ...computedIgnoreGroupedFilters]}
-            />
-          </div>
-        )}
+      {isDisplayFilterEnabled("sub_group_by") && displayFilters?.layout === "kanban" && (
+        <div className="py-2">
+          <FilterSubGroupBy
+            displayFilters={displayFilters}
+            handleUpdate={(val) =>
+              handleDisplayFiltersUpdate({
+                sub_group_by: val,
+              })
+            }
+            subGroupByOptions={layoutDisplayFiltersOptions?.display_filters.sub_group_by ?? []}
+            ignoreGroupedFilters={[...ignoreGroupedFilters, ...computedIgnoreGroupedFilters]}
+          />
+        </div>
+      )}
 
       {/* order by */}
       {isDisplayFilterEnabled("order_by") && !isEmpty(layoutDisplayFiltersOptions?.display_filters?.order_by) && (

--- a/web/core/components/workspace/views/form.tsx
+++ b/web/core/components/workspace/views/form.tsx
@@ -4,11 +4,11 @@ import { useEffect } from "react";
 import { observer } from "mobx-react";
 import { Controller, useForm } from "react-hook-form";
 // types
-import { IIssueFilterOptions, IWorkspaceView } from "@plane/types";
+import { IIssueDisplayFilterOptions, IIssueDisplayProperties, IIssueFilterOptions, IWorkspaceView } from "@plane/types";
 // ui
 import { Button, Input, TextArea } from "@plane/ui";
 // components
-import { AppliedFiltersList, FilterSelection, FiltersDropdown } from "@/components/issues";
+import { AppliedFiltersList, DisplayFiltersSelection, FilterSelection, FiltersDropdown } from "@/components/issues";
 // constants
 import { ISSUE_DISPLAY_FILTERS_BY_LAYOUT } from "@/constants/issue";
 import { EViewAccess } from "@/constants/views";
@@ -155,6 +155,7 @@ export const WorkspaceViewForm: React.FC<Props> = observer((props) => {
           </div>
           <div className="flex gap-2">
             <AccessController control={control} />
+            {/* filters dropdown */}
             <Controller
               control={control}
               name="filters"
@@ -184,6 +185,39 @@ export const WorkspaceViewForm: React.FC<Props> = observer((props) => {
                     memberIds={workspaceMemberIds ?? undefined}
                   />
                 </FiltersDropdown>
+              )}
+            />
+
+            {/* display filters dropdown */}
+            <Controller
+              control={control}
+              name="display_filters"
+              render={({ field: { onChange: onDisplayFiltersChange, value: displayFilters } }) => (
+                <Controller
+                  control={control}
+                  name="display_properties"
+                  render={({ field: { onChange: onDisplayPropertiesChange, value: displayProperties } }) => (
+                    <FiltersDropdown title="Display">
+                      <DisplayFiltersSelection
+                        layoutDisplayFiltersOptions={ISSUE_DISPLAY_FILTERS_BY_LAYOUT.my_issues.spreadsheet}
+                        displayFilters={displayFilters ?? {}}
+                        handleDisplayFiltersUpdate={(updatedDisplayFilter: Partial<IIssueDisplayFilterOptions>) => {
+                          onDisplayFiltersChange({
+                            ...displayFilters,
+                            ...updatedDisplayFilter,
+                          });
+                        }}
+                        displayProperties={displayProperties ?? {}}
+                        handleDisplayPropertiesUpdate={(updatedDisplayProperties: Partial<IIssueDisplayProperties>) => {
+                          onDisplayPropertiesChange({
+                            ...displayProperties,
+                            ...updatedDisplayProperties,
+                          });
+                        }}
+                      />
+                    </FiltersDropdown>
+                  )}
+                />
               )}
             />
           </div>


### PR DESCRIPTION
This PR add the display filters and properties to create/update view dialog

https://github.com/user-attachments/assets/10ccdab0-9915-4aac-abf1-d518ad997bd9



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced `ProjectViewForm` and `WorkspaceViewForm` components with improved display filter management.
	- Introduced a hierarchical structure for managing display filters and properties, allowing for a more integrated user interaction.
	- Added a new `DisplayFiltersSelection` component for better handling of filter updates.
  
- **Bug Fixes**
	- Improved responsiveness and organization of form components, enhancing user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->