### PR TITLE
[WEB-2443] fix: issue properties dropdown

### DIFF
--- a/web/core/components/dropdowns/cycle/index.tsx
+++ b/web/core/components/dropdowns/cycle/index.tsx
@@ -84,6 +84,7 @@ export const CycleDropdown: React.FC<Props> = observer((props) => {
             buttonContainerClassName
           )}
           onClick={handleOnClick}
+          disabled={disabled}
         >
           {button}
         </button>
@@ -100,6 +101,7 @@ export const CycleDropdown: React.FC<Props> = observer((props) => {
             buttonContainerClassName
           )}
           onClick={handleOnClick}
+          disabled={disabled}
         >
           <DropdownButton
             className={buttonClassName}

--- a/web/core/components/dropdowns/date-range.tsx
+++ b/web/core/components/dropdowns/date-range.tsx
@@ -146,6 +146,7 @@ export const DateRangeDropdown: React.FC<Props> = (props) => {
         buttonContainerClassName
       )}
       onClick={handleOnClick}
+      disabled={disabled}
     >
       <DropdownButton
         className={buttonClassName}

--- a/web/core/components/dropdowns/date.tsx
+++ b/web/core/components/dropdowns/date.tsx
@@ -115,6 +115,7 @@ export const DateDropdown: React.FC<Props> = (props) => {
       )}
       ref={setReferenceElement}
       onClick={handleOnClick}
+      disabled={disabled}
     >
       <DropdownButton
         className={buttonClassName}

--- a/web/core/components/dropdowns/estimate.tsx
+++ b/web/core/components/dropdowns/estimate.tsx
@@ -154,6 +154,7 @@ export const EstimateDropdown: React.FC<Props> = observer((props) => {
           type="button"
           className={cn("clickable block h-full w-full outline-none", buttonContainerClassName)}
           onClick={handleOnClick}
+          disabled={disabled}
         >
           {button}
         </button>
@@ -170,6 +171,7 @@ export const EstimateDropdown: React.FC<Props> = observer((props) => {
             buttonContainerClassName
           )}
           onClick={handleOnClick}
+          disabled={disabled}
         >
           <DropdownButton
             className={buttonClassName}

--- a/web/core/components/dropdowns/member/index.tsx
+++ b/web/core/components/dropdowns/member/index.tsx
@@ -106,6 +106,7 @@ export const MemberDropdown: React.FC<Props> = observer((props) => {
           type="button"
           className={cn("clickable block h-full w-full outline-none", buttonContainerClassName)}
           onClick={handleOnClick}
+          disabled={disabled}
         >
           {button}
         </button>
@@ -122,6 +123,7 @@ export const MemberDropdown: React.FC<Props> = observer((props) => {
             buttonContainerClassName
           )}
           onClick={handleOnClick}
+          disabled={disabled}
         >
           <DropdownButton
             className={cn("text-xs", buttonClassName)}

--- a/web/core/components/dropdowns/module/index.tsx
+++ b/web/core/components/dropdowns/module/index.tsx
@@ -234,6 +234,7 @@ export const ModuleDropdown: React.FC<Props> = observer((props) => {
             buttonContainerClassName
           )}
           onClick={handleOnClick}
+          disabled={disabled}
         >
           {button}
         </button>
@@ -250,6 +251,7 @@ export const ModuleDropdown: React.FC<Props> = observer((props) => {
             buttonContainerClassName
           )}
           onClick={handleOnClick}
+          disabled={disabled}
         >
           <DropdownButton
             className={buttonClassName}

--- a/web/core/components/dropdowns/priority.tsx
+++ b/web/core/components/dropdowns/priority.tsx
@@ -379,6 +379,7 @@ export const PriorityDropdown: React.FC<Props> = (props) => {
           type="button"
           className={cn("clickable block h-full w-full outline-none", buttonContainerClassName)}
           onClick={handleOnClick}
+          disabled={disabled}
         >
           {button}
         </button>
@@ -395,6 +396,7 @@ export const PriorityDropdown: React.FC<Props> = (props) => {
             buttonContainerClassName
           )}
           onClick={handleOnClick}
+          disabled={disabled}
         >
           <ButtonToRender
             priority={value ?? undefined}

--- a/web/core/components/dropdowns/project.tsx
+++ b/web/core/components/dropdowns/project.tsx
@@ -124,6 +124,7 @@ export const ProjectDropdown: React.FC<Props> = observer((props) => {
           type="button"
           className={cn("clickable block h-full w-full outline-none", buttonContainerClassName)}
           onClick={handleOnClick}
+          disabled={disabled}
         >
           {button}
         </button>
@@ -140,6 +141,7 @@ export const ProjectDropdown: React.FC<Props> = observer((props) => {
             buttonContainerClassName
           )}
           onClick={handleOnClick}
+          disabled={disabled}
         >
           <DropdownButton
             className={buttonClassName}

--- a/web/core/components/dropdowns/state.tsx
+++ b/web/core/components/dropdowns/state.tsx
@@ -135,6 +135,7 @@ export const StateDropdown: React.FC<Props> = observer((props) => {
           type="button"
           className={cn("clickable block h-full w-full outline-none", buttonContainerClassName)}
           onClick={handleOnClick}
+          disabled={disabled}
         >
           {button}
         </button>
@@ -151,6 +152,7 @@ export const StateDropdown: React.FC<Props> = observer((props) => {
             buttonContainerClassName
           )}
           onClick={handleOnClick}
+          disabled={disabled}
         >
           <DropdownButton
             className={buttonClassName}

--- a/web/core/components/issues/issue-layouts/properties/labels.tsx
+++ b/web/core/components/issues/issue-layouts/properties/labels.tsx
@@ -241,6 +241,7 @@ export const IssuePropertyLabels: React.FC<IIssuePropertyLabels> = observer((pro
             : "cursor-pointer hover:bg-custom-background-80"
       }  ${buttonClassName}`}
       onClick={handleOnClick}
+      disabled={disabled}
     >
       {label}
       {!hideDropdownArrow && !disabled && <ChevronDown className="h-3 w-3" aria-hidden="true" />}


### PR DESCRIPTION
#### Changes:
This PR resolves the issue with the properties dropdown, where users were still able to access it even when it was disabled.

#### Reference:
[[WEB-2443]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/58b4a823-43ab-41ac-8b39-532349148815/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a `disabled` property across various dropdown components (Cycle, Date Range, Date, Estimate, Member, Module, Priority, Project, State, and Issue Property Labels) to enhance user interaction control.
	- Buttons within these dropdowns can now be conditionally disabled, improving user experience by preventing actions when the dropdown is not usable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->