### PR TITLE
[WEB-2503] chore: remove line-through decoration from checked todo list items

### DIFF
--- a/packages/editor/src/styles/editor.css
+++ b/packages/editor/src/styles/editor.css
@@ -243,8 +243,7 @@ ul[data-type="taskList"] li > div > p {
 
 ul[data-type="taskList"] li[data-checked="true"] > div > p {
   color: rgb(var(--color-text-400));
-  text-decoration: line-through;
-  text-decoration-thickness: 2px;
+  transition: color 0.2s ease;
 }
 /* end to-do list */
 
@@ -263,7 +262,6 @@ ul[data-type="taskList"] li[data-checked="true"] > div > p {
   opacity: 0;
   transition: opacity 0.2s ease-out;
 }
-
 
 @keyframes spinning {
   to {


### PR DESCRIPTION
#### Improvements:

1. Removed `line-through` text decoration from checked todo list items.
2. Added a color transition to todo list items for a smoother looking UI.

#### GitHub issue: #5394

#### Plane issue: [WEB-2503](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/ce0b803b-1677-4577-b9af-57ca26fd1758)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a smoother visual transition for completed task list items, enhancing user experience.
  
- **Style**
	- Updated the styling of checked task items by removing the line-through effect and adding a color transition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->