### PR TITLE
[WEB-2460] chore: restrict member to see private projects

### DIFF
--- a/apiserver/plane/app/views/project/base.py
+++ b/apiserver/plane/app/views/project/base.py
@@ -173,7 +173,7 @@ class ProjectViewSet(BaseViewSet):
             member=request.user,
             workspace__slug=slug,
             is_active=True,
-            role=10,
+            role=15,
         ).exists():
             projects = projects.filter(
                 Q(


### PR DESCRIPTION
chore: 
- workspace member should not see the private projects.

Issue Link: [WEB-2460](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/57ef16fc-6925-4d36-bce6-83ece64d2c7d/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated user role permissions for project access, potentially allowing users with the new role to see additional projects or restricting access to some previously available.
  
- **Bug Fixes**
	- Adjusted filtering logic for project listings based on the updated role value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->