### PR TITLE
fix: todo list item color when item is checked and custom color is applied

### DIFF
--- a/packages/editor/src/styles/editor.css
+++ b/packages/editor/src/styles/editor.css
@@ -179,13 +179,26 @@ ul[data-type="taskList"] li > label input[type="checkbox"] {
   }
 }
 
-ul[data-type="taskList"] li > div > p {
-  margin-top: 10px;
+ul[data-type="taskList"] li > div {
+  & > p {
+    margin-top: 10px;
+    transition: color 0.2s ease;
+  }
+
+  [data-text-color] {
+    transition: opacity 0.2s ease;
+  }
 }
 
-ul[data-type="taskList"] li[data-checked="true"] > div > p {
-  color: rgb(var(--color-text-400));
-  transition: color 0.2s ease;
+ul[data-type="taskList"] li[data-checked="true"] {
+  & > div > p {
+    color: rgb(var(--color-text-400));
+  }
+
+  [data-text-color] {
+    opacity: 0.6;
+    transition: opacity 0.2s ease;
+  }
 }
 /* end to-do list */
 


### PR DESCRIPTION
#### Bug fix:

When a todo list item contains some characters with custom color applied, checking the item doesn't mute that color.

#### Media:

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/d21e487f-8e83-43fd-a632-da47fb80e967"></video> | <video src="https://github.com/user-attachments/assets/aa5319e6-77c6-432c-9c6c-fdc36ee9ef89"></video> | 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced styles for task lists, improving visual hierarchy and interactivity.
	- Added transitions for color and opacity in task list items and checkboxes.

- **Bug Fixes**
	- Improved specificity for task list item selectors, ensuring consistent appearance for checked items.

- **Style**
	- Adjusted margin and padding for consistent spacing in the editor.
	- Maintained responsive design for smaller screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->