### PR TITLE
[WEB-2732] fix: global css conflicts

### DIFF
--- a/packages/editor/src/styles/editor.css
+++ b/packages/editor/src/styles/editor.css
@@ -1,7 +1,3 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
-
 .ProseMirror {
   position: relative;
   word-wrap: break-word;


### PR DESCRIPTION
**_Problem:_**
Web app UI was broken, due to conflict with editor tailwind CSS base directives.

 **_Solution:_**
Removed `@tailwind base;`, `@tailwind components;`, and `@tailwind utilities;` directives.

Issues:
- closes [WEB-2732](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/676990f9-1336-4416-8343-d8b3c8e4b364)