### PR TITLE
[WEB-2450] fix: image resize component

### DIFF
--- a/packages/editor/src/core/extensions/custom-image/components/image-block.tsx
+++ b/packages/editor/src/core/extensions/custom-image/components/image-block.tsx
@@ -48,11 +48,8 @@ export const CustomImageBlock: React.FC<CustomImageNodeViewProps> = (props) => {
 
           setSize(newSize);
           updateAttributes(newSize);
-          setInitialResizeComplete(true);
-        } else {
-          setInitialResizeComplete(true);
         }
-
+        setInitialResizeComplete(true);
         setIsLoading(false);
       };
     }

--- a/packages/editor/src/core/extensions/custom-image/components/image-block.tsx
+++ b/packages/editor/src/core/extensions/custom-image/components/image-block.tsx
@@ -1,6 +1,8 @@
 import React, { useRef, useState, useCallback, useLayoutEffect, useEffect } from "react";
 import { NodeSelection } from "@tiptap/pm/state";
+// extensions
 import { CustomImageNodeViewProps } from "@/extensions/custom-image";
+// helpers
 import { cn } from "@/helpers/common";
 
 const MIN_SIZE = 100;
@@ -75,11 +77,13 @@ export const CustomImageBlock: React.FC<CustomImageNodeViewProps> = (props) => {
 
   const handleResize = useCallback(
     (e: MouseEvent | TouchEvent) => {
+      if (!isResizing.current || !containerRef.current || !containerRect.current) return;
+
       if (size) {
         aspectRatioRef.current = Number(size.width.replace("px", "")) / Number(size.height.replace("px", ""));
       }
 
-      if (!isResizing.current || !containerRef.current || !containerRect.current || !aspectRatioRef.current) return;
+      if (!aspectRatioRef.current) return;
 
       const clientX = "touches" in e ? e.touches[0].clientX : e.clientX;
 

--- a/packages/editor/src/core/plugins/image/delete-image.ts
+++ b/packages/editor/src/core/plugins/image/delete-image.ts
@@ -46,6 +46,7 @@ export const TrackImageDeletionPlugin = (editor: Editor, deleteImage: DeleteImag
 
 async function onNodeDeleted(src: string, deleteImage: DeleteImage): Promise<void> {
   try {
+    if (!src) return;
     const assetUrlWithWorkspaceId = new URL(src).pathname.substring(1);
     await deleteImage(assetUrlWithWorkspaceId);
   } catch (error) {

--- a/packages/editor/src/core/plugins/image/restore-image.ts
+++ b/packages/editor/src/core/plugins/image/restore-image.ts
@@ -49,6 +49,7 @@ export const TrackImageRestorationPlugin = (editor: Editor, restoreImage: Restor
 
 async function onNodeRestored(src: string, restoreImage: RestoreImage): Promise<void> {
   try {
+    if (!src) return;
     const assetUrlWithWorkspaceId = new URL(src).pathname.substring(1);
     await restoreImage(assetUrlWithWorkspaceId);
   } catch (error) {


### PR DESCRIPTION
## Description

The width is now fixed (35% of the editor container in px) instead of 35% which was the old default....

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced image loading and resizing functionality within the editor.
	- Introduced a loading shimmer effect during image loading.
- **Bug Fixes**
	- Improved error handling in image deletion and restoration processes to prevent issues with empty or invalid image sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->