### PR TITLE
fix: Add `/live` Path to Proxy Pass

### DIFF
--- a/nginx/nginx.conf.template
+++ b/nginx/nginx.conf.template
@@ -57,7 +57,7 @@ http {
             proxy_set_header Upgrade ${dollar}http_upgrade;
             proxy_set_header Connection "upgrade";
             proxy_set_header Host ${dollar}http_host;
-            proxy_pass http://live:3000/;
+            proxy_pass http://live:3000/live/;
         }
 
         location /spaces/ {


### PR DESCRIPTION
Add the `/live` path to the proxy pass, ensuring proper routing for the requests.








<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated routing for live traffic, directing requests from `/live/` to a more specific endpoint at `/live/`.

- **Bug Fixes**
	- Improved traffic handling for live requests to ensure better performance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->