### PR TITLE
Update `backupData` Function: Add SERVICE_FOLDER value

### DIFF
--- a/deploy/selfhost/install.sh
+++ b/deploy/selfhost/install.sh
@@ -442,10 +442,10 @@ function backupData() {
     local BACKUP_FOLDER=$PLANE_INSTALL_DIR/backup/$datetime
     mkdir -p "$BACKUP_FOLDER"
 
-    volumes=$(docker volume ls -f "name=plane-app" --format "{{.Name}}" | grep -E "_pgdata|_redisdata|_uploads")
+    volumes=$(docker volume ls -f "name=$SERVICE_FOLDER" --format "{{.Name}}" | grep -E "_pgdata|_redisdata|_uploads")
     # Check if there are any matching volumes
     if [ -z "$volumes" ]; then
-        echo "No volumes found starting with 'plane-app'"
+        echo "No volumes found starting with '$SERVICE_FOLDER'"
         exit 1
     fi
 


### PR DESCRIPTION
This PR updates the `backupData` function to include the `SERVICE_FOLDER` value inside `install.sh` script, improving the organization by categorizing backups by service.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the backup script to dynamically reference service folder names, improving adaptability for different setups.
  
- **Bug Fixes**
	- Updated error messages for clarity when no matching Docker volumes are found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->