### PR TITLE
[WEB-2373] chore: add favorites option inside a page

### DIFF
--- a/web/core/components/pages/list/block-item-action.tsx
+++ b/web/core/components/pages/list/block-item-action.tsx
@@ -7,12 +7,10 @@ import { Earth, Info, Lock, Minus } from "lucide-react";
 import { Avatar, FavoriteStar, TOAST_TYPE, Tooltip, setToast } from "@plane/ui";
 // components
 import { PageQuickActions } from "@/components/pages/dropdowns";
-// constants
-import { EUserProjectRoles } from "@/constants/project";
 // helpers
 import { renderFormattedDate } from "@/helpers/date-time.helper";
 // hooks
-import { useMember, usePage, useProject } from "@/hooks/store";
+import { useMember, usePage } from "@/hooks/store";
 
 type Props = {
   workspaceSlug: string;
@@ -23,24 +21,24 @@ type Props = {
 
 export const BlockItemAction: FC<Props> = observer((props) => {
   const { workspaceSlug, projectId, pageId, parentRef } = props;
-
   // store hooks
   const page = usePage(pageId);
   const { getUserDetails } = useMember();
-  const { getProjectById } = useProject();
-
   // derived values
-  const { access, created_at, is_favorite, owned_by, addToFavorites, removePageFromFavorites } = page;
-
-  // derived values
-  const project = getProjectById(projectId);
-  const isViewerOrGuest =
-    project?.member_role && [EUserProjectRoles.VIEWER, EUserProjectRoles.GUEST].includes(project.member_role);
+  const {
+    access,
+    created_at,
+    is_favorite,
+    owned_by,
+    canCurrentUserFavoritePage,
+    addToFavorites,
+    removePageFromFavorites,
+  } = page;
   const ownerDetails = owned_by ? getUserDetails(owned_by) : undefined;
 
   // handlers
   const handleFavorites = () => {
-    if (is_favorite)
+    if (is_favorite) {
       removePageFromFavorites().then(() =>
         setToast({
           type: TOAST_TYPE.SUCCESS,
@@ -48,7 +46,7 @@ export const BlockItemAction: FC<Props> = observer((props) => {
           message: "Page removed from favorites.",
         })
       );
-    else
+    } else {
       addToFavorites().then(() =>
         setToast({
           type: TOAST_TYPE.SUCCESS,
@@ -56,7 +54,9 @@ export const BlockItemAction: FC<Props> = observer((props) => {
           message: "Page added to favorites.",
         })
       );
+    }
   };
+
   return (
     <>
       {/* page details */}
@@ -81,7 +81,7 @@ export const BlockItemAction: FC<Props> = observer((props) => {
       </Tooltip>
 
       {/* favorite/unfavorite */}
-      {!isViewerOrGuest && (
+      {canCurrentUserFavoritePage && (
         <FavoriteStar
           onClick={(e) => {
             e.preventDefault();

--- a/web/core/store/pages/page.ts
+++ b/web/core/store/pages/page.ts
@@ -24,6 +24,7 @@ export interface IPage extends TPage {
   canCurrentUserChangeAccess: boolean;
   canCurrentUserArchivePage: boolean;
   canCurrentUserDeletePage: boolean;
+  canCurrentUserFavoritePage: boolean;
   isContentEditable: boolean;
   // helpers
   oldName: string;
@@ -133,6 +134,7 @@ export class Page implements IPage {
       canCurrentUserChangeAccess: computed,
       canCurrentUserArchivePage: computed,
       canCurrentUserDeletePage: computed,
+      canCurrentUserFavoritePage: computed,
       isContentEditable: computed,
       // actions
       update: action,
@@ -253,6 +255,14 @@ export class Page implements IPage {
   get canCurrentUserDeletePage() {
     const currentUserProjectRole = this.store.user.membership.currentProjectRole;
     return this.isCurrentUserOwner || currentUserProjectRole === EUserProjectRoles.ADMIN;
+  }
+
+  /**
+   * @description returns true if the current logged in user can favorite the page
+   */
+  get canCurrentUserFavoritePage() {
+    const currentUserProjectRole = this.store.user.membership.currentProjectRole;
+    return !!currentUserProjectRole && currentUserProjectRole >= EUserProjectRoles.MEMBER;
   }
 
   /**


### PR DESCRIPTION
#### Improvements:

A page can now be marked as favorite/removed from inside the page details as well.

#### Media:

https://github.com/user-attachments/assets/639100df-c7d5-4a13-a07e-1361f49800b2

#### Plane issue: [WEB-2373](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/48219638-d97f-46b1-aedd-699756ce024a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a favorite handling feature, allowing users to add or remove pages from their favorites.
	- Updated UI to conditionally render a favorite star based on user permissions and page status.
  
- **Bug Fixes**
	- Simplified state management by removing unnecessary dependencies, improving component performance and clarity.

- **Refactor**
	- Enhanced the `Page` class to manage user permissions for favoriting pages, streamlining control flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->