### PR TITLE
[WEB-2734] fix: Add missing config to get issues api call

### DIFF
--- a/web/core/local-db/storage.sqlite.ts
+++ b/web/core/local-db/storage.sqlite.ts
@@ -310,7 +310,7 @@ export class Storage {
     } catch (e) {
       logError(e);
       const issueService = new IssueService();
-      return await issueService.getIssuesFromServer(workspaceSlug, projectId, queries);
+      return await issueService.getIssuesFromServer(workspaceSlug, projectId, queries, config);
     }
     const end = performance.now();
 


### PR DESCRIPTION
This PR adds missing config for fetching getIssues from server. The config is mainly used for Abort controller to cancel previous api if a new one is called before the Promise is returned.