### PR TITLE
[WEB-2534] fix: Add requestIdleCallback polyfill to fix crash in Safari browser

### DIFF
--- a/web/app/provider.tsx
+++ b/web/app/provider.tsx
@@ -12,6 +12,8 @@ import { SWR_CONFIG } from "@/constants/swr-config";
 import { resolveGeneralTheme } from "@/helpers/theme.helper";
 // nprogress
 import { AppProgressBar } from "@/lib/n-progress";
+// polyfills
+import "@/lib/polyfills";
 // mobx store provider
 import { StoreProvider } from "@/lib/store-context";
 // wrappers

--- a/web/core/lib/polyfills/index.ts
+++ b/web/core/lib/polyfills/index.ts
@@ -1,0 +1,1 @@
+export * from "./requestIdleCallback";

--- a/web/core/lib/polyfills/requestIdleCallback.ts
+++ b/web/core/lib/polyfills/requestIdleCallback.ts
@@ -1,0 +1,24 @@
+if (typeof window !== "undefined" && window) {
+  // Add request callback polyfill to browser incase it does not exist
+  window.requestIdleCallback =
+    window.requestIdleCallback ??
+    function (cb) {
+      var start = Date.now();
+      return setTimeout(function () {
+        cb({
+          didTimeout: false,
+          timeRemaining: function () {
+            return Math.max(0, 50 - (Date.now() - start));
+          },
+        });
+      }, 1);
+    };
+
+  window.cancelIdleCallback =
+    window.cancelIdleCallback ??
+    function (id) {
+      clearTimeout(id);
+    };
+}
+
+export {};


### PR DESCRIPTION
This PR adds a polyfill for `requestIdleCallback` to fix the crash in Safari browser because of the non support of the function on the browser

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced polyfills for `requestIdleCallback` and `cancelIdleCallback` functions to enhance performance during idle periods.
	- Added a consolidated export for easier access to polyfills related to idle callback functionality.

- **Chores**
	- Updated import statements to include the new polyfills in the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->