### PR TITLE
[WEB-2106] fix: add date and state change functionalities to list and grid view

### DIFF
--- a/web/core/components/modules/module-list-item-action.tsx
+++ b/web/core/components/modules/module-list-item-action.tsx
@@ -4,22 +4,24 @@ import React, { FC } from "react";
 import { observer } from "mobx-react";
 import { useParams } from "next/navigation";
 // icons
-import { CalendarCheck2, CalendarClock, MoveRight, SquareUser } from "lucide-react";
+import { SquareUser } from "lucide-react";
 // types
 import { IModule } from "@plane/types";
 // ui
-import { FavoriteStar, Tooltip, setPromiseToast } from "@plane/ui";
+import { FavoriteStar, TOAST_TYPE, Tooltip, setPromiseToast, setToast } from "@plane/ui";
 // components
 import { ModuleQuickActions } from "@/components/modules";
 // constants
-import { MODULE_FAVORITED, MODULE_UNFAVORITED } from "@/constants/event-tracker";
-import { MODULE_STATUS } from "@/constants/module";
+import { MODULE_FAVORITED, MODULE_UNFAVORITED, MODULE_UPDATED } from "@/constants/event-tracker";
 import { EUserProjectRoles } from "@/constants/project";
-// helpers
-import { getDate, renderFormattedDate } from "@/helpers/date-time.helper";
 // hooks
 import { useEventTracker, useMember, useModule, useUser } from "@/hooks/store";
 import { ButtonAvatars } from "../dropdowns/member/avatar";
