### PR TITLE
[WEB-2360] fix: highlight current user on read only lite text editor

### DIFF
--- a/web/core/components/editor/lite-text-editor/lite-text-read-only-editor.tsx
+++ b/web/core/components/editor/lite-text-editor/lite-text-read-only-editor.tsx
@@ -4,13 +4,17 @@ import { EditorReadOnlyRefApi, ILiteTextReadOnlyEditor, LiteTextReadOnlyEditorWi
 // helpers
 import { cn } from "@/helpers/common.helper";
 // hooks
-import { useMention } from "@/hooks/store";
+import { useMention, useUser } from "@/hooks/store";
 
 interface LiteTextReadOnlyEditorWrapperProps extends Omit<ILiteTextReadOnlyEditor, "mentionHandler"> {}
 
 export const LiteTextReadOnlyEditor = React.forwardRef<EditorReadOnlyRefApi, LiteTextReadOnlyEditorWrapperProps>(
   ({ ...props }, ref) => {
-    const { mentionHighlights } = useMention({});
+    // store hooks
+    const { data: currentUser } = useUser();
+    const { mentionHighlights } = useMention({
+      user: currentUser,
+    });
 
     return (
       <LiteTextReadOnlyEditorWithRef


### PR DESCRIPTION
#### Problem:

Self-mentions on comment box don't appear in yellow color, which is the required behavior.

#### Solution:

Added the missing `currentUser` key to the `useMention` hook of the. lite text read-only editor.

#### Media:

| Before | After |
|--------|--------|
| <img width="1112" alt="image" src="https://github.com/user-attachments/assets/19238f23-853e-4e98-a5cd-41e079145bce"> | <img width="1112" alt="image" src="https://github.com/user-attachments/assets/a5ad673c-e668-46a1-9c55-0ca872e0ca04"> | 

#### Plane issue: [WEB-2360](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/1a0596c8-ead9-4f09-bb45-6896493d3d25)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the Lite Text Read-Only Editor to provide personalized mention suggestions based on the current user's data. 

- **Improvements**
  - Integrated user-specific context into the mention handling for a more interactive editing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->