### PR TITLE
fix: svg not supported in image uploads in the editor

### DIFF
--- a/packages/editor/src/core/helpers/editor-commands.ts
+++ b/packages/editor/src/core/helpers/editor-commands.ts
@@ -146,7 +146,7 @@ export const insertImageCommand = (
   if (range) editor.chain().focus().deleteRange(range).run();
   const input = document.createElement("input");
   input.type = "file";
-  input.accept = ".jpeg, .jpg, .png, .webp, .svg";
+  input.accept = ".jpeg, .jpg, .png, .webp";
   input.onchange = async () => {
     if (input.files?.length) {
       const file = input.files[0];

--- a/packages/editor/src/core/plugins/image/utils/validate-file.ts
+++ b/packages/editor/src/core/plugins/image/utils/validate-file.ts
@@ -6,7 +6,7 @@ export function isFileValid(file: File): boolean {
 
   const allowedTypes = ["image/jpeg", "image/jpg", "image/png", "image/webp"];
   if (!allowedTypes.includes(file.type)) {
-    alert("Invalid file type. Please select a JPEG, JPG, PNG, WEBP, or SVG image file.");
+    alert("Invalid file type. Please select a JPEG, JPG, PNG, or WEBP image file.");
     return false;
   }
 

--- a/packages/editor/src/core/plugins/image/utils/validate-file.ts
+++ b/packages/editor/src/core/plugins/image/utils/validate-file.ts
@@ -4,7 +4,7 @@ export function isFileValid(file: File): boolean {
     return false;
   }
 
-  const allowedTypes = ["image/jpeg", "image/jpg", "image/png", "image/webp", "image/svg+xml"];
+  const allowedTypes = ["image/jpeg", "image/jpg", "image/png", "image/webp"];
   if (!allowedTypes.includes(file.type)) {
     alert("Invalid file type. Please select a JPEG, JPG, PNG, WEBP, or SVG image file.");
     return false;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Updated image upload functionality to restrict accepted file types to JPEG, JPG, PNG, and WEBP, excluding SVG files.

- **Bug Fixes**
	- Enhanced validation logic to ensure only supported image formats can be uploaded, providing clearer alerts for unsupported formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->