### PR TITLE
chore: remove check for already existing project member

### DIFF
--- a/apiserver/plane/db/management/commands/create_project_member.py
+++ b/apiserver/plane/db/management/commands/create_project_member.py
@@ -65,12 +65,6 @@ class Command(BaseCommand):
             ).exists():
                 raise CommandError("User not member in workspace")
 
-            # Check if the user is already a member of the project
-            if ProjectMember.objects.filter(
-                project=project, member=user, is_active=True
-            ).exists():
-                raise CommandError("User already a member of the project")
-
             # Get the smallest sort order
             smallest_sort_order = (
                 ProjectMember.objects.filter(


### PR DESCRIPTION
### Description
chore: remove check for already existing project member. Always update the project member with the given role.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Users can now be added to a project without restrictions based on existing membership status.

- **Bug Fixes**
	- Resolved an issue where users could not be added to a project if they were already members.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->