### PR TITLE
[WEB-2293] fix: version history editor overflow

### DIFF
--- a/web/core/components/pages/version/main-content.tsx
+++ b/web/core/components/pages/version/main-content.tsx
@@ -71,7 +71,7 @@ export const PageVersionsMainContent: React.FC<Props> = observer((props) => {
   const VersionEditor = editorComponent;
 
   return (
-    <div className="flex-grow flex flex-col">
+    <div className="flex-grow flex flex-col overflow-hidden">
       {versionDetailsError ? (
         <div className="flex-grow grid place-items-center">
           <div className="flex flex-col items-center gap-4 text-center">


### PR DESCRIPTION
This PR fixes the overflow issue in the version history read-only editor when a text without any white spaces is added to the editor.

#### Media:

| Before | After |
|--------|--------|
| <img width="1916" alt="image" src="https://github.com/user-attachments/assets/f678e25c-7a11-4641-953f-7035c2633fa1"> | <img width="1916" alt="image" src="https://github.com/user-attachments/assets/7a4bca34-0f48-4a2f-a313-4cceb63e4935"> | 