### PR TITLE
[WEB-2676 ] fix: workspace draft move to project

### DIFF
--- a/web/core/components/issues/issue-modal/form.tsx
+++ b/web/core/components/issues/issue-modal/form.tsx
@@ -432,9 +432,14 @@ export const IssueFormRoot: FC<IssueFormProps> = observer((props) => {
                   type="button"
                   size="sm"
                   loading={isSubmitting}
-                  onClick={() =>
-                    data?.id && data && moveIssue(workspaceSlug.toString(), data?.id, data as TWorkspaceDraftIssue)
-                  }
+                  onClick={() => {
+                    if (data?.id && data) {
+                      moveIssue(workspaceSlug.toString(), data?.id, {
+                        ...data,
+                        ...getValues(),
+                      } as TWorkspaceDraftIssue);
+                    }
+                  }}
                 >
                   Add to project
                 </Button>


### PR DESCRIPTION
### Changes:
This PR includes a fix for the "Move to project" action in the workspace draft. Previously, when an issue was moved from a draft to a project, any updates made by the user during the transition were not being saved. I've implemented the necessary changes to ensure that updates are now properly applied

### Reference:
[[WEB-2676]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/48e16e2e-e4fb-42c1-9679-bfa7892ec082)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved functionality of the "Add to project" button to ensure accurate data processing when moving issues.

- **Bug Fixes**
	- Fixed the issue with data merging when moving an issue, enhancing the reliability of the feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->