### PR TITLE
[WEB-2776] fix: restrict notifications

### DIFF
--- a/apiserver/plane/utils/issue_filters.py
+++ b/apiserver/plane/utils/issue_filters.py
@@ -185,6 +185,7 @@ def filter_labels(params, issue_filter, method, prefix=""):
             and params.get("labels") != "null"
         ):
             issue_filter[f"{prefix}labels__in"] = params.get("labels")
+    issue_filter[f"{prefix}label_issue__deleted_at__isnull"] = True
     return issue_filter
 
 


### PR DESCRIPTION
fix:
- restrict sending notifications to users who are not part of the project.


Issue Link: [WEB-2776](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/1dcb0cb4-36f1-41d3-9b7f-3062835e3a28/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced notification system to notify only active project members when mentioned in issues and comments.
	- Improved filtering for subscribers to ensure only active members are included.
	- Updated filtering logic to exclude deleted labels and assignees in issue management.

- **Bug Fixes**
	- Resolved issues with duplicate notifications by checking existing subscribers, assignees, and creators before adding new ones.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->