### PR TITLE
[WEB-2488] fix: only the owner of a view can publish their project views

### DIFF
--- a/web/core/components/views/quick-actions.tsx
+++ b/web/core/components/views/quick-actions.tsx
@@ -34,6 +34,10 @@ export const ViewQuickActions: React.FC<Props> = observer((props) => {
   const { allowPermissions } = useUserPermissions();
   // auth
   const isOwner = view?.owned_by === data?.id;
+  const canPublishView = allowPermissions(
+    [EUserPermissions.ADMIN, EUserPermissions.MEMBER],
+    EUserPermissionsLevel.PROJECT
+  );
   const isAdmin = allowPermissions([EUserPermissions.ADMIN], EUserPermissionsLevel.PROJECT, workspaceSlug, projectId);
 
   const { isPublishModalOpen, setPublishModalOpen, publishContextMenu } = useViewPublish(
@@ -98,6 +102,7 @@ export const ViewQuickActions: React.FC<Props> = observer((props) => {
       <CustomMenu ellipsis placement="bottom-end" closeOnSelect>
         {MENU_ITEMS.map((item) => {
           if (item.shouldRender === false) return null;
+          if (item.key === "publish" && !canPublishView) return null;
           return (
             <CustomMenu.MenuItem
               key={item.key}

--- a/web/core/components/views/quick-actions.tsx
+++ b/web/core/components/views/quick-actions.tsx
@@ -40,10 +40,7 @@ export const ViewQuickActions: React.FC<Props> = observer((props) => {
   );
   const isAdmin = allowPermissions([EUserPermissions.ADMIN], EUserPermissionsLevel.PROJECT, workspaceSlug, projectId);
 
-  const { isPublishModalOpen, setPublishModalOpen, publishContextMenu } = useViewPublish(
-    !!view.anchor,
-    isOwner
-  );
+  const { isPublishModalOpen, setPublishModalOpen, publishContextMenu } = useViewPublish(!!view.anchor, isOwner);
 
   const viewLink = `${workspaceSlug}/projects/${projectId}/views/${view.id}`;
   const handleCopyText = () =>

--- a/web/core/components/views/quick-actions.tsx
+++ b/web/core/components/views/quick-actions.tsx
@@ -38,7 +38,7 @@ export const ViewQuickActions: React.FC<Props> = observer((props) => {
 
   const { isPublishModalOpen, setPublishModalOpen, publishContextMenu } = useViewPublish(
     !!view.anchor,
-    isAdmin || isOwner
+    isOwner
   );
 
   const viewLink = `${workspaceSlug}/projects/${projectId}/views/${view.id}`;


### PR DESCRIPTION
## [[WEB-2488]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/8cefd146-dd41-4a40-818a-223f7a303e07/)

This PR changes the permission level of Project Views: Only the owner of a Project View can publish the view.

### For Admin:

https://github.com/user-attachments/assets/7022a1be-1e10-4e26-a460-cb01e3577213

### For Member:


https://github.com/user-attachments/assets/552bcbde-16d2-4c17-89f4-99db5236b77d






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated user permissions for the publish modal, now allowing only owners to open it.
	- Introduced a new check for publishing views based on user roles.

- **Bug Fixes**
	- Improved control flow related to user permissions for enhanced security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->