### PR TITLE
[WEB-2778] chore: private project join restriction

### DIFF
--- a/apiserver/plane/app/views/project/base.py
+++ b/apiserver/plane/app/views/project/base.py
@@ -176,6 +176,10 @@ class ProjectViewSet(BaseViewSet):
     def retrieve(self, request, slug, pk):
         project = (
             self.get_queryset()
+            .filter(
+                project_projectmember__member=self.request.user,
+                project_projectmember__is_active=True,
+            )
             .filter(archived_at__isnull=True)
             .filter(pk=pk)
             .annotate(

--- a/apiserver/plane/app/views/project/invite.py
+++ b/apiserver/plane/app/views/project/invite.py
@@ -136,6 +136,12 @@ class UserProjectInvitationsViewset(BaseViewSet):
             member=request.user, workspace__slug=slug, is_active=True
         )
 
+        if workspace_member.role != 20:
+            return Response(
+                {"error": "You do not have permission to join the project"},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
         workspace_role = workspace_member.role
         workspace = workspace_member.workspace
 

--- a/apiserver/plane/app/views/project/invite.py
+++ b/apiserver/plane/app/views/project/invite.py
@@ -136,7 +136,7 @@ class UserProjectInvitationsViewset(BaseViewSet):
             member=request.user, workspace__slug=slug, is_active=True
         )
 
-        if workspace_member.role != 20:
+        if workspace_member.role != ROLE.ADMIN:
             return Response(
                 {"error": "You do not have permission to join the project"},
                 status=status.HTTP_403_FORBIDDEN,

--- a/apiserver/pyproject.toml
+++ b/apiserver/pyproject.toml
@@ -1,8 +1,7 @@
 [project]
-name = "your-project-name"
-version = "0.1.0"
-description = "Your project description"
-requires-python = ">=3.8"
+name = "Plane"
+version = "0.24.0"
+description = "Open-source project management that unlocks customer value"
 
 [tool.ruff]
 # Exclude a variety of commonly ignored directories.


### PR DESCRIPTION
chore:
- added restriction on joining private projects for members and guest.
Issue Link: [WEB-2778](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/e4f2354a-f318-43ca-b796-33a2241d4ef1/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced project retrieval to only show projects associated with active members.
	- Improved error handling for project creation and updates, providing clearer feedback on issues like duplicate names and invalid email addresses.
	- Stricter permission checks for project deletion and invitation creation, ensuring only authorized users can perform these actions.

- **Bug Fixes**
	- Adjusted rendering logic for the project wrapper component to simplify structure when a project is not found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->