### PR TITLE
[WEB-2419] chore: add toast alerts post access change of a page

### DIFF
--- a/web/core/components/pages/dropdowns/quick-actions.tsx
+++ b/web/core/components/pages/dropdowns/quick-actions.tsx
@@ -48,7 +48,26 @@ export const PageQuickActions: React.FC<Props> = observer((props) => {
   const MENU_ITEMS: TContextMenuItem[] = [
     {
       key: "make-public-private",
-      action: access === 0 ? makePrivate : makePublic,
+      action: async () => {
+        const changedPageType = access === 0 ? "private" : "public";
+
+        try {
+          if (access === 0) await makePrivate();
+          else await makePublic();
+
+          setToast({
+            type: TOAST_TYPE.SUCCESS,
+            title: "Success!",
+            message: `The page has been marked ${changedPageType} and moved to the ${changedPageType} section.`,
+          });
+        } catch (err) {
+          setToast({
+            type: TOAST_TYPE.ERROR,
+            title: "Error!",
+            message: `The page couldn't be marked ${changedPageType}. Please try again.`,
+          });
+        }
+      },
       title: access === 0 ? "Make private" : "Make public",
       icon: access === 0 ? Lock : UsersRound,
       shouldRender: canCurrentUserChangeAccess && !archived_at,


### PR DESCRIPTION
#### Improvements:

A toast alert now appears when the user changes the access of a page.

#### Media:

https://github.com/user-attachments/assets/dae8fd52-0ce5-4f42-8981-14733f0909c1

#### Plane issue: [WEB-2419](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/61711e9c-5f0d-454c-b09d-b936b6d457b1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the Page Quick Actions component with asynchronous access level changes.
	- Introduced success and error toast notifications to improve user feedback during access changes.

- **Bug Fixes**
	- Improved error handling during access level changes to provide better user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->