### PR TITLE
[WEB-2466] fix-Date Sorting Dropdown Not Mutating Between Ascending and Descending

### DIFF
--- a/web/core/components/modules/dropdowns/order-by.tsx
+++ b/web/core/components/modules/dropdowns/order-by.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ArrowDownWideNarrow, Check, ChevronDown } from "lucide-react";
+import { ArrowDownWideNarrow, ArrowUpWideNarrow, Check, ChevronDown } from "lucide-react";
 import { TModuleOrderByOptions } from "@plane/types";
 // ui
 import { CustomMenu, getButtonStyling } from "@plane/ui";
@@ -27,9 +27,9 @@ export const ModuleOrderByDropdown: React.FC<Props> = (props) => {
     <CustomMenu
       customButton={
         <div className={cn(getButtonStyling("neutral-primary", "sm"), "px-2 text-custom-text-300")}>
-          <ArrowDownWideNarrow className="h-3 w-3" />
+          {!isDescending ? <ArrowUpWideNarrow className="size-3 " /> : <ArrowDownWideNarrow className="size-3 " />}
           {orderByDetails?.label}
-          <ChevronDown className="h-3 w-3" strokeWidth={2} />
+          <ChevronDown className="size-3" strokeWidth={2} />
         </div>
       }
       placement="bottom-end"

--- a/web/core/components/pages/list/order-by.tsx
+++ b/web/core/components/pages/list/order-by.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ArrowDownWideNarrow, Check, ChevronDown } from "lucide-react";
+import { ArrowDownWideNarrow, ArrowUpWideNarrow, Check, ChevronDown } from "lucide-react";
 // types
 import { TPageFiltersSortBy, TPageFiltersSortKey } from "@plane/types";
 // ui
@@ -26,7 +26,7 @@ export const PageOrderByDropdown: React.FC<Props> = (props) => {
     <CustomMenu
       customButton={
         <div className={cn(getButtonStyling("neutral-primary", "sm"), "px-2 text-custom-text-300")}>
-          <ArrowDownWideNarrow className="h-3 w-3" />
+          {!isDescending ? <ArrowUpWideNarrow className="size-3 " /> : <ArrowDownWideNarrow className="size-3 " />}
           {orderByDetails?.label}
           <ChevronDown className="h-3 w-3" strokeWidth={2} />
         </div>

--- a/web/core/components/views/filters/order-by.tsx
+++ b/web/core/components/views/filters/order-by.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ArrowDownWideNarrow, Check, ChevronDown } from "lucide-react";
+import { ArrowDownWideNarrow, ArrowUpWideNarrow, Check, ChevronDown } from "lucide-react";
 // types
 import { TViewFiltersSortBy, TViewFiltersSortKey } from "@plane/types";
 // ui
@@ -31,12 +31,14 @@ export const ViewOrderByDropdown: React.FC<Props> = (props) => {
     : `${getButtonStyling("neutral-primary", "sm")} px-2 text-custom-text-300`;
 
   const chevronClassName = isMobile ? "h-4 w-4 text-custom-text-200" : "h-3 w-3";
-
+  const icon = (
+    <>{!isDescending ? <ArrowUpWideNarrow className="size-3 " /> : <ArrowDownWideNarrow className="size-3 " />}</>
+  );
   return (
     <CustomMenu
       customButton={
         <span className={buttonClassName}>
-          {!isMobile && <ArrowDownWideNarrow className="h-3 w-3" />}
+          {!isMobile && icon}
           <span className="flex-shrink-0"> {orderByDetails?.label}</span>
           <ChevronDown className={chevronClassName} strokeWidth={2} />
         </span>


### PR DESCRIPTION
### Problem Statement
The sorting icons weren't mutating when option was changed from ascending to descending and visa-versa in views, models and pages. 

### Solution
Icon was hard coded to downwards arrow. Added conditional to mutate icons as states change.

### Screenshots and Media

Before:
![image](https://github.com/user-attachments/assets/f96a9de1-0ffc-4d52-9e8e-52a5a5500fca)
![image](https://github.com/user-attachments/assets/472f3b6a-df9c-438e-ab2e-86ab0a4161ee)

After:
![image](https://github.com/user-attachments/assets/8a31ac69-6e08-43c0-88e2-76dd71e5bb15)
![image](https://github.com/user-attachments/assets/3ce05486-e822-41c0-8cf8-8cfe4771ba25)

### References
[[WEB-2466]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/6fac821e-c6bc-4db1-b980-a64490e1cf5f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced dynamic sorting icons in the dropdown menus, allowing users to easily identify ascending or descending order.
	- Added the `ArrowUpWideNarrow` icon for improved visual representation of sorting states.

- **Bug Fixes**
	- Enhanced icon rendering logic to ensure the correct icon displays based on the sorting order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->