### PR TITLE
fix: Local Setup on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf


### PR DESCRIPTION
This PR addresses #5420 . The setup issue was because of the line endings on the `*-entrypoint.sh` files. The linux containers expects `LF` as EOL but on windows on clone, git by default updates the line endings to `CRLF`.

For contributers with already a local copy, run the following:

```sh
git rm -rf --cached .         # Clean the index
git reset --hard HEAD         # Reset to last commit with revaluation as we cleared the index
```

Here's more info: https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the project configuration to ensure shell script files have consistent line endings across different operating systems, enhancing compatibility and reducing potential execution errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->