### PR TITLE
[WEB-2710] fix: issue widget modal rendering

### DIFF
--- a/web/core/components/issues/issue-detail-widgets/root.tsx
+++ b/web/core/components/issues/issue-detail-widgets/root.tsx
@@ -12,10 +12,11 @@ type Props = {
   projectId: string;
   issueId: string;
   disabled: boolean;
+  renderWidgetModals?: boolean;
 };
 
 export const IssueDetailWidgets: FC<Props> = (props) => {
-  const { workspaceSlug, projectId, issueId, disabled } = props;
+  const { workspaceSlug, projectId, issueId, disabled, renderWidgetModals = true } = props;
   return (
     <>
       <div className="flex flex-col gap-5">
@@ -32,7 +33,9 @@ export const IssueDetailWidgets: FC<Props> = (props) => {
           disabled={disabled}
         />
       </div>
-      <IssueDetailWidgetModals workspaceSlug={workspaceSlug} projectId={projectId} issueId={issueId} />
+      {renderWidgetModals && (
+        <IssueDetailWidgetModals workspaceSlug={workspaceSlug} projectId={projectId} issueId={issueId} />
+      )}
     </>
   );
 };

--- a/web/core/components/issues/issue-detail/main-content.tsx
+++ b/web/core/components/issues/issue-detail/main-content.tsx
@@ -40,6 +40,7 @@ export const IssueMainContent: React.FC<Props> = observer((props) => {
   const { data: currentUser } = useUser();
   const {
     issue: { getIssueById },
+    peekIssue,
   } = useIssueDetail();
   const { setShowAlert } = useReloadConfirmations(isSubmitting === "submitting");
 
@@ -52,6 +53,8 @@ export const IssueMainContent: React.FC<Props> = observer((props) => {
 
   const issue = issueId ? getIssueById(issueId) : undefined;
   if (!issue || !issue.project_id) return <></>;
+
+  const isPeekModeActive = Boolean(peekIssue);
 
   return (
     <>
@@ -110,6 +113,7 @@ export const IssueMainContent: React.FC<Props> = observer((props) => {
         projectId={projectId}
         issueId={issueId}
         disabled={!isEditable || isArchived}
+        renderWidgetModals={!isPeekModeActive}
       />
 
       {windowSize[0] < 768 && (


### PR DESCRIPTION
### Changes:
This PR resolves a bug related to the widget modal rendering. The issue occurred when a user opened a sub-issue in peek overview mode from the detail page and then tried to open a widget modal. This action triggered the widget modal for both the peek overview and the issue detail page, causing two modals to open simultaneously.

To fix this, I have added a render condition for the issue detail widget modal. Now, when peek overview mode is active, the issue detail widget modal will not render, preventing two modals from opening at the same time.

### Reference:
[[WEB-2710]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/b20ad9dd-8b22-4775-8bee-5d34ff7e5c60)
