### PR TITLE
[WEB-2781] fix: project view application error

### DIFF
--- a/web/app/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/views/(list)/page.tsx
+++ b/web/app/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/views/(list)/page.tsx
@@ -28,18 +28,6 @@ const ProjectViewsPage = observer(() => {
   const project = projectId ? getProjectById(projectId.toString()) : undefined;
   const pageTitle = project?.name ? `${project?.name} - Views` : undefined;
 
-  if (!workspaceSlug || !projectId) return <></>;
-
-  // No access to
-  if (currentProjectDetails?.issue_views_view === false)
-    return (
-      <div className="flex items-center justify-center h-full w-full">
-        <EmptyState
-          type={EmptyStateType.DISABLED_PROJECT_VIEW}
-          primaryButtonLink={`/${workspaceSlug}/projects/${projectId}/settings/features`}
-        />
-      </div>
-    );
   const handleRemoveFilter = useCallback(
     (key: keyof TViewFilterProps, value: string | EViewAccess | null) => {
       let newValues = filters.filters?.[key];
@@ -58,6 +46,19 @@ const ProjectViewsPage = observer(() => {
   );
 
   const isFiltersApplied = calculateTotalFilters(filters?.filters ?? {}) !== 0;
+
+  if (!workspaceSlug || !projectId) return <></>;
+
+  // No access to
+  if (currentProjectDetails?.issue_views_view === false)
+    return (
+      <div className="flex items-center justify-center h-full w-full">
+        <EmptyState
+          type={EmptyStateType.DISABLED_PROJECT_VIEW}
+          primaryButtonLink={`/${workspaceSlug}/projects/${projectId}/settings/features`}
+        />
+      </div>
+    );
 
   return (
     <>


### PR DESCRIPTION
### Changes:
This PR resolves an issue where clicking on “Project View” from a project with the view disabled resulted in an application error. Necessary updates have been made to fix this behavior.

### Reference:
[[WEB-2781]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/e165d002-cd56-4cd3-9340-bb9c8d4f6145/)

### Media:
| Before | After |
|--------|--------|
| ![before](https://github.com/user-attachments/assets/c5ad5b21-991d-4c6c-bc85-afb04b8b6677) | ![after](https://github.com/user-attachments/assets/2b3ac958-9678-44ed-b1e9-34dd1bf00833) |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Restored conditional checks for project identification and access permissions, improving error handling.
	- Added an `EmptyState` component to inform users when project views are disabled, with a link to project settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->