### PR TITLE
[WEB-2486] Fix: archive page break issue resolved

### DIFF
--- a/web/core/layouts/auth-layout/project-wrapper.tsx
+++ b/web/core/layouts/auth-layout/project-wrapper.tsx
@@ -109,7 +109,7 @@ export const ProjectAuthWrapper: FC<IProjectAuthWrapper> = observer((props) => {
     [EUserPermissions.ADMIN, EUserPermissions.MEMBER, EUserPermissions.GUEST],
     EUserPermissionsLevel.PROJECT,
     workspaceSlug.toString(),
-    projectId.toString()
+    projectId?.toString()
   );
 
   // check if the project member apis is loading


### PR DESCRIPTION
**Summary**
- Archive page was breaking cause projectId was being accessed without being set

[[WEB-2486]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/76153059-d11d-48b1-8848-032f555ab1e0/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of `projectId` to prevent runtime errors when it is `null` or `undefined`, enhancing overall application stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->