### PR TITLE
[WEB-2570] fix: convert image size to string before calculations

### DIFF
--- a/packages/editor/src/core/extensions/custom-image/components/image-block.tsx
+++ b/packages/editor/src/core/extensions/custom-image/components/image-block.tsx
@@ -11,7 +11,10 @@ export const CustomImageBlock: React.FC<CustomImageNodeViewProps> = (props) => {
   const { node, updateAttributes, selected, getPos, editor } = props;
   const { src, width, height } = node.attrs;
 
-  const [size, setSize] = useState({ width: width || "35%", height: height || "auto" });
+  const [size, setSize] = useState({
+    width: width?.toString() || "35%",
+    height: height?.toString() || "auto",
+  });
   const [isLoading, setIsLoading] = useState(true);
   const [initialResizeComplete, setInitialResizeComplete] = useState(false);
   const isShimmerVisible = isLoading || !initialResizeComplete;
@@ -56,7 +59,10 @@ export const CustomImageBlock: React.FC<CustomImageNodeViewProps> = (props) => {
   }, [width, height, updateAttributes]);
 
   useLayoutEffect(() => {
-    setSize({ width, height });
+    setSize({
+      width: width?.toString(),
+      height: height?.toString(),
+    });
   }, [width, height]);
 
   const handleResizeStart = useCallback(

--- a/packages/editor/src/core/extensions/custom-image/components/image-node.tsx
+++ b/packages/editor/src/core/extensions/custom-image/components/image-node.tsx
@@ -15,8 +15,8 @@ export type CustomImageNodeViewProps = {
   node: ProsemirrorNode & {
     attrs: {
       src: string;
-      width: string;
-      height: string;
+      width: number | string;
+      height: number | string;
     };
   };
   updateAttributes: (attrs: Record<string, any>) => void;


### PR DESCRIPTION
#### Bug fix:

Convert image height and width to string before calculations.

#### Plane issue: [WEB-2570](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/e2ecacf4-4949-4779-b49f-833e7280e643/)