### PR TITLE
[WEB-2266] chore-No favorites should be  aligned like the rest of the things

### DIFF
--- a/web/core/components/workspace/sidebar/favorites/favorites-menu.tsx
+++ b/web/core/components/workspace/sidebar/favorites/favorites-menu.tsx
@@ -173,7 +173,7 @@ export const SidebarFavoritesMenu = observer(() => {
               {Object.keys(groupedFavorites).length === 0 ? (
                 <>
                   {!sidebarCollapsed && (
-                    <span className="text-custom-text-400 text-xs font-medium px-4 py-1.5">No favorites yet</span>
+                    <span className="text-custom-text-400 text-xs font-medium px-8 py-1.5">No favorites yet</span>
                   )}
                 </>
               ) : (

--- a/web/core/components/workspace/sidebar/favorites/favorites-menu.tsx
+++ b/web/core/components/workspace/sidebar/favorites/favorites-menu.tsx
@@ -173,7 +173,7 @@ export const SidebarFavoritesMenu = observer(() => {
               {Object.keys(groupedFavorites).length === 0 ? (
                 <>
                   {!sidebarCollapsed && (
-                    <span className="text-custom-text-400 text-xs text-center font-medium py-1">No favorites yet</span>
+                    <span className="text-custom-text-400 text-xs font-medium px-4 py-1.5">No favorites yet</span>
                   )}
                 </>
               ) : (


### PR DESCRIPTION
### Clean Reason
Changed the alignment of empty favorites text from center to right like other elements. 

### Implementation
Before:
![image](https://github.com/user-attachments/assets/006a071d-bf46-4075-b14e-2731d59d4299)

After:
![image](https://github.com/user-attachments/assets/547e1aa7-74ac-46f6-bcc3-4350b99b9597)


### References
[[WEB-2266]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/4014e90d-add6-4c0c-af6f-62b5705ba14c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
	- Enhanced the presentation of the "No favorites yet" message in the sidebar for better readability and visual appeal with updated padding styles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->