### PR TITLE
[WEB-2367] fix: completed cycle issue transfer

### DIFF
--- a/web/core/components/cycles/transfer-issues.tsx
+++ b/web/core/components/cycles/transfer-issues.tsx
@@ -1,44 +1,17 @@
 "use client";
-
 import React from "react";
-
-import isEmpty from "lodash/isEmpty";
-import { useParams } from "next/navigation";
-
-import useSWR from "swr";
-
-// component
 import { AlertCircle } from "lucide-react";
+// ui
 import { Button, TransferIcon } from "@plane/ui";
-// icon
-// services
-import { CYCLE_DETAILS } from "@/constants/fetch-keys";
-import { CycleService } from "@/services/cycle.service";
-// fetch-key
 
 type Props = {
   handleClick: () => void;
+  canTransferIssues?: boolean;
   disabled?: boolean;
 };
 
-const cycleService = new CycleService();
-
 export const TransferIssues: React.FC<Props> = (props) => {
-  const { handleClick, disabled = false } = props;
-
-  const { workspaceSlug, projectId, cycleId } = useParams();
-
-  const { data: cycleDetails } = useSWR(
-    cycleId ? CYCLE_DETAILS(cycleId as string) : null,
-    workspaceSlug && projectId && cycleId
-      ? () => cycleService.getCycleDetails(workspaceSlug as string, projectId as string, cycleId as string)
-      : null
-  );
-
-  const transferableIssuesCount = cycleDetails
-    ? cycleDetails.backlog_issues + cycleDetails.unstarted_issues + cycleDetails.started_issues
-    : 0;
-
+  const { handleClick, canTransferIssues = false, disabled = false } = props;
   return (
     <div className="-mt-2 mb-4 flex items-center justify-between px-4 pt-6">
       <div className="flex items-center gap-2 text-sm text-custom-text-200">
@@ -46,7 +19,7 @@ export const TransferIssues: React.FC<Props> = (props) => {
         <span>Completed cycles are not editable.</span>
       </div>
 
-      {isEmpty(cycleDetails?.progress_snapshot) && transferableIssuesCount > 0 && (
+      {canTransferIssues && (
         <div>
           <Button
             variant="primary"

--- a/web/core/components/issues/issue-layouts/roots/cycle-layout-root.tsx
+++ b/web/core/components/issues/issue-layouts/roots/cycle-layout-root.tsx
@@ -67,6 +67,11 @@ export const CycleLayoutRoot: React.FC = observer(() => {
   const cycleDetails = cycleId ? getCycleById(cycleId.toString()) : undefined;
   const cycleStatus = cycleDetails?.status?.toLocaleLowerCase() ?? "draft";
   const isCompletedCycle = cycleStatus === "completed";
+  const isProgressSnapshotEmpty = isEmpty(cycleDetails?.progress_snapshot);
+  const transferableIssuesCount = cycleDetails
+    ? cycleDetails.backlog_issues + cycleDetails.unstarted_issues + cycleDetails.started_issues
+    : 0;
+  const canTransferIssues = isProgressSnapshotEmpty && transferableIssuesCount > 0;
 
   if (!workspaceSlug || !projectId || !cycleId) return <></>;
 
@@ -77,6 +82,7 @@ export const CycleLayoutRoot: React.FC = observer(() => {
         {cycleStatus === "completed" && (
           <TransferIssues
             handleClick={() => setTransferIssuesModal(true)}
+            canTransferIssues={canTransferIssues}
             disabled={!isEmpty(cycleDetails?.progress_snapshot) ?? false}
           />
         )}


### PR DESCRIPTION
### Changes:
This PR fixes a bug related to issue transfer after cycle completion. The transfer issue button wasn't rendering correctly due to a recent change in the response.

### Reference:
[[WEB-2367]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/6801a288-48c1-4648-a9b7-900d97587266/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `TransferIssues` component to conditionally display the transfer button based on the `canTransferIssues` property.
	- Improved logic in the `CycleLayoutRoot` component to determine the transferability of issues based on the cycle's progress and available transferable issues.

- **Bug Fixes**
	- Streamlined functionality by removing unnecessary data fetching, ensuring the transfer button reflects the current state accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->