### PR TITLE
[PE-80] fix: escape markdown content for images

### DIFF
--- a/packages/editor/src/core/extensions/custom-image/custom-image.ts
+++ b/packages/editor/src/core/extensions/custom-image/custom-image.ts
@@ -1,11 +1,9 @@
 import { Editor, mergeAttributes } from "@tiptap/core";
 import { Image } from "@tiptap/extension-image";
-import { MarkdownSerializerState } from "@tiptap/pm/markdown";
-import { Node } from "@tiptap/pm/model";
 import { ReactNodeViewRenderer } from "@tiptap/react";
 import { v4 as uuidv4 } from "uuid";
 // extensions
-import { CustomImageNode, ImageAttributes } from "@/extensions/custom-image";
+import { CustomImageNode } from "@/extensions/custom-image";
 // plugins
 import { TrackImageDeletionPlugin, TrackImageRestorationPlugin, isFileValid } from "@/plugins/image";
 // types
@@ -126,14 +124,9 @@ export const CustomImageExtension = (props: TFileHandler) => {
         deletedImageSet: new Map<string, boolean>(),
         uploadInProgress: false,
         maxFileSize,
+        // escape markdown for images
         markdown: {
-          serialize(state: MarkdownSerializerState, node: Node) {
-            const attrs = node.attrs as ImageAttributes;
-            const imageSource = state.esc(this?.editor?.commands?.getImageSource?.(attrs.src) || attrs.src);
-            const imageWidth = state.esc(attrs.width?.toString());
-            state.write(`<img src="${state.esc(imageSource)}" width="${imageWidth}" />`);
-            state.closeBlock(node);
-          },
+          serialize() {},
         },
       };
     },

--- a/packages/editor/src/core/extensions/custom-image/read-only-custom-image.ts
+++ b/packages/editor/src/core/extensions/custom-image/read-only-custom-image.ts
@@ -1,10 +1,8 @@
 import { mergeAttributes } from "@tiptap/core";
 import { Image } from "@tiptap/extension-image";
-import { MarkdownSerializerState } from "@tiptap/pm/markdown";
-import { Node } from "@tiptap/pm/model";
 import { ReactNodeViewRenderer } from "@tiptap/react";
 // components
-import { CustomImageNode, ImageAttributes, UploadImageExtensionStorage } from "@/extensions/custom-image";
+import { CustomImageNode, UploadImageExtensionStorage } from "@/extensions/custom-image";
 // types
 import { TFileHandler } from "@/types";
 
@@ -54,14 +52,9 @@ export const CustomReadOnlyImageExtension = (props: Pick<TFileHandler, "getAsset
     addStorage() {
       return {
         fileMap: new Map(),
+        // escape markdown for images
         markdown: {
-          serialize(state: MarkdownSerializerState, node: Node) {
-            const attrs = node.attrs as ImageAttributes;
-            const imageSource = state.esc(this?.editor?.commands?.getImageSource?.(attrs.src) || attrs.src);
-            const imageWidth = state.esc(attrs.width?.toString());
-            state.write(`<img src="${state.esc(imageSource)}" width="${imageWidth}" />`);
-            state.closeBlock(node);
-          },
+          serialize() {},
         },
       };
     },


### PR DESCRIPTION
#### Bug fix:

Escape image components when copying/exporting editor content as markdown.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced image insertion functionality with file validation to ensure only appropriate files are processed.
  
- **Bug Fixes**
	- Removed outdated markdown serialization for images, streamlining image handling.

- **Refactor**
	- Updated method signatures to simplify the image serialization process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->