### PR TITLE
[WEB-2313] chore: Custom Theming needed as an option in Search

### DIFF
--- a/web/core/components/command-palette/actions/theme-actions.tsx
+++ b/web/core/components/command-palette/actions/theme-actions.tsx
@@ -42,7 +42,7 @@ export const CommandPaletteThemeActions: FC<Props> = observer((props) => {
 
   return (
     <>
-      {THEME_OPTIONS.filter((t) => t.value !== "custom").map((theme) => (
+      {THEME_OPTIONS.map((theme) => (
         <Command.Item
           key={theme.value}
           onSelect={() => {


### PR DESCRIPTION
### Clean Reason
Improved search by adding custom theming search option to search.
Before
![image](https://github.com/user-attachments/assets/c57531ec-8471-430b-8a03-a5ffbd6cdcf2)

After
![image](https://github.com/user-attachments/assets/46202765-3583-4d72-bf82-7519aac063f1)


### Implementation
Removed filter from the themes  which was filtering custom theme when searching for theme options.

### References
[[WEB-2313]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/06b402c2-01fe-4ec9-9bda-45f5c74a7a52)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The command palette now includes the "custom" theme option, enhancing user choice in theme selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->