### PR TITLE
[WEB-2609] fix: inconsistent background colour of hamburger menu in inbox

### DIFF
--- a/web/core/components/workspace-notifications/sidebar/header/options/menu-option/root.tsx
+++ b/web/core/components/workspace-notifications/sidebar/header/options/menu-option/root.tsx
@@ -71,7 +71,7 @@ export const NotificationHeaderMenuOption = observer(() => {
   return (
     <PopoverMenu
       data={popoverMenuOptions}
-      buttonClassName="flex-shrink-0 w-5 h-5 flex justify-center items-center overflow-hidden cursor-pointer transition-all hover:bg-custom-background-80 rounded-sm outline-none"
+      buttonClassName="flex-shrink-0 w-5 h-5 flex justify-center items-center overflow-hidden cursor-pointer transition-all hover:bg-custom-background-80 bg-custom-background-100 rounded-sm outline-none"
       keyExtractor={(item: TPopoverMenuOptions) => item.key}
       panelClassName="p-0 py-2 rounded-md border border-custom-border-200 bg-custom-background-100 space-y-1"
       render={(item: TPopoverMenuOptions) => <NotificationMenuOptionItem {...item} />}


### PR DESCRIPTION
## [[WEB-2609]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/5ee326a7-83e4-4501-9051-25edfe4404fb/)

### Previous State: 
<img width="425" alt="Screenshot 2024-10-10 at 3 57 17 PM" src="https://github.com/user-attachments/assets/69a7650e-adbc-4592-8669-9b7f1ab86372">

### Current State: 
<img width="474" alt="Screenshot 2024-10-10 at 3 59 47 PM" src="https://github.com/user-attachments/assets/d9747fbc-e57e-4c38-8b73-4e1a008e54ec">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated the visual styling of the notification header menu option, changing the button's default background color for improved visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->