### PR TITLE
[WEB-2808] chore: remove workspace-level toggle from parent select modal

### DIFF
--- a/web/core/components/issues/parent-issues-list-modal.tsx
+++ b/web/core/components/issues/parent-issues-list-modal.tsx
@@ -9,7 +9,7 @@ import { Combobox, Dialog, Transition } from "@headlessui/react";
 // types
 import { ISearchIssueResponse } from "@plane/types";
 // ui
-import { Loader, ToggleSwitch, Tooltip } from "@plane/ui";
+import { Loader } from "@plane/ui";
 // components
 import { IssueSearchModalEmptyState } from "@/components/core";
 // helpers
@@ -48,7 +48,6 @@ export const ParentIssuesListModal: React.FC<Props> = ({
   const [searchTerm, setSearchTerm] = useState("");
   const [issues, setIssues] = useState<ISearchIssueResponse[]>([]);
   const [isSearching, setIsSearching] = useState(false);
-  const [isWorkspaceLevel, setIsWorkspaceLevel] = useState(false);
   const { isMobile } = usePlatformOS();
   const debouncedSearchTerm: string = useDebounce(searchTerm, 500);
 
@@ -59,7 +58,6 @@ export const ParentIssuesListModal: React.FC<Props> = ({
   const handleClose = () => {
     onClose();
     setSearchTerm("");
-    setIsWorkspaceLevel(false);
   };
 
   useEffect(() => {
@@ -73,7 +71,7 @@ export const ParentIssuesListModal: React.FC<Props> = ({
         search: debouncedSearchTerm,
         parent: true,
         issue_id: issueId,
-        workspace_search: isWorkspaceLevel,
+        workspace_search: false,
         epic: searchEpic ? true : undefined,
       })
       .then((res) => setIssues(res))
@@ -81,7 +79,7 @@ export const ParentIssuesListModal: React.FC<Props> = ({
         setIsSearching(false);
         setIsLoading(false);
       });
-  }, [debouncedSearchTerm, isOpen, issueId, isWorkspaceLevel, projectId, workspaceSlug]);
+  }, [debouncedSearchTerm, isOpen, issueId, projectId, workspaceSlug]);
 
   return (
     <>
@@ -130,28 +128,6 @@ export const ParentIssuesListModal: React.FC<Props> = ({
                       displayValue={() => ""}
                       tabIndex={baseTabIndex}
                     />
-                  </div>
-                  <div className="flex p-2 sm:justify-end">
-                    <Tooltip tooltipContent="Toggle workspace level search" isMobile={isMobile}>
-                      <div
-                        className={`flex flex-shrink-0 cursor-pointer items-center gap-1 text-xs ${
-                          isWorkspaceLevel ? "text-custom-text-100" : "text-custom-text-200"
-                        }`}
-                      >
-                        <ToggleSwitch
-                          value={isWorkspaceLevel}
-                          onChange={() => setIsWorkspaceLevel((prevData) => !prevData)}
-                          label="Workspace level"
-                        />
-                        <button
-                          type="button"
-                          onClick={() => setIsWorkspaceLevel((prevData) => !prevData)}
-                          className="flex-shrink-0"
-                        >
-                          Workspace Level
-                        </button>
-                      </div>
-                    </Tooltip>
                   </div>
                   <Combobox.Options
                     static


### PR DESCRIPTION
### Description
This PR makes the following updates:
- Removes the workspace-level toggle option from the parent select modal.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

### Media
| Before | After |
|--------|--------|
| ![WEB-2808 Before](https://github.com/user-attachments/assets/c73a256d-f2a5-4679-8a1b-1ce476dcd32e) | ![WEB-2808 After](https://github.com/user-attachments/assets/90973416-2b07-4211-b84e-c6c3df1f0990) |

### Test Scenarios 
- Verified functionality in all affected areas.

### Affected areas:
- Project Issues:
   - Create/Update modal: Parent select actions.
   - Issue Peek View: Parent properties.
   - Issue Detail Page: Sidebar parent properties.
- Inbox Issues:
   - Create/Update Intake Issue modal: Parent select actions.
   - Intake Issue Detail Page: Sidebar parent properties.
   
### References
[[WEB-2808]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/589432cf-1f04-4d16-ac49-82279a4e8acc)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Streamlined the `ParentIssuesListModal` component by removing workspace-level search functionality.

- **Bug Fixes**
	- Eliminated unnecessary state management related to workspace-level searching, simplifying the component's behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->