### PR TITLE
feat: add audio playback support for WAV and MP3 attachments

### DIFF
--- a/web/core/components/issues/attachment/attachment-list-item.tsx
+++ b/web/core/components/issues/attachment/attachment-list-item.tsx
@@ -59,6 +59,16 @@ export const IssueAttachmentsListItem: FC<TIssueAttachmentsListItem> = observer(
             <span className="flex-shrink-0 text-custom-text-400">{convertBytesToSize(attachment.attributes.size)}</span>
           </div>
 
+
+          {(getFileExtension(attachment.asset) === "wav" || getFileExtension(attachment.asset) == "mp3") && (
+            <>
+            <audio controls style={{height: "20px"}}>
+              <source src={attachment.asset} type="audio/wav"/>
+              Your browser does not support the audio element.
+            </audio>
+            </>
+          )
+          }
           <div className="flex items-center gap-3">
             {attachment?.updated_by && (
               <>


### PR DESCRIPTION
This PR adds audio control support. I've leaving this as a draft because I'll take any feedback especially around styling or any other feedback others might have. 

Our use case is to listen to voicemail messages from the attachments. This should only impact audio files (wav and mp3). 