### PR TITLE
[WEB-2145] chore: added copy button for intake issues

### DIFF
--- a/web/core/components/inbox/content/inbox-issue-header.tsx
+++ b/web/core/components/inbox/content/inbox-issue-header.tsx
@@ -168,15 +168,6 @@ export const InboxIssueActionsHeader: FC<TInboxIssueActionsHeader> = observer((p
       })
     );
 
-  // const handleCopyIntakeIssueLink = () =>
-  //   copyUrlToClipboard(intakeIssueLink).then(() =>
-  //     setToast({
-  //       type: TOAST_TYPE.SUCCESS,
-  //       title: "Link copied",
-  //       message: "Issue link copied to clipboard",
-  //     })
-  //   );
-
   const currentIssueIndex = filteredInboxIssueIds.findIndex((issueId) => issueId === currentInboxIssueId) ?? 0;
 
   const handleInboxIssueNavigation = useCallback(

--- a/web/core/components/inbox/content/inbox-issue-header.tsx
+++ b/web/core/components/inbox/content/inbox-issue-header.tsx
@@ -13,6 +13,7 @@ import {
   Link,
   Trash2,
   MoveRight,
+  Copy
 } from "lucide-react";
 import { Button, ControlLink, CustomMenu, TOAST_TYPE, setToast } from "@plane/ui";
 // components
@@ -93,6 +94,7 @@ export const InboxIssueActionsHeader: FC<TInboxIssueActionsHeader> = observer((p
   const currentInboxIssueId = inboxIssue?.issue?.id;
 
   const issueLink = `${workspaceSlug}/projects/${issue?.project_id}/issues/${currentInboxIssueId}`;
+  const intakeIssueLink = `${workspaceSlug}/projects/${issue?.project_id}/inbox/?currentTab=${currentTab}&inboxIssueId=${currentInboxIssueId}`;
 
   const redirectIssue = (): string | undefined => {
     let nextOrPreviousIssueId: string | undefined = undefined;
@@ -159,6 +161,15 @@ export const InboxIssueActionsHeader: FC<TInboxIssueActionsHeader> = observer((p
 
   const handleCopyIssueLink = () =>
     copyUrlToClipboard(issueLink).then(() =>
+      setToast({
+        type: TOAST_TYPE.SUCCESS,
+        title: "Link copied",
+        message: "Issue link copied to clipboard",
+      })
+    );
+
+  const handleCopyIntakeIssueLink = () =>
+    copyUrlToClipboard(intakeIssueLink).then(() =>
       setToast({
         type: TOAST_TYPE.SUCCESS,
         title: "Link copied",
@@ -362,6 +373,12 @@ export const InboxIssueActionsHeader: FC<TInboxIssueActionsHeader> = observer((p
                         </div>
                       </CustomMenu.MenuItem>
                     )}
+                    <CustomMenu.MenuItem onClick={handleCopyIntakeIssueLink}>
+                      <div className="flex items-center gap-2">
+                        <Copy size={14} strokeWidth={2} />
+                        Copy
+                      </div>
+                    </CustomMenu.MenuItem>
                   </CustomMenu>
                 )}
               </>

--- a/web/core/components/inbox/content/inbox-issue-header.tsx
+++ b/web/core/components/inbox/content/inbox-issue-header.tsx
@@ -159,8 +159,8 @@ export const InboxIssueActionsHeader: FC<TInboxIssueActionsHeader> = observer((p
     }
   };
 
-  const handleCopyIssueLink = () =>
-    copyUrlToClipboard(issueLink).then(() =>
+  const handleCopyIssueLink = (path: string) =>
+    copyUrlToClipboard(path).then(() =>
       setToast({
         type: TOAST_TYPE.SUCCESS,
         title: "Link copied",
@@ -168,14 +168,14 @@ export const InboxIssueActionsHeader: FC<TInboxIssueActionsHeader> = observer((p
       })
     );
 
-  const handleCopyIntakeIssueLink = () =>
-    copyUrlToClipboard(intakeIssueLink).then(() =>
-      setToast({
-        type: TOAST_TYPE.SUCCESS,
-        title: "Link copied",
-        message: "Issue link copied to clipboard",
-      })
-    );
+  // const handleCopyIntakeIssueLink = () =>
+  //   copyUrlToClipboard(intakeIssueLink).then(() =>
+  //     setToast({
+  //       type: TOAST_TYPE.SUCCESS,
+  //       title: "Link copied",
+  //       message: "Issue link copied to clipboard",
+  //     })
+  //   );
 
   const currentIssueIndex = filteredInboxIssueIds.findIndex((issueId) => issueId === currentInboxIssueId) ?? 0;
 
@@ -327,7 +327,7 @@ export const InboxIssueActionsHeader: FC<TInboxIssueActionsHeader> = observer((p
                   variant="neutral-primary"
                   prependIcon={<Link className="h-2.5 w-2.5" />}
                   size="sm"
-                  onClick={handleCopyIssueLink}
+                  onClick={() => handleCopyIssueLink(issueLink)}
                 >
                   Copy issue link
                 </Button>
@@ -365,6 +365,12 @@ export const InboxIssueActionsHeader: FC<TInboxIssueActionsHeader> = observer((p
                         </div>
                       </CustomMenu.MenuItem>
                     )}
+                    <CustomMenu.MenuItem onClick={() => handleCopyIssueLink(intakeIssueLink)}>
+                      <div className="flex items-center gap-2">
+                        <Copy size={14} strokeWidth={2} />
+                        Copy issue link
+                      </div>
+                    </CustomMenu.MenuItem>
                     {canDelete && (
                       <CustomMenu.MenuItem onClick={() => setDeleteIssueModal(true)}>
                         <div className="flex items-center gap-2">
@@ -373,12 +379,7 @@ export const InboxIssueActionsHeader: FC<TInboxIssueActionsHeader> = observer((p
                         </div>
                       </CustomMenu.MenuItem>
                     )}
-                    <CustomMenu.MenuItem onClick={handleCopyIntakeIssueLink}>
-                      <div className="flex items-center gap-2">
-                        <Copy size={14} strokeWidth={2} />
-                        Copy
-                      </div>
-                    </CustomMenu.MenuItem>
+                    
                   </CustomMenu>
                 )}
               </>
@@ -391,7 +392,7 @@ export const InboxIssueActionsHeader: FC<TInboxIssueActionsHeader> = observer((p
         <InboxIssueActionsMobileHeader
           inboxIssue={inboxIssue}
           isSubmitting={isSubmitting}
-          handleCopyIssueLink={handleCopyIssueLink}
+          handleCopyIssueLink={() => handleCopyIssueLink(issueLink)}
           setAcceptIssueModal={setAcceptIssueModal}
           setDeclineIssueModal={setDeclineIssueModal}
           handleIssueSnoozeAction={handleIssueSnoozeAction}


### PR DESCRIPTION
### Changes
No 'copy link' option was available for issues in intake like in other features.

![image](https://github.com/user-attachments/assets/cc5f41d9-b5a7-4558-a492-54da68de4c34)
![image](https://github.com/user-attachments/assets/3e122d86-d83c-4049-91ba-57addcc9eb15)

### Implementation

- Created a copy button element inside Inbox-issue-header file action headers which copies the path to the issues in intake.
- Created a new variable for path to the intake issue.
- Created new handle click function which handles the copy to clipboard functionality every time button is clicked.

### References
[[WEB-2145]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/34c6548c-505d-426e-b25b-7ddeeec698f3)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a link to copy the URL of specific inbox issues directly to the clipboard.
	- Added a new menu item in the Custom Menu for easy access to the copy functionality.
	- Integrated a success toast notification to inform users when the link has been copied.

These enhancements improve user interaction and streamline workflows related to inbox issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->