### PR TITLE
fix: custom background color for table header not working

### DIFF
--- a/packages/editor/src/styles/table.css
+++ b/packages/editor/src/styles/table.css
@@ -27,10 +27,18 @@
   }
 }
 
-.table-wrapper table th {
-  font-weight: 500;
-  text-align: left;
-  background-color: rgba(var(--color-background-90));
+.table-wrapper table {
+  th {
+    font-weight: 500;
+    text-align: left;
+  }
+
+  tr[background="none"],
+  tr:not([background]) {
+    th {
+      background-color: rgba(var(--color-background-90));
+    }
+  }
 }
 
 .table-wrapper table .selectedCell {


### PR DESCRIPTION
#### Bug fix:

Use the default background color for a table header only when a custom color is not applied.

#### Media:

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/f20bc90f-894f-4c50-9b7c-f80a91a137c9"></video> | <video src="https://github.com/user-attachments/assets/2df82094-c631-4c5b-a5e6-2f2d041af379"></video> | 