### PR TITLE
[WEB-2616] fix: issue widget attachment

### DIFF
--- a/web/core/components/issues/issue-detail-widgets/attachments/quick-action-button.tsx
+++ b/web/core/components/issues/issue-detail-widgets/attachments/quick-action-button.tsx
@@ -78,9 +78,15 @@ export const IssueAttachmentActionButton: FC<Props> = observer((props) => {
   });
 
   return (
-    <button {...getRootProps()} type="button" disabled={disabled}>
-      <input {...getInputProps()} />
-      {customButton ? customButton : <Plus className="h-4 w-4" />}
-    </button>
+    <div
+      onClick={(e) => {
+        e.stopPropagation();
+      }}
+    >
+      <button {...getRootProps()} type="button" disabled={disabled}>
+        <input {...getInputProps()} />
+        {customButton ? customButton : <Plus className="h-4 w-4" />}
+      </button>
+    </div>
   );
 });

--- a/web/core/components/issues/issue-detail-widgets/attachments/quick-action-button.tsx
+++ b/web/core/components/issues/issue-detail-widgets/attachments/quick-action-button.tsx
@@ -80,6 +80,7 @@ export const IssueAttachmentActionButton: FC<Props> = observer((props) => {
   return (
     <div
       onClick={(e) => {
+        // TODO: Remove extra div and move event propagation to button
         e.stopPropagation();
       }}
     >


### PR DESCRIPTION
### Changes:
This PR addresses the attachment bug where clicking the "Add" button in the widget header opens the upload modal, but the file is not uploaded, and the widget collapses unexpectedly.

### Reference:
[[WEB-2616]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/46c3781e-dda7-40de-b8c0-d8e9889e5944)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved button functionality by preventing click events from triggering parent components, enhancing user interaction.

- **Refactor**
	- Wrapped the existing button element in a `<div>` to manage event propagation without altering existing features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->