### PR TITLE
[WEB-2443] fix: page permission validation

### DIFF
--- a/web/app/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/pages/(detail)/header.tsx
+++ b/web/app/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/pages/(detail)/header.tsx
@@ -15,10 +15,11 @@ import { PageEditInformationPopover } from "@/components/pages";
 import { convertHexEmojiToDecimal } from "@/helpers/emoji.helper";
 import { getPageName } from "@/helpers/page.helper";
 // hooks
-import { usePage, useProject } from "@/hooks/store";
+import { usePage, useProject, useUser, useUserPermissions } from "@/hooks/store";
 import { usePlatformOS } from "@/hooks/use-platform-os";
 // plane web components
 import { PageDetailsHeaderExtraActions } from "@/plane-web/components/pages";
+import { EUserPermissions, EUserPermissionsLevel } from "ee/constants/user-permissions";
 
 export interface IPagesHeaderProps {
   showButton?: boolean;
@@ -32,9 +33,16 @@ export const PageDetailsHeader = observer(() => {
   // store hooks
   const { currentProjectDetails, loader } = useProject();
   const page = usePage(pageId?.toString() ?? "");
-  const { name, logo_props, updatePageLogo } = page;
+  const { name, logo_props, updatePageLogo, owned_by } = page;
+  const { allowPermissions } = useUserPermissions();
+  const { data: currentUser } = useUser();
   // use platform
   const { isMobile } = usePlatformOS();
+
+  const isAdmin = allowPermissions([EUserPermissions.ADMIN], EUserPermissionsLevel.PROJECT);
+  const isOwner = owned_by === currentUser?.id;
+
+  const isEditable = isAdmin || isOwner;
 
   const handlePageLogoUpdate = async (data: TLogoProps) => {
     if (data) {
@@ -144,6 +152,7 @@ export const PageDetailsHeader = observer(() => {
                               ? EmojiIconPickerTypes.EMOJI
                               : EmojiIconPickerTypes.ICON
                           }
+                          disabled={!isEditable}
                         />
                       </div>
                       <Tooltip tooltipContent={pageTitle} position="bottom" isMobile={isMobile}>

--- a/web/app/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/pages/(list)/header.tsx
+++ b/web/app/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/pages/(list)/header.tsx
@@ -26,7 +26,7 @@ export const PagesListHeader = observer(() => {
   const { setTrackElement } = useEventTracker();
 
   const canUserCreatePage = allowPermissions(
-    [EUserPermissions.ADMIN, EUserPermissions.MEMBER],
+    [EUserPermissions.ADMIN, EUserPermissions.MEMBER, EUserPermissions.GUEST],
     EUserPermissionsLevel.PROJECT
   );
 


### PR DESCRIPTION
### Changes:
This PR fixes the page permission validation issue. Previously, the "Add Page" button was not visible to guest users, and guest user were able to change the emoji of other users pages, which was unintended behavior.

### Reference:
[[WEB-2443]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/58b4a823-43ab-41ac-8b39-532349148815)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced page header functionality to conditionally enable editing based on user permissions.
	- Expanded permissions for page creation to include users with guest access.

- **Bug Fixes**
	- Improved control flow to prevent unauthorized users from editing page details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->