### PR TITLE
[WEB-2743] chore: restrict sub-issue to have different project id than parent

### DIFF
--- a/web/core/components/issues/issue-detail-widgets/issue-detail-widget-modals.tsx
+++ b/web/core/components/issues/issue-detail-widgets/issue-detail-widget-modals.tsx
@@ -151,6 +151,7 @@ export const IssueDetailWidgetModals: FC<Props> = observer((props) => {
           data={createUpdateModalData}
           onClose={handleCreateUpdateModalClose}
           onSubmit={handleCreateUpdateModalOnSubmit}
+          isProjectSelectionDisabled
         />
       )}
 
@@ -162,7 +163,6 @@ export const IssueDetailWidgetModals: FC<Props> = observer((props) => {
           handleClose={handleExistingIssuesModalClose}
           searchParams={existingIssuesModalSearchParams}
           handleOnSubmit={handleExistingIssuesModalOnSubmit}
-          workspaceLevelToggle
         />
       )}
 

--- a/web/core/components/issues/issue-modal/base.tsx
+++ b/web/core/components/issues/issue-modal/base.tsx
@@ -37,6 +37,7 @@ export const CreateUpdateIssueModalBase: React.FC<IssuesModalProps> = observer((
     moveToIssue = false,
     modalTitle,
     primaryButtonText,
+    isProjectSelectionDisabled = false,
   } = props;
   const issueStoreType = useIssueStoreType();
 
@@ -361,6 +362,7 @@ export const CreateUpdateIssueModalBase: React.FC<IssuesModalProps> = observer((
           moveToIssue={moveToIssue}
           isDuplicateModalOpen={isDuplicateModalOpen}
           handleDuplicateIssueModal={handleDuplicateIssueModal}
+          isProjectSelectionDisabled={isProjectSelectionDisabled}
         />
       ) : (
         <IssueFormRoot
@@ -383,6 +385,7 @@ export const CreateUpdateIssueModalBase: React.FC<IssuesModalProps> = observer((
           primaryButtonText={primaryButtonText}
           isDuplicateModalOpen={isDuplicateModalOpen}
           handleDuplicateIssueModal={handleDuplicateIssueModal}
+          isProjectSelectionDisabled={isProjectSelectionDisabled}
         />
       )}
     </ModalCore>

--- a/web/core/components/issues/issue-modal/draft-issue-layout.tsx
+++ b/web/core/components/issues/issue-modal/draft-issue-layout.tsx
@@ -38,6 +38,7 @@ export interface DraftIssueProps {
   };
   isDuplicateModalOpen: boolean;
   handleDuplicateIssueModal: (isOpen: boolean) => void;
+  isProjectSelectionDisabled?: boolean;
 }
 
 export const DraftIssueLayout: React.FC<DraftIssueProps> = observer((props) => {
@@ -58,6 +59,7 @@ export const DraftIssueLayout: React.FC<DraftIssueProps> = observer((props) => {
     primaryButtonText,
     isDuplicateModalOpen,
     handleDuplicateIssueModal,
+    isProjectSelectionDisabled = false,
   } = props;
   // states
   const [issueDiscardModal, setIssueDiscardModal] = useState(false);
@@ -179,6 +181,7 @@ export const DraftIssueLayout: React.FC<DraftIssueProps> = observer((props) => {
         primaryButtonText={primaryButtonText}
         isDuplicateModalOpen={isDuplicateModalOpen}
         handleDuplicateIssueModal={handleDuplicateIssueModal}
+        isProjectSelectionDisabled={isProjectSelectionDisabled}
       />
     </>
   );

--- a/web/core/components/issues/issue-modal/form.tsx
+++ b/web/core/components/issues/issue-modal/form.tsx
@@ -71,6 +71,7 @@ export interface IssueFormProps {
   };
   isDuplicateModalOpen: boolean;
   handleDuplicateIssueModal: (isOpen: boolean) => void;
+  isProjectSelectionDisabled?: boolean;
 }
 
 export const IssueFormRoot: FC<IssueFormProps> = observer((props) => {
@@ -93,6 +94,7 @@ export const IssueFormRoot: FC<IssueFormProps> = observer((props) => {
     },
     isDuplicateModalOpen,
     handleDuplicateIssueModal,
+    isProjectSelectionDisabled = false,
   } = props;
 
   // states
@@ -336,7 +338,7 @@ export const IssueFormRoot: FC<IssueFormProps> = observer((props) => {
                 <div className="flex items-center gap-x-1">
                   <IssueProjectSelect
                     control={control}
-                    disabled={!!data?.id || !!data?.sourceIssueId}
+                    disabled={!!data?.id || !!data?.sourceIssueId || isProjectSelectionDisabled}
                     handleFormChange={handleFormChange}
                   />
                   {projectId && (

--- a/web/core/components/issues/issue-modal/modal.tsx
+++ b/web/core/components/issues/issue-modal/modal.tsx
@@ -27,6 +27,7 @@ export interface IssuesModalProps {
     default: string;
     loading: string;
   };
+  isProjectSelectionDisabled?: boolean;
 }
 
 export const CreateUpdateIssueModal: React.FC<IssuesModalProps> = observer(


### PR DESCRIPTION
### Changes:
This PR includes following changes: 
- Restricts users to only add sub-issues within the same project when linking an existing issue.
- Disables project selection when creating a new sub-issue.

### Reference:
[[WEB-2743]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/8bd3746c-66fc-4ae5-adc1-d90e8b5b3c25/)

### Media:
| Before | After |
|--------|--------|
| ![before](https://github.com/user-attachments/assets/c2f708f6-d255-46c0-b3b4-1201356effb7) | ![after](https://github.com/user-attachments/assets/9df5028b-5585-4a61-8c99-399f6a10ab04) |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a new property, `isProjectSelectionDisabled`, across various modal components to enhance control over project selection.
	- Improved handling of project selection state in the `DraftIssueLayout` and `IssueFormRoot` components.

- **Bug Fixes**
	- Enhanced logic for handling changes in the draft issue, ensuring proper removal of unnecessary properties.

- **Documentation**
	- Updated interfaces to reflect the addition of the `isProjectSelectionDisabled` property in relevant components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->