### PR TITLE
[WEB-2510] fix-"Start your first project " text should be displayed in button present under Analytics empty state

### DIFF
--- a/web/core/constants/empty-state.ts
+++ b/web/core/constants/empty-state.ts
@@ -134,7 +134,7 @@ const emptyStateDetails = {
       "See scope versus demand, estimates, and scope creep. Get performance by team members and teams, and make sure your project runs on time.",
     path: "/empty-state/onboarding/analytics",
     primaryButton: {
-      text: "Create Cycles and Modules first",
+      text: "Start your first project",
       comicBox: {
         title: "Analytics works best with Cycles + Modules",
         description:


### PR DESCRIPTION
### Problem Statement
Start your first project text should be displayed in the button present under the Analytics empty state

### Solution
Changed the primary button text from "Create Cycles and Modules first" to "Start your first project".

### Screenshots and Media

Before
![image](https://github.com/user-attachments/assets/83684fc2-0b82-4e77-b4ac-1140ccb9cc4e)

After
![image](https://github.com/user-attachments/assets/ca0a0944-430f-463d-90f6-5f2fe26b1966)

### References
[[WEB-2510]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/db5c7bbc-90c9-4dfd-8176-2c6fc594fc7f)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the empty state prompt to guide users to "Start your first project."
  
This change enhances the user experience by providing clearer instructions on how to engage with the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->