### PR TITLE
[WEB-2612] fix: truncated project name in analytics dropdown

### DIFF
--- a/web/core/components/analytics/custom-analytics/select/project.tsx
+++ b/web/core/components/analytics/custom-analytics/select/project.tsx
@@ -23,7 +23,7 @@ export const SelectProject: React.FC<Props> = observer((props) => {
       value: projectDetails?.id,
       query: `${projectDetails?.name} ${projectDetails?.identifier}`,
       content: (
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 max-w-[300px]">
           <span className="text-[0.65rem] text-custom-text-200 flex-shrink-0">{projectDetails?.identifier}</span>
           <span className="flex-grow truncate">{projectDetails?.name}</span>
         </div>


### PR DESCRIPTION
**Summary**
This PR fixes the project name overflow in analytics dropddown

[[WEB-2612]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/eb50e1fa-7946-4498-a96e-49d563be09e6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the layout of project details in the dropdown options for better readability by constraining the maximum width.

- **Bug Fixes**
	- Improved the display of project information to prevent overflow and maintain a clean user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->