+import { ModuleStatusSelection } from  "@/components/modules/module-status-dropdown";
+import { DateRangeDropdown } from "@/components/dropdowns";
+import { getDate } from '@/helpers/date-time.helper';
+import { renderFormattedPayloadDate } from "@/helpers/date-time.helper";
+import { MODULE_STATUS } from "@/constants/module";
 
 type Props = {
   moduleId: string;
@@ -32,6 +34,7 @@ export const ModuleListItemAction: FC<Props> = observer((props) => {
   // router
   const { workspaceSlug, projectId } = useParams();
   //   store hooks
+  const { updateModuleDetails } = useModule();
   const {
     membership: { currentProjectRole },
   } = useUser();
@@ -40,14 +43,11 @@ export const ModuleListItemAction: FC<Props> = observer((props) => {
   const { captureEvent } = useEventTracker();
 
   // derived values
-  const endDate = getDate(moduleDetails.target_date);
-  const startDate = getDate(moduleDetails.start_date);
-
-  const renderDate = moduleDetails.start_date || moduleDetails.target_date;
 
   const moduleStatus = MODULE_STATUS.find((status) => status.value === moduleDetails.status);
-
   const isEditingAllowed = !!currentProjectRole && currentProjectRole >= EUserProjectRoles.MEMBER;
+  const isDisabled = !isEditingAllowed || (moduleDetails.archived_at ? true : false) ;
+  const renderIcon = Boolean(moduleDetails.start_date) || Boolean(moduleDetails.target_date);
 
   // handlers
   const handleAddToFavorites = (e: React.MouseEvent<HTMLButtonElement>) => {
@@ -108,30 +108,59 @@ export const ModuleListItemAction: FC<Props> = observer((props) => {
     });
   };
 
+  const handleModuleDetailsChange = async (payload: Partial<IModule>) => {
+    if (!workspaceSlug || !projectId) return;
+
+    await updateModuleDetails(workspaceSlug.toString(), projectId.toString(), moduleId, payload)
+      .then((res) => {
+        setToast({
+          type: TOAST_TYPE.SUCCESS,
+          title: "Success!",
+          message: "Module updated successfully.",
+        });
+      })
+      .catch((err) => {
+        setToast({
+          type: TOAST_TYPE.ERROR,
+          title: "Error!",
+          message: err?.detail ?? "Module could not be updated. Please try again.",
+        });
+      });
+  };
+  
   const moduleLeadDetails = moduleDetails.lead_id ? getUserDetails(moduleDetails.lead_id) : undefined;
 
   return (
     <>
-      {renderDate && (
-        <div className="h-6 flex items-center gap-1.5 text-custom-text-300 border-[0.5px] border-custom-border-300 rounded text-xs px-2 cursor-default">
-          <CalendarClock className="h-3 w-3 flex-shrink-0" />
-          <span className="flex-grow truncate">{renderFormattedDate(startDate)}</span>
-          <MoveRight className="h-3 w-3 flex-shrink-0" />
-          <CalendarCheck2 className="h-3 w-3 flex-shrink-0" />
-          <span className="flex-grow truncate">{renderFormattedDate(endDate)}</span>
-        </div>
-      )}
+
+      <DateRangeDropdown
+        buttonContainerClassName={`h-6 w-full flex ${isDisabled ? "cursor-not-allowed" : "cursor-pointer"} items-center gap-1.5 text-custom-text-300 border-[0.5px] border-custom-border-300 rounded text-xs`}
+        buttonVariant="transparent-with-text"
+        className="h-7"
+        value={{
+          from: getDate(moduleDetails.start_date),
+          to: getDate(moduleDetails.target_date),
+        }}
+        onSelect={(val) => {
+          handleModuleDetailsChange({
+            start_date: (val?.from ? renderFormattedPayloadDate(val.from) : null),
+            target_date: (val?.to ? renderFormattedPayloadDate(val.to) : null)
+          })
+        }}
+        placeholder={{
+          from: "Start date",
+          to: "End date",
+        }}
+        disabled={isDisabled}
+        hideIcon={{ from: renderIcon ?? true, to: renderIcon }}
+      />
 
       {moduleStatus && (
-        <span
-          className="flex h-6 w-20 flex-shrink-0 items-center justify-center rounded-sm text-center text-xs cursor-default"
-          style={{
-            color: moduleStatus.color,
-            backgroundColor: `${moduleStatus.color}20`,
-          }}
-        >
-          {moduleStatus.label}
-        </span>
+        <ModuleStatusSelection
+        isEditingAllowed={isEditingAllowed}
+        moduleDetails={moduleDetails}
+        handleModuleDetailsChange={handleModuleDetailsChange}
+        />
       )}
 
       {moduleLeadDetails ? (

--- a/web/core/components/modules/module-status-dropdown.tsx
+++ b/web/core/components/modules/module-status-dropdown.tsx
@@ -1,0 +1,50 @@
+import { MODULE_STATUS } from '@/constants/module'
+import { IModule } from '@plane/types';
+import { CustomSelect, TModuleStatus, ModuleStatusIcon } from '@plane/ui'
+import { observer } from 'mobx-react';
+import React, { FC } from 'react'
+
+type Props = {
+    isEditingAllowed: boolean;
+    moduleDetails: IModule;
+    handleModuleDetailsChange: (payload: Partial<IModule>) => Promise<void>;
+};
+
+export const ModuleStatusSelection : FC<Props> = observer((props : Props) => {
+    const {isEditingAllowed, moduleDetails, handleModuleDetailsChange} = props;
+    const moduleStatus = MODULE_STATUS.find((status) => status.value === moduleDetails.status);
+
+    if(!moduleStatus) return <></>
+
+return (
+    <CustomSelect
+        customButton={
+            <span
+            className={`flex h-6 w-20 items-center justify-center rounded-sm text-center text-xs ${
+                isEditingAllowed ? "cursor-pointer" : "cursor-not-allowed"
+            }`}
+            style={{
+                color: moduleStatus ? moduleStatus.color : "#a3a3a2",
+                backgroundColor: moduleStatus ? `${moduleStatus.color}20` : "#a3a3a220",
+            }}
+            >
+            {moduleStatus?.label ?? "Backlog"}
+            </span>
+        }
+        value={moduleStatus?.value}
+        onChange={(val: TModuleStatus)=>{
+            handleModuleDetailsChange({status: val})
+        }}
+        disabled={!isEditingAllowed}
+    >
+        {MODULE_STATUS.map((status) => (
+            <CustomSelect.Option key={status.value} value={status.value}>
+            <div className="flex items-center gap-2">
+                <ModuleStatusIcon status={status.value} />
+                {status.label}
+            </div>
+            </CustomSelect.Option>
+        ))}
+        </CustomSelect>
+    )
+})


### PR DESCRIPTION
This PR introduces the ability to change the state and date of Module from any list and grid view.
Previously possible via edit and info button only.
All the styling is made similar to the date picker present in the cycles view.
## Changes: 

#### LIST VIEW: 

- Date Picker
<img width="430" alt="Screenshot 2024-09-05 at 5 59 50 PM" src="https://github.com/user-attachments/assets/f24965bb-ae78-457c-8595-3e555c39eb8b">

- Status Selector
<img width="420" alt="Screenshot 2024-09-05 at 6 00 00 PM" src="https://github.com/user-attachments/assets/07323466-acba-4322-9fee-8d0f7a5d460c">

#### GRID VIEW: 

- Date Picker
<img width="573" alt="Screenshot 2024-09-05 at 6 06 41 PM" src="https://github.com/user-attachments/assets/ea6a5e03-cc5a-48aa-a3bd-b8edb8b25467">

- Status Selector
<img width="576" alt="Screenshot 2024-09-05 at 6 07 04 PM" src="https://github.com/user-attachments/assets/3df58559-67a8-480f-862c-222bb0680ddb">


## STYLING DETAILS: 
#### LIST VIEW: 

- With Date (once date is set) v/s No Date ( default state when new module is created)
<img width="208" alt="Screenshot 2024-09-05 at 6 36 23 PM" src="https://github.com/user-attachments/assets/0b72f6c9-de03-4e3e-a3ea-47e05c60c9d3">

#### GRID VIEW: 
- With Date (once date is set) v/s No Date ( default state when new module is created)
<img width="580" alt="Screenshot 2024-09-05 at 6 09 27 PM" src="https://github.com/user-attachments/assets/9d2a87d8-074a-4958-866b-f1150457e883">

#### CYCLE VIEW: 
- Cycle view styling for comparison
<img width="420" alt="Screenshot 2024-09-05 at 6 37 18 PM" src="https://github.com/user-attachments/assets/882eb2c3-df13-4d88-9d51-c316d2972f5d">

#### ARCHIVED MODULES:
- The cursor shows "disable" when hovered over an archived module status and date picker.

https://github.com/user-attachments/assets/fd0e7578-23e6-4316-9c77-e8d847e591eb


## Reference: 
### [[WEB-2106]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/d0682e73-5b28-4414-bc27-55fedcc0ff60/)


