### PR TITLE
fix: sidebar new issue button paper cuts

### DIFF
--- a/web/core/components/workspace/sidebar/quick-actions.tsx
+++ b/web/core/components/workspace/sidebar/quick-actions.tsx
@@ -83,6 +83,14 @@ export const SidebarQuickActions = observer(() => {
           )}
           onMouseEnter={handleMouseEnter}
           onMouseLeave={handleMouseLeave}
+          onClick={() => {
+            if (disabled) {
+              return;
+            }
+
+            setTrackElement("APP_SIDEBAR_QUICK_ACTIONS");
+            toggleCreateIssueModal(true);
+          }}
         >
           <button
             type="button"
@@ -93,10 +101,6 @@ export const SidebarQuickActions = observer(() => {
                 "cursor-not-allowed opacity-50": disabled,
               }
             )}
-            onClick={() => {
-              setTrackElement("APP_SIDEBAR_QUICK_ACTIONS");
-              toggleCreateIssueModal(true);
-            }}
             disabled={disabled}
           >
             <PenSquare className="size-4" />


### PR DESCRIPTION
The "New issue" button in the sidebar is deceptively larger than its actually clickable area:

![CleanShot 2024-10-18 at 11 47 04@2x](https://github.com/user-attachments/assets/8ed3f608-45de-43a5-981c-a11401643ea6)

I have encountered this paper cut bug several times, hence this proposed fix.

https://github.com/user-attachments/assets/7790f179-cc1c-429b-9513-4bbfb11bf2d2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the sidebar quick actions with a new button for creating issues, now responsive to user permissions and project membership.
  
- **Bug Fixes**
	- Improved button interaction by directly managing the disabled state to prevent unauthorized actions.

- **Chores**
	- Cleaned up the code by removing commented-out sections, streamlining the component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->