### PR TITLE
fix: draft issue asset conversion to issue

### DIFF
--- a/apiserver/plane/app/views/workspace/draft.py
+++ b/apiserver/plane/app/views/workspace/draft.py
@@ -37,6 +37,7 @@ from plane.db.models import (
     DraftIssueModule,
     DraftIssueCycle,
     Workspace,
+    FileAsset,
 )
 from .. import BaseViewSet
 from plane.bgtasks.issue_activities_task import issue_activity
@@ -319,6 +320,14 @@ class WorkspaceDraftIssueViewSet(BaseViewSet):
                     )
                     for module in draft_issue.module_ids
                 ]
+
+            # Update file assets
+            file_assets = FileAsset.objects.filter(draft_issue_id=draft_id)
+            file_assets.update(
+                issue_id=serializer.data.get("id", None),
+                entity_type=FileAsset.EntityTypeContext.ISSUE_DESCRIPTION,
+                draft_issue_id=None,
+            )
 
             # delete the draft issue
             draft_issue.delete()


### PR DESCRIPTION
### Description
Update asset fields when moving drafts to project issues. Update `entity_type` and `issue_id` and remove `draft_issue_id`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced functionality for managing file assets during the transition from draft issues to actual issues.

- **Bug Fixes**
	- Improved handling of file asset updates associated with draft issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->