### PR TITLE
[WEB-2311] fix: update the message display when deactivating/deleting project

### DIFF
--- a/web/app/profile/page.tsx
+++ b/web/app/profile/page.tsx
@@ -426,8 +426,7 @@ const ProfileSettingsPage = observer(() => {
                 <Disclosure.Panel>
                   <div className="flex flex-col gap-8">
                     <span className="text-sm tracking-tight">
-                      The danger zone of the profile page is a critical area that requires careful consideration and
-                      attention. When deactivating an account, all of the data and resources within that account will be
+                      When deactivating an account, all of the data and resources within that account will be
                       permanently removed and cannot be recovered.
                     </span>
                     <div>

--- a/web/core/components/project/settings/delete-project-section.tsx
+++ b/web/core/components/project/settings/delete-project-section.tsx
@@ -37,8 +37,7 @@ export const DeleteProjectSection: React.FC<IDeleteProjectSection> = (props) => 
             <Disclosure.Panel>
               <div className="flex flex-col gap-8 pt-4">
                 <span className="text-sm tracking-tight">
-                  The danger zone of the project delete page is a critical area that requires careful consideration and
-                  attention. When deleting a project, all of the data and resources within that project will be
+                  When deleting a project, all of the data and resources within that project will be
                   permanently removed and cannot be recovered.
                 </span>
                 <div>


### PR DESCRIPTION
### Changes:
Update the message display when deactivating/deleting.

Previous State: 
<img width="1512" alt="Screenshot 2024-08-30 at 7 52 29 PM" src="https://github.com/user-attachments/assets/e0d90de1-40af-4fa0-b3e9-bab862d9a8d3">

New State: 
1. Change appears when deactivation ID.
<img width="1512" alt="Screenshot 2024-08-30 at 7 49 12 PM" src="https://github.com/user-attachments/assets/954b5b00-727c-4956-b285-24f8432fb13e">

2. Change appears when deleting project.
<img width="1512" alt="Screenshot 2024-08-30 at 7 50 40 PM" src="https://github.com/user-attachments/assets/9a6d534b-91b0-4edb-898d-f6e0db6bcf3d">

### Reference:

[[WEB-2311]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/be7c02b7-0962-4585-b033-78ca4a36b4a5/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Content Updates**
	- Modified warning messages on the Profile Settings and Project Deletion pages to simplify language, reducing emphasis on caution for account deactivation and project deletion.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->