### PR TITLE
fix: image deletion on submit fixed in comments

### DIFF
--- a/packages/editor/src/core/extensions/custom-image/components/image-block.tsx
+++ b/packages/editor/src/core/extensions/custom-image/components/image-block.tsx
@@ -71,6 +71,17 @@ export const CustomImageBlock: React.FC<CustomImageBlockProps> = (props) => {
   const containerRect = useRef<DOMRect | null>(null);
   const imageRef = useRef<HTMLImageElement>(null);
 
+  const updateAttributesSafely = useCallback(
+    (attributes: Partial<ImageAttributes>, errorMessage: string) => {
+      try {
+        updateAttributes(attributes);
+      } catch (error) {
+        console.error(`${errorMessage}:`, error);
+      }
+    },
+    [updateAttributes]
+  );
+
   const handleImageLoad = useCallback(() => {
     const img = imageRef.current;
     if (!img) return;
@@ -105,13 +116,19 @@ export const CustomImageBlock: React.FC<CustomImageBlockProps> = (props) => {
       };
 
       setSize(initialComputedSize);
-      updateAttributes(initialComputedSize);
+      updateAttributesSafely(
+        initialComputedSize,
+        "Failed to update attributes while initializing an image for the first time:"
+      );
     } else {
       // as the aspect ratio in not stored for old images, we need to update the attrs
       if (!aspectRatio) {
         setSize((prevSize) => {
           const newSize = { ...prevSize, aspectRatio };
-          updateAttributes(newSize);
+          updateAttributesSafely(
+            newSize,
+            "Failed to update attributes while initializing images with width but no aspect ratio:"
+          );
           return newSize;
         });
       }
@@ -144,7 +161,7 @@ export const CustomImageBlock: React.FC<CustomImageBlockProps> = (props) => {
 
   const handleResizeEnd = useCallback(() => {
     setIsResizing(false);
-    updateAttributes(size);
+    updateAttributesSafely(size, "Failed to update attributes at the end of resizing:");
   }, [size, updateAttributes]);
 
   const handleResizeStart = useCallback((e: React.MouseEvent | React.TouchEvent) => {

--- a/packages/editor/src/core/extensions/custom-image/components/image-block.tsx
+++ b/packages/editor/src/core/extensions/custom-image/components/image-block.tsx
@@ -108,14 +108,16 @@ export const CustomImageBlock: React.FC<CustomImageBlockProps> = (props) => {
       updateAttributes(initialComputedSize);
     } else {
       // as the aspect ratio in not stored for old images, we need to update the attrs
-      setSize((prevSize) => {
-        const newSize = { ...prevSize, aspectRatio };
-        updateAttributes(newSize);
-        return newSize;
-      });
+      if (!aspectRatio) {
+        setSize((prevSize) => {
+          const newSize = { ...prevSize, aspectRatio };
+          updateAttributes(newSize);
+          return newSize;
+        });
+      }
     }
     setInitialResizeComplete(true);
-  }, [width, updateAttributes, editorContainer]);
+  }, [width, updateAttributes, editorContainer, aspectRatio]);
 
   // for real time resizing
   useLayoutEffect(() => {

--- a/packages/editor/src/core/extensions/custom-image/components/image-uploader.tsx
+++ b/packages/editor/src/core/extensions/custom-image/components/image-uploader.tsx
@@ -128,8 +128,9 @@ export const CustomImageUploader = (props: {
   return (
     <div
       className={cn(
-        "image-upload-component flex items-center justify-start gap-2 py-3 px-2 rounded-lg text-custom-text-300 hover:text-custom-text-200 bg-custom-background-90 hover:bg-custom-background-80 border border-dashed border-custom-border-300 cursor-pointer transition-all duration-200 ease-in-out",
+        "image-upload-component flex items-center justify-start gap-2 py-3 px-2 rounded-lg text-custom-text-300 hover:text-custom-text-200 bg-custom-background-90 hover:bg-custom-background-80 border border-dashed border-custom-border-300 cursor-pointer transition-all duration-200 ease-in-out cursor-default",
         {
+          "hover:text-custom-text-200 cursor-pointer": editor.isEditable,
           "bg-custom-background-80 text-custom-text-200": draggedInside,
           "text-custom-primary-200 bg-custom-primary-100/10 hover:bg-custom-primary-100/10 hover:text-custom-primary-200 border-custom-primary-200/10":
             selected,
@@ -142,7 +143,7 @@ export const CustomImageUploader = (props: {
       onDragLeave={onDragLeave}
       contentEditable={false}
       onClick={() => {
-        if (!failedToLoadImage) {
+        if (!failedToLoadImage && editor.isEditable) {
           fileInputRef.current?.click();
         }
       }}

--- a/packages/editor/src/core/extensions/custom-image/components/image-uploader.tsx
+++ b/packages/editor/src/core/extensions/custom-image/components/image-uploader.tsx
@@ -5,9 +5,7 @@ import { ImageIcon } from "lucide-react";
 // helpers
 import { cn } from "@/helpers/common";
 // hooks
-import { useUploader, useDropZone } from "@/hooks/use-file-upload";
-// plugins
-import { isFileValid } from "@/plugins/image";
+import { useUploader, useDropZone, uploadFirstImageAndInsertRemaining } from "@/hooks/use-file-upload";
 // extensions
 import { getImageComponentImageFileMap, ImageAttributes } from "@/extensions/custom-image";
 
@@ -74,7 +72,11 @@ export const CustomImageUploader = (props: {
   );
   // hooks
   const { uploading: isImageBeingUploaded, uploadFile } = useUploader({ onUpload, editor, loadImageFromFileSystem });
-  const { draggedInside, onDrop, onDragEnter, onDragLeave } = useDropZone({ uploader: uploadFile });
+  const { draggedInside, onDrop, onDragEnter, onDragLeave } = useDropZone({
+    uploader: uploadFile,
+    editor,
+    pos: getPos(),
+  });
 
   // the meta data of the image component
   const meta = useMemo(
@@ -99,12 +101,9 @@ export const CustomImageUploader = (props: {
 
   const onFileChange = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
-      const file = e.target.files?.[0];
-      if (file) {
-        if (isFileValid(file)) {
-          uploadFile(file);
-        }
-      }
+      e.preventDefault();
+      const fileList = e.target.files;
+      uploadFirstImageAndInsertRemaining(editor, fileList, getPos(), uploadFile);
     },
     [uploadFile]
   );
@@ -157,6 +156,7 @@ export const CustomImageUploader = (props: {
         type="file"
         accept=".jpg,.jpeg,.png,.webp"
         onChange={onFileChange}
+        multiple
       />
     </div>
   );

--- a/packages/editor/src/core/extensions/custom-image/components/image-uploader.tsx
+++ b/packages/editor/src/core/extensions/custom-image/components/image-uploader.tsx
@@ -82,9 +82,6 @@ export const CustomImageUploader = (props: {
     [imageComponentImageFileMap, imageEntityId]
   );
 
-  // if the image component is dropped, we check if it has an existing file
-  const existingFile = useMemo(() => (meta && meta.event === "drop" ? meta.file : undefined), [meta]);
-
   // after the image component is mounted we start the upload process based on
   // it's uploaded
   useEffect(() => {
@@ -100,13 +97,6 @@ export const CustomImageUploader = (props: {
     }
   }, [meta, uploadFile, imageComponentImageFileMap]);
 
-  // check if the image is dropped and set the local image as the existing file
-  useEffect(() => {
-    if (existingFile) {
-      uploadFile(existingFile);
-    }
-  }, [existingFile, uploadFile]);
-
   const onFileChange = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
       const file = e.target.files?.[0];
@@ -120,7 +110,7 @@ export const CustomImageUploader = (props: {
   );
 
   const getDisplayMessage = useCallback(() => {
-    const isUploading = isImageBeingUploaded || existingFile;
+    const isUploading = isImageBeingUploaded;
     if (failedToLoadImage) {
       return "Error loading image";
     }
@@ -134,7 +124,7 @@ export const CustomImageUploader = (props: {
     }
 
     return "Add an image";
-  }, [draggedInside, failedToLoadImage, existingFile, isImageBeingUploaded]);
+  }, [draggedInside, failedToLoadImage, isImageBeingUploaded]);
 
   return (
     <div

--- a/packages/editor/src/core/extensions/custom-image/components/image-uploader.tsx
+++ b/packages/editor/src/core/extensions/custom-image/components/image-uploader.tsx
@@ -100,12 +100,12 @@ export const CustomImageUploader = (props: {
   }, [meta, uploadFile, imageComponentImageFileMap]);
 
   const onFileChange = useCallback(
-    (e: ChangeEvent<HTMLInputElement>) => {
+    async (e: ChangeEvent<HTMLInputElement>) => {
       e.preventDefault();
       const fileList = e.target.files;
-      uploadFirstImageAndInsertRemaining(editor, fileList, getPos(), uploadFile);
+      await uploadFirstImageAndInsertRemaining(editor, fileList, getPos(), uploadFile);
     },
-    [uploadFile]
+    [uploadFile, editor, getPos, uploadFile]
   );
 
   const getDisplayMessage = useCallback(() => {

--- a/packages/editor/src/core/extensions/custom-image/components/image-uploader.tsx
+++ b/packages/editor/src/core/extensions/custom-image/components/image-uploader.tsx
@@ -103,9 +103,12 @@ export const CustomImageUploader = (props: {
     async (e: ChangeEvent<HTMLInputElement>) => {
       e.preventDefault();
       const fileList = e.target.files;
+      if (!fileList) {
+        return;
+      }
       await uploadFirstImageAndInsertRemaining(editor, fileList, getPos(), uploadFile);
     },
-    [uploadFile, editor, getPos, uploadFile]
+    [uploadFile, editor, getPos]
   );
 
   const getDisplayMessage = useCallback(() => {
@@ -128,7 +131,7 @@ export const CustomImageUploader = (props: {
   return (
     <div
       className={cn(
-        "image-upload-component flex items-center justify-start gap-2 py-3 px-2 rounded-lg text-custom-text-300 hover:text-custom-text-200 bg-custom-background-90 hover:bg-custom-background-80 border border-dashed border-custom-border-300 cursor-pointer transition-all duration-200 ease-in-out cursor-default",
+        "image-upload-component flex items-center justify-start gap-2 py-3 px-2 rounded-lg text-custom-text-300 hover:text-custom-text-200 bg-custom-background-90 hover:bg-custom-background-80 border border-dashed border-custom-border-300 transition-all duration-200 ease-in-out cursor-default",
         {
           "hover:text-custom-text-200 cursor-pointer": editor.isEditable,
           "bg-custom-background-80 text-custom-text-200": draggedInside,

--- a/packages/editor/src/core/extensions/drop.tsx
+++ b/packages/editor/src/core/extensions/drop.tsx
@@ -21,7 +21,7 @@ export const DropHandlerExtension = () =>
 
                 if (imageFiles.length > 0) {
                   const pos = view.state.selection.from;
-                  insertImages({ editor, files: imageFiles, initialPos: pos, event: "drop" });
+                  insertImagesSafely({ editor, files: imageFiles, initialPos: pos, event: "drop" });
                 }
                 return true;
               }
@@ -41,7 +41,7 @@ export const DropHandlerExtension = () =>
 
                   if (coordinates) {
                     const pos = coordinates.pos;
-                    insertImages({ editor, files: imageFiles, initialPos: pos, event: "drop" });
+                    insertImagesSafely({ editor, files: imageFiles, initialPos: pos, event: "drop" });
                   }
                   return true;
                 }
@@ -54,7 +54,7 @@ export const DropHandlerExtension = () =>
     },
   });
 
-const insertImages = async ({
+export const insertImagesSafely = async ({
   editor,
   files,
   initialPos,
@@ -71,13 +71,6 @@ const insertImages = async ({
     // safe insertion
     const docSize = editor.state.doc.content.size;
     pos = Math.min(pos, docSize);
-
-    // Check if the position has a non-empty node
-    const nodeAtPos = editor.state.doc.nodeAt(pos);
-    if (nodeAtPos && nodeAtPos.content.size > 0) {
-      // Move to the end of the current node
-      pos += nodeAtPos.nodeSize;
-    }
 
     try {
       // Insert the image at the current position

--- a/packages/editor/src/core/hooks/use-editor.ts
+++ b/packages/editor/src/core/hooks/use-editor.ts
@@ -126,7 +126,7 @@ export const useEditor = (props: CustomEditorProps) => {
     forwardedRef,
     () => ({
       clearEditor: (emitUpdate = false) => {
-        editorRef.current?.commands.clearContent(emitUpdate);
+        editorRef.current?.chain().setMeta("skipImageDeletion", true).clearContent(emitUpdate).run();
       },
       setEditorValue: (content: string) => {
         editorRef.current?.commands.setContent(content, false, { preserveWhitespace: "full" });

--- a/packages/editor/src/core/hooks/use-file-upload.ts
+++ b/packages/editor/src/core/hooks/use-file-upload.ts
@@ -137,18 +137,14 @@ export async function uploadFirstImageAndInsertRemaining(
   pos: number,
   uploaderFn: (file: File) => Promise<void>
 ) {
-  const files: File[] = [];
+  const filteredFiles: File[] = [];
   for (let i = 0; i < fileList.length; i += 1) {
     const item = fileList.item(i);
-    if (item) {
-      files.push(item);
+    if (item && item.type.indexOf("image") !== -1 && isFileValid(item)) {
+      filteredFiles.push(item);
     }
   }
-  if (files.some((file) => file.type.indexOf("image") === -1)) {
-    return;
-  }
-  const filteredFiles = files.filter((f) => f.type.indexOf("image") !== -1);
-  if (filteredFiles.length !== files.length) {
+  if (filteredFiles.length !== fileList.length) {
     console.warn("Some files were not images and have been ignored.");
   }
   if (filteredFiles.length === 0) {

--- a/packages/editor/src/core/hooks/use-file-upload.ts
+++ b/packages/editor/src/core/hooks/use-file-upload.ts
@@ -95,15 +95,15 @@ export const useDropZone = ({
   }, []);
 
   const onDrop = useCallback(
-    (e: DragEvent<HTMLDivElement>) => {
+    async (e: DragEvent<HTMLDivElement>) => {
       setDraggedInside(false);
       if (e.dataTransfer.files.length === 0) {
         return;
       }
       const fileList = e.dataTransfer.files;
-      uploadFirstImageAndInsertRemaining(editor, fileList, pos, uploader);
+      await uploadFirstImageAndInsertRemaining(editor, fileList, pos, uploader);
     },
-    [uploader]
+    [uploader, editor, pos]
   );
 
   const onDragEnter = () => {
@@ -130,7 +130,7 @@ function trimFileName(fileName: string, maxLength = 100) {
 
 // Upload the first image and insert the remaining images for uploading multiple image
 // post insertion of image-component
-export function uploadFirstImageAndInsertRemaining(
+export async function uploadFirstImageAndInsertRemaining(
   editor: Editor,
   fileList: FileList,
   pos: number,
@@ -147,6 +147,9 @@ export function uploadFirstImageAndInsertRemaining(
     return;
   }
   const filteredFiles = files.filter((f) => f.type.indexOf("image") !== -1);
+  if (filteredFiles.length !== files.length) {
+    console.warn("Some files were not images and have been ignored.");
+  }
   if (filteredFiles.length === 0) {
     console.error("No image files found to upload");
     return;
@@ -154,7 +157,7 @@ export function uploadFirstImageAndInsertRemaining(
 
   // Upload the first image
   const firstFile = filteredFiles[0];
-  uploaderFn(firstFile);
+  await uploaderFn(firstFile);
 
   // Insert the remaining images
   const remainingFiles = filteredFiles.slice(1);

--- a/packages/editor/src/core/hooks/use-file-upload.ts
+++ b/packages/editor/src/core/hooks/use-file-upload.ts
@@ -1,6 +1,7 @@
 import { DragEvent, useCallback, useEffect, useState } from "react";
 import { Editor } from "@tiptap/core";
 import { isFileValid } from "@/plugins/image";
+import { insertImagesSafely } from "@/extensions/drop";
 
 export const useUploader = ({
   onUpload,
@@ -63,7 +64,15 @@ export const useUploader = ({
   return { uploading, uploadFile };
 };
 
-export const useDropZone = ({ uploader }: { uploader: (file: File) => void }) => {
+export const useDropZone = ({
+  uploader,
+  editor,
+  pos,
+}: {
+  uploader: (file: File) => Promise<void>;
+  editor: Editor;
+  pos: number;
+}) => {
   const [isDragging, setIsDragging] = useState<boolean>(false);
   const [draggedInside, setDraggedInside] = useState<boolean>(false);
 
@@ -91,33 +100,8 @@ export const useDropZone = ({ uploader }: { uploader: (file: File) => void }) =>
       if (e.dataTransfer.files.length === 0) {
         return;
       }
-
       const fileList = e.dataTransfer.files;
-
-      const files: File[] = [];
-
-      for (let i = 0; i < fileList.length; i += 1) {
-        const item = fileList.item(i);
-        if (item) {
-          files.push(item);
-        }
-      }
-
-      if (files.some((file) => file.type.indexOf("image") === -1)) {
-        return;
-      }
-
-      e.preventDefault();
-
-      const filteredFiles = files.filter((f) => f.type.indexOf("image") !== -1);
-
-      const file = filteredFiles.length > 0 ? filteredFiles[0] : undefined;
-
-      if (file) {
-        uploader(file);
-      } else {
-        console.error("No file found");
-      }
+      uploadFirstImageAndInsertRemaining(editor, fileList, pos, uploader);
     },
     [uploader]
   );
@@ -142,4 +126,42 @@ function trimFileName(fileName: string, maxLength = 100) {
   }
 
   return fileName;
+}
+
+// Upload the first image and insert the remaining images for uploading multiple image
+// post insertion of image-component
+export function uploadFirstImageAndInsertRemaining(
+  editor: Editor,
+  fileList: FileList,
+  pos: number,
+  uploaderFn: (file: File) => Promise<void>
+) {
+  const files: File[] = [];
+  for (let i = 0; i < fileList.length; i += 1) {
+    const item = fileList.item(i);
+    if (item) {
+      files.push(item);
+    }
+  }
+  if (files.some((file) => file.type.indexOf("image") === -1)) {
+    return;
+  }
+  const filteredFiles = files.filter((f) => f.type.indexOf("image") !== -1);
+  if (filteredFiles.length === 0) {
+    console.error("No image files found to upload");
+    return;
+  }
+
+  // Upload the first image
+  const firstFile = filteredFiles[0];
+  uploaderFn(firstFile);
+
+  // Insert the remaining images
+  const remainingFiles = filteredFiles.slice(1);
+
+  if (remainingFiles.length > 0) {
+    const docSize = editor.state.doc.content.size;
+    const posOfNextImageToBeInserted = Math.min(pos + 1, docSize);
+    insertImagesSafely({ editor, files: remainingFiles, initialPos: posOfNextImageToBeInserted, event: "drop" });
+  }
 }

--- a/packages/editor/src/core/hooks/use-file-upload.ts
+++ b/packages/editor/src/core/hooks/use-file-upload.ts
@@ -96,6 +96,7 @@ export const useDropZone = ({
 
   const onDrop = useCallback(
     async (e: DragEvent<HTMLDivElement>) => {
+      e.preventDefault();
       setDraggedInside(false);
       if (e.dataTransfer.files.length === 0) {
         return;
@@ -157,7 +158,7 @@ export async function uploadFirstImageAndInsertRemaining(
 
   // Upload the first image
   const firstFile = filteredFiles[0];
-  await uploaderFn(firstFile);
+  uploaderFn(firstFile);
 
   // Insert the remaining images
   const remainingFiles = filteredFiles.slice(1);

--- a/packages/editor/src/core/hooks/use-read-only-editor.ts
+++ b/packages/editor/src/core/hooks/use-read-only-editor.ts
@@ -70,8 +70,8 @@ export const useReadOnlyEditor = (props: CustomReadOnlyEditorProps) => {
   const editorRef: MutableRefObject<Editor | null> = useRef(null);
 
   useImperativeHandle(forwardedRef, () => ({
-    clearEditor: () => {
-      editorRef.current?.commands.clearContent();
+    clearEditor: (emitUpdate = false) => {
+      editorRef.current?.chain().setMeta("skipImageDeletion", true).clearContent(emitUpdate).run();
     },
     setEditorValue: (content: string) => {
       editorRef.current?.commands.setContent(content, false, { preserveWhitespace: "full" });

--- a/packages/editor/src/core/plugins/image/delete-image.ts
+++ b/packages/editor/src/core/plugins/image/delete-image.ts
@@ -17,6 +17,8 @@ export const TrackImageDeletionPlugin = (editor: Editor, deleteImage: DeleteImag
       });
 
       transactions.forEach((transaction) => {
+        // if the transaction has meta of skipImageDeletion get to true, then return (like while clearing the editor content programatically)
+        if (transaction.getMeta("skipImageDeletion")) return;
         // transaction could be a selection
         if (!transaction.docChanged) return;
 


### PR DESCRIPTION
## Description

1. When you submit a comment with an uploaded image, the image is marked for deletion on submit as we clear the content of the editor (the subsequent calls do restore them, but this is not good). So now while clearing the editor content we set the meta data of "skipImageDeletion" to `true` while clearing the content of our editor via the editor ref APIs.
2. Fixed a bug due to which multiple upload calls were being made for dropped images
3. Fixed a bug causing extra update for issues with an image.
4. Added the ability for users to select multiple images while post insertion of the image-component's uploader.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced the editor's content clearing functionality to optionally skip image deletions.
	- Streamlined image upload process to support multiple file uploads.
	- Introduced a safer image insertion method during paste and drop events.
- **Bug Fixes**
	- Improved control flow for image deletion, allowing specific transactions to bypass deletion when required.
- **Improvements**
	- Refined aspect ratio handling during image loading, enhancing state update efficiency.
	- Updated error handling during attribute updates for better reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->