### PR TITLE
[WEB-2759] fix: intake issue permission

### DIFF
--- a/web/core/components/inbox/content/root.tsx
+++ b/web/core/components/inbox/content/root.tsx
@@ -64,7 +64,7 @@ export const InboxContentRoot: FC<TInboxContentRoot> = observer((props) => {
 
   const isEditable =
     allowPermissions([EUserPermissions.ADMIN], EUserPermissionsLevel.PROJECT, workspaceSlug, projectId) ||
-    inboxIssue?.created_by === currentUser?.id;
+    inboxIssue?.issue.created_by === currentUser?.id;
 
   const isGuest = projectPermissionsByWorkspaceSlugAndProjectId(workspaceSlug, projectId) === EUserPermissions.GUEST;
   const isOwner = inboxIssue?.issue.created_by === currentUser?.id;


### PR DESCRIPTION
### Changes:
This PR resolves a bug with intake issue permissions where users with member-level permissions couldn't edit their own issue immediately after creation without refreshing the page.


### Reference:
[[WEB-2759]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/f52cd0fb-e695-4362-9d68-e0d559854793/)