### PR TITLE
[WEB-2515] style: updated create workspace option text color

### DIFF
--- a/web/core/components/workspace/sidebar/dropdown.tsx
+++ b/web/core/components/workspace/sidebar/dropdown.tsx
@@ -205,7 +205,7 @@ export const SidebarDropdown = observer(() => {
                     <Link href="/create-workspace" className="w-full">
                       <Menu.Item
                         as="div"
-                        className="flex items-center gap-2 rounded px-2 py-1 text-sm font-medium text-custom-sidebar-text-100 hover:bg-custom-sidebar-background-80"
+                        className="flex items-center gap-2 rounded px-2 py-1 text-sm font-medium text-custom-sidebar-text-200 hover:bg-custom-sidebar-background-80"
                       >
                         <PlusSquare strokeWidth={1.75} className="h-4 w-4 flex-shrink-0" />
                         Create workspace


### PR DESCRIPTION
#### Improvements:

Updated the text color of the `Create workspace` option in the workspace dropdown to match the color of other options.

| Before | After |
|--------|--------|
| <img width="339" alt="image" src="https://github.com/user-attachments/assets/ba5da480-dcf6-462d-b801-3eaeb63623bc"> | <img width="339" alt="image" src="https://github.com/user-attachments/assets/51620915-9dec-4724-b60c-66f34ad9818b"> | 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated the text color of the "Create workspace" menu item in the SidebarDropdown for improved visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->