### PR TITLE
[WEB-2512] fix:  Large dropdown properties truncation

### DIFF
--- a/web/core/components/dropdowns/buttons.tsx
+++ b/web/core/components/dropdowns/buttons.tsx
@@ -74,7 +74,7 @@ const BorderButton: React.FC<ButtonProps> = (props) => {
     >
       <div
         className={cn(
-          "h-full flex items-center gap-1.5 border-[0.5px] border-custom-border-300 hover:bg-custom-background-80 rounded text-xs px-2 py-0.5",
+          "h-full w-full flex items-center gap-1.5 border-[0.5px] border-custom-border-300 hover:bg-custom-background-80 rounded text-xs px-2 py-0.5",
           { "bg-custom-background-80": isActive },
           className
         )}
@@ -98,7 +98,7 @@ const BackgroundButton: React.FC<ButtonProps> = (props) => {
     >
       <div
         className={cn(
-          "h-full flex items-center gap-1.5 rounded text-xs px-2 py-0.5 bg-custom-background-80",
+          "h-full w-full flex items-center gap-1.5 rounded text-xs px-2 py-0.5 bg-custom-background-80",
           className
         )}
       >


### PR DESCRIPTION
This PR adds a minor UI fix to fix truncation on issues with large properties.

Before
<img width="1240" alt="Screenshot 2024-09-20 at 9 08 50 PM" src="https://github.com/user-attachments/assets/f1ac1c30-3ece-4578-bd78-b7e32dbaa4b3">

After 
<img width="1249" alt="Screenshot 2024-09-20 at 9 09 31 PM" src="https://github.com/user-attachments/assets/569691ea-8563-4490-9277-94ef54c62c5f">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated button components to occupy the full width of their parent containers for improved layout consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->