### PR TITLE
[WEB-2455] fix: Quick action menu is overflowing for created link notification under inbox

### DIFF
--- a/web/core/components/workspace-notifications/sidebar/notification-card/item.tsx
+++ b/web/core/components/workspace-notifications/sidebar/notification-card/item.tsx
@@ -86,7 +86,7 @@ export const NotificationItem: FC<TNotificationItem> = observer((props) => {
 
         <div className="w-full space-y-1 -mt-2">
           <div className="relative flex items-center gap-3 h-8">
-            <div className="w-full overflow-hidden whitespace-normal break-words truncate line-clamp-1 text-sm text-custom-text-100">
+            <div className="w-full overflow-hidden whitespace-normal break-all truncate line-clamp-1 text-sm text-custom-text-100">
               {!notification.message ? (
                 <>
                   <span className="font-semibold">


### PR DESCRIPTION
### Problem Statement
Quick action menu on hover was overflowing for created and updated link notifications in inbox.

### Solution
When the links were long the words weren't wrapping correctly inside the div which lead it to push the menu items to right and made them overflow. The wrap text property was set to word which only wrapped whole words. Changing it to all fixed the issue.

### Screenshots and Media
Before:

![image](https://github.com/user-attachments/assets/90b5278d-f407-4da1-84cc-769183e2d47b)

After:

![image](https://github.com/user-attachments/assets/5b4d2748-09d2-4d66-91c7-aab837250d37)

### References
[[WEB-2455]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/0cbade72-a2b3-4fb0-ba13-b02b12a67def)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved readability of notification messages by allowing text to break at any character, preventing overflow in the notification card.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->