### PR TITLE
[PE-68] fix: markdown transformation of mention and custom image components

### DIFF
--- a/packages/editor/src/core/extensions/custom-image/custom-image.ts
+++ b/packages/editor/src/core/extensions/custom-image/custom-image.ts
@@ -1,9 +1,11 @@
 import { Editor, mergeAttributes } from "@tiptap/core";
 import { Image } from "@tiptap/extension-image";
+import { MarkdownSerializerState } from "@tiptap/pm/markdown";
+import { Node } from "@tiptap/pm/model";
 import { ReactNodeViewRenderer } from "@tiptap/react";
 import { v4 as uuidv4 } from "uuid";
 // extensions
-import { CustomImageNode } from "@/extensions/custom-image";
+import { CustomImageNode, ImageAttributes } from "@/extensions/custom-image";
 // plugins
 import { TrackImageDeletionPlugin, TrackImageRestorationPlugin, isFileValid } from "@/plugins/image";
 // types
@@ -121,6 +123,14 @@ export const CustomImageExtension = (props: TFileHandler) => {
         deletedImageSet: new Map<string, boolean>(),
         uploadInProgress: false,
         maxFileSize,
+        markdown: {
+          serialize(state: MarkdownSerializerState, node: Node) {
+            const attrs = node.attrs as ImageAttributes;
+            const imageSource = this?.editor?.commands?.getImageSource?.(attrs.src) || attrs.src;
+            state.write(`<img src="${imageSource}" width="${attrs.width}" />`);
+            state.closeBlock(node);
+          },
+        },
       };
     },
 

