### PR TITLE
[WEB-2361] fix: Sidebar loosing its collapse context of on refresh and on changing the size of the window

### DIFF
--- a/web/app/[workspaceSlug]/(projects)/sidebar.tsx
+++ b/web/app/[workspaceSlug]/(projects)/sidebar.tsx
@@ -39,7 +39,6 @@ export const AppSidebar: FC<IAppSidebar> = observer(() => {
 
   useEffect(() => {
     if (windowSize[0] < 768) !sidebarCollapsed && toggleSidebar();
-    else sidebarCollapsed && toggleSidebar();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [windowSize]);
 


### PR DESCRIPTION
### Problem Statement
Sidebar loosing its collapse context of on refresh and on changing the size of the window. 

### Solution
No context was being lost. There was if else statement which when the windows size changed or ran for first time, ran. The if else statement checked whether the window Size is less than 768px, the sidebar is to be collapsed else it should be expanded irrespective of value if it's previously collapsed or not.

### Screenshots and Media

Before

https://github.com/user-attachments/assets/960f94ca-b017-47cf-8697-150f2de6091f

After

https://github.com/user-attachments/assets/f540c8b1-3995-4831-ad15-58bbe3c98083


### References
[[WEB-2361]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/d44d78fd-8bbd-432d-82ea-f801a124a6f3)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced sidebar behavior for improved user experience by simplifying the toggle logic based on window size.
  
- **Bug Fixes**
	- Resolved an issue where the sidebar could be inconsistently toggled when collapsed, leading to a more predictable interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->