### PR TITLE
[WEB-2606] fix: project members shouldn't be able to change others roles

### DIFF
--- a/web/core/components/project/settings/member-columns.tsx
+++ b/web/core/components/project/settings/member-columns.tsx
@@ -90,7 +90,7 @@ export const AccountTypeColumn: React.FC<AccountTypeProps> = observer((props) =>
   } = useForm();
   // store hooks
   const {
-    project: { updateMember },
+    project: { updateMember, getProjectMemberDetails },
     workspace: { getWorkspaceMemberDetails },
   } = useMember();
   const { data: currentUser } = useUser();
@@ -101,7 +101,9 @@ export const AccountTypeColumn: React.FC<AccountTypeProps> = observer((props) =>
   const isWorkspaceMember = [EUserPermissions.MEMBER].includes(
     Number(getWorkspaceMemberDetails(rowData.member.id)?.role) ?? EUserPermissions.GUEST
   );
-  const isRoleNonEditable = isCurrentUser || (isProjectAdminOrGuest && !isWorkspaceMember);
+  const isCurrentUserProjectMember = getProjectMemberDetails(currentUser?.id ?? "")?.role == EUserPermissions.MEMBER;
+  const isRoleNonEditable =
+    isCurrentUser || (isProjectAdminOrGuest && !isWorkspaceMember) || isCurrentUserProjectMember;
 
   const checkCurrentOptionWorkspaceRole = (value: string) => {
     const currentMemberWorkspaceRole = getWorkspaceMemberDetails(value)?.role as EUserPermissions | undefined;

--- a/web/core/components/project/settings/member-columns.tsx
+++ b/web/core/components/project/settings/member-columns.tsx
@@ -101,7 +101,9 @@ export const AccountTypeColumn: React.FC<AccountTypeProps> = observer((props) =>
   const isWorkspaceMember = [EUserPermissions.MEMBER].includes(
     Number(getWorkspaceMemberDetails(rowData.member.id)?.role) ?? EUserPermissions.GUEST
   );
-  const isCurrentUserProjectMember = getProjectMemberDetails(currentUser?.id ?? "")?.role == EUserPermissions.MEMBER;
+  const isCurrentUserProjectMember = currentUser
+    ? getProjectMemberDetails(currentUser.id)?.role === EUserPermissions.MEMBER
+    : false;
   const isRoleNonEditable =
     isCurrentUser || (isProjectAdminOrGuest && !isWorkspaceMember) || isCurrentUserProjectMember;
 


### PR DESCRIPTION
## [[WEB-2606]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/79a49da0-e6d8-478b-a9a2-13a608db5f25/)

This PR aims to fix the bug where a Project Member is able to edit the details in the frontend of other Project Members in the Project Settings

### Previous State: 

https://github.com/user-attachments/assets/ec51ae2e-75ec-4b6e-aaea-2ff5784c354e

### Current State: 
No Dropdown appears on other Project Members name.

<img width="944" alt="Screenshot 2024-10-09 at 4 19 28 PM" src="https://github.com/user-attachments/assets/6a2d1595-354e-42ec-9f28-8cd7005f2a8d">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced role management for project members, allowing for more nuanced control over role editability based on user membership status.
	- Introduced a method to retrieve specific project member details.

- **Bug Fixes**
	- Improved logic for determining non-editable roles based on current user membership in the project.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->