### PR TITLE
[WEB-2885] fix: retain issue description when creating an issue copy

### DIFF
--- a/web/core/components/issues/issue-modal/base.tsx
+++ b/web/core/components/issues/issue-modal/base.tsx
@@ -92,7 +92,7 @@ export const CreateUpdateIssueModalBase: React.FC<IssuesModalProps> = observer((
 
   useEffect(() => {
     // fetching issue details
-    if (isOpen) fetchIssueDetail(data?.id);
+    if (isOpen) fetchIssueDetail(data?.id ?? data?.sourceIssueId);
 
     // if modal is closed, reset active project to null
     // and return to avoid activeProjectId being set to some other project
@@ -115,7 +115,8 @@ export const CreateUpdateIssueModalBase: React.FC<IssuesModalProps> = observer((
 
     // clearing up the description state when we leave the component
     return () => setDescription(undefined);
-  }, [data, projectId, isOpen, activeProjectId]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data?.project_id, data?.id, data?.sourceIssueId, projectId, isOpen, activeProjectId]);
 
   const addIssueToCycle = async (issue: TIssue, cycleId: string) => {
     if (!workspaceSlug || !issue.project_id) return;


### PR DESCRIPTION
### Description
Ensure the description is included when copying an issue, even if the source issue isn't opened beforehand.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media 
https://github.com/user-attachments/assets/ff1125b8-df98-4737-8f60-b8064cd456ec


### References
[WEB-2885](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/375a9960-5acc-4b6f-b007-ca13804a2f61)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced issue modal to fetch details based on multiple identifiers when opened.
	- Improved handling of issue descriptions based on available data.

- **Bug Fixes**
	- Refined logic for state management in the issue modal to ensure accurate data retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->