### PR TITLE
[WEB-2254] fix: change message for issue via link empty state

### DIFF
--- a/web/app/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/issues/(detail)/[issueId]/page.tsx
+++ b/web/app/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/issues/(detail)/[issueId]/page.tsx
@@ -61,7 +61,7 @@ const IssueDetailsPage = observer(() => {
     handleToggleIssueDetailSidebar();
     return () => window.removeEventListener("resize", handleToggleIssueDetailSidebar);
   }, [issueDetailSidebarCollapsed, toggleIssueDetailSidebar]);
-
+  console.log("WASSUP")
   return (
     <>
       <PageHead title={pageTitle} />
@@ -69,7 +69,7 @@ const IssueDetailsPage = observer(() => {
         <EmptyState
           image={resolvedTheme === "dark" ? emptyIssueDark : emptyIssueLight}
           title="Issue does not exist"
-          description="The issue you are looking for does not exist or has been deleted."
+          description="The issue you are looking for does not exist, has been archived, or has been deleted."
           primaryButton={{
             text: "View other issues",
             onClick: () => router.push(`/${workspaceSlug}/projects/${projectId}/issues`),

--- a/web/app/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/issues/(detail)/[issueId]/page.tsx
+++ b/web/app/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/issues/(detail)/[issueId]/page.tsx
@@ -61,7 +61,7 @@ const IssueDetailsPage = observer(() => {
     handleToggleIssueDetailSidebar();
     return () => window.removeEventListener("resize", handleToggleIssueDetailSidebar);
   }, [issueDetailSidebarCollapsed, toggleIssueDetailSidebar]);
-  console.log("WASSUP")
+
   return (
     <>
       <PageHead title={pageTitle} />


### PR DESCRIPTION
When an issue is opened via the following order the previous message was: 
**PREVIOUSLY:** "The issue you are looking for does not exist or has been deleted."
**NOW:** "The issue you are looking for does not exist, has been archived, or has been deleted."

<img width="800" alt="image" src="https://github.com/user-attachments/assets/c97883c0-537d-4c51-ae15-3df50e9e011d">

New State: 
<img width="1512" alt="Screenshot 2024-09-02 at 4 15 09 PM" src="https://github.com/user-attachments/assets/e89d1829-a807-4a3b-bee2-4f1bf8991525">

[[WEB-2254]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/57eece3e-756b-4777-a807-b644620a3e56/)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the message in the `EmptyState` component on the Issue Details Page to clarify that an issue may be archived or deleted, enhancing user understanding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->