### PR TITLE
[WEB-2555] fix: add "mark all as read" in the notifications header

### DIFF
--- a/web/core/components/workspace-notifications/sidebar/header/options/menu-option/root.tsx
+++ b/web/core/components/workspace-notifications/sidebar/header/options/menu-option/root.tsx
@@ -2,19 +2,17 @@
 
 import { FC, ReactNode } from "react";
 import { observer } from "mobx-react";
-import { Check, CheckCheck, CheckCircle, Clock } from "lucide-react";
+import { Check, CheckCircle, Clock } from "lucide-react";
 import { TNotificationFilter } from "@plane/types";
-import { ArchiveIcon, PopoverMenu, Spinner } from "@plane/ui";
+import { ArchiveIcon, PopoverMenu } from "@plane/ui";
 // components
 import { NotificationMenuOptionItem } from "@/components/workspace-notifications";
 // constants
-import { NOTIFICATIONS_READ } from "@/constants/event-tracker";
-import { ENotificationLoader } from "@/constants/notification";
 // hooks
-import { useEventTracker, useWorkspaceNotifications } from "@/hooks/store";
+import { useWorkspaceNotifications } from "@/hooks/store";
 
 type TNotificationHeaderMenuOption = {
-  workspaceSlug: string;
+  workspaceSlug?: string;
 };
 
 export type TPopoverMenuOptions = {
@@ -27,44 +25,16 @@ export type TPopoverMenuOptions = {
   onClick?: (() => void) | undefined;
 };
 
-export const NotificationHeaderMenuOption: FC<TNotificationHeaderMenuOption> = observer((props) => {
-  const { workspaceSlug } = props;
+export const NotificationHeaderMenuOption: FC<TNotificationHeaderMenuOption> = observer(() => {
   // hooks
-  const { captureEvent } = useEventTracker();
-  const { loader, filters, updateFilters, updateBulkFilters, markAllNotificationsAsRead } = useWorkspaceNotifications();
+  const { filters, updateFilters, updateBulkFilters } = useWorkspaceNotifications();
 
   const handleFilterChange = (filterType: keyof TNotificationFilter, filterValue: boolean) =>
     updateFilters(filterType, filterValue);
 
   const handleBulkFilterChange = (filter: Partial<TNotificationFilter>) => updateBulkFilters(filter);
 
-  const handleMarkAllNotificationsAsRead = async () => {
-    // NOTE: We are using loader to prevent continues request when we are making all the notification to read
-    if (loader) return;
-    try {
-      await markAllNotificationsAsRead(workspaceSlug);
-    } catch (error) {
-      console.error(error);
-    }
-  };
-
   const popoverMenuOptions: TPopoverMenuOptions[] = [
-    {
-      key: "menu-mark-all-read",
-      type: "menu-item",
-      label: "Mark all as read",
-      isActive: true,
-      prependIcon: <CheckCheck className="h-3 w-3" />,
-      appendIcon: loader === ENotificationLoader.MARK_ALL_AS_READY ? <Spinner height="14px" width="14px" /> : undefined,
-      onClick: () => {
-        captureEvent(NOTIFICATIONS_READ);
-        handleMarkAllNotificationsAsRead();
-      },
-    },
-    {
-      key: "menu-divider",
-      type: "divider",
-    },
     {
       key: "menu-unread",
       type: "menu-item",

--- a/web/core/components/workspace-notifications/sidebar/header/options/menu-option/root.tsx
+++ b/web/core/components/workspace-notifications/sidebar/header/options/menu-option/root.tsx
@@ -11,10 +11,6 @@ import { NotificationMenuOptionItem } from "@/components/workspace-notifications
 // hooks
 import { useWorkspaceNotifications } from "@/hooks/store";
 
-type TNotificationHeaderMenuOption = {
-  workspaceSlug?: string;
-};
-
 export type TPopoverMenuOptions = {
   key: string;
   type: string;
@@ -25,7 +21,7 @@ export type TPopoverMenuOptions = {
   onClick?: (() => void) | undefined;
 };
 
-export const NotificationHeaderMenuOption: FC<TNotificationHeaderMenuOption> = observer(() => {
+export const NotificationHeaderMenuOption = observer(() => {
   // hooks
   const { filters, updateFilters, updateBulkFilters } = useWorkspaceNotifications();
 

--- a/web/core/components/workspace-notifications/sidebar/header/options/root.tsx
+++ b/web/core/components/workspace-notifications/sidebar/header/options/root.tsx
@@ -1,13 +1,14 @@
 import { FC } from "react";
 import { observer } from "mobx-react";
-import { RefreshCw } from "lucide-react";
-import { Tooltip } from "@plane/ui";
+import { CheckCheck, RefreshCw } from "lucide-react";
+import { Spinner, Tooltip } from "@plane/ui";
 // components
 import { NotificationFilter, NotificationHeaderMenuOption } from "@/components/workspace-notifications";
 // constants
+import { NOTIFICATIONS_READ } from "@/constants/event-tracker";
 import { ENotificationLoader, ENotificationQueryParamType } from "@/constants/notification";
 // hooks
-import { useWorkspaceNotifications } from "@/hooks/store";
+import { useEventTracker, useWorkspaceNotifications } from "@/hooks/store";
 import { usePlatformOS } from "@/hooks/use-platform-os";
 
 type TNotificationSidebarHeaderOptions = {
@@ -19,6 +20,8 @@ export const NotificationSidebarHeaderOptions: FC<TNotificationSidebarHeaderOpti
   // hooks
   const { isMobile } = usePlatformOS();
   const { loader, getNotifications } = useWorkspaceNotifications();
+  const { captureEvent } = useEventTracker();
+  const { markAllNotificationsAsRead } = useWorkspaceNotifications();
 
   const refreshNotifications = async () => {
     if (loader) return;
@@ -29,8 +32,35 @@ export const NotificationSidebarHeaderOptions: FC<TNotificationSidebarHeaderOpti
     }
   };
 
+  const handleMarkAllNotificationsAsRead = async () => {
+    // NOTE: We are using loader to prevent continues request when we are making all the notification to read
+    if (loader) return;
+    try {
+      await markAllNotificationsAsRead(workspaceSlug);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
   return (
     <div className="relative flex justify-center items-center gap-2 text-sm">
+      {/* mark all notifications as read*/}
+      <Tooltip tooltipContent="Mark all as read" isMobile={isMobile} position="bottom">
+        <div
+          className="flex-shrink-0 w-5 h-5 flex justify-center items-center overflow-hidden cursor-pointer transition-all hover:bg-custom-background-80 rounded-sm"
+          onClick={() => {
+            captureEvent(NOTIFICATIONS_READ);
+            handleMarkAllNotificationsAsRead();
+          }}
+        >
+          {loader === ENotificationLoader.MARK_ALL_AS_READY ? (
+            <Spinner height="14px" width="14px" />
+          ) : (
+            <CheckCheck className="h-3 w-3" />
+          )}
+        </div>
+      </Tooltip>
+
       {/* refetch current notifications */}
       <Tooltip tooltipContent="Refresh" isMobile={isMobile} position="bottom">
         <div
@@ -45,7 +75,7 @@ export const NotificationSidebarHeaderOptions: FC<TNotificationSidebarHeaderOpti
       <NotificationFilter />
 
       {/* notification menu options */}
-      <NotificationHeaderMenuOption workspaceSlug={workspaceSlug} />
+      <NotificationHeaderMenuOption />
     </div>
   );
 });

--- a/web/core/components/workspace-notifications/sidebar/header/options/root.tsx
+++ b/web/core/components/workspace-notifications/sidebar/header/options/root.tsx
@@ -19,9 +19,8 @@ export const NotificationSidebarHeaderOptions: FC<TNotificationSidebarHeaderOpti
   const { workspaceSlug } = props;
   // hooks
   const { isMobile } = usePlatformOS();
-  const { loader, getNotifications } = useWorkspaceNotifications();
+  const { loader, getNotifications, markAllNotificationsAsRead } = useWorkspaceNotifications();
   const { captureEvent } = useEventTracker();
-  const { markAllNotificationsAsRead } = useWorkspaceNotifications();
 
   const refreshNotifications = async () => {
     if (loader) return;


### PR DESCRIPTION
## [[WEB-2555]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/395d13e3-4e73-4171-aa8d-aa264fca359e/)

This PR aims to relocate the "Mark all as read" button from the dropdown to the header in the notifications header. 

### Previous State:

https://github.com/user-attachments/assets/cbb64dde-b543-4465-ad1c-087273453db0

### New State:
Note: The below video is recorded on 3G speed using dev-tools

https://github.com/user-attachments/assets/79374ca0-4cfa-41d8-afcd-cd01952bff1b



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Users can now mark all notifications as read with a new tooltip and loading indicator.
	- The notification sidebar has been enhanced for better usability while maintaining existing refresh functionality.

- **Bug Fixes**
	- Removed unused event tracking functionality, streamlining the notification menu options.

- **Refactor**
	- Simplified the props structure for the notification components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->