### PR TITLE
[WEB-2374] fix: untitle page title in favorites list

### DIFF
--- a/web/core/hooks/use-favorite-item-details.tsx
+++ b/web/core/hooks/use-favorite-item-details.tsx
@@ -1,8 +1,13 @@
+// plane types
 import { IFavorite } from "@plane/types";
+// components
 import {
   generateFavoriteItemLink,
   getFavoriteItemIcon,
 } from "@/components/workspace/sidebar/favorites/favorite-items/common";
+// helpers
+import { getPageName } from "@/helpers/page.helper";
+// hooks
 import { useProject, usePage, useProjectView, useCycle, useModule } from "@/hooks/store";
 
 export const useFavoriteItemDetails = (workspaceSlug: string, favorite: IFavorite) => {
@@ -35,7 +40,7 @@ export const useFavoriteItemDetails = (workspaceSlug: string, favorite: IFavorit
       itemIcon = getFavoriteItemIcon("project", currentProjectDetails?.logo_props || favoriteItemLogoProps);
       break;
     case "page":
-      itemTitle = pageDetail.name || favoriteItemName;
+      itemTitle = getPageName(pageDetail.name || favoriteItemName);
       itemIcon = getFavoriteItemIcon("page", pageDetail?.logo_props || favoriteItemLogoProps);
       break;
     case "view":


### PR DESCRIPTION
#### Problem:

Name of pages with no title not being rendered on the sidebar favorites' list.

#### Solution:

Added the helper function `getPageName` to render the page title.

#### Plane issue: [WEB-2374](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/382866b2-9f3d-4abc-a2e4-e9285f6de5cb)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced title retrieval for favorite items, improving consistency in how page names are processed.
- **Refactor**
	- Reorganized import statements for better clarity and structure in the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->