### PR TITLE
[WEB-2550] fix: spacing by removing the right border

### DIFF
--- a/space/core/components/editor/toolbar.tsx
+++ b/space/core/components/editor/toolbar.tsx
@@ -57,7 +57,6 @@ export const IssueCommentToolbar: React.FC<Props> = (props) => {
               key={key}
               className={cn("flex items-stretch gap-0.5 border-r border-custom-border-200 px-2.5", {
                 "pl-0": index === 0,
-                "pr-0": index === Object.keys(toolbarItems).length - 1,
               })}
             >
               {toolbarItems[key].map((item) => (

--- a/web/core/components/editor/lite-text-editor/toolbar.tsx
+++ b/web/core/components/editor/lite-text-editor/toolbar.tsx
@@ -44,6 +44,7 @@ const COMMENT_ACCESS_SPECIFIERS: TCommentAccessType[] = [
 ];
 
 const toolbarItems = TOOLBAR_ITEMS.lite;
+console.log(toolbarItems);
 
 export const IssueCommentToolbar: React.FC<Props> = (props) => {
   const {
@@ -118,7 +119,6 @@ export const IssueCommentToolbar: React.FC<Props> = (props) => {
               key={key}
               className={cn("flex items-stretch gap-0.5 border-r border-custom-border-200 px-2.5", {
                 "pl-0": index === 0,
-                "pr-0": index === Object.keys(toolbarItems).length - 1,
               })}
             >
               {toolbarItems[key].map((item) => (

--- a/web/core/components/editor/lite-text-editor/toolbar.tsx
+++ b/web/core/components/editor/lite-text-editor/toolbar.tsx
@@ -44,7 +44,6 @@ const COMMENT_ACCESS_SPECIFIERS: TCommentAccessType[] = [
 ];
 
 const toolbarItems = TOOLBAR_ITEMS.lite;
-console.log(toolbarItems);
 
 export const IssueCommentToolbar: React.FC<Props> = (props) => {
   const {


### PR DESCRIPTION
## [[WEB-2550]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/inbox/?currentTab=open&inboxIssueId=8db53d67-9ab9-4f6a-b459-0a7b8e345f3d)
The PR aims to fix the alignment of the last icon in the Comment Toolbar. 

The right most icon does not require a pr-0 (which is now removed in this PR) because it breaks the alignment and the responsive behaviour allows scrolling.

Previous Desktop State: 
<img width="1075" alt="image" src="https://github.com/user-attachments/assets/df3fd276-c9c5-472c-b8e4-5a584f8abcdb">

Previous Mobile State: 

https://github.com/user-attachments/assets/80789407-5a66-49a1-8a26-e22c75e9a5dd


New Desktop State:
<img width="1070" alt="Screenshot 2024-09-26 at 11 37 34 AM" src="https://github.com/user-attachments/assets/b26b676d-d3f2-4d7d-b1a8-f41420c5c232">

New Mobile State:

https://github.com/user-attachments/assets/c23b2466-9f3a-4ebf-b0cb-787ddd8b4f91




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted the styling for the last item in the toolbar, which may improve visual consistency with adjacent items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->