### PR TITLE
[WEB-2718] fix: background task metadata

### DIFF
--- a/apiserver/plane/app/views/asset/base.py
+++ b/apiserver/plane/app/views/asset/base.py
@@ -50,7 +50,7 @@ class FileAssetEndpoint(BaseAPIView):
         asset_key = str(workspace_id) + "/" + asset_key
         file_asset = FileAsset.objects.get(asset=asset_key)
         file_asset.is_deleted = True
-        file_asset.save()
+        file_asset.save(update_fields=["is_deleted"])
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 
@@ -59,7 +59,7 @@ class FileAssetViewSet(BaseViewSet):
         asset_key = str(workspace_id) + "/" + asset_key
         file_asset = FileAsset.objects.get(asset=asset_key)
         file_asset.is_deleted = False
-        file_asset.save()
+        file_asset.save(update_fields=["is_deleted"])
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 
@@ -96,5 +96,5 @@ class UserAssetsEndpoint(BaseAPIView):
             asset=asset_key, created_by=request.user
         )
         file_asset.is_deleted = True
-        file_asset.save()
+        file_asset.save(update_fields=["is_deleted"])
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/apiserver/plane/app/views/asset/v2.py
+++ b/apiserver/plane/app/views/asset/v2.py
@@ -34,7 +34,7 @@ class UserAssetsV2Endpoint(BaseAPIView):
             return
         asset.is_deleted = True
         asset.deleted_at = timezone.now()
-        asset.save()
+        asset.save(update_fields=["is_deleted", "deleted_at"])
         return
 
     def entity_asset_save(self, asset_id, entity_type, asset, request):
@@ -209,8 +209,7 @@ class UserAssetsV2Endpoint(BaseAPIView):
         # update the attributes
         asset.attributes = request.data.get("attributes", asset.attributes)
         # save the asset
-        asset.created_by = request.user
-        asset.save()
+        asset.save(update_fields=["is_uploaded", "attributes"])
         return Response(status=status.HTTP_204_NO_CONTENT)
 
     def delete(self, request, asset_id):
@@ -221,7 +220,7 @@ class UserAssetsV2Endpoint(BaseAPIView):
         self.entity_asset_delete(
             entity_type=asset.entity_type, asset=asset, request=request
         )
-        asset.save()
+        asset.save(update_fields=["is_deleted", "deleted_at"])
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 
@@ -280,7 +279,7 @@ class WorkspaceFileAssetEndpoint(BaseAPIView):
         # Mark the asset as deleted
         asset.is_deleted = True
         asset.deleted_at = timezone.now()
-        asset.save()
+        asset.save(update_fields=["is_deleted", "deleted_at"])
         return
 
     def entity_asset_save(self, asset_id, entity_type, asset, request):
@@ -460,8 +459,7 @@ class WorkspaceFileAssetEndpoint(BaseAPIView):
         # update the attributes
         asset.attributes = request.data.get("attributes", asset.attributes)
         # save the asset
-        asset.created_by = request.user
-        asset.save()
+        asset.save(update_fields=["is_uploaded", "attributes"])
         return Response(status=status.HTTP_204_NO_CONTENT)
 
     def delete(self, request, slug, asset_id):
@@ -472,7 +470,7 @@ class WorkspaceFileAssetEndpoint(BaseAPIView):
         self.entity_asset_delete(
             entity_type=asset.entity_type, asset=asset, request=request
         )
-        asset.save()
+        asset.save(update_fields=["is_deleted", "deleted_at"])
         return Response(status=status.HTTP_204_NO_CONTENT)
 
     def get(self, request, slug, asset_id):
@@ -551,7 +549,7 @@ class AssetRestoreEndpoint(BaseAPIView):
         asset = FileAsset.all_objects.get(id=asset_id, workspace__slug=slug)
         asset.is_deleted = False
         asset.deleted_at = None
-        asset.save()
+        asset.save(update_fields=["is_deleted", "deleted_at"])
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 
@@ -692,8 +690,7 @@ class ProjectAssetEndpoint(BaseAPIView):
         # update the attributes
         asset.attributes = request.data.get("attributes", asset.attributes)
         # save the asset
-        asset.created_by = request.user
-        asset.save()
+        asset.save(update_fields=["is_uploaded", "attributes"])
         return Response(status=status.HTTP_204_NO_CONTENT)
 
     @allow_permission([ROLE.ADMIN, ROLE.MEMBER, ROLE.GUEST])
@@ -708,7 +705,7 @@ class ProjectAssetEndpoint(BaseAPIView):
         asset.is_deleted = True
         asset.deleted_at = timezone.now()
         # Save the asset
-        asset.save()
+        asset.save(update_fields=["is_deleted", "deleted_at"])
         return Response(status=status.HTTP_204_NO_CONTENT)
 
     @allow_permission([ROLE.ADMIN, ROLE.MEMBER, ROLE.GUEST])

--- a/apiserver/plane/bgtasks/storage_metadata_task.py
+++ b/apiserver/plane/bgtasks/storage_metadata_task.py
@@ -19,7 +19,7 @@ def get_asset_object_metadata(asset_id):
             object_name=asset.asset.name
         )
         # Save the asset
-        asset.save()
+        asset.save(update_fields=["storage_metadata"])
         return
     except FileAsset.DoesNotExist:
         return

--- a/apiserver/plane/space/views/asset.py
+++ b/apiserver/plane/space/views/asset.py
@@ -169,8 +169,7 @@ class EntityAssetEndpoint(BaseAPIView):
         # update the attributes
         asset.attributes = request.data.get("attributes", asset.attributes)
         # save the asset
-        asset.created_by = request.user
-        asset.save()
+        asset.save(update_fields=["attributes", "is_uploaded"])
         return Response(status=status.HTTP_204_NO_CONTENT)
 
     def delete(self, request, anchor, pk):
@@ -194,7 +193,7 @@ class EntityAssetEndpoint(BaseAPIView):
         asset.is_deleted = True
         asset.deleted_at = timezone.now()
         # Save the asset
-        asset.save()
+        asset.save(update_fields=["is_deleted", "deleted_at"])
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 
@@ -219,7 +218,7 @@ class AssetRestoreEndpoint(BaseAPIView):
         )
         asset.is_deleted = False
         asset.deleted_at = None
-        asset.save()
+        asset.save(update_fields=["is_deleted", "deleted_at"])
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 


### PR DESCRIPTION
fix: 
- this pull request fixes the issue where the creator field was updating to null when updating the metadata for file uploads.

Issue Link: [WEB-2718](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/3dc0b52d-b6d1-499d-a014-641713c0894f/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced save operations across various asset management endpoints for improved efficiency by updating only specific fields in the database.
  
- **Bug Fixes**
	- Optimized error handling and response structures remain intact, ensuring consistent API behavior.

- **Chores**
	- General improvements in the codebase to streamline asset management processes without altering existing functionalities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->