### PR TITLE
[WEB-2501] chore: add server name to the HocusPocus server while initialization

### DIFF
--- a/live/package.json
+++ b/live/package.json
@@ -35,6 +35,7 @@
     "morgan": "^1.10.0",
     "pino-http": "^10.3.0",
     "pino-pretty": "^11.2.2",
+    "uuid": "^10.0.0",
     "y-prosemirror": "^1.2.9",
     "y-protocols": "^1.0.6",
     "yjs": "^13.6.14"

--- a/live/src/core/hocuspocus-server.ts
+++ b/live/src/core/hocuspocus-server.ts
@@ -1,11 +1,15 @@
 import { Server } from "@hocuspocus/server";
-
+import { v4 as uuidv4 } from "uuid";
+// lib
 import { handleAuthentication } from "@/core/lib/authentication.js";
+// extensions
 import { getExtensions } from "@/core/extensions/index.js";
 
 export const getHocusPocusServer = async () => {
   const extensions = await getExtensions();
+  const serverName = process.env.HOSTNAME || uuidv4();
   return Server.configure({
+    name: serverName,
     onAuthenticate: async ({
       requestHeaders,
       requestParameters,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a unique naming mechanism for the HocusPocus server, utilizing UUIDs for better identification.
	- Enhanced server configurability by allowing the server name to default to a UUID if not specified in the environment.

- **Chores**
	- Added the `uuid` package as a new dependency to support unique identifier generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->