### PR TITLE
[WEB-2415] fix:remove input type to fix image upload

### DIFF
--- a/web/core/components/core/image-picker-popover.tsx
+++ b/web/core/components/core/image-picker-popover.tsx
@@ -344,7 +344,7 @@ export const ImagePickerPopover: React.FC<Props> = observer((props) => {
                           </div>
                         )}
 
-                        <input {...getInputProps()} type="text" />
+                        <input {...getInputProps()} />
                       </div>
                     </div>
                     {fileRejections.length > 0 && (

--- a/web/core/components/core/modals/user-image-upload-modal.tsx
+++ b/web/core/components/core/modals/user-image-upload-modal.tsx
@@ -144,7 +144,7 @@ export const UserImageUploadModal: React.FC<Props> = observer((props) => {
                           </div>
                         )}
 
-                        <input {...getInputProps()} type="text" />
+                        <input {...getInputProps()} />
                       </div>
                     </div>
                     {fileRejections.length > 0 && (

--- a/web/core/components/core/modals/workspace-image-upload-modal.tsx
+++ b/web/core/components/core/modals/workspace-image-upload-modal.tsx
@@ -150,7 +150,7 @@ export const WorkspaceImageUploadModal: React.FC<Props> = observer((props) => {
                           </div>
                         )}
 
-                        <input {...getInputProps()} type="text" />
+                        <input {...getInputProps()}/>
                       </div>
                     </div>
                     {fileRejections.length > 0 && (


### PR DESCRIPTION
## [[WEB-2415]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/c6590342-f51e-4d2a-b528-e8bf29ecc039/)

The input type is removed as it was causing trouble if no prior background image is present, same is done for all other required places.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Simplified the input declaration in the Image Picker component and related modals by removing the type attribute, enhancing flexibility in input handling.

- **Bug Fixes**
	- No bug fixes were implemented in this release.

- **Documentation**
	- No updates to documentation were made in this release.

- **Refactor**
	- Streamlined the input elements across multiple components for improved usability without changing their core functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->