### PR TITLE
[WEB-2453] fix: Render on hover only when enabled

### DIFF
--- a/web/core/components/dropdowns/buttons.tsx
+++ b/web/core/components/dropdowns/buttons.tsx
@@ -16,6 +16,7 @@ export type DropdownButtonProps = {
   tooltipHeading: string;
   showTooltip: boolean;
   variant: TButtonVariants;
+  renderToolTipByDefault?: boolean;
 };
 
 type ButtonProps = {
@@ -25,10 +26,20 @@ type ButtonProps = {
   tooltipContent: string | React.ReactNode;
   tooltipHeading: string;
   showTooltip: boolean;
+  renderToolTipByDefault?: boolean;
 };
 
 export const DropdownButton: React.FC<DropdownButtonProps> = (props) => {
-  const { children, className, isActive, tooltipContent, tooltipHeading, showTooltip, variant } = props;
+  const {
+    children,
+    className,
+    isActive,
+    tooltipContent,
+    renderToolTipByDefault = true,
+    tooltipHeading,
+    showTooltip,
+    variant,
+  } = props;
   const ButtonToRender: React.FC<ButtonProps> = BORDER_BUTTON_VARIANTS.includes(variant)
     ? BorderButton
     : BACKGROUND_BUTTON_VARIANTS.includes(variant)
@@ -42,6 +53,7 @@ export const DropdownButton: React.FC<DropdownButtonProps> = (props) => {
       tooltipContent={tooltipContent}
       tooltipHeading={tooltipHeading}
       showTooltip={showTooltip}
+      renderToolTipByDefault={renderToolTipByDefault}
     >
       {children}
     </ButtonToRender>
@@ -49,7 +61,7 @@ export const DropdownButton: React.FC<DropdownButtonProps> = (props) => {
 };
 
 const BorderButton: React.FC<ButtonProps> = (props) => {
-  const { children, className, isActive, tooltipContent, tooltipHeading, showTooltip } = props;
+  const { children, className, isActive, tooltipContent, renderToolTipByDefault, tooltipHeading, showTooltip } = props;
   const { isMobile } = usePlatformOS();
 
   return (
@@ -58,7 +70,7 @@ const BorderButton: React.FC<ButtonProps> = (props) => {
       tooltipContent={tooltipContent}
       disabled={!showTooltip}
       isMobile={isMobile}
-      renderByDefault={false}
+      renderByDefault={renderToolTipByDefault}
     >
       <div
         className={cn(
@@ -74,7 +86,7 @@ const BorderButton: React.FC<ButtonProps> = (props) => {
 };
 
 const BackgroundButton: React.FC<ButtonProps> = (props) => {
-  const { children, className, tooltipContent, tooltipHeading, showTooltip } = props;
+  const { children, className, tooltipContent, tooltipHeading, renderToolTipByDefault, showTooltip } = props;
   const { isMobile } = usePlatformOS();
   return (
     <Tooltip
@@ -82,7 +94,7 @@ const BackgroundButton: React.FC<ButtonProps> = (props) => {
       tooltipContent={tooltipContent}
       disabled={!showTooltip}
       isMobile={isMobile}
-      renderByDefault={false}
+      renderByDefault={renderToolTipByDefault}
     >
       <div
         className={cn(
@@ -97,7 +109,7 @@ const BackgroundButton: React.FC<ButtonProps> = (props) => {
 };
 
 const TransparentButton: React.FC<ButtonProps> = (props) => {
-  const { children, className, isActive, tooltipContent, tooltipHeading, showTooltip } = props;
+  const { children, className, isActive, tooltipContent, tooltipHeading, renderToolTipByDefault, showTooltip } = props;
   const { isMobile } = usePlatformOS();
   return (
     <Tooltip
@@ -105,7 +117,7 @@ const TransparentButton: React.FC<ButtonProps> = (props) => {
       tooltipContent={tooltipContent}
       disabled={!showTooltip}
       isMobile={isMobile}
-      renderByDefault={false}
+      renderByDefault={renderToolTipByDefault}
     >
       <div
         className={cn(

--- a/web/core/components/dropdowns/cycle/index.tsx
+++ b/web/core/components/dropdowns/cycle/index.tsx
@@ -110,6 +110,7 @@ export const CycleDropdown: React.FC<Props> = observer((props) => {
             tooltipContent={selectedName ?? placeholder}
             showTooltip={showTooltip}
             variant={buttonVariant}
+            renderToolTipByDefault={renderByDefault}
           >
             {!hideIcon && <ContrastIcon className="h-3 w-3 flex-shrink-0" />}
             {BUTTON_VARIANTS_WITH_TEXT.includes(buttonVariant) && (!!selectedName || !!placeholder) && (

--- a/web/core/components/dropdowns/date-range.tsx
+++ b/web/core/components/dropdowns/date-range.tsx
@@ -161,6 +161,7 @@ export const DateRangeDropdown: React.FC<Props> = (props) => {
         }
         showTooltip={showTooltip}
         variant={buttonVariant}
+        renderToolTipByDefault={renderByDefault}
       >
         <span
           className={cn("h-full flex items-center justify-center gap-1 rounded-sm flex-grow", buttonFromDateClassName)}

--- a/web/core/components/dropdowns/date.tsx
+++ b/web/core/components/dropdowns/date.tsx
@@ -126,6 +126,7 @@ export const DateDropdown: React.FC<Props> = (props) => {
         tooltipContent={value ? renderFormattedDate(value, formatToken) : "None"}
         showTooltip={showTooltip}
         variant={buttonVariant}
+        renderToolTipByDefault={renderByDefault}
       >
         {!hideIcon && icon}
         {BUTTON_VARIANTS_WITH_TEXT.includes(buttonVariant) && (

--- a/web/core/components/dropdowns/estimate.tsx
+++ b/web/core/components/dropdowns/estimate.tsx
@@ -180,6 +180,7 @@ export const EstimateDropdown: React.FC<Props> = observer((props) => {
             tooltipContent={selectedEstimate ? selectedEstimate?.value : placeholder}
             showTooltip={showTooltip}
             variant={buttonVariant}
+            renderToolTipByDefault={renderByDefault}
           >
             {!hideIcon && <Triangle className="h-3 w-3 flex-shrink-0" />}
             {(selectedEstimate || placeholder) && BUTTON_VARIANTS_WITH_TEXT.includes(buttonVariant) && (

--- a/web/core/components/dropdowns/member/index.tsx
+++ b/web/core/components/dropdowns/member/index.tsx
@@ -22,7 +22,7 @@ type Props = {
   icon?: LucideIcon;
   onClose?: () => void;
   renderByDefault?: boolean;
-  optionsClassName? : string;
+  optionsClassName?: string;
 } & MemberDropdownProps;
 
 export const MemberDropdown: React.FC<Props> = observer((props) => {
@@ -134,6 +134,7 @@ export const MemberDropdown: React.FC<Props> = observer((props) => {
             tooltipContent={tooltipContent ?? `${value?.length ?? 0} assignee${value?.length !== 1 ? "s" : ""}`}
             showTooltip={showTooltip}
             variant={buttonVariant}
+            renderToolTipByDefault={renderByDefault}
           >
             {!hideIcon && <ButtonAvatars showTooltip={showTooltip} userIds={value} icon={icon} />}
             {BUTTON_VARIANTS_WITH_TEXT.includes(buttonVariant) && (

--- a/web/core/components/dropdowns/module/index.tsx
+++ b/web/core/components/dropdowns/module/index.tsx
@@ -267,6 +267,7 @@ export const ModuleDropdown: React.FC<Props> = observer((props) => {
             }
             showTooltip={showTooltip}
             variant={buttonVariant}
+            renderToolTipByDefault={renderByDefault}
           >
             <ButtonContent
               disabled={disabled}

--- a/web/core/components/dropdowns/priority.tsx
+++ b/web/core/components/dropdowns/priority.tsx
@@ -43,6 +43,7 @@ type ButtonProps = {
   placeholder: string;
   priority: TIssuePriorities | undefined;
   showTooltip: boolean;
+  renderToolTipByDefault?: boolean;
 };
 
 const BorderButton = (props: ButtonProps) => {
@@ -56,6 +57,7 @@ const BorderButton = (props: ButtonProps) => {
     placeholder,
     priority,
     showTooltip,
+    renderToolTipByDefault = true,
   } = props;
 
   const priorityDetails = ISSUE_PRIORITIES.find((p) => p.key === priority);
@@ -76,7 +78,7 @@ const BorderButton = (props: ButtonProps) => {
       tooltipContent={priorityDetails?.title ?? "None"}
       disabled={!showTooltip}
       isMobile={isMobile}
-      renderByDefault={false}
+      renderByDefault={renderToolTipByDefault}
     >
       <div
         className={cn(
@@ -137,6 +139,7 @@ const BackgroundButton = (props: ButtonProps) => {
     placeholder,
     priority,
     showTooltip,
+    renderToolTipByDefault = true,
   } = props;
 
   const priorityDetails = ISSUE_PRIORITIES.find((p) => p.key === priority);
@@ -157,7 +160,7 @@ const BackgroundButton = (props: ButtonProps) => {
       tooltipContent={priorityDetails?.title ?? "None"}
       disabled={!showTooltip}
       isMobile={isMobile}
-      renderByDefault={false}
+      renderByDefault={renderToolTipByDefault}
     >
       <div
         className={cn(
@@ -219,6 +222,7 @@ const TransparentButton = (props: ButtonProps) => {
     placeholder,
     priority,
     showTooltip,
+    renderToolTipByDefault = true,
   } = props;
 
   const priorityDetails = ISSUE_PRIORITIES.find((p) => p.key === priority);
@@ -239,7 +243,7 @@ const TransparentButton = (props: ButtonProps) => {
       tooltipContent={priorityDetails?.title ?? "None"}
       disabled={!showTooltip}
       isMobile={isMobile}
-      renderByDefault={false}
+      renderByDefault={renderToolTipByDefault}
     >
       <div
         className={cn(

--- a/web/core/components/dropdowns/priority.tsx
+++ b/web/core/components/dropdowns/priority.tsx
@@ -414,6 +414,7 @@ export const PriorityDropdown: React.FC<Props> = (props) => {
             placeholder={placeholder}
             showTooltip={showTooltip}
             hideText={BUTTON_VARIANTS_WITHOUT_TEXT.includes(buttonVariant)}
+            renderToolTipByDefault={renderByDefault}
           />
         </button>
       )}

--- a/web/core/components/dropdowns/project.tsx
+++ b/web/core/components/dropdowns/project.tsx
@@ -150,6 +150,7 @@ export const ProjectDropdown: React.FC<Props> = observer((props) => {
             tooltipContent={selectedProject?.name ?? placeholder}
             showTooltip={showTooltip}
             variant={buttonVariant}
+            renderToolTipByDefault={renderByDefault}
           >
             {!hideIcon && selectedProject && (
               <span className="grid place-items-center flex-shrink-0 h-4 w-4">

--- a/web/core/components/dropdowns/state.tsx
+++ b/web/core/components/dropdowns/state.tsx
@@ -161,6 +161,7 @@ export const StateDropdown: React.FC<Props> = observer((props) => {
             tooltipContent={selectedState?.name ?? "State"}
             showTooltip={showTooltip}
             variant={buttonVariant}
+            renderToolTipByDefault={renderByDefault}
           >
             {stateLoader ? (
               <Spinner className="h-3.5 w-3.5" />

--- a/web/core/components/issues/issue-layouts/properties/labels.tsx
+++ b/web/core/components/issues/issue-layouts/properties/labels.tsx
@@ -165,7 +165,7 @@ export const IssuePropertyLabels: React.FC<IIssuePropertyLabels> = observer((pro
                   tooltipHeading="Labels"
                   tooltipContent={label?.name ?? ""}
                   isMobile={isMobile}
-                  renderByDefault={false}
+                  renderByDefault={renderByDefault}
                 >
                   <div
                     key={label?.id}

--- a/web/core/components/issues/issue-layouts/spreadsheet/columns/assignee-column.tsx
+++ b/web/core/components/issues/issue-layouts/spreadsheet/columns/assignee-column.tsx
@@ -40,6 +40,7 @@ export const SpreadsheetAssigneeColumn: React.FC<Props> = observer((props: Props
         buttonContainerClassName="w-full"
         optionsClassName="z-[9]"
         onClose={onClose}
+        renderByDefault={false}
       />
     </div>
   );

--- a/web/core/components/issues/issue-layouts/spreadsheet/columns/cycle-column.tsx
+++ b/web/core/components/issues/issue-layouts/spreadsheet/columns/cycle-column.tsx
@@ -57,6 +57,7 @@ export const SpreadsheetCycleColumn: React.FC<Props> = observer((props) => {
         buttonContainerClassName="w-full relative flex items-center p-2 group-[.selected-issue-row]:bg-custom-primary-100/5 group-[.selected-issue-row]:hover:bg-custom-primary-100/10 px-page-x"
         buttonClassName="relative leading-4 h-4.5 bg-transparent hover:bg-transparent px-0"
         onClose={onClose}
+        renderByDefault={false}
       />
     </div>
   );

--- a/web/core/components/issues/issue-layouts/spreadsheet/columns/due-date-column.tsx
+++ b/web/core/components/issues/issue-layouts/spreadsheet/columns/due-date-column.tsx
@@ -56,6 +56,7 @@ export const SpreadsheetDueDateColumn: React.FC<Props> = observer((props: Props)
         optionsClassName="z-[9]"
         clearIconClassName="!text-custom-text-100"
         onClose={onClose}
+        renderByDefault={false}
       />
     </div>
   );

--- a/web/core/components/issues/issue-layouts/spreadsheet/columns/estimate-column.tsx
+++ b/web/core/components/issues/issue-layouts/spreadsheet/columns/estimate-column.tsx
@@ -28,6 +28,7 @@ export const SpreadsheetEstimateColumn: React.FC<Props> = observer((props: Props
         buttonClassName="text-left rounded-none group-[.selected-issue-row]:bg-custom-primary-100/5 group-[.selected-issue-row]:hover:bg-custom-primary-100/10 px-page-x"
         buttonContainerClassName="w-full"
         onClose={onClose}
+        renderByDefault={false}
       />
     </div>
   );

--- a/web/core/components/issues/issue-layouts/spreadsheet/columns/label-column.tsx
+++ b/web/core/components/issues/issue-layouts/spreadsheet/columns/label-column.tsx
@@ -35,6 +35,7 @@ export const SpreadsheetLabelColumn: React.FC<Props> = observer((props: Props) =
         disabled={disabled}
         placeholderText="Select labels"
         onClose={onClose}
+        renderByDefault={false}
         noLabelBorder
         fullWidth
       />

--- a/web/core/components/issues/issue-layouts/spreadsheet/columns/module-column.tsx
+++ b/web/core/components/issues/issue-layouts/spreadsheet/columns/module-column.tsx
@@ -67,6 +67,7 @@ export const SpreadsheetModuleColumn: React.FC<Props> = observer((props) => {
         buttonContainerClassName="w-full relative flex items-center p-2 group-[.selected-issue-row]:bg-custom-primary-100/5 group-[.selected-issue-row]:hover:bg-custom-primary-100/10 px-page-x"
         buttonClassName="relative leading-4 h-4.5 bg-transparent hover:bg-transparent !px-0"
         onClose={onClose}
+        renderByDefault={false}
         multiple
         showCount
         showTooltip

--- a/web/core/components/issues/issue-layouts/spreadsheet/columns/priority-column.tsx
+++ b/web/core/components/issues/issue-layouts/spreadsheet/columns/priority-column.tsx
@@ -25,6 +25,7 @@ export const SpreadsheetPriorityColumn: React.FC<Props> = observer((props: Props
         buttonClassName="text-left rounded-none group-[.selected-issue-row]:bg-custom-primary-100/5 group-[.selected-issue-row]:hover:bg-custom-primary-100/10 px-page-x"
         buttonContainerClassName="w-full"
         onClose={onClose}
+        renderByDefault={false}
       />
     </div>
   );

--- a/web/core/components/issues/issue-layouts/spreadsheet/columns/start-date-column.tsx
+++ b/web/core/components/issues/issue-layouts/spreadsheet/columns/start-date-column.tsx
@@ -42,6 +42,7 @@ export const SpreadsheetStartDateColumn: React.FC<Props> = observer((props: Prop
         buttonContainerClassName="w-full"
         optionsClassName="z-[9]"
         onClose={onClose}
+        renderByDefault={false}
       />
     </div>
   );

--- a/web/core/components/issues/issue-layouts/spreadsheet/columns/state-column.tsx
+++ b/web/core/components/issues/issue-layouts/spreadsheet/columns/state-column.tsx
@@ -26,6 +26,7 @@ export const SpreadsheetStateColumn: React.FC<Props> = observer((props) => {
         buttonClassName="text-left rounded-none group-[.selected-issue-row]:bg-custom-primary-100/5 group-[.selected-issue-row]:hover:bg-custom-primary-100/10 px-page-x"
         buttonContainerClassName="w-full"
         onClose={onClose}
+        renderByDefault={false}
         showTooltip
       />
     </div>


### PR DESCRIPTION
This PR changes the code to enable render on Hover for both dropdown and tooltip only when enabled and treats `renderByDefault` as the single source of truth for issue property dropdowns