### PR TITLE
[WEB-2250] fix: filter projects with create permission while selecting the project in create issue modal.

### DIFF
--- a/apiserver/plane/app/views/project/member.py
+++ b/apiserver/plane/app/views/project/member.py
@@ -414,6 +414,7 @@ class UserProjectRolesEndpoint(BaseAPIView):
         project_members = ProjectMember.objects.filter(
             workspace__slug=slug,
             member_id=request.user.id,
+            is_active=True,
         ).values("project_id", "role")
 
         project_members = {

--- a/web/core/components/issues/issue-modal/base.tsx
+++ b/web/core/components/issues/issue-modal/base.tsx
@@ -13,7 +13,7 @@ import { ISSUE_CREATED, ISSUE_UPDATED } from "@/constants/event-tracker";
 import { EIssuesStoreType } from "@/constants/issue";
 // hooks
 import { useIssueModal } from "@/hooks/context/use-issue-modal";
-import { useEventTracker, useCycle, useIssues, useModule, useProject, useIssueDetail } from "@/hooks/store";
+import { useEventTracker, useCycle, useIssues, useModule, useProject, useIssueDetail, useUser } from "@/hooks/store";
 import { useIssueStoreType } from "@/hooks/use-issue-layout-store";
 import { useIssuesActions } from "@/hooks/use-issues-actions";
 import useLocalStorage from "@/hooks/use-local-storage";
@@ -44,7 +44,7 @@ export const CreateUpdateIssueModalBase: React.FC<IssuesModalProps> = observer((
   // store hooks
   const { captureIssueEvent } = useEventTracker();
   const { workspaceSlug, projectId, cycleId, moduleId } = useParams();
-  const { workspaceProjectIds } = useProject();
+  const { projectsWithCreatePermissions } = useUser();
   const { fetchCycleDetails } = useCycle();
   const { fetchModuleDetails } = useModule();
   const { issues } = useIssues(storeType);
@@ -60,6 +60,8 @@ export const CreateUpdateIssueModalBase: React.FC<IssuesModalProps> = observer((
   >("draftedIssue", {});
   // current store details
   const { createIssue, updateIssue } = useIssuesActions(storeType);
+  // derived values
+  const projectIdsWithCreatePermissions = Object.keys(projectsWithCreatePermissions ?? {});
 
   const fetchIssueDetail = async (issueId: string | undefined) => {
     setDescription(undefined);
@@ -98,8 +100,8 @@ export const CreateUpdateIssueModalBase: React.FC<IssuesModalProps> = observer((
 
     // if data is not present, set active project to the project
     // in the url. This has the least priority.
-    if (workspaceProjectIds && workspaceProjectIds.length > 0 && !activeProjectId)
-      setActiveProjectId(projectId?.toString() ?? workspaceProjectIds?.[0]);
+    if (projectIdsWithCreatePermissions && projectIdsWithCreatePermissions.length > 0 && !activeProjectId)
+      setActiveProjectId(projectId?.toString() ?? projectIdsWithCreatePermissions?.[0]);
 
     // clearing up the description state when we leave the component
     return () => setDescription(undefined);
@@ -288,7 +290,7 @@ export const CreateUpdateIssueModalBase: React.FC<IssuesModalProps> = observer((
   const handleFormChange = (formData: Partial<TIssue> | null) => setChangesMade(formData);
 
   // don't open the modal if there are no projects
-  if (!workspaceProjectIds || workspaceProjectIds.length === 0 || !activeProjectId) return null;
+  if (!projectIdsWithCreatePermissions || projectIdsWithCreatePermissions.length === 0 || !activeProjectId) return null;
 
   return (
     <ModalCore


### PR DESCRIPTION
#### Issue link: [WEB-2250](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/97b860ec-23e5-437d-a427-d899573712ac)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced project member retrieval to only include active members, improving data accuracy.
	- Updated issue creation modal to only display projects the user has permission to create issues in, enhancing user experience.
  
- **Bug Fixes**
	- Resolved issues with the modal displaying when no actionable projects are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->