### PR TITLE
[WEB-2316] chore: use-platform-os hook optimization to not cause re renders

### DIFF
--- a/packages/ui/src/hooks/use-platform-os.ts
+++ b/packages/ui/src/hooks/use-platform-os.ts
@@ -1,15 +1,6 @@
-import { useEffect, useState } from "react";
-
 export const usePlatformOS = () => {
-  // states
-  const [isMobile, setIsMobile] = useState(false);
-
-  useEffect(() => {
-    const userAgent = window.navigator.userAgent;
-    const isMobile = /iPhone|iPad|iPod|Android/i.test(userAgent);
-
-    if (isMobile) setIsMobile(isMobile);
-  }, []);
+  const userAgent = window.navigator.userAgent;
+  const isMobile = /iPhone|iPad|iPod|Android/i.test(userAgent);
 
   return { isMobile };
 };

--- a/web/core/hooks/use-platform-os.tsx
+++ b/web/core/hooks/use-platform-os.tsx
@@ -1,29 +1,20 @@
 "use client";
 
-import { useEffect, useState } from "react";
-
 export const usePlatformOS = () => {
-  const [isMobile, setIsMobile] = useState(false);
-  const [platform, setPlatform] = useState("");
-  useEffect(() => {
-    const userAgent = window.navigator.userAgent;
-    const isMobile = /iPhone|iPad|iPod|Android/i.test(userAgent);
-    let detectedPlatform = "";
+  const userAgent = window.navigator.userAgent;
+  const isMobile = /iPhone|iPad|iPod|Android/i.test(userAgent);
+  let platform = "";
 
-    if (isMobile) {
-      setIsMobile(isMobile)
+  if (!isMobile) {
+    if (userAgent.indexOf("Win") !== -1) {
+      platform = "Windows";
+    } else if (userAgent.indexOf("Mac") !== -1) {
+      platform = "MacOS";
+    } else if (userAgent.indexOf("Linux") !== -1) {
+      platform = "Linux";
     } else {
-      if (userAgent.indexOf("Win") !== -1) {
-        detectedPlatform = "Windows";
-      } else if (userAgent.indexOf("Mac") !== -1) {
-        detectedPlatform = "MacOS";
-      } else if (userAgent.indexOf("Linux") !== -1) {
-        detectedPlatform = "Linux";
-      } else {
-        detectedPlatform = "Unknown";
-      }
-    };
-    setPlatform(detectedPlatform);
-  }, []);
+      platform = "Unknown";
+    }
+  }
   return { isMobile, platform };
 };


### PR DESCRIPTION
Modify usePlatformOS hook to not cause re renders in components by directly assigning values instead of using useEffect and useState to get values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `usePlatformOS` hook for improved efficiency in detecting mobile platforms and operating systems.
  
- **Bug Fixes**
	- Streamlined logic to eliminate unnecessary state management, improving performance.

- **Documentation**
	- Updated comments and descriptions to reflect the simplified implementation of the `usePlatformOS` hook.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->