### PR TITLE
[WEB-2330] fix: you don't have permission toast on on bulk delete

### DIFF
--- a/web/core/components/command-palette/command-palette.tsx
+++ b/web/core/components/command-palette/command-palette.tsx
@@ -129,7 +129,7 @@ export const CommandPalette: FC = observer(() => {
 
   const performProjectBulkDeleteActions = useCallback(
     (showToast: boolean = true) => {
-      if (!canPerformProjectAdminActions && showToast)
+      if (!canPerformProjectAdminActions && projectId && showToast)
         setToast({
           type: TOAST_TYPE.ERROR,
           title: "You don't have permission to perform this action.",
@@ -137,7 +137,7 @@ export const CommandPalette: FC = observer(() => {
 
       return canPerformProjectAdminActions;
     },
-    [canPerformProjectAdminActions]
+    [canPerformProjectAdminActions, projectId]
   );
 
   const performWorkspaceCreateActions = useCallback(
@@ -256,9 +256,10 @@ export const CommandPalette: FC = observer(() => {
         toggleShortcutModal(true);
       }
 
-      if (deleteKey && canPerformProjectAdminActions) {
-        performProjectBulkDeleteActions()
-        shortcutsList.project.delete.action();
+      if (deleteKey) {
+        if (performProjectBulkDeleteActions()) {
+          shortcutsList.project.delete.action();
+        }
       } else if (cmdClicked) {
         if (keyPressed === "c" && ((platform === "MacOS" && ctrlKey) || altKey)) {
           e.preventDefault();

--- a/web/core/components/command-palette/command-palette.tsx
+++ b/web/core/components/command-palette/command-palette.tsx
@@ -256,11 +256,9 @@ export const CommandPalette: FC = observer(() => {
         toggleShortcutModal(true);
       }
 
-      if (deleteKey) {
-        if(canPerformProjectAdminActions){
-          performProjectBulkDeleteActions()
-          shortcutsList.project.delete.action();
-        }
+      if (deleteKey && canPerformProjectAdminActions) {
+        performProjectBulkDeleteActions()
+        shortcutsList.project.delete.action();
       } else if (cmdClicked) {
         if (keyPressed === "c" && ((platform === "MacOS" && ctrlKey) || altKey)) {
           e.preventDefault();

--- a/web/core/components/command-palette/command-palette.tsx
+++ b/web/core/components/command-palette/command-palette.tsx
@@ -257,7 +257,8 @@ export const CommandPalette: FC = observer(() => {
       }
 
       if (deleteKey) {
-        if (performProjectBulkDeleteActions()) {
+        if(canPerformProjectAdminActions){
+          performProjectBulkDeleteActions()
           shortcutsList.project.delete.action();
         }
       } else if (cmdClicked) {


### PR DESCRIPTION
## [[WEB-2330]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/bf0b5774-052b-46bd-ba5a-d9106ca1e5c4/)

### Changes: 

- Bulk delete error modal is now visible only when non admins press delete/backspace in an open project.
- Previously it was visible for all users on all routes, except when admin were in an open project.

- For non admin, toast appears when a project is open.

<img width="1151" alt="Screenshot 2024-09-13 at 5 55 47 PM" src="https://github.com/user-attachments/assets/40f4e9ff-2e44-4bb9-9787-1a71ee4d8ad1">

- For admin, modal appears when a project is open.
<img width="1920" alt="Screenshot 2024-09-13 at 5 56 37 PM" src="https://github.com/user-attachments/assets/96a9d6fb-a66f-4688-89fb-dc980a474a4a">



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved security for project deletion via keyboard shortcuts by adding permission checks.
  
- **Bug Fixes**
	- Enhanced control flow to prevent unauthorized deletion actions in the Command Palette.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->