### PR TITLE
[WEB-2545] fix: peek overview loading state

### DIFF
--- a/web/app/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/archives/issues/(detail)/[archivedIssueId]/page.tsx
+++ b/web/app/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/archives/issues/(detail)/[archivedIssueId]/page.tsx
@@ -19,7 +19,7 @@ const ArchivedIssueDetailsPage = observer(() => {
   // hooks
   const {
     fetchIssue,
-    issue: { getIssueById, isFetchingIssueDetails },
+    issue: { getIssueById, getIsFetchingIssueDetails },
   } = useIssueDetail();
 
   const { getProjectById } = useProject();
@@ -40,7 +40,7 @@ const ArchivedIssueDetailsPage = observer(() => {
 
   if (!issue) return <></>;
 
-  const issueLoader = !issue || isFetchingIssueDetails ? true : false;
+  const issueLoader = !issue || getIsFetchingIssueDetails(issue?.id) ? true : false;
 
   return (
     <>

--- a/web/app/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/issues/(detail)/[issueId]/page.tsx
+++ b/web/app/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/issues/(detail)/[issueId]/page.tsx
@@ -27,7 +27,7 @@ const IssueDetailsPage = observer(() => {
   // store hooks
   const {
     fetchIssue,
-    issue: { getIssueById, isFetchingIssueDetails },
+    issue: { getIssueById, getIsFetchingIssueDetails },
   } = useIssueDetail();
   const { getProjectById } = useProject();
   const { toggleIssueDetailSidebar, issueDetailSidebarCollapsed } = useAppTheme();
@@ -41,7 +41,7 @@ const IssueDetailsPage = observer(() => {
   // derived values
   const issue = getIssueById(issueId?.toString() || "") || undefined;
   const project = (issue?.project_id && getProjectById(issue?.project_id)) || undefined;
-  const issueLoader = !issue || isFetchingIssueDetails ? true : false;
+  const issueLoader = !issue || getIsFetchingIssueDetails(issue?.id) ? true : false;
   const pageTitle = project && issue ? `${project?.identifier}-${issue?.sequence_id} ${issue?.name}` : undefined;
 
   useEffect(() => {

--- a/web/core/components/issues/peek-overview/root.tsx
+++ b/web/core/components/issues/peek-overview/root.tsx
@@ -35,7 +35,7 @@ export const IssuePeekOverview: FC<IIssuePeekOverview> = observer((props) => {
   const {
     peekIssue,
     setPeekIssue,
-    issue: { fetchIssue, isFetchingIssueDetails },
+    issue: { fetchIssue, getIsFetchingIssueDetails },
     fetchActivities,
   } = useIssueDetail();
 
@@ -344,7 +344,7 @@ export const IssuePeekOverview: FC<IIssuePeekOverview> = observer((props) => {
       workspaceSlug={peekIssue.workspaceSlug}
       projectId={peekIssue.projectId}
       issueId={peekIssue.issueId}
-      isLoading={isFetchingIssueDetails}
+      isLoading={getIsFetchingIssueDetails(peekIssue.issueId)}
       isError={error}
       is_archived={is_archived}
       disabled={!isEditable}

--- a/web/core/components/issues/peek-overview/view.tsx
+++ b/web/core/components/issues/peek-overview/view.tsx
@@ -60,7 +60,7 @@ export const IssueView: FC<IIssueView> = observer((props) => {
     isArchiveIssueModalOpen,
     toggleDeleteIssueModal,
     toggleArchiveIssueModal,
-    issue: { getIssueById, isLocalDBIssueDescription },
+    issue: { getIssueById, getIsLocalDBIssueDescription },
   } = useIssueDetail();
   const issue = getIssueById(issueId);
   // remove peek id
@@ -68,6 +68,8 @@ export const IssueView: FC<IIssueView> = observer((props) => {
     setPeekIssue(undefined);
     if (embedIssue) embedRemoveCurrentNotification && embedRemoveCurrentNotification();
   };
+
+  const isLocalDBIssueDescription = getIsLocalDBIssueDescription(issueId);
 
   usePeekOverviewOutsideClickDetector(
     issuePeekOverviewRef,


### PR DESCRIPTION
This PR changes the loading states for peek overview from boolean to issueIds to ensure that it only applies to the particular issue.


https://github.com/user-attachments/assets/7f396a73-3eec-40d1-8cef-141694ad95da



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced loading state management for issue details, allowing for more dynamic checks based on issue IDs.
	- Introduced new methods for fetching issue details and local database descriptions.

- **Bug Fixes**
	- Resolved inconsistencies in how the loading state was determined for issues.

- **Refactor**
	- Updated existing methods to improve clarity and functionality, moving from boolean flags to computed functions for fetching states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->