--- a/packages/editor/src/core/extensions/custom-image/custom-image.ts
+++ b/packages/editor/src/core/extensions/custom-image/custom-image.ts
@@ -126,8 +126,9 @@ export const CustomImageExtension = (props: TFileHandler) => {
         markdown: {
           serialize(state: MarkdownSerializerState, node: Node) {
             const attrs = node.attrs as ImageAttributes;
-            const imageSource = this?.editor?.commands?.getImageSource?.(attrs.src) || attrs.src;
-            state.write(`<img src="${imageSource}" width="${attrs.width}" />`);
+            const imageSource = state.esc(this?.editor?.commands?.getImageSource?.(attrs.src) || attrs.src);
+            const imageWidth = state.esc(attrs.width?.toString());
+            state.write(`<img src="${state.esc(imageSource)}" width="${imageWidth}" />`);
             state.closeBlock(node);
           },
         },

--- a/packages/editor/src/core/extensions/custom-image/read-only-custom-image.ts
+++ b/packages/editor/src/core/extensions/custom-image/read-only-custom-image.ts
@@ -1,8 +1,10 @@
 import { mergeAttributes } from "@tiptap/core";
 import { Image } from "@tiptap/extension-image";
+import { MarkdownSerializerState } from "@tiptap/pm/markdown";
+import { Node } from "@tiptap/pm/model";
 import { ReactNodeViewRenderer } from "@tiptap/react";
 // components
-import { CustomImageNode, UploadImageExtensionStorage } from "@/extensions/custom-image";
+import { CustomImageNode, ImageAttributes, UploadImageExtensionStorage } from "@/extensions/custom-image";
 // types
 import { TFileHandler } from "@/types";
 
@@ -52,6 +54,14 @@ export const CustomReadOnlyImageExtension = (props: Pick<TFileHandler, "getAsset
     addStorage() {
       return {
         fileMap: new Map(),
+        markdown: {
+          serialize(state: MarkdownSerializerState, node: Node) {
+            const attrs = node.attrs as ImageAttributes;
+            const imageSource = this?.editor?.commands?.getImageSource?.(attrs.src) || attrs.src;
+            state.write(`<img src="${imageSource}" width="${attrs.width}" />`);
+            state.closeBlock(node);
+          },
+        },
       };
     },
 

--- a/packages/editor/src/core/extensions/custom-image/read-only-custom-image.ts
+++ b/packages/editor/src/core/extensions/custom-image/read-only-custom-image.ts
@@ -57,8 +57,9 @@ export const CustomReadOnlyImageExtension = (props: Pick<TFileHandler, "getAsset
         markdown: {
           serialize(state: MarkdownSerializerState, node: Node) {
             const attrs = node.attrs as ImageAttributes;
-            const imageSource = this?.editor?.commands?.getImageSource?.(attrs.src) || attrs.src;
-            state.write(`<img src="${imageSource}" width="${attrs.width}" />`);
+            const imageSource = state.esc(this?.editor?.commands?.getImageSource?.(attrs.src) || attrs.src);
+            const imageWidth = state.esc(attrs.width?.toString());
+            state.write(`<img src="${state.esc(imageSource)}" width="${imageWidth}" />`);
             state.closeBlock(node);
           },
         },

--- a/packages/editor/src/core/extensions/mentions/extension.tsx
+++ b/packages/editor/src/core/extensions/mentions/extension.tsx
@@ -30,20 +30,16 @@ export const CustomMention = ({
         markdown: {
           serialize(state: MarkdownSerializerState, node: Node) {
             const { attrs } = node;
-            // add link text
-            state.write("[");
-            state.write(`@${attrs.label}`);
-            state.write("]");
-            // add link url
-            state.write("(");
+            const label = `@${state.esc(attrs.label)}`;
             const originUrl = typeof window !== "undefined" && window.location.origin ? window.location.origin : "";
-            state.write(`${originUrl}/${attrs.redirect_uri}`);
-            state.write(")");
-            state.closeBlock(node);
+            const safeRedirectionPath = state.esc(attrs.redirect_uri);
+            const url = `${originUrl}${safeRedirectionPath}`;
+            state.write(`[${label}](${url})`);
           },
         },
       };
     },
+
     addAttributes() {
       return {
         id: {

--- a/packages/editor/src/core/extensions/mentions/extension.tsx
+++ b/packages/editor/src/core/extensions/mentions/extension.tsx
@@ -1,5 +1,7 @@
 import { Editor, mergeAttributes } from "@tiptap/core";
 import Mention, { MentionOptions } from "@tiptap/extension-mention";
+import { MarkdownSerializerState } from "@tiptap/pm/markdown";
+import { Node } from "@tiptap/pm/model";
 import { ReactNodeViewRenderer, ReactRenderer } from "@tiptap/react";
 import tippy from "tippy.js";
 // extensions
@@ -25,6 +27,21 @@ export const CustomMention = ({
     addStorage(this) {
       return {
         mentionsOpen: false,
+        markdown: {
+          serialize(state: MarkdownSerializerState, node: Node) {
+            const { attrs } = node;
+            // add link text
+            state.write("[");
+            state.write(`@${attrs.label}`);
+            state.write("]");
+            // add link url
+            state.write("(");
+            const originUrl = typeof window !== "undefined" && window.location.origin ? window.location.origin : "";
+            state.write(`${originUrl}/${attrs.redirect_uri}`);
+            state.write(")");
+            state.closeBlock(node);
+          },
+        },
       };
     },
     addAttributes() {

--- a/web/ce/components/pages/editor/embed/issue-embed-upgrade-card.tsx
+++ b/web/ce/components/pages/editor/embed/issue-embed-upgrade-card.tsx
@@ -1,31 +1,34 @@
-// ui
-import { Button } from "@plane/ui";
+// plane ui
+import { getButtonStyling } from "@plane/ui";
 // components
 import { ProIcon } from "@/components/common";
+// helpers
+import { cn } from "@/helpers/common.helper";
 
 export const IssueEmbedUpgradeCard: React.FC<any> = (props) => (
   <div
-    className={`${
-      props.selected ? "border-custom-primary-200 border-[2px]" : ""
-    } w-full h-[100px] cursor-pointer space-y-2 rounded-md border-[0.5px] border-custom-border-200 shadow-custom-shadow-2xs`}
+    className={cn(
+      "w-full h-20 bg-custom-background-80 rounded-md border-[0.5px] border-custom-border-200 shadow-custom-shadow-2xs",
+      {
+        "border-2": props.selected,
+      }
+    )}
   >
-    <h5 className="h-[20%] text-xs text-custom-text-300 p-2">
-      {props.node?.attrs?.project_identifier}-{props?.node?.attrs?.sequence_id}
-    </h5>
-    <div className="relative h-[71%]">
-      <div className="h-full backdrop-filter backdrop-blur-[30px] bg-custom-background-80 bg-opacity-30 flex items-center w-full justify-between gap-5 mt-2.5 pl-4 pr-5 py-3 max-md:max-w-full max-md:flex-wrap relative">
-        <div className="flex gap-2 items-center">
-          <div className="rounded">
-            <ProIcon className="m-2 w-4 h-4" />
-          </div>
-          <div className="text-custom-text text-sm">
-            Embed and access issues in pages seamlessly, upgrade to plane pro now.
-          </div>
-        </div>
-        <a href="https://plane.so/pricing" target="_blank" rel="noopener noreferrer">
-          <Button>Upgrade</Button>
-        </a>
+    <div className="flex items-center justify-between gap-5 mt-2.5 pl-4 pr-5 py-3 w-full max-md:max-w-full max-md:flex-wrap rounded-md">
+      <div className="flex items-center gap-4">
+        <ProIcon className="flex-shrink-0 size-4" />
+        <p className="text-custom-text !text-base">
+          Embed and access issues in pages seamlessly, upgrade to Plane Pro now.
+        </p>
       </div>
+      <a
+        href="https://plane.so/pro"
+        target="_blank"
+        rel="noopener noreferrer"
+        className={cn(getButtonStyling("primary", "md"), "no-underline")}
+      >
+        Upgrade
+      </a>
     </div>
   </div>
 );


### PR DESCRIPTION
#### Improvements:

1. Added markdown parsing rules for custom components.
2. Updated the UI and CTA link of the issue embed upgrade card.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced image serialization to Markdown format for both custom and read-only image extensions.
	- Added Markdown serialization for mentions, creating links with mention labels.
	- Updated `IssueEmbedUpgradeCard` for improved layout and dynamic styling.

- **Bug Fixes**
	- Adjusted attributes for image nodes to ensure proper serialization.

- **Refactor**
	- Simplified structure of the `IssueEmbedUpgradeCard` component for better readability and maintainability.
	- Improved styling approach for the `IssueEmbedUpgradeCard` component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->