### PR TITLE
[WEB-2715] fix: draft issue type update outside click

### DIFF
--- a/web/core/components/issues/issue-modal/base.tsx
+++ b/web/core/components/issues/issue-modal/base.tsx
@@ -204,7 +204,7 @@ export const CreateUpdateIssueModalBase: React.FC<IssuesModalProps> = observer((
           issueTypeId: response.type_id,
           projectId: response.project_id,
           workspaceSlug: workspaceSlug.toString(),
-          isDraft: isDraft,
+          isDraft: is_draft_issue,
         });
       }
 


### PR DESCRIPTION
### Changes:
This PR addresses an issue where the custom properties data would be lost when clicking outside the draft issue form. Previously, the correct custom properties endpoint was not being triggered when the user filled out the "create issue" form and click outside. I've made the necessary changes to ensure the endpoint is now properly hit, resolving the issue.

### Reference:
[[WEB-2715]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/ccbd48a4-a496-47b4-b7c5-474f25c262f1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced issue creation and updating logic.
	- Improved management of draft status for issues.
  
- **Bug Fixes**
	- Refined error handling for issue creation and updates to ensure accurate error messages.
  
- **Refactor**
	- Updated component state management related to project and issue details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->