### PR TITLE
[WEB-2333] chore: intake issue back date snooze disabled

### DIFF
--- a/web/core/components/inbox/modals/snooze-issue-modal.tsx
+++ b/web/core/components/inbox/modals/snooze-issue-modal.tsx
@@ -54,11 +54,11 @@ export const InboxIssueSnoozeModal: FC<InboxIssueSnoozeModalProps> = (props) => 
                     }}
                     mode="single"
                     className="rounded-md border border-custom-border-200 p-3"
-                    // disabled={[
-                    //   {
-                    //     before: tomorrow,
-                    //   },
-                    // ]}
+                    disabled={[
+                      {
+                        before: new Date(),
+                      },
+                    ]}
                   />
                   <Button
                     variant="primary"


### PR DESCRIPTION
### Changes:
This PR disables the ability to snooze intake issues to a backdated time.

### Reference:
[[WEB-2333]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/f877c381-bd08-4116-b7f2-8959e67d2911)

### Media:
| Before | After |
|--------|--------|
| ![before](https://github.com/user-attachments/assets/101775fa-9a93-4b37-a946-510d0a23baae) | ![after](https://github.com/user-attachments/assets/c75fce3a-4949-48ab-86c8-a67f9a685979) |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the date selection in the Snooze Issue modal to prevent users from selecting past dates, allowing only today and future dates.

- **Bug Fixes**
	- Adjusted the modal's close behavior for improved functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->