### PR TITLE
[WEB-2539] fix: update version history overlay z-index

### DIFF
--- a/web/core/components/pages/version/root.tsx
+++ b/web/core/components/pages/version/root.tsx
@@ -40,7 +40,7 @@ export const PageVersionsOverlay: React.FC<Props> = observer((props) => {
   return (
     <div
       className={cn(
-        "absolute inset-0 z-10 size-full bg-custom-background-100 flex overflow-hidden opacity-0 pointer-events-none transition-opacity",
+        "absolute inset-0 z-20 size-full bg-custom-background-100 flex overflow-hidden opacity-0 pointer-events-none transition-opacity",
         {
           "opacity-100 pointer-events-auto": isOpen,
         }


### PR DESCRIPTION
#### Problem:

Editor toolbar is appearing over the version history overlay.

#### Solution:

Updated the `z-index` of the version history overlay.

#### Plane issue: [WEB-2539](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/9c44a914-5be7-4f01-b7ef-11930a4def7c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved visibility of the `PageVersionsOverlay` by adjusting its stacking order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->