### PR TITLE
[WEB-2393] chore: removal of .svg from supported image formats

### DIFF
--- a/web/core/components/core/image-picker-popover.tsx
+++ b/web/core/components/core/image-picker-popover.tsx
@@ -89,7 +89,7 @@ export const ImagePickerPopover: React.FC<Props> = observer((props) => {
   const { getRootProps, getInputProps, isDragActive, fileRejections } = useDropzone({
     onDrop,
     accept: {
-      "image/*": [".png", ".jpg", ".jpeg", ".svg", ".webp"],
+      "image/*": [".png", ".jpg", ".jpeg", ".webp"],
     },
     maxSize: config?.file_size_limit ?? MAX_FILE_SIZE,
   });

--- a/web/core/components/core/image-picker-popover.tsx
+++ b/web/core/components/core/image-picker-popover.tsx
@@ -355,9 +355,7 @@ export const ImagePickerPopover: React.FC<Props> = observer((props) => {
                       </p>
                     )}
 
-                    <p className="text-sm text-custom-text-200">
-                      File formats supported- .jpeg, .jpg, .png, .webp, .svg
-                    </p>
+                    <p className="text-sm text-custom-text-200">File formats supported- .jpeg, .jpg, .png, .webp</p>
 
                     <div className="flex h-12 items-start justify-end gap-2">
                       <Button

--- a/web/core/components/core/modals/user-image-upload-modal.tsx
+++ b/web/core/components/core/modals/user-image-upload-modal.tsx
@@ -156,9 +156,7 @@ export const UserImageUploadModal: React.FC<Props> = observer((props) => {
                     )}
                   </div>
                 </div>
-                <p className="my-4 text-sm text-custom-text-200">
-                  File formats supported- .jpeg, .jpg, .png, .webp, .svg
-                </p>
+                <p className="my-4 text-sm text-custom-text-200">File formats supported- .jpeg, .jpg, .png, .webp</p>
                 <div className="flex items-center justify-between">
                   {handleDelete && (
                     <Button variant="danger" size="sm" onClick={handleDelete} disabled={!value}>

--- a/web/core/components/core/modals/user-image-upload-modal.tsx
+++ b/web/core/components/core/modals/user-image-upload-modal.tsx
@@ -39,7 +39,7 @@ export const UserImageUploadModal: React.FC<Props> = observer((props) => {
   const { getRootProps, getInputProps, isDragActive, fileRejections } = useDropzone({
     onDrop,
     accept: {
-      "image/*": [".png", ".jpg", ".jpeg", ".svg", ".webp"],
+      "image/*": [".png", ".jpg", ".jpeg", ".webp"],
     },
     maxSize: config?.file_size_limit ?? MAX_FILE_SIZE,
     multiple: false,

--- a/web/core/components/core/modals/workspace-image-upload-modal.tsx
+++ b/web/core/components/core/modals/workspace-image-upload-modal.tsx
@@ -150,7 +150,7 @@ export const WorkspaceImageUploadModal: React.FC<Props> = observer((props) => {
                           </div>
                         )}
 
-                        <input {...getInputProps()}/>
+                        <input {...getInputProps()} />
                       </div>
                     </div>
                     {fileRejections.length > 0 && (
@@ -162,9 +162,7 @@ export const WorkspaceImageUploadModal: React.FC<Props> = observer((props) => {
                     )}
                   </div>
                 </div>
-                <p className="my-4 text-sm text-custom-text-200">
-                  File formats supported- .jpeg, .jpg, .png, .webp, .svg
-                </p>
+                <p className="my-4 text-sm text-custom-text-200">File formats supported- .jpeg, .jpg, .png, .webp</p>
                 <div className="flex items-center justify-between">
                   {handleRemove && (
                     <Button variant="danger" size="sm" onClick={handleRemove} disabled={!value}>

--- a/web/core/components/core/modals/workspace-image-upload-modal.tsx
+++ b/web/core/components/core/modals/workspace-image-upload-modal.tsx
@@ -43,7 +43,7 @@ export const WorkspaceImageUploadModal: React.FC<Props> = observer((props) => {
   const { getRootProps, getInputProps, isDragActive, fileRejections } = useDropzone({
     onDrop,
     accept: {
-      "image/*": [".png", ".jpg", ".jpeg", ".svg", ".webp"],
+      "image/*": [".png", ".jpg", ".jpeg", ".webp"],
     },
     maxSize: config?.file_size_limit ?? MAX_FILE_SIZE,
     multiple: false,


### PR DESCRIPTION
### Clean Reason
Removal of .svg from supported image formats while uploading images as svg's are no longer supported.

### Implementation
Before
![image](https://github.com/user-attachments/assets/94608dab-7859-4eb6-98ee-4323f7e5651c)

After
![image](https://github.com/user-attachments/assets/c0581d59-aacd-40ff-8ced-8610696a106b)

### References
[[WEB-2393]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/7fbf1912-0fae-420d-83d5-44d692b73306)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Updated the file format listings across multiple components to reflect the removal of `.svg`, now supporting only `.jpeg`, `.jpg`, `.png`, and `.webp`.

- **Bug Fixes**
	- Corrected the text in the user interface to accurately represent the supported file formats for image uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->