### PR TITLE
fix(webhook): allow private ip to be used as payload url

### DIFF
--- a/apiserver/plane/app/serializers/webhook.py
+++ b/apiserver/plane/app/serializers/webhook.py
@@ -40,7 +40,7 @@ class WebhookSerializer(DynamicBaseSerializer):
 
         for addr in ip_addresses:
             ip = ipaddress.ip_address(addr[4][0])
-            if ip.is_private or ip.is_loopback:
+            if ip.is_loopback:
                 raise serializers.ValidationError(
                     {"url": "URL resolves to a blocked IP address."}
                 )
@@ -92,7 +92,7 @@ class WebhookSerializer(DynamicBaseSerializer):
 
             for addr in ip_addresses:
                 ip = ipaddress.ip_address(addr[4][0])
-                if ip.is_private or ip.is_loopback:
+                if ip.is_loopback:
                     raise serializers.ValidationError(
                         {"url": "URL resolves to a blocked IP address."}
                     )


### PR DESCRIPTION
Hello guys,

Currently, in a self hosted plane, we cannot use any automation software hosted in a private domain.
 
In order to enable it, remove the statement checking if IP is private.

Feedbacks are welcome :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated IP address validation to allow private IP addresses, enhancing flexibility in accepted inputs.
  
- **Bug Fixes**
	- Resolved issues related to validation errors for private IP addresses, improving user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->