### PR TITLE
fix kanban view localStorage

### DIFF
--- a/web/core/store/issue/archived/filter.store.ts
+++ b/web/core/store/issue/archived/filter.store.ts
@@ -254,7 +254,7 @@ export class ArchivedIssuesFilter extends IssueFilterHelperStore implements IArc
 
           const currentUserId = this.rootIssueStore.currentUserId;
           if (currentUserId)
-            this.handleIssuesLocalFilters.set(EIssuesStoreType.PROJECT, type, workspaceSlug, projectId, undefined, {
+            this.handleIssuesLocalFilters.set(EIssuesStoreType.ARCHIVED, type, workspaceSlug, projectId, undefined, {
               kanban_filters: _filters.kanbanFilters,
             });
 

--- a/web/core/store/issue/cycle/filter.store.ts
+++ b/web/core/store/issue/cycle/filter.store.ts
@@ -273,7 +273,7 @@ export class CycleIssuesFilter extends IssueFilterHelperStore implements ICycleI
 
           const currentUserId = this.rootIssueStore.currentUserId;
           if (currentUserId)
-            this.handleIssuesLocalFilters.set(EIssuesStoreType.PROJECT, type, workspaceSlug, cycleId, currentUserId, {
+            this.handleIssuesLocalFilters.set(EIssuesStoreType.CYCLE, type, workspaceSlug, cycleId, currentUserId, {
               kanban_filters: _filters.kanbanFilters,
             });
 

--- a/web/core/store/issue/draft/filter.store.ts
+++ b/web/core/store/issue/draft/filter.store.ts
@@ -250,7 +250,7 @@ export class DraftIssuesFilter extends IssueFilterHelperStore implements IDraftI
 
           const currentUserId = this.rootIssueStore.currentUserId;
           if (currentUserId)
-            this.handleIssuesLocalFilters.set(EIssuesStoreType.PROJECT, type, workspaceSlug, projectId, undefined, {
+            this.handleIssuesLocalFilters.set(EIssuesStoreType.DRAFT, type, workspaceSlug, projectId, undefined, {
               kanban_filters: _filters.kanbanFilters,
             });
 

--- a/web/core/store/issue/module/filter.store.ts
+++ b/web/core/store/issue/module/filter.store.ts
@@ -276,7 +276,7 @@ export class ModuleIssuesFilter extends IssueFilterHelperStore implements IModul
 
           const currentUserId = this.rootIssueStore.currentUserId;
           if (currentUserId)
-            this.handleIssuesLocalFilters.set(EIssuesStoreType.PROJECT, type, workspaceSlug, moduleId, currentUserId, {
+            this.handleIssuesLocalFilters.set(EIssuesStoreType.MODULE, type, workspaceSlug, moduleId, currentUserId, {
               kanban_filters: _filters.kanbanFilters,
             });
 

--- a/web/core/store/issue/profile/filter.store.ts
+++ b/web/core/store/issue/profile/filter.store.ts
@@ -260,7 +260,7 @@ export class ProfileIssuesFilter extends IssueFilterHelperStore implements IProf
 
           const currentUserId = this.rootIssueStore.currentUserId;
           if (currentUserId)
-            this.handleIssuesLocalFilters.set(EIssuesStoreType.PROJECT, type, workspaceSlug, userId, undefined, {
+            this.handleIssuesLocalFilters.set(EIssuesStoreType.PROFILE, type, workspaceSlug, userId, undefined, {
               kanban_filters: _filters.kanbanFilters,
             });
 

--- a/web/core/store/issue/project-views/filter.store.ts
+++ b/web/core/store/issue/project-views/filter.store.ts
@@ -264,7 +264,7 @@ export class ProjectViewIssuesFilter extends IssueFilterHelperStore implements I
 
           const currentUserId = this.rootIssueStore.currentUserId;
           if (currentUserId)
-            this.handleIssuesLocalFilters.set(EIssuesStoreType.PROJECT, type, workspaceSlug, viewId, currentUserId, {
+            this.handleIssuesLocalFilters.set(EIssuesStoreType.PROJECT_VIEW, type, workspaceSlug, viewId, currentUserId, {
               kanban_filters: _filters.kanbanFilters,
             });
 

--- a/web/core/store/issue/workspace/filter.store.ts
+++ b/web/core/store/issue/workspace/filter.store.ts
@@ -285,7 +285,7 @@ export class WorkspaceIssuesFilter extends IssueFilterHelperStore implements IWo
 
           const currentUserId = this.rootIssueStore.currentUserId;
           if (currentUserId)
-            this.handleIssuesLocalFilters.set(EIssuesStoreType.PROJECT, type, workspaceSlug, undefined, viewId, {
+            this.handleIssuesLocalFilters.set(EIssuesStoreType.GLOBAL, type, workspaceSlug, undefined, viewId, {
               kanban_filters: _filters.kanbanFilters,
             });
 


### PR DESCRIPTION
## Changes: 
Correct Keys were not set localStorage for Kanban view when groups were expanded/collapsed.
This PR changes the wrong keys to the correct ones. 

### New State: 
<img width="1920" alt="Screenshot 2024-09-10 at 6 56 42 PM" src="https://github.com/user-attachments/assets/ea62ec22-27c1-493e-865f-ed00f33e77bb">
