### PR TITLE
[WEB-2854] chore: trigger issue_description_version task on issue create and update

### DIFF
--- a/apiserver/plane/app/views/issue/base.py
+++ b/apiserver/plane/app/views/issue/base.py
@@ -58,6 +58,7 @@ from plane.utils.timezone_converter import user_timezone_converter
 from plane.bgtasks.recent_visited_task import recent_visited_task
 from plane.utils.global_paginator import paginate
 from plane.bgtasks.webhook_task import model_activity
+from plane.bgtasks.issue_description_version_task import issue_description_version_task
 
 
 class IssueListEndpoint(BaseAPIView):
@@ -428,6 +429,13 @@ class IssueViewSet(BaseViewSet):
                 slug=slug,
                 origin=request.META.get("HTTP_ORIGIN"),
             )
+            # updated issue description version
+            issue_description_version_task.delay(
+                updated_issue=json.dumps(request.data, cls=DjangoJSONEncoder),
+                issue_id=str(serializer.data["id"]),
+                user_id=request.user.id,
+                is_creating=True,
+            )
             return Response(issue, status=status.HTTP_201_CREATED)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
@@ -648,6 +656,12 @@ class IssueViewSet(BaseViewSet):
                 actor_id=request.user.id,
                 slug=slug,
                 origin=request.META.get("HTTP_ORIGIN"),
+            )
+            # updated issue description version
+            issue_description_version_task.delay(
+                updated_issue=current_instance,
+                issue_id=str(serializer.data.get("id", None)),
+                user_id=request.user.id,
             )
             return Response(status=status.HTTP_204_NO_CONTENT)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/apiserver/plane/bgtasks/issue_description_version_task.py
+++ b/apiserver/plane/bgtasks/issue_description_version_task.py
@@ -41,7 +41,7 @@ def update_existing_version(version: IssueDescriptionVersion, issue) -> None:
 
 @shared_task
 def issue_description_version_task(
-    updated_issue, issue_id, user_id, is_creating
+    updated_issue, issue_id, user_id, is_creating=False
 ) -> Optional[bool]:
     try:
         # Parse updated issue data

--- a/apiserver/plane/bgtasks/issue_description_version_task.py
+++ b/apiserver/plane/bgtasks/issue_description_version_task.py
@@ -1,0 +1,84 @@
+from celery import shared_task
+from django.db import transaction
+from django.utils import timezone
+from typing import Optional, Dict
+import json
+
+from plane.db.models import Issue, IssueDescriptionVersion
+from plane.utils.exception_logger import log_exception
+
+
+def should_update_existing_version(
+    version: IssueDescriptionVersion, user_id: str, max_time_difference: int = 600
+) -> bool:
+    if not version:
+        return
+
+    time_difference = (timezone.now() - version.last_saved_at).total_seconds()
+    return (
+        str(version.owned_by_id) == str(user_id)
+        and time_difference <= max_time_difference
+    )
+
+
+def update_existing_version(version: IssueDescriptionVersion, issue) -> None:
+    version.description_json = issue.description
+    version.description_html = issue.description_html
+    version.description_binary = issue.description_binary
+    version.description_stripped = issue.description_stripped
+    version.last_saved_at = timezone.now()
+
+    version.save(
+        update_fields=[
+            "description_json",
+            "description_html",
+            "description_binary",
+            "description_stripped",
+            "last_saved_at",
+        ]
+    )
+
+
+@shared_task
+def issue_description_version_task(
+    updated_issue, issue_id, user_id, is_creating
+) -> Optional[bool]:
+    try:
+        # Parse updated issue data
+        current_issue: Dict = json.loads(updated_issue) if updated_issue else {}
+
+        # Get current issue
+        issue = Issue.objects.get(id=issue_id)
+
+        # Check if description has changed
+        if (
+            current_issue.get("description_html") == issue.description_html
+            and not is_creating
+        ):
+            return
+
+        with transaction.atomic():
+            # Get latest version
+            latest_version = (
+                IssueDescriptionVersion.objects.filter(issue_id=issue_id)
+                .order_by("-last_saved_at")
+                .first()
+            )
+
+            # Determine whether to update existing or create new version
+            if should_update_existing_version(version=latest_version, user_id=user_id):
+                update_existing_version(latest_version, issue)
+            else:
+                IssueDescriptionVersion.log_issue_description_version(issue, user_id)
+
+            return
+
+    except Issue.DoesNotExist:
+        # Issue no longer exists, skip processing
+        return
+    except json.JSONDecodeError as e:
+        log_exception(f"Invalid JSON for updated_issue: {e}")
+        return
+    except Exception as e:
+        log_exception(f"Error processing issue description version: {e}")
+        return

--- a/apiserver/plane/db/models/issue.py
+++ b/apiserver/plane/db/models/issue.py
@@ -804,13 +804,17 @@ class IssueDescriptionVersion(ProjectBaseModel):
             Log the issue description version
             """
             cls.objects.create(
-                issue=issue,
+                workspace_id=issue.workspace_id,
+                project_id=issue.project_id,
+                created_by_id=issue.created_by_id,
+                updated_by_id=issue.updated_by_id,
+                owned_by_id=user,
+                last_saved_at=timezone.now(),
+                issue_id=issue.id,
                 description_binary=issue.description_binary,
                 description_html=issue.description_html,
                 description_stripped=issue.description_stripped,
                 description_json=issue.description,
-                last_saved_at=timezone.now(),
-                owned_by=user,
             )
             return True
         except Exception as e:

--- a/apiserver/plane/settings/common.py
+++ b/apiserver/plane/settings/common.py
@@ -262,6 +262,9 @@ CELERY_IMPORTS = (
     "plane.license.bgtasks.tracer",
     # management tasks
     "plane.bgtasks.dummy_data_task",
+    # issue version tasks
+    "plane.bgtasks.issue_version_sync",
+    "plane.bgtasks.issue_description_version_sync",
 )
 
 # Sentry Settings


### PR DESCRIPTION
### Description  
- Implemented a trigger for the `issue_description_version` task to execute automatically during issue creation and update operations.  
- Ensures the issue description versions are always kept up-to-date in real-time.  

### Type of Change  
<!-- Put an 'x' in the boxes that apply -->  
- [x] Feature (non-breaking change which adds functionality)  

### References  
[[WEB-2854]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/178d1141-6de7-45c9-8165-376f328f969b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced version tracking for issue descriptions to enhance issue management.
  - Added asynchronous task processing for managing issue description versions.

- **Bug Fixes**
  - Improved error handling for issue description updates, ensuring data integrity.

- **Documentation**
  - Updated method signatures to reflect new parameters for logging issue description versions.

- **Chores**
  - Added new task imports to the application settings for better task management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->