### PR TITLE
[WEB-2394] chore: workspace page favourite filter

### DIFF
--- a/apiserver/plane/app/views/workspace/favorite.py
+++ b/apiserver/plane/app/views/workspace/favorite.py
@@ -24,7 +24,7 @@ class WorkspaceFavoriteEndpoint(BaseAPIView):
             workspace__slug=slug,
             parent__isnull=True,
         ).filter(
-            Q(project__isnull=True)
+            Q(project__isnull=True) & ~Q(entity_type="page")
             | (
                 Q(project__isnull=False)
                 & Q(project__project_projectmember__member=request.user)


### PR DESCRIPTION
chore: 
- added the filter for not rendering the workspace level page in the favourites list.

Issue Link: [WEB-2394](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/06f1fa34-c054-428e-962c-cf95299cd9e7/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced filtering for workspace queries to exclude entities of type "page" when the project field is null, improving the relevance of displayed results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->