### PR TITLE
[WEB-2129] fix: module creation and updation toast error

### DIFF
--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -8,7 +8,7 @@ import "@/styles/react-day-picker.css";
 // meta data info
 import { SITE_NAME, SITE_DESCRIPTION } from "@/constants/meta";
 // helpers
-import { API_BASE_URL } from "@/helpers/common.helper";
+import { API_BASE_URL, cn } from "@/helpers/common.helper";
 // local
 import { AppProvider } from "./provider";
 
@@ -75,7 +75,14 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <body>
         <div id="context-menu-portal" />
         <AppProvider>
-          <div className={`h-screen w-full overflow-hidden bg-custom-background-100`}>{children}</div>
+          <div
+            className={cn(
+              "h-screen w-full overflow-hidden bg-custom-background-100 relative flex flex-col",
+              "app-container"
+            )}
+          >
+            <div className="w-full h-full overflow-hidden relative">{children}</div>
+          </div>
         </AppProvider>
       </body>
       {process.env.NEXT_PUBLIC_PLAUSIBLE_DOMAIN && (

--- a/web/core/components/modules/modal.tsx
+++ b/web/core/components/modules/modal.tsx
@@ -71,7 +71,7 @@ export const CreateUpdateModuleModal: React.FC<Props> = observer((props) => {
         setToast({
           type: TOAST_TYPE.ERROR,
           title: "Error!",
-          message: err?.detail ?? "Module could not be created. Please try again.",
+          message: err?.detail ?? err?.error ?? "Module could not be created. Please try again.",
         });
         captureModuleEvent({
           eventName: MODULE_CREATED,
@@ -102,7 +102,7 @@ export const CreateUpdateModuleModal: React.FC<Props> = observer((props) => {
         setToast({
           type: TOAST_TYPE.ERROR,
           title: "Error!",
-          message: err?.detail ?? "Module could not be updated. Please try again.",
+          message: err?.detail ?? err?.error ?? "Module could not be updated. Please try again.",
         });
         captureModuleEvent({
           eventName: MODULE_UPDATED,


### PR DESCRIPTION
## [[WEB-2129]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/825628e3-8f41-43a6-9c01-a3dfe3eb559b/)

- FRONTEND CHANGE: This PR changes the Toast Error Message for module updation and creation. 
- BACKEND CHANGE: 400 Bad Request response given when module with the same name exists is updated.
- NOTE: An updated/created module can not have the same name as of an archived one.

## Changes:
### Previous State: 
- Backend message: "The payload is not valid."
- Frontend message: "Module could not be created. Please try again."

<img width="1920" alt="Screenshot 2024-09-06 at 8 16 26 PM" src="https://github.com/user-attachments/assets/2a0b3785-e2b7-47d2-9e43-f7af2abf2272">

### New State: 
- Backend message: "Module with the same name already exists."
- Frontend message: "Module with the same name already exists."
<img width="1920" alt="Screenshot 2024-09-06 at 8 12 55 PM" src="https://github.com/user-attachments/assets/360577b2-1247-4496-8f15-28c23555cafe">

## Reference: [[WEB-2129]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/825628e3-8f41-43a6-9c01-a3dfe3eb559b/)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced validation for module names to prevent duplicates during creation and updates.
	- Improved error handling in toast notifications for module operations, providing more specific feedback to users.

- **Bug Fixes**
	- Resolved issues related to duplicate module names, ensuring data integrity within projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->