### PR TITLE
[WEB-2474] chore: update page lock authorization

### DIFF
--- a/web/core/store/pages/page.ts
+++ b/web/core/store/pages/page.ts
@@ -240,13 +240,7 @@ export class Page implements IPage {
    * @description returns true if the current logged in user can lock the page
    */
   get canCurrentUserLockPage() {
-    const { workspaceSlug, projectId } = this.store.router;
-
-    const currentUserProjectRole = this.store.user.permission.projectPermissionsByWorkspaceSlugAndProjectId(
-      workspaceSlug?.toString() || "",
-      projectId?.toString() || ""
-    );
-    return this.isCurrentUserOwner || (!!currentUserProjectRole && currentUserProjectRole >= EUserPermissions.MEMBER);
+    return this.isCurrentUserOwner;
   }
 
   /**


### PR DESCRIPTION
#### Improvements:

This PR updates the authorization for locking/unlocking a page. Now, only the creator/owner of a page can lock/unlock a page.

#### Plane issue: [WEB-2474](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/5d9ee99c-e894-4fbc-804d-01dadc7cecd8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated permission logic for locking pages, now allowing only page owners to lock their respective pages.

- **Bug Fixes**
	- Simplified the logic for determining page lock permissions, enhancing clarity and reducing complexity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->