### PR TITLE
[WEB-2372] fix: parent key added for expansion in external api

### DIFF
--- a/apiserver/plane/api/serializers/__init__.py
+++ b/apiserver/plane/api/serializers/__init__.py
@@ -10,6 +10,7 @@ from .issue import (
     IssueAttachmentSerializer,
     IssueActivitySerializer,
     IssueExpandSerializer,
+    IssueLiteSerializer,
 )
 from .state import StateLiteSerializer, StateSerializer
 from .cycle import CycleSerializer, CycleIssueSerializer, CycleLiteSerializer

--- a/apiserver/plane/api/serializers/base.py
+++ b/apiserver/plane/api/serializers/base.py
@@ -67,6 +67,7 @@ class BaseSerializer(serializers.ModelSerializer):
                     # Import all the expandable serializers
                     from . import (
                         IssueSerializer,
+                        IssueLiteSerializer,
                         ProjectLiteSerializer,
                         StateLiteSerializer,
                         UserLiteSerializer,
@@ -86,6 +87,7 @@ class BaseSerializer(serializers.ModelSerializer):
                         "actor": UserLiteSerializer,
                         "owned_by": UserLiteSerializer,
                         "members": UserLiteSerializer,
+                        "parent": IssueLiteSerializer,
                     }
                     # Check if field in expansion  then expand the field
                     if expand in expansion:

--- a/apiserver/plane/api/serializers/issue.py
+++ b/apiserver/plane/api/serializers/issue.py
@@ -274,6 +274,17 @@ class IssueSerializer(BaseSerializer):
         return data
 
 
+class IssueLiteSerializer(BaseSerializer):
+    class Meta:
+        model = Issue
+        fields = [
+            "id",
+            "sequence_id",
+            "project_id",
+        ]
+        read_only_fields = fields
+
+
 class LabelSerializer(BaseSerializer):
     class Meta:
         model = Label


### PR DESCRIPTION
fix:
- this pull request adds a parent key to the API response structure, allowing clients to request expanded related data within a single response by using the expand parameter.


Issue Link: [WEB-2372](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/58f52f8c-d773-493b-8b0a-d540a9e7cfcf/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced the `IssueLiteSerializer` for a lightweight representation of issue data, enhancing API serialization capabilities.
	- Expanded the serialization logic to include parent issue relationships for improved data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->