### PR TITLE
feat: allow binding apiserver on ipv6

### DIFF
--- a/apiserver/bin/docker-entrypoint-api.sh
+++ b/apiserver/bin/docker-entrypoint-api.sh
@@ -32,4 +32,4 @@ python manage.py create_bucket
 # Clear Cache before starting to remove stale values
 python manage.py clear_cache
 
-exec gunicorn -w "$GUNICORN_WORKERS" -k uvicorn.workers.UvicornWorker plane.asgi:application --bind 0.0.0.0:"${PORT:-8000}" --max-requests 1200 --max-requests-jitter 1000 --access-logfile -
+exec gunicorn -w "$GUNICORN_WORKERS" -k uvicorn.workers.UvicornWorker plane.asgi:application --bind "${BIND_HOST:-[::]}":"${PORT:-8000}" --max-requests 1200 --max-requests-jitter 1000 --access-logfile -


### PR DESCRIPTION
needed this to deploy plane on an ipv6-only network

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced server binding to support both IPv4 and IPv6 connections, improving accessibility and flexibility for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->