### PR TITLE
[WEB-2682] fix: delete project mutation and workspace draft header validation

### DIFF
--- a/web/app/[workspaceSlug]/(projects)/drafts/header.tsx
+++ b/web/app/[workspaceSlug]/(projects)/drafts/header.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { FC, useState } from "react";
+import { useState } from "react";
 import { observer } from "mobx-react";
 import { PenSquare } from "lucide-react";
 // ui
@@ -11,16 +11,17 @@ import { CreateUpdateIssueModal } from "@/components/issues";
 // constants
 import { EIssuesStoreType } from "@/constants/issue";
 // hooks
-import { useUserPermissions, useWorkspaceDraftIssues } from "@/hooks/store";
+import { useProject, useUserPermissions, useWorkspaceDraftIssues } from "@/hooks/store";
 // plane-web
 import { EUserPermissions, EUserPermissionsLevel } from "@/plane-web/constants/user-permissions";
 
-export const WorkspaceDraftHeader: FC = observer(() => {
+export const WorkspaceDraftHeader = observer(() => {
   // state
   const [isDraftIssueModalOpen, setIsDraftIssueModalOpen] = useState(false);
   // store hooks
   const { allowPermissions } = useUserPermissions();
   const { paginationInfo } = useWorkspaceDraftIssues();
+  const { joinedProjectIds } = useProject();
   // check if user is authorized to create draft issue
   const isAuthorizedUser = allowPermissions(
     [EUserPermissions.ADMIN, EUserPermissions.MEMBER],
@@ -53,15 +54,17 @@ export const WorkspaceDraftHeader: FC = observer(() => {
         </Header.LeftItem>
 
         <Header.RightItem>
-          <Button
-            variant="primary"
-            size="sm"
-            className="items-center gap-1"
-            onClick={() => setIsDraftIssueModalOpen(true)}
-            disabled={!isAuthorizedUser}
-          >
-            Draft<span className="hidden sm:inline-block"> an issue</span>
-          </Button>
+          {joinedProjectIds && joinedProjectIds.length > 0 && (
+            <Button
+              variant="primary"
+              size="sm"
+              className="items-center gap-1"
+              onClick={() => setIsDraftIssueModalOpen(true)}
+              disabled={!isAuthorizedUser}
+            >
+              Draft<span className="hidden sm:inline-block"> an issue</span>
+            </Button>
+          )}
         </Header.RightItem>
       </Header>
     </>

--- a/web/core/store/project/project.store.ts
+++ b/web/core/store/project/project.store.ts
@@ -404,6 +404,7 @@ export class ProjectStore implements IProjectStore {
       runInAction(() => {
         delete this.projectMap[projectId];
         if (this.rootStore.favorite.entityMap[projectId]) this.rootStore.favorite.removeFavoriteFromStore(projectId);
+        delete this.rootStore.user.permission.workspaceProjectsPermissions[workspaceSlug][projectId];
       });
     } catch (error) {
       console.log("Failed to delete project from project store");


### PR DESCRIPTION
### Changes:
This PR addresses the following changes:
- Resolved the issue with the delete project mutation in the permission store.
- Added validation for the Workspace draft header action button.

### Reference:
[[WEB-2682]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/0dc6c1e9-1e94-40f3-afb1-3fef15b16718)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced `WorkspaceDraftHeader` component to conditionally display the button based on project IDs.
	- Improved project deletion process by automatically removing associated permissions.

- **Bug Fixes**
	- Streamlined export declaration for the `WorkspaceDraftHeader` component.

- **Refactor**
	- Updated method signatures for better clarity and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->