### PR TITLE
[WEB-2520] fix-Sorted Icon Not Updating Dynamically in Spreadsheet View

### DIFF
--- a/web/core/components/issues/issue-layouts/spreadsheet/columns/header-column.tsx
+++ b/web/core/components/issues/issue-layouts/spreadsheet/columns/header-column.tsx
@@ -1,15 +1,7 @@
 "use client";
 
 //ui
-import {
-  ArrowDownWideNarrow,
-  ArrowUpNarrowWide,
-  CheckIcon,
-  ChevronDownIcon,
-  Eraser,
-  ListFilter,
-  MoveRight,
-} from "lucide-react";
+import { ArrowDownWideNarrow, ArrowUpNarrowWide, CheckIcon, ChevronDownIcon, Eraser, MoveRight } from "lucide-react";
 import { IIssueDisplayFilterOptions, IIssueDisplayProperties, TIssueOrderByOptions } from "@plane/types";
 import { CustomMenu, Row } from "@plane/ui";
 //hooks

--- a/web/core/components/issues/issue-layouts/spreadsheet/columns/header-column.tsx
+++ b/web/core/components/issues/issue-layouts/spreadsheet/columns/header-column.tsx
@@ -59,7 +59,11 @@ export const HeaderColumn = (props: Props) => {
           <div className="ml-3 flex">
             {activeSortingProperty === property && (
               <div className="flex h-3.5 w-3.5 items-center justify-center rounded-full">
-                <ListFilter className="h-3 w-3" />
+                {propertyDetails.ascendingOrderKey === displayFilters.order_by ? (
+                  <ArrowDownWideNarrow className="h-3 w-3" />
+                ) : (
+                  <ArrowUpNarrowWide className="h-3 w-3" />
+                )}
               </div>
             )}
             <ChevronDownIcon className="h-3 w-3" aria-hidden="true" />


### PR DESCRIPTION
### Problem Statement
Sort icon along the headers in spreadsheet view wasn't getting updated when sorting order was changed. 

### Solution
Added conditional rendering for the icon to get updated whenever the sorting order gets changed.

### Screenshots and Media

Before
![image](https://github.com/user-attachments/assets/7aa7f4aa-e416-46f6-a9b7-6fad379232dd)

After
![image](https://github.com/user-attachments/assets/a131ba31-06e6-4b89-92aa-2c7bfbd025ef)
![image](https://github.com/user-attachments/assets/7d1ab85f-ac6b-4d96-a859-c062c778a96e)


### References
[[WEB-2520]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/b8af4240-2484-46c0-ab33-3093724c72a4)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved visual feedback for sorting direction in the issue spreadsheet, enhancing user experience when filtering data.
  
- **Bug Fixes**
	- Resolved inconsistencies in the display of sorting indicators based on active filters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->