### PR TITLE
[WEB-2803] fix: Timeline chart half block dragging

### DIFF
--- a/web/core/components/gantt-chart/views/helpers.ts
+++ b/web/core/components/gantt-chart/views/helpers.ts
@@ -99,7 +99,7 @@ export const getItemPositionWidth = (chartData: ChartDataType, itemData: IGanttB
   // get scroll position from the number of days and width of each day
   scrollPosition = itemStartDate
     ? getPositionFromDate(chartData, itemStartDate, 0)
-    : getPositionFromDate(chartData, itemTargetDate!, -1 * DEFAULT_BLOCK_WIDTH);
+    : getPositionFromDate(chartData, itemTargetDate!, -1 * DEFAULT_BLOCK_WIDTH + chartData.data.dayWidth);
 
   if (itemStartDate && itemTargetDate) {
     // get width of block


### PR DESCRIPTION
This PR fixes half block dragging to have better UX and only update the incomplete block when required.


https://github.com/user-attachments/assets/c0246da3-a2fa-42bf-839c-efeda603d8d2



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced block resizing logic in the Gantt chart, allowing blocks to revert to a default size when necessary.
	- Improved date positioning calculations in the timeline chart for better accuracy.

- **Bug Fixes**
	- Corrected error handling for undefined dates in various functions, ensuring proper behavior when dates are missing.

- **Documentation**
	- Updated comments and descriptions to reflect changes in logic and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->