### PR TITLE
[WEB-2478] style: remove side menu position transition

### DIFF
--- a/packages/editor/src/styles/drag-drop.css
+++ b/packages/editor/src/styles/drag-drop.css
@@ -4,10 +4,7 @@
   display: flex;
   align-items: center;
   opacity: 1;
-  transition:
-    opacity 0.2s ease 0.2s,
-    top 0.2s ease,
-    left 0.2s ease;
+  transition: opacity 0.2s ease 0.2s;
   transform: translateX(-50%);
 
   &.side-menu-hidden {


### PR DESCRIPTION
#### Improvements:

Removed transition from `top` and `bottom` CSS properties to avoid the visibility of drag handle movement when the mouse moves across nested nodes.

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/8c784802-28f9-4759-be75-4936fc70da2c"></video> | <video src="https://github.com/user-attachments/assets/e2faa19b-ba30-44f5-9116-68f778ddc74b"></video> | 

#### Plane issue: [WEB-2478](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/d064b58c-1e6b-4bf8-b9b2-378f07027de4)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Simplified transition effects for drag-and-drop elements, focusing solely on opacity changes for a smoother visual response during state changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->