### PR TITLE
fix: attachment_count in issue pagination v2 endpoint

### DIFF
--- a/apiserver/plane/app/views/issue/base.py
+++ b/apiserver/plane/app/views/issue/base.py
@@ -756,6 +756,15 @@ class IssuePaginatedViewSet(BaseViewSet):
                 .values("count")
             )
             .annotate(
+                attachment_count=FileAsset.objects.filter(
+                    issue_id=OuterRef("id"),
+                    entity_type=FileAsset.EntityTypeContext.ISSUE_ATTACHMENT,
+                )
+                .order_by()
+                .annotate(count=Func(F("id"), function="Count"))
+                .values("count")
+            )
+            .annotate(
                 sub_issues_count=Issue.issue_objects.filter(
                     parent=OuterRef("id")
                 )
@@ -812,7 +821,7 @@ class IssuePaginatedViewSet(BaseViewSet):
             "sub_issues_count",
         ]
 
-        if is_description_required:
+        if is_description_required and is_description_required == "true":
             required_fields.append("description_html")
 
         # querying issues

--- a/apiserver/plane/app/views/issue/base.py
+++ b/apiserver/plane/app/views/issue/base.py
@@ -788,7 +788,7 @@ class IssuePaginatedViewSet(BaseViewSet):
     @allow_permission([ROLE.ADMIN, ROLE.MEMBER, ROLE.GUEST])
     def list(self, request, slug, project_id):
         cursor = request.GET.get("cursor", None)
-        is_description_required = request.GET.get("description", False)
+        is_description_required = request.GET.get("description", "false")
         updated_at = request.GET.get("updated_at__gt", None)
 
         # required fields
@@ -821,7 +821,7 @@ class IssuePaginatedViewSet(BaseViewSet):
             "sub_issues_count",
         ]
 
-        if is_description_required and is_description_required == "true":
+        if str(is_description_required).lower() == "true":
             required_fields.append("description_html")
 
         # querying issues


### PR DESCRIPTION
#### Summary
This fix addresses the issue where the attachment_count field was missing or incorrect in the issue pagination v2 endpoint.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced issue retrieval with attachment count for each issue.
	- Conditional inclusion of the description field based on user request, defaulting to "false" if not specified.
- **Bug Fixes**
	- Improved handling of query parameters and response structure for better user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->