### PR TITLE
fix: remove credentials for file uploads

### DIFF
--- a/space/core/services/file-upload.service.ts
+++ b/space/core/services/file-upload.service.ts
@@ -16,6 +16,7 @@ export class FileUploadService extends APIService {
         "Content-Type": "multipart/form-data",
       },
       cancelToken: this.cancelSource.token,
+      withCredentials: false,
     })
       .then((response) => response?.data)
       .catch((error) => {

--- a/web/core/services/file-upload.service.ts
+++ b/web/core/services/file-upload.service.ts
@@ -16,6 +16,7 @@ export class FileUploadService extends APIService {
         "Content-Type": "multipart/form-data",
       },
       cancelToken: this.cancelSource.token,
+      withCredentials: false,
     })
       .then((response) => response?.data)
       .catch((error) => {


### PR DESCRIPTION
### Description
Remove `withCredentials` from file uploads service in web and space.