### PR TITLE
[WEB-2496] style: fix invite member input alignment on error state.

### DIFF
--- a/web/core/components/project/send-project-invitation-modal.tsx
+++ b/web/core/components/project/send-project-invitation-modal.tsx
@@ -220,7 +220,7 @@ export const SendProjectInvitationModal: React.FC<Props> = observer((props) => {
                       {fields.map((field, index) => (
                         <div
                           key={field.id}
-                          className="group mb-1 flex items-center justify-between gap-x-4 text-sm w-full"
+                          className="group mb-1 flex items-start justify-between gap-x-4 text-sm w-full"
                         >
                           <div className="flex flex-col gap-1 flex-grow w-full">
                             <Controller


### PR DESCRIPTION
#### Media
* Before
   <img width="711" alt="image" src="https://github.com/user-attachments/assets/b505d28b-df0b-4213-8af9-3c3e2f24364b">

* After
     <img width="757" alt="image" src="https://github.com/user-attachments/assets/32062750-8517-4aae-aa43-6d6d4fadabe3">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Adjusted the vertical alignment of fields in the project invitation modal for improved visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->