### PR TITLE
[WEB-2310] fix: Issue count alignment when states are collapsed in kanban layout

### DIFF
--- a/web/core/components/issues/issue-layouts/kanban/headers/group-by-card.tsx
+++ b/web/core/components/issues/issue-layouts/kanban/headers/group-by-card.tsx
@@ -112,8 +112,8 @@ export const HeaderGroupByCard: FC<IHeaderGroupByCard> = observer((props) => {
         </div>
 
         <div
-          className={`relative flex items-baseline gap-1 ${
-            verticalAlignPosition ? `flex-col` : `w-full flex-row overflow-hidden`
+          className={`relative flex gap-1 ${
+            verticalAlignPosition ? `flex-col items-center` : `w-full flex-row items-baseline overflow-hidden`
           }`}
         >
           <div
@@ -124,7 +124,7 @@ export const HeaderGroupByCard: FC<IHeaderGroupByCard> = observer((props) => {
             {title}
           </div>
           <div
-            className={`flex-shrink-0 text-sm font-medium text-custom-text-300 ${verticalAlignPosition ? `` : `pl-2`}`}
+            className={`flex-shrink-0 text-sm font-medium text-custom-text-300 ${verticalAlignPosition ? `pr-0.5` : `pl-2`}`}
           >
             {count || 0}
           </div>


### PR DESCRIPTION
### Problem Statement
Issue count when kanban header were minimized was aligned to the right instead of being in the center.

### Solution
Changed align items to center when minimized and to baseline when maximized. 

### Screenshots and Media
Before

![image](https://github.com/user-attachments/assets/eb75bd24-437b-45d9-a143-b42c81f4b23c)

After

![image](https://github.com/user-attachments/assets/cdd0ba76-fb8c-4b38-bb4b-e89d98e46908)

### References
[[WEB-2310]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/1ee10dc3-c5b1-4704-a8cf-6af2f2a78c83)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
	- Enhanced vertical alignment in the Header Group By Card component for better content presentation.
	- Adjusted padding for improved spacing based on vertical alignment settings, refining the overall layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->