### PR TITLE
[WEB-2237] fix: intake issue accept modal

### DIFF
--- a/web/core/components/inbox/modals/create-edit-modal/issue-properties.tsx
+++ b/web/core/components/inbox/modals/create-edit-modal/issue-properties.tsx
@@ -179,7 +179,13 @@ export const InboxIssueProperties: FC<TInboxIssueProperties> = observer((props) 
                 <CustomMenu.MenuItem className="!p-1" onClick={() => setParentIssueModalOpen(true)}>
                   Change parent issue
                 </CustomMenu.MenuItem>
-                <CustomMenu.MenuItem className="!p-1" onClick={() => handleData("parent_id", "")}>
+                <CustomMenu.MenuItem
+                  className="!p-1"
+                  onClick={() => {
+                    handleData("parent_id", "");
+                    setSelectedParentIssue(undefined);
+                  }}
+                >
                   Remove parent issue
                 </CustomMenu.MenuItem>
               </>


### PR DESCRIPTION
### Changes:
This PR fixes a bug in the intake create/update modal where users couldn't unselect parent once selected. I've made the necessary changes to resolve this issue.

### Reference:
[[WEB-2237]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/9bd5c83b-2b96-4daf-afff-f2cf7af77533)