### PR TITLE
[WEB-2443] fix: project favorite permission validation

### DIFF
--- a/web/core/components/project/card.tsx
+++ b/web/core/components/project/card.tsx
@@ -29,11 +29,11 @@ import { cn } from "@/helpers/common.helper";
 import { renderFormattedDate } from "@/helpers/date-time.helper";
 import { copyUrlToClipboard } from "@/helpers/string.helper";
 // hooks
-import { useProject } from "@/hooks/store";
+import { useProject, useUserPermissions } from "@/hooks/store";
 import { useAppRouter } from "@/hooks/use-app-router";
 import { usePlatformOS } from "@/hooks/use-platform-os";
 // plane-web constants
-import { EUserPermissions } from "@/plane-web/constants/user-permissions";
+import { EUserPermissions, EUserPermissionsLevel } from "@/plane-web/constants/user-permissions";
 
 type Props = {
   project: IProject;
@@ -52,11 +52,16 @@ export const ProjectCard: React.FC<Props> = observer((props) => {
   const { workspaceSlug } = useParams();
   // store hooks
   const { addProjectToFavorites, removeProjectFromFavorites } = useProject();
+  const { allowPermissions } = useUserPermissions();
   // hooks
   const { isMobile } = usePlatformOS();
   project.member_role;
   // derived values
   const projectMembersIds = project.members?.map((member) => member.member_id);
+  const shouldRenderFavorite = allowPermissions(
+    [EUserPermissions.ADMIN, EUserPermissions.MEMBER],
+    EUserPermissionsLevel.WORKSPACE
+  );
   // auth
   const isOwner = project.member_role === EUserPermissions.ADMIN;
   const isMember = project.member_role === EUserPermissions.MEMBER;
@@ -233,19 +238,21 @@ export const ProjectCard: React.FC<Props> = observer((props) => {
                 >
                   <LinkIcon className="h-3 w-3 text-white" />
                 </button>
-                <FavoriteStar
-                  buttonClassName="h-6 w-6 bg-white/10"
-                  iconClassName={cn("h-3 w-3", {
-                    "text-white": !project.is_favorite,
-                  })}
-                  onClick={(e) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    if (project.is_favorite) handleRemoveFromFavorites();
-                    else handleAddToFavorites();
-                  }}
-                  selected={project.is_favorite}
-                />
+                {shouldRenderFavorite && (
+                  <FavoriteStar
+                    buttonClassName="h-6 w-6 bg-white/10"
+                    iconClassName={cn("h-3 w-3", {
+                      "text-white": !project.is_favorite,
+                    })}
+                    onClick={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      if (project.is_favorite) handleRemoveFromFavorites();
+                      else handleAddToFavorites();
+                    }}
+                    selected={project.is_favorite}
+                  />
+                )}
               </div>
             )}
           </div>


### PR DESCRIPTION
### Changes:
This PR addresses the validation of the project favorite functionality for guest users. Previously, users with the guest role were able to see and favorite the project icon, which was unintended.

### Reference:
[[WEB-2443]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/58b4a823-43ab-41ac-8b39-532349148815)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced user permission checks for the favorite star feature in the ProjectCard component, ensuring only authorized users can access it.

- **Bug Fixes**
	- Enhanced UI logic to conditionally render the favorite functionality based on user permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->