### PR TITLE
fix: remove caching for avatar and logo apis to handle updates on avatar and logos.

### DIFF
--- a/apiserver/plane/app/views/workspace/base.py
+++ b/apiserver/plane/app/views/workspace/base.py
@@ -44,7 +44,6 @@ from plane.db.models import (
     WorkspaceTheme,
 )
 from plane.app.permissions import ROLE, allow_permission
-from plane.utils.cache import cache_response, invalidate_cache
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_control
 from django.views.decorators.vary import vary_on_cookie
@@ -99,9 +98,6 @@ class WorkSpaceViewSet(BaseViewSet):
             .select_related("owner")
         )
 
-    @invalidate_cache(path="/api/workspaces/", user=False)
-    @invalidate_cache(path="/api/users/me/workspaces/")
-    @invalidate_cache(path="/api/instances/", user=False)
     def create(self, request):
         try:
             serializer = WorkSpaceSerializer(data=request.data)
@@ -147,7 +143,6 @@ class WorkSpaceViewSet(BaseViewSet):
                     status=status.HTTP_410_GONE,
                 )
 
-    @cache_response(60 * 60 * 2)
     @allow_permission(
         [
             ROLE.ADMIN,
@@ -159,8 +154,6 @@ class WorkSpaceViewSet(BaseViewSet):
     def list(self, request, *args, **kwargs):
         return super().list(request, *args, **kwargs)
 
-    @invalidate_cache(path="/api/workspaces/", user=False)
-    @invalidate_cache(path="/api/users/me/workspaces/")
     @allow_permission(
         [
             ROLE.ADMIN,
@@ -170,13 +163,6 @@ class WorkSpaceViewSet(BaseViewSet):
     def partial_update(self, request, *args, **kwargs):
         return super().partial_update(request, *args, **kwargs)
 
-    @invalidate_cache(path="/api/workspaces/", user=False)
-    @invalidate_cache(
-        path="/api/users/me/workspaces/", multiple=True, user=False
-    )
-    @invalidate_cache(
-        path="/api/users/me/settings/", multiple=True, user=False
-    )
     @allow_permission([ROLE.ADMIN], level="WORKSPACE")
     def destroy(self, request, *args, **kwargs):
         return super().destroy(request, *args, **kwargs)
@@ -190,7 +176,6 @@ class UserWorkSpacesEndpoint(BaseAPIView):
         "owner",
     ]
 
-    @cache_response(60 * 60 * 2)
     @method_decorator(cache_control(private=True, max_age=12))
     @method_decorator(vary_on_cookie)
     def get(self, request):

--- a/apiserver/plane/app/views/workspace/member.py
+++ b/apiserver/plane/app/views/workspace/member.py
@@ -40,7 +40,7 @@ from plane.db.models import (
     WorkspaceMember,
     DraftIssue,
 )
-from plane.utils.cache import cache_response, invalidate_cache
+from plane.utils.cache import invalidate_cache
 
 from .. import BaseViewSet
 
@@ -66,7 +66,6 @@ class WorkSpaceMemberViewSet(BaseViewSet):
             .select_related("member")
         )
 
-    @cache_response(60 * 60 * 2)
     @allow_permission(
         allowed_roles=[ROLE.ADMIN, ROLE.MEMBER, ROLE.GUEST], level="WORKSPACE"
     )
@@ -93,12 +92,6 @@ class WorkSpaceMemberViewSet(BaseViewSet):
             )
         return Response(serializer.data, status=status.HTTP_200_OK)
 
-    @invalidate_cache(
-        path="/api/workspaces/:slug/members/",
-        url_params=True,
-        user=False,
-        multiple=True,
-    )
     @allow_permission(allowed_roles=[ROLE.ADMIN], level="WORKSPACE")
     def partial_update(self, request, slug, pk):
         workspace_member = WorkspaceMember.objects.get(
@@ -127,16 +120,6 @@ class WorkSpaceMemberViewSet(BaseViewSet):
             return Response(serializer.data, status=status.HTTP_200_OK)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
-    @invalidate_cache(
-        path="/api/workspaces/:slug/members/",
-        url_params=True,
-        user=False,
-        multiple=True,
-    )
-    @invalidate_cache(path="/api/users/me/settings/", multiple=True)
-    @invalidate_cache(
-        path="/api/users/me/workspaces/", user=False, multiple=True
-    )
     @allow_permission(allowed_roles=[ROLE.ADMIN], level="WORKSPACE")
     def destroy(self, request, slug, pk):
         # Check the user role who is deleting the user


### PR DESCRIPTION
### Description
Remove caching from user related apis to handle updates to avatars and cover images. Old image links are still returned even when the new images are uploaded resulting in broken UI.