### PR TITLE
[WEB-2713] fix: guest user intake issue edit validation

### DIFF
--- a/web/core/components/inbox/content/root.tsx
+++ b/web/core/components/inbox/content/root.tsx
@@ -64,7 +64,7 @@ export const InboxContentRoot: FC<TInboxContentRoot> = observer((props) => {
 
   const isEditable =
     allowPermissions([EUserPermissions.ADMIN], EUserPermissionsLevel.PROJECT) ||
-    inboxIssue?.created_by === currentUser?.id;
+    inboxIssue?.issue?.created_by === currentUser?.id;
 
   const isGuest = projectPermissionsByWorkspaceSlugAndProjectId(workspaceSlug, projectId) === EUserPermissions.GUEST;
   const isOwner = inboxIssue?.issue.created_by === currentUser?.id;


### PR DESCRIPTION
### Changes:
This PR addresses the issue where guest users were unable to edit an intake issue immediately after creation.

### Reference:
[[WEB-2713]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/e79eda34-2a82-4aa2-bbea-73298eaee6ca)




