### PR TITLE
[WEB-2216] fix: added validation check for white space for create issue modal

### DIFF
--- a/web/core/components/issues/issue-modal/components/title-input.tsx
+++ b/web/core/components/issues/issue-modal/components/title-input.tsx
@@ -19,13 +19,19 @@ type TIssueTitleInputProps = {
 
 export const IssueTitleInput: React.FC<TIssueTitleInputProps> = observer((props) => {
   const { control, issueTitleRef, errors, handleFormChange } = props;
-
+  const validateWhitespace = (value: string) => {
+    if (value.trim() === "") {
+      return "Title is required";
+    }
+    return undefined;
+  };
   return (
     <>
       <Controller
         control={control}
         name="name"
         rules={{
+          validate: validateWhitespace,
           required: "Title is required",
           maxLength: {
             value: 255,


### PR DESCRIPTION
### Problem 
When a issue title is a single space and there are properties added and try to create a issue the properties are being reset.

![image](https://github.com/user-attachments/assets/d25ee0c0-d667-484a-aa45-df7f8dadb4d9)
![image](https://github.com/user-attachments/assets/7ea538c7-2b14-454f-a37b-f588749dcdb1)

### Solution
Added a validation check for the modal form for rejecting whitespace character as input.

![image](https://github.com/user-attachments/assets/d648dc15-a6e5-48fc-9d35-b9d5779a5986)
 
### References
[[WEB-2216]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/5346b59e-6c2a-458c-a219-73c18921d341)