### PR TITLE
[PE-98] fix: page title fixed height

### DIFF
--- a/web/core/components/pages/editor/editor-body.tsx
+++ b/web/core/components/pages/editor/editor-body.tsx
@@ -166,14 +166,12 @@ export const PageEditorBody: React.FC<Props> = observer((props) => {
         })}
       >
         <div className="size-full flex flex-col gap-y-7 overflow-y-auto overflow-x-hidden">
-          <div className="relative w-full flex-shrink-0 md:pl-5 px-4 h-[38px]">
-            <PageEditorTitle
-              editorRef={editorRef}
-              title={pageTitle}
-              updateTitle={updateTitle}
-              readOnly={!isContentEditable}
-            />
-          </div>
+          <PageEditorTitle
+            editorRef={editorRef}
+            title={pageTitle}
+            updateTitle={updateTitle}
+            readOnly={!isContentEditable}
+          />
           <CollaborativeDocumentEditorWithRef
             editable={isContentEditable}
             id={pageId}

--- a/web/core/components/pages/editor/title.tsx
+++ b/web/core/components/pages/editor/title.tsx
@@ -31,9 +31,9 @@ export const PageEditorTitle: React.FC<Props> = observer((props) => {
   });
 
   return (
-    <>
+    <div className="relative w-full flex-shrink-0 md:pl-5 px-4">
       {readOnly ? (
-        <h6 className={cn(titleClassName, "break-words")}>{title}</h6>
+        <h6 className={cn(titleClassName, "break-words pb-1.5")}>{title}</h6>
       ) : (
         <>
           <TextArea
@@ -71,6 +71,6 @@ export const PageEditorTitle: React.FC<Props> = observer((props) => {
           </div>
         </>
       )}
-    </>
+    </div>
   );
 });


### PR DESCRIPTION
### Description

This PR fixes the fixed height bug of a page title causing long page titles to overflow out of the container.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### Media

| Before | After |
|--------|--------|
| <img width="1512" alt="image" src="https://github.com/user-attachments/assets/d381d707-9327-46b4-b457-1f49bd6a96fa" /> | <img width="1512" alt="image" src="https://github.com/user-attachments/assets/748225cd-8e2a-4eb4-86e1-3db69f9065fc" /> | 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced layout and styling for the title display in read-only mode.
- **Bug Fixes**
	- Improved structural integrity of the Page Editor components without affecting functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->