### PR TITLE
chore: search on enter for image picker popover unsplash input

### DIFF
--- a/web/core/components/core/image-picker-popover.tsx
+++ b/web/core/components/core/image-picker-popover.tsx
@@ -215,6 +215,12 @@ export const ImagePickerPopover: React.FC<Props> = observer((props) => {
                             id="search"
                             name="search"
                             type="text"
+                            onKeyDown={(e) => {
+                              if (e.key === "Enter") {
+                                e.preventDefault();
+                                setSearchParams(formData.search);
+                              }
+                            }}
                             value={value}
                             onChange={(e) => setFormData({ ...formData, search: e.target.value })}
                             ref={ref}


### PR DESCRIPTION
### Changes:
Enhanced the functionality of the Unsplash search in project settings by ensuring that pressing the **enter** key triggers a search instead of closing the popup.

![CleanShot 2024-09-02 at 19 03 55](https://github.com/user-attachments/assets/c6c73b4b-da57-4029-b550-70f492f19255)

### Previous State:
- In the project settings -> change cover -> Unsplash, after typing a search parameter (e.g., "cool img") and pressing **enter** (or **return** on mac), the popup would close unexpectedly instead of performing the search.



### New State:
- The popup now correctly performs a search when the **enter** key is pressed, providing a more intuitive and seamless user experience.


### Why should this be worked on?
Improved UX for the user, thanks to faster and more intuitive **enter** key usage.

### Summary by CodeRabbit:
Content Updates:
- Fixed the issue where pressing the **enter** key in the Unsplash search input would close the popup instead of triggering a search.
- Enhanced the user experience by making the search functionality more intuitive and responsive.

**Reference:**
Closes #5498 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the search input in the Image Picker Popover to allow users to submit queries using the "Enter" key, improving overall usability.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->