### PR TITLE
[WEB-1506] chore: workspace role demotion

### DIFF
--- a/apiserver/plane/app/views/project/invite.py
+++ b/apiserver/plane/app/views/project/invite.py
@@ -164,7 +164,7 @@ class UserProjectInvitationsViewset(BaseViewSet):
                 ProjectMember(
                     project_id=project_id,
                     member=request.user,
-                    role=15 if workspace_role >= 15 else 5,
+                    role=workspace_role,
                     workspace=workspace,
                     created_by=request.user,
                 )


### PR DESCRIPTION
chore: 

- If a workspace admin is demoted to a member, their role in all associated projects will also be changed to member.
- Similarly, if a workspace admin is demoted to a guest, they will be assigned the guest role across all projects.
- When a workspace member is demoted to guest, their role in all projects they are part of will be updated to guest as well.
- If a workspace admin joins a project, they will automatically be assigned the admin role for that project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified role assignment for project members, allowing direct reflection of workspace roles.
	- Updated logic for updating workspace member roles, enabling easier role adjustments without restrictions on higher roles.

- **Bug Fixes**
	- Improved error handling and validation during workspace member role updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->