### PR TITLE
[WEB-2513] fix: page container height

### DIFF
--- a/web/core/components/pages/editor/editor-body.tsx
+++ b/web/core/components/pages/editor/editor-body.tsx
@@ -176,7 +176,7 @@ export const PageEditorBody: React.FC<Props> = observer((props) => {
               }}
               handleEditorReady={handleEditorReady}
               ref={editorRef}
-              containerClassName="p-0 pb-64"
+              containerClassName="h-full p-0 pb-64"
               displayConfig={displayConfig}
               editorClassName="pl-10"
               mentionHandler={{


### PR DESCRIPTION
#### Problem:

The pages container height doesn't extend to the complete screen height. Use has to click on a specific area to focus on the page.

#### Solution:

Added `h-full` class to Increase the page container height to match the screen height.

#### Media:

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/cd2dc30b-b046-4848-a585-97e578c70899"></video> | <video src="https://github.com/user-attachments/assets/50051e8e-a574-4329-8561-36c6f09a26f2"></video> | 

#### Plane issue: [WEB-2513](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/bc1ab610-40a2-4027-b2a4-4c24e4bbdfea)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved height styling for the page editor component, enhancing the overall layout and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->