### PR TITLE
[WEB-2613] chore: open parent and sibling issue in new tab from peek-overview/ issue detail page.

### DIFF
--- a/web/core/components/issues/issue-detail/parent/root.tsx
+++ b/web/core/components/issues/issue-detail/parent/root.tsx
@@ -42,7 +42,7 @@ export const IssueParentDetail: FC<TIssueParentDetail> = observer((props) => {
   return (
     <>
       <div className="mb-5 flex w-min items-center gap-3 whitespace-nowrap rounded-md border border-custom-border-300 bg-custom-background-80 px-2.5 py-1 text-xs">
-        <Link href={`/${workspaceSlug}/projects/${parentIssue?.project_id}/issues/${parentIssue.id}`}>
+        <Link href={`/${workspaceSlug}/projects/${parentIssue?.project_id}/issues/${parentIssue.id}`} target="_blank">
           <div className="flex items-center gap-2">
             <div className="flex items-center gap-2.5">
               <span className="block h-2 w-2 rounded-full" style={{ backgroundColor: stateColor }} />

--- a/web/core/components/issues/issue-detail/parent/sibling-item.tsx
+++ b/web/core/components/issues/issue-detail/parent/sibling-item.tsx
@@ -33,6 +33,7 @@ export const IssueParentSiblingItem: FC<TIssueParentSiblingItem> = observer((pro
       <CustomMenu.MenuItem key={issueDetail.id}>
         <Link
           href={`/${workspaceSlug}/projects/${issueDetail?.project_id as string}/issues/${issueDetail.id}`}
+          target="_blank"
           className="flex items-center gap-2 py-0.5"
         >
           {issueDetail.project_id && projectDetails?.identifier && (


### PR DESCRIPTION
#### Issue link: [WEB-2613](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/cc96ab95-45e0-4439-bdf8-9f5e5a365267)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Links in the Issue Parent Detail and Sibling Item components now open in a new tab for improved navigation.
  
- **Bug Fixes**
	- No bug fixes were included in this release. 

- **Documentation**
	- No documentation updates were made in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->