### PR TITLE
[WEB-2201] fix:changed onClick to onMouseDown

### DIFF
--- a/web/core/components/account/auth-forms/email.tsx
+++ b/web/core/components/account/auth-forms/email.tsx
@@ -69,7 +69,7 @@ export const AuthEmailForm: FC<TAuthEmailForm> = observer((props) => {
           {email.length > 0 && (
             <XCircle
               className="absolute right-3 h-5 w-5 stroke-custom-text-400 hover:cursor-pointer"
-              onClick={() => setEmail("")}
+              onMouseDown={() => setEmail("")}
             />
           )}
         </div>


### PR DESCRIPTION
### Changes: 

Moved to onMouseDown from onClick, to prevent triggering other events while the button is "being clicked".

https://github.com/user-attachments/assets/6d848f3b-4066-4a1d-aa78-ee4810a211ea




### Reference: 

[[WEB-2201]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/df3b328b-ce17-4f77-a12c-46581cfc9162/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved responsiveness of the email input field by changing the clear action trigger from a click to a mouse button press.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->