### PR TITLE
[WEB-2525] fix: activity filters

### DIFF
--- a/web/ce/components/issues/worklog/activity/filter-root.tsx
+++ b/web/ce/components/issues/worklog/activity/filter-root.tsx
@@ -9,8 +9,8 @@ import { TActivityFilters, ACTIVITY_FILTER_TYPE_OPTIONS, TActivityFilterOption }
 export type TActivityFilterRoot = {
   selectedFilters: TActivityFilters[];
   toggleFilter: (filter: TActivityFilters) => void;
+  projectId: string;
   isIntakeIssue?: boolean;
-  projectId?: string;
 };
 
 export const ActivityFilterRoot: FC<TActivityFilterRoot> = (props) => {

--- a/web/ce/components/issues/worklog/activity/filter-root.tsx
+++ b/web/ce/components/issues/worklog/activity/filter-root.tsx
@@ -10,6 +10,7 @@ export type TActivityFilterRoot = {
   selectedFilters: TActivityFilters[];
   toggleFilter: (filter: TActivityFilters) => void;
   isIntakeIssue?: boolean;
+  projectId?: string;
 };
 
 export const ActivityFilterRoot: FC<TActivityFilterRoot> = (props) => {

--- a/web/core/components/issues/issue-detail/issue-activity/root.tsx
+++ b/web/core/components/issues/issue-detail/issue-activity/root.tsx
@@ -123,7 +123,12 @@ export const IssueActivity: FC<TIssueActivity> = observer((props) => {
               disabled={disabled}
             />
           )}
-          <ActivityFilterRoot selectedFilters={selectedFilters} toggleFilter={toggleFilter} isIntakeIssue={isIntakeIssue}/>
+          <ActivityFilterRoot
+            selectedFilters={selectedFilters}
+            toggleFilter={toggleFilter}
+            isIntakeIssue={isIntakeIssue}
+            projectId={projectId}
+          />
         </div>
       </div>
 


### PR DESCRIPTION
### Changes:
This PR addresses a fix for the issue activity filters. Previously, the intake and inbox issue activity filters were not rendering as they expected a project ID from the route. Now, the project ID is passed as a prop, resolving the issue.

### Reference:
[[WEB-2525]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/c4d33e64-1cff-48a2-8e0c-94b074184596)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a required `projectId` filter for more precise activity filtering in the Activity Filter component.
	- Enhanced the Issue Activity component to support the new `projectId` parameter.

These updates allow users to filter activities based on specific projects, improving the overall functionality and user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->