### PR TITLE
[WEB-2589] Chore: inbox issue permissions

### DIFF
--- a/apiserver/plane/api/views/inbox.py
+++ b/apiserver/plane/api/views/inbox.py
@@ -285,7 +285,7 @@ class InboxIssueAPIEndpoint(BaseAPIView):
                 )
 
         # Only project admins and members can edit inbox issue attributes
-        if project_member.role > 5:
+        if project_member.role > 15:
             serializer = InboxIssueSerializer(
                 inbox_issue, data=request.data, partial=True
             )

--- a/apiserver/plane/app/views/inbox/base.py
+++ b/apiserver/plane/app/views/inbox/base.py
@@ -323,7 +323,7 @@ class InboxIssueViewSet(BaseViewSet):
                 serializer.errors, status=status.HTTP_400_BAD_REQUEST
             )
 
-    @allow_permission([ROLE.ADMIN, ROLE.MEMBER, ROLE.GUEST])
+    @allow_permission(allowed_roles=[ROLE.ADMIN], creator=True, model=Issue)
     def partial_update(self, request, slug, project_id, pk):
         inbox_id = Inbox.objects.filter(
             workspace__slug=slug, project_id=project_id
@@ -418,7 +418,7 @@ class InboxIssueViewSet(BaseViewSet):
                 )
 
         # Only project admins and members can edit inbox issue attributes
-        if project_member.role > 5:
+        if project_member.role > 15:
             serializer = InboxIssueSerializer(
                 inbox_issue, data=request.data, partial=True
             )

--- a/web/core/components/inbox/content/inbox-issue-header.tsx
+++ b/web/core/components/inbox/content/inbox-issue-header.tsx
@@ -205,6 +205,17 @@ export const InboxIssueActionsHeader: FC<TInboxIssueActionsHeader> = observer((p
     [handleInboxIssueNavigation]
   );
 
+  const handleActionWithPermission = (isAdmin: boolean, action: () => void, errorMessage: string) => {
+    if (isAdmin) action();
+    else {
+      setToast({
+        type: TOAST_TYPE.ERROR,
+        title: "Permission denied",
+        message: errorMessage,
+      });
+    }
+  };
+
   useEffect(() => {
     if (!isNotificationEmbed) document.addEventListener("keydown", onKeyDown);
     return () => {
@@ -300,13 +311,11 @@ export const InboxIssueActionsHeader: FC<TInboxIssueActionsHeader> = observer((p
                   prependIcon={<CircleCheck className="w-3 h-3" />}
                   className="text-green-500 border-0.5 border-green-500 bg-green-500/20 focus:bg-green-500/20 focus:text-green-500 hover:bg-green-500/40 bg-opacity-20"
                   onClick={() =>
-                    isProjectAdmin
-                      ? setAcceptIssueModal(true)
-                      : setToast({
-                          type: TOAST_TYPE.ERROR,
-                          title: "Permission denied",
-                          message: "Only project admins can accept issues",
-                        })
+                    handleActionWithPermission(
+                      isProjectAdmin,
+                      () => setAcceptIssueModal(true),
+                      "Only project admins can accept issues"
+                    )
                   }
                 >
                   Accept
@@ -322,13 +331,11 @@ export const InboxIssueActionsHeader: FC<TInboxIssueActionsHeader> = observer((p
                   prependIcon={<CircleX className="w-3 h-3" />}
                   className="text-red-500 border-0.5 border-red-500 bg-red-500/20 focus:bg-red-500/20 focus:text-red-500 hover:bg-red-500/40 bg-opacity-20"
                   onClick={() =>
-                    isProjectAdmin
-                      ? setDeclineIssueModal(true)
-                      : setToast({
-                          type: TOAST_TYPE.ERROR,
-                          title: "Permission denied",
-                          message: "Only project admins can deny issues",
-                        })
+                    handleActionWithPermission(
+                      isProjectAdmin,
+                      () => setDeclineIssueModal(true),
+                      "Only project admins can deny issues"
+                    )
                   }
                 >
                   Decline
@@ -365,13 +372,11 @@ export const InboxIssueActionsHeader: FC<TInboxIssueActionsHeader> = observer((p
                     {canMarkAsAccepted && (
                       <CustomMenu.MenuItem
                         onClick={() =>
-                          isProjectAdmin
-                            ? handleIssueSnoozeAction()
-                            : setToast({
-                                type: TOAST_TYPE.ERROR,
-                                title: "Permission denied",
-                                message: "Only project admins can snooze/Un-snooze issues",
-                              })
+                          handleActionWithPermission(
+                            isProjectAdmin,
+                            handleIssueSnoozeAction,
+                            "Only project admins can snooze/Un-snooze issues"
+                          )
                         }
                       >
                         <div className="flex items-center gap-2">
@@ -385,13 +390,11 @@ export const InboxIssueActionsHeader: FC<TInboxIssueActionsHeader> = observer((p
                     {canMarkAsDuplicate && (
                       <CustomMenu.MenuItem
                         onClick={() =>
-                          isProjectAdmin
-                            ? setSelectDuplicateIssue(true)
-                            : setToast({
-                                type: TOAST_TYPE.ERROR,
-                                title: "Permission denied",
-                                message: "Only project admins can mark issues as duplicate",
-                              })
+                          handleActionWithPermission(
+                            isProjectAdmin,
+                            () => setSelectDuplicateIssue(true),
+                            "Only project admins can mark issues as duplicate"
+                          )
                         }
                       >
                         <div className="flex items-center gap-2">
@@ -444,6 +447,7 @@ export const InboxIssueActionsHeader: FC<TInboxIssueActionsHeader> = observer((p
           isNotificationEmbed={isNotificationEmbed}
           embedRemoveCurrentNotification={embedRemoveCurrentNotification}
           isProjectAdmin={isProjectAdmin}
+          handleActionWithPermission={handleActionWithPermission}
         />
       </div>
     </>

--- a/web/core/components/inbox/content/inbox-issue-header.tsx
+++ b/web/core/components/inbox/content/inbox-issue-header.tsx
@@ -89,6 +89,12 @@ export const InboxIssueActionsHeader: FC<TInboxIssueActionsHeader> = observer((p
   const canDelete =
     allowPermissions([EUserPermissions.ADMIN], EUserPermissionsLevel.PROJECT, workspaceSlug, projectId) ||
     issue?.created_by === currentUser?.id;
+  const isProjectAdmin = allowPermissions(
+    [EUserPermissions.ADMIN],
+    EUserPermissionsLevel.PROJECT,
+    workspaceSlug,
+    projectId
+  );
   const isAcceptedOrDeclined = inboxIssue?.status ? [-1, 1, 2].includes(inboxIssue.status) : undefined;
   // days left for snooze
   const numberOfDaysLeft = findHowManyDaysLeft(inboxIssue?.snoozed_till);
@@ -293,7 +299,15 @@ export const InboxIssueActionsHeader: FC<TInboxIssueActionsHeader> = observer((p
                   size="sm"
                   prependIcon={<CircleCheck className="w-3 h-3" />}
                   className="text-green-500 border-0.5 border-green-500 bg-green-500/20 focus:bg-green-500/20 focus:text-green-500 hover:bg-green-500/40 bg-opacity-20"
-                  onClick={() => setAcceptIssueModal(true)}
+                  onClick={() =>
+                    isProjectAdmin
+                      ? setAcceptIssueModal(true)
+                      : setToast({
+                          type: TOAST_TYPE.ERROR,
+                          title: "Permission denied",
+                          message: "Only project admins can accept issues",
+                        })
+                  }
                 >
                   Accept
                 </Button>
@@ -307,7 +321,15 @@ export const InboxIssueActionsHeader: FC<TInboxIssueActionsHeader> = observer((p
                   size="sm"
                   prependIcon={<CircleX className="w-3 h-3" />}
                   className="text-red-500 border-0.5 border-red-500 bg-red-500/20 focus:bg-red-500/20 focus:text-red-500 hover:bg-red-500/40 bg-opacity-20"
-                  onClick={() => setDeclineIssueModal(true)}
+                  onClick={() =>
+                    isProjectAdmin
+                      ? setDeclineIssueModal(true)
+                      : setToast({
+                          type: TOAST_TYPE.ERROR,
+                          title: "Permission denied",
+                          message: "Only project admins can deny issues",
+                        })
+                  }
                 >
                   Decline
                 </Button>
@@ -341,7 +363,17 @@ export const InboxIssueActionsHeader: FC<TInboxIssueActionsHeader> = observer((p
                 {isAllowed && (
                   <CustomMenu verticalEllipsis placement="bottom-start">
                     {canMarkAsAccepted && (
-                      <CustomMenu.MenuItem onClick={handleIssueSnoozeAction}>
+                      <CustomMenu.MenuItem
+                        onClick={() =>
+                          isProjectAdmin
+                            ? handleIssueSnoozeAction()
+                            : setToast({
+                                type: TOAST_TYPE.ERROR,
+                                title: "Permission denied",
+                                message: "Only project admins can snooze/Un-snooze issues",
+                              })
+                        }
+                      >
                         <div className="flex items-center gap-2">
                           <Clock size={14} strokeWidth={2} />
                           {inboxIssue?.snoozed_till && numberOfDaysLeft && numberOfDaysLeft > 0
@@ -351,7 +383,17 @@ export const InboxIssueActionsHeader: FC<TInboxIssueActionsHeader> = observer((p
                       </CustomMenu.MenuItem>
                     )}
                     {canMarkAsDuplicate && (
-                      <CustomMenu.MenuItem onClick={() => setSelectDuplicateIssue(true)}>
+                      <CustomMenu.MenuItem
+                        onClick={() =>
+                          isProjectAdmin
+                            ? setSelectDuplicateIssue(true)
+                            : setToast({
+                                type: TOAST_TYPE.ERROR,
+                                title: "Permission denied",
+                                message: "Only project admins can mark issues as duplicate",
+                              })
+                        }
+                      >
                         <div className="flex items-center gap-2">
                           <FileStack size={14} strokeWidth={2} />
                           Mark as duplicate
@@ -401,6 +443,7 @@ export const InboxIssueActionsHeader: FC<TInboxIssueActionsHeader> = observer((p
           setIsMobileSidebar={setIsMobileSidebar}
           isNotificationEmbed={isNotificationEmbed}
           embedRemoveCurrentNotification={embedRemoveCurrentNotification}
+          isProjectAdmin={isProjectAdmin}
         />
       </div>
     </>

--- a/web/core/components/inbox/content/inbox-issue-mobile-header.tsx
+++ b/web/core/components/inbox/content/inbox-issue-mobile-header.tsx
@@ -48,6 +48,7 @@ type Props = {
   isNotificationEmbed: boolean;
   embedRemoveCurrentNotification?: () => void;
   isProjectAdmin: boolean;
+  handleActionWithPermission: (isAdmin: boolean, action: () => void, errorMessage: string) => void;
 };
 
 export const InboxIssueActionsMobileHeader: React.FC<Props> = observer((props) => {
@@ -72,6 +73,7 @@ export const InboxIssueActionsMobileHeader: React.FC<Props> = observer((props) =
     isNotificationEmbed,
     embedRemoveCurrentNotification,
     isProjectAdmin,
+    handleActionWithPermission,
   } = props;
   const router = useAppRouter();
   const issue = inboxIssue?.issue;
@@ -143,13 +145,11 @@ export const InboxIssueActionsMobileHeader: React.FC<Props> = observer((props) =
             {canMarkAsAccepted && !isAcceptedOrDeclined && (
               <CustomMenu.MenuItem
                 onClick={() =>
-                  isProjectAdmin
-                    ? handleIssueSnoozeAction()
-                    : setToast({
-                        type: TOAST_TYPE.ERROR,
-                        title: "Permission denied",
-                        message: "Only project admins can snooze/Un-snooze issues",
-                      })
+                  handleActionWithPermission(
+                    isProjectAdmin,
+                    handleIssueSnoozeAction,
+                    "Only project admins can snooze/Un-snooze issues"
+                  )
                 }
               >
                 <div className="flex items-center gap-2">
@@ -161,13 +161,11 @@ export const InboxIssueActionsMobileHeader: React.FC<Props> = observer((props) =
             {canMarkAsDuplicate && !isAcceptedOrDeclined && (
               <CustomMenu.MenuItem
                 onClick={() =>
-                  isProjectAdmin
-                    ? setSelectDuplicateIssue(true)
-                    : setToast({
-                        type: TOAST_TYPE.ERROR,
-                        title: "Permission denied",
-                        message: "Only project admins can mark issues as duplicate",
-                      })
+                  handleActionWithPermission(
+                    isProjectAdmin,
+                    () => setSelectDuplicateIssue(true),
+                    "Only project admins can mark issues as duplicate"
+                  )
                 }
               >
                 <div className="flex items-center gap-2">
@@ -179,13 +177,11 @@ export const InboxIssueActionsMobileHeader: React.FC<Props> = observer((props) =
             {canMarkAsAccepted && (
               <CustomMenu.MenuItem
                 onClick={() =>
-                  isProjectAdmin
-                    ? setAcceptIssueModal(true)
-                    : setToast({
-                        type: TOAST_TYPE.ERROR,
-                        title: "Permission denied",
-                        message: "Only project admins can accept issues",
-                      })
+                  handleActionWithPermission(
+                    isProjectAdmin,
+                    () => setAcceptIssueModal(true),
+                    "Only project admins can accept issues"
+                  )
                 }
               >
                 <div className="flex items-center gap-2 text-green-500">
@@ -197,13 +193,11 @@ export const InboxIssueActionsMobileHeader: React.FC<Props> = observer((props) =
             {canMarkAsDeclined && (
               <CustomMenu.MenuItem
                 onClick={() =>
-                  isProjectAdmin
-                    ? setDeclineIssueModal(true)
-                    : setToast({
-                        type: TOAST_TYPE.ERROR,
-                        title: "Permission denied",
-                        message: "Only project admins can deny issues",
-                      })
+                  handleActionWithPermission(
+                    isProjectAdmin,
+                    () => setDeclineIssueModal(true),
+                    "Only project admins can deny issues"
+                  )
                 }
               >
                 <div className="flex items-center gap-2 text-red-500">

--- a/web/core/components/inbox/content/inbox-issue-mobile-header.tsx
+++ b/web/core/components/inbox/content/inbox-issue-mobile-header.tsx
@@ -15,7 +15,7 @@ import {
   PanelLeft,
   MoveRight,
 } from "lucide-react";
-import { Header, CustomMenu, EHeaderVariant } from "@plane/ui";
+import { Header, CustomMenu, EHeaderVariant, TOAST_TYPE, setToast } from "@plane/ui";
 // components
 import { InboxIssueStatus } from "@/components/inbox";
 import { IssueUpdateStatus } from "@/components/issues";
@@ -47,6 +47,7 @@ type Props = {
   setIsMobileSidebar: (value: boolean) => void;
   isNotificationEmbed: boolean;
   embedRemoveCurrentNotification?: () => void;
+  isProjectAdmin: boolean;
 };
 
 export const InboxIssueActionsMobileHeader: React.FC<Props> = observer((props) => {
@@ -70,6 +71,7 @@ export const InboxIssueActionsMobileHeader: React.FC<Props> = observer((props) =
     setIsMobileSidebar,
     isNotificationEmbed,
     embedRemoveCurrentNotification,
+    isProjectAdmin,
   } = props;
   const router = useAppRouter();
   const issue = inboxIssue?.issue;
@@ -139,7 +141,17 @@ export const InboxIssueActionsMobileHeader: React.FC<Props> = observer((props) =
               </CustomMenu.MenuItem>
             )}
             {canMarkAsAccepted && !isAcceptedOrDeclined && (
-              <CustomMenu.MenuItem onClick={handleIssueSnoozeAction}>
+              <CustomMenu.MenuItem
+                onClick={() =>
+                  isProjectAdmin
+                    ? handleIssueSnoozeAction()
+                    : setToast({
+                        type: TOAST_TYPE.ERROR,
+                        title: "Permission denied",
+                        message: "Only project admins can snooze/Un-snooze issues",
+                      })
+                }
+              >
                 <div className="flex items-center gap-2">
                   <Clock size={14} strokeWidth={2} />
                   {inboxIssue?.snoozed_till && numberOfDaysLeft && numberOfDaysLeft > 0 ? "Un-snooze" : "Snooze"}
@@ -147,7 +159,17 @@ export const InboxIssueActionsMobileHeader: React.FC<Props> = observer((props) =
               </CustomMenu.MenuItem>
             )}
             {canMarkAsDuplicate && !isAcceptedOrDeclined && (
-              <CustomMenu.MenuItem onClick={() => setSelectDuplicateIssue(true)}>
+              <CustomMenu.MenuItem
+                onClick={() =>
+                  isProjectAdmin
+                    ? setSelectDuplicateIssue(true)
+                    : setToast({
+                        type: TOAST_TYPE.ERROR,
+                        title: "Permission denied",
+                        message: "Only project admins can mark issues as duplicate",
+                      })
+                }
+              >
                 <div className="flex items-center gap-2">
                   <FileStack size={14} strokeWidth={2} />
                   Mark as duplicate
@@ -155,7 +177,17 @@ export const InboxIssueActionsMobileHeader: React.FC<Props> = observer((props) =
               </CustomMenu.MenuItem>
             )}
             {canMarkAsAccepted && (
-              <CustomMenu.MenuItem onClick={() => setAcceptIssueModal(true)}>
+              <CustomMenu.MenuItem
+                onClick={() =>
+                  isProjectAdmin
+                    ? setAcceptIssueModal(true)
+                    : setToast({
+                        type: TOAST_TYPE.ERROR,
+                        title: "Permission denied",
+                        message: "Only project admins can accept issues",
+                      })
+                }
+              >
                 <div className="flex items-center gap-2 text-green-500">
                   <CircleCheck size={14} strokeWidth={2} />
                   Accept
@@ -163,7 +195,17 @@ export const InboxIssueActionsMobileHeader: React.FC<Props> = observer((props) =
               </CustomMenu.MenuItem>
             )}
             {canMarkAsDeclined && (
-              <CustomMenu.MenuItem onClick={() => setDeclineIssueModal(true)}>
+              <CustomMenu.MenuItem
+                onClick={() =>
+                  isProjectAdmin
+                    ? setDeclineIssueModal(true)
+                    : setToast({
+                        type: TOAST_TYPE.ERROR,
+                        title: "Permission denied",
+                        message: "Only project admins can deny issues",
+                      })
+                }
+              >
                 <div className="flex items-center gap-2 text-red-500">
                   <CircleX size={14} strokeWidth={2} />
                   Decline

--- a/web/core/components/inbox/content/inbox-issue-mobile-header.tsx
+++ b/web/core/components/inbox/content/inbox-issue-mobile-header.tsx
@@ -15,7 +15,7 @@ import {
   PanelLeft,
   MoveRight,
 } from "lucide-react";
-import { Header, CustomMenu, EHeaderVariant, TOAST_TYPE, setToast } from "@plane/ui";
+import { Header, CustomMenu, EHeaderVariant } from "@plane/ui";
 // components
 import { InboxIssueStatus } from "@/components/inbox";
 import { IssueUpdateStatus } from "@/components/issues";

--- a/web/core/components/inbox/content/root.tsx
+++ b/web/core/components/inbox/content/root.tsx
@@ -62,10 +62,10 @@ export const InboxContentRoot: FC<TInboxContentRoot> = observer((props) => {
     }
   );
 
-  const isEditable = allowPermissions(
-    [EUserPermissions.ADMIN, EUserPermissions.MEMBER, EUserPermissions.GUEST],
-    EUserPermissionsLevel.PROJECT
-  );
+  const isEditable =
+    allowPermissions([EUserPermissions.ADMIN], EUserPermissionsLevel.PROJECT) ||
+    inboxIssue.created_by === currentUser?.id;
+
   const isGuest = projectPermissionsByWorkspaceSlugAndProjectId(workspaceSlug, projectId) === EUserPermissions.GUEST;
   const isOwner = inboxIssue?.issue.created_by === currentUser?.id;
   const readOnly = !isOwner && isGuest;

--- a/web/core/store/inbox/project-inbox.store.ts
+++ b/web/core/store/inbox/project-inbox.store.ts
@@ -423,7 +423,7 @@ export class ProjectInboxStore implements IProjectInboxStore {
 
       if (inboxIssue && issueId) {
         runInAction(() => {
-          set(this.inboxIssues, [issueId], new InboxIssueStore(workspaceSlug, projectId, inboxIssue, this.store));
+          this.createOrUpdateInboxIssue([inboxIssue], workspaceSlug, projectId);
           set(this, "loader", undefined);
         });
         await Promise.all([


### PR DESCRIPTION
**Summary**

- Only admin will be able to edit intake issue other that he intake issue creator
- Only admin will be able to accept, deny, snooze , mark duplicate for an intake issue

[[WEB-2589]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/7e5c4a1c-4c11-45c6-82ff-ea4f9af74d99)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced permission handling for inbox issue actions, restricting certain functionalities to project admins only.
	- Added toast notifications for users attempting actions without the necessary permissions.

- **Bug Fixes**
	- Improved error handling and standardized messages for permission-related actions.

- **Refactor**
	- Streamlined logic for creating and updating inbox issues to improve maintainability.
	- Updated permission logic for editing inbox issues, requiring higher role thresholds for certain actions.

These updates ensure a more secure and user-friendly experience when managing inbox issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->