### PR TITLE
[WEB-2504] chore: issue relation hard delete

### DIFF
--- a/apiserver/plane/api/views/project.py
+++ b/apiserver/plane/api/views/project.py
@@ -301,11 +301,16 @@ class ProjectAPIEndpoint(BaseAPIView):
             if serializer.is_valid():
                 serializer.save()
                 if serializer.data["inbox_view"]:
-                    Inbox.objects.get_or_create(
-                        defaults={"name": f"{project.name} Inbox"},
+                    inbox = Inbox.objects.filter(
                         project=project,
                         is_default=True,
-                    )
+                    ).first()
+                    if not inbox:
+                        Inbox.objects.create(
+                            name=f"{project.name} Inbox",
+                            project=project,
+                            is_default=True,
+                        )
 
                     # Create the triage state in Backlog group
                     State.objects.get_or_create(

--- a/apiserver/plane/app/views/issue/relation.py
+++ b/apiserver/plane/app/views/issue/relation.py
@@ -267,7 +267,7 @@ class IssueRelationViewSet(BaseViewSet):
             IssueRelationSerializer(issue_relation).data,
             cls=DjangoJSONEncoder,
         )
-        issue_relation.delete()
+        issue_relation.delete(soft=False)
         issue_activity.delay(
             type="issue_relation.activity.deleted",
             requested_data=json.dumps(request.data, cls=DjangoJSONEncoder),

--- a/apiserver/plane/app/views/project/base.py
+++ b/apiserver/plane/app/views/project/base.py
@@ -438,11 +438,16 @@ class ProjectViewSet(BaseViewSet):
             if serializer.is_valid():
                 serializer.save()
                 if serializer.data["inbox_view"]:
-                    Inbox.objects.get_or_create(
-                        defaults={"name": f"{project.name} Inbox"},
+                    inbox = Inbox.objects.filter(
                         project=project,
                         is_default=True,
-                    )
+                    ).first()
+                    if not inbox:
+                        Inbox.objects.create(
+                            name=f"{project.name} Inbox",
+                            project=project,
+                            is_default=True,
+                        )
 
                     # Create the triage state in Backlog group
                     State.objects.get_or_create(


### PR DESCRIPTION
chore: 

- perform a hard delete on the issue relation.
- handled the multiple inboxes returned in the get_or_create.


Issue Link: [WEB-2504](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/4f137d06-611a-47e4-af22-5d6d453aeb37)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced logic for managing `Inbox` objects associated with projects, ensuring that new `Inbox` instances are only created when no existing default `Inbox` is found.
  
- **Bug Fixes**
	- Updated deletion behavior for `issue_relation` objects, shifting from a soft delete to a hard delete for improved data management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->