### PR TITLE
[WEB-2795]chore:removed header links for project bread crumb inside project detail and list

### DIFF
--- a/packages/types/src/issues/issue.d.ts
+++ b/packages/types/src/issues/issue.d.ts
@@ -95,6 +95,7 @@ export type TIssuesResponse = {
   total_pages: number;
   extra_stats: null;
   results: TIssueResponseResults;
+  total_results: number;
 };
 
 export type TBulkIssueProperties = Pick<

--- a/web/app/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/archives/header.tsx
+++ b/web/app/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/archives/header.tsx
@@ -46,7 +46,6 @@ export const ProjectArchivesHeader: FC<TProps> = observer((props: TProps) => {
               type="text"
               link={
                 <BreadcrumbLink
-                  href={`/${workspaceSlug}/projects`}
                   label={currentProjectDetails?.name ?? "Project"}
                   icon={
                     currentProjectDetails && (

--- a/web/app/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/archives/issues/(detail)/header.tsx
+++ b/web/app/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/archives/issues/(detail)/header.tsx
@@ -38,7 +38,6 @@ export const ProjectArchivedIssueDetailsHeader = observer(() => {
             type="text"
             link={
               <BreadcrumbLink
-                href={`/${workspaceSlug}/projects`}
                 label={currentProjectDetails?.name ?? "Project"}
                 icon={
                   currentProjectDetails && (

--- a/web/app/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/cycles/(detail)/header.tsx
+++ b/web/app/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/cycles/(detail)/header.tsx
@@ -172,7 +172,6 @@ export const CycleIssuesHeader: React.FC = observer(() => {
                     <span className="hidden md:block">
                       <BreadcrumbLink
                         label={currentProjectDetails?.name ?? "Project"}
-                        href={`/${workspaceSlug}/projects/${currentProjectDetails?.id}/issues`}
                         icon={
                           currentProjectDetails && (
                             <span className="grid h-4 w-4 flex-shrink-0 place-items-center">

--- a/web/app/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/cycles/(list)/header.tsx
+++ b/web/app/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/cycles/(list)/header.tsx
@@ -38,7 +38,6 @@ export const CyclesListHeader: FC = observer(() => {
             link={
               <BreadcrumbLink
                 label={currentProjectDetails?.name ?? "Project"}
-                href={`/${workspaceSlug}/projects/${currentProjectDetails?.id}/issues`}
                 icon={
                   currentProjectDetails && (
                     <span className="grid place-items-center flex-shrink-0 h-4 w-4">

--- a/web/app/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/draft-issues/header.tsx
+++ b/web/app/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/draft-issues/header.tsx
@@ -99,7 +99,6 @@ export const ProjectDraftIssueHeader: FC = observer(() => {
               type="text"
               link={
                 <BreadcrumbLink
-                  href={`/${workspaceSlug}/projects`}
                   label={currentProjectDetails?.name ?? "Project"}
                   icon={
                     currentProjectDetails && (

--- a/web/app/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/issues/(detail)/header.tsx
+++ b/web/app/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/issues/(detail)/header.tsx
@@ -32,7 +32,6 @@ export const ProjectIssueDetailsHeader = observer(() => {
               type="text"
               link={
                 <BreadcrumbLink
-                  href={`/${workspaceSlug}/projects`}
                   label={currentProjectDetails?.name ?? "Project"}
                   icon={
                     currentProjectDetails && (

--- a/web/app/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/issues/(list)/header.tsx
+++ b/web/app/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/issues/(list)/header.tsx
@@ -54,7 +54,6 @@ export const ProjectIssuesHeader = observer(() => {
               type="text"
               link={
                 <BreadcrumbLink
-                  href={`/${workspaceSlug}/projects`}
                   label={currentProjectDetails?.name ?? "Project"}
                   icon={
                     currentProjectDetails ? (

--- a/web/app/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/modules/(detail)/header.tsx
+++ b/web/app/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/modules/(detail)/header.tsx
@@ -171,7 +171,6 @@ export const ModuleIssuesHeader: React.FC = observer(() => {
                   <span className="hidden md:block">
                     <BreadcrumbLink
                       label={currentProjectDetails?.name ?? "Project"}
-                      href={`/${workspaceSlug}/projects/${currentProjectDetails?.id}/issues`}
                       icon={
                         currentProjectDetails && (
                           <span className="grid h-4 w-4 flex-shrink-0 place-items-center">

--- a/web/app/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/modules/(list)/header.tsx
+++ b/web/app/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/modules/(list)/header.tsx
@@ -39,7 +39,6 @@ export const ModulesListHeader: React.FC = observer(() => {
               type="text"
               link={
                 <BreadcrumbLink
-                  href={`/${workspaceSlug}/projects/${currentProjectDetails?.id}/issues`}
                   label={currentProjectDetails?.name ?? "Project"}
                   icon={
                     currentProjectDetails && (

--- a/web/app/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/pages/(detail)/header.tsx
+++ b/web/app/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/pages/(detail)/header.tsx
@@ -77,7 +77,6 @@ export const PageDetailsHeader = observer(() => {
                 <span>
                   <span className="hidden md:block">
                     <BreadcrumbLink
-                      href={`/${workspaceSlug}/projects/${currentProjectDetails?.id}/issues`}
                       label={currentProjectDetails?.name ?? "Project"}
                       icon={
                         currentProjectDetails && (

--- a/web/app/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/pages/(list)/header.tsx
+++ b/web/app/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/pages/(list)/header.tsx
@@ -69,7 +69,6 @@ export const PagesListHeader = observer(() => {
               type="text"
               link={
                 <BreadcrumbLink
-                  href={`/${workspaceSlug}/projects/${currentProjectDetails?.id}/issues`}
                   label={currentProjectDetails?.name ?? "Project"}
                   icon={
                     currentProjectDetails && (

--- a/web/app/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/settings/header.tsx
+++ b/web/app/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/settings/header.tsx
@@ -34,7 +34,6 @@ export const ProjectSettingHeader: FC = observer(() => {
                 type="text"
                 link={
                   <BreadcrumbLink
-                    href={`/${workspaceSlug}/projects/${currentProjectDetails?.id}/issues`}
                     label={currentProjectDetails?.name ?? "Project"}
                     icon={
                       currentProjectDetails && (

--- a/web/app/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/views/(detail)/[viewId]/header.tsx
+++ b/web/app/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/views/(detail)/[viewId]/header.tsx
@@ -144,7 +144,6 @@ export const ProjectViewIssuesHeader: React.FC = observer(() => {
             type="text"
             link={
               <BreadcrumbLink
-                href={`/${workspaceSlug}/projects/${currentProjectDetails?.id}/issues`}
                 label={currentProjectDetails?.name ?? "Project"}
                 icon={
                   currentProjectDetails && (

--- a/web/app/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/views/(list)/header.tsx
+++ b/web/app/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/views/(list)/header.tsx
@@ -27,7 +27,6 @@ export const ProjectViewsHeader = observer(() => {
               type="text"
               link={
                 <BreadcrumbLink
-                  href={`/${workspaceSlug}/projects/${currentProjectDetails?.id}/issues`}
                   label={currentProjectDetails?.name ?? "Project"}
                   icon={
                     currentProjectDetails && (

--- a/web/ce/components/projects/settings/intake/header.tsx
+++ b/web/ce/components/projects/settings/intake/header.tsx
@@ -39,7 +39,6 @@ export const ProjectInboxHeader: FC = observer(() => {
               type="text"
               link={
                 <BreadcrumbLink
-                  href={`/${workspaceSlug}/projects`}
                   label={currentProjectDetails?.name ?? "Project"}
                   icon={
                     currentProjectDetails && (

--- a/web/core/local-db/storage.sqlite.ts
+++ b/web/core/local-db/storage.sqlite.ts
@@ -251,7 +251,7 @@ export class Storage {
 
     activeSpan?.setAttributes({
       projectId: projectId,
-      count: response.total_count,
+      count: response?.total_results,
     });
   };
 


### PR DESCRIPTION
### Summary
Removed the link for the project breadcrumb across all detail and list pages within a project.

### Reference
[WEB-2795](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/6df41a6d-53db-411c-b30f-869a73f39710)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Enhanced breadcrumb navigation across various project components, improving user access to project-related pages.
  - Added dynamic links to project overview and issues pages in specific headers.
  - Introduced new dropdown options for managing filters and layouts in the CycleIssuesHeader and ModuleIssuesHeader.

- **Bug Fixes**
  - Removed outdated or incorrect links in breadcrumbs, ensuring accurate navigation.

- **Improvements**
  - Streamlined user interactions with new state management for filters and layouts in the CycleIssuesHeader and other components.
  - Improved the functionality of the ProjectDraftIssueHeader and PageDetailsHeader by refining logo update processes and breadcrumb structures.
  - Updated breadcrumb links to ensure they correctly reference the current project context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->