### PR TITLE
[WEB-2482] fix: list layout quick action styling

### DIFF
--- a/web/core/components/issues/issue-layouts/list/list-group.tsx
+++ b/web/core/components/issues/issue-layouts/list/list-group.tsx
@@ -233,7 +233,11 @@ export const ListGroup = observer((props: Props) => {
         "border-custom-error-200": isDraggingOverColumn && !!group.isDropDisabled,
       })}
     >
-      <Row className="sticky top-0 z-[2] w-full flex-shrink-0 border-b border-custom-border-200 bg-custom-background-90 pr-3 py-1">
+      <Row
+        className={cn("w-full flex-shrink-0 border-b border-custom-border-200 bg-custom-background-90 pr-3 py-1", {
+          "sticky top-0 z-[2]": isExpanded && groupIssueCount > 0,
+        })}
+      >
         <HeaderGroupByCard
           groupID={group.id}
           icon={group.icon}


### PR DESCRIPTION
### Changes:
This PR addresses list layout quick action menu overlapping issue. 

### Reference:
[[WEB-2482]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/254618d8-8052-4230-92d5-68a74fb686e7)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the list group's header behavior to become sticky when the group is expanded and contains issues, improving visibility and usability.
  
- **Bug Fixes**
	- Improved responsiveness of the list group component to user interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->