### PR TITLE
[WEB-2557] fix: wrong spacing of swimlanes group header

### DIFF
--- a/web/core/components/issues/issue-layouts/kanban/swimlanes.tsx
+++ b/web/core/components/issues/issue-layouts/kanban/swimlanes.tsx
@@ -54,7 +54,7 @@ const visibilitySubGroupByGroupCount = (subGroupIssueCount: number, showEmptyGro
 
 const SubGroupSwimlaneHeader: React.FC<ISubGroupSwimlaneHeader> = observer(
   ({ getGroupIssueCount, sub_group_by, group_by, list, collapsedGroups, handleCollapsedGroups, showEmptyGroup }) => (
-    <div className="relative flex h-max min-h-full w-full items-center gap-2">
+    <div className="relative flex h-max min-h-full w-full items-center gap-4">
       {list &&
         list.length > 0 &&
         list.map((_list: IGroupByColumn) => {


### PR DESCRIPTION
#### Bug fix:

Increased the spacing between group headers in a swimlane from `0.5rem` to `1rem`.

#### Media:

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/e864005f-7c18-4976-a358-b44b841d7dd9"></video> | <video src="https://github.com/user-attachments/assets/acea872e-3c2a-461f-84c5-46f980338943"></video> | 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved layout spacing in the Kanban swimlane headers for better visual clarity.
  
- **Bug Fixes**
	- Ensured subgroup visibility logic remains consistent while displaying relevant subgroups based on issue counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->