### PR TITLE
[PE-93] regression: mention users highlight color, reomve bot users from search list

### DIFF
--- a/apiserver/plane/app/views/search/base.py
+++ b/apiserver/plane/app/views/search/base.py
@@ -274,7 +274,7 @@ class SearchEndpoint(BaseAPIView):
                         q |= Q(**{f"{field}__icontains": query})
                 users = (
                     ProjectMember.objects.filter(
-                        q, is_active=True, project_id=project_id, workspace__slug=slug
+                        q, is_active=True, project_id=project_id, workspace__slug=slug, member__is_bot=False
                     )
                     .annotate(
                         member__avatar_url=Case(

--- a/space/core/components/editor/embeds/mentions/user.tsx
+++ b/space/core/components/editor/embeds/mentions/user.tsx
@@ -26,9 +26,12 @@ export const EditorUserMention: React.FC<Props> = observer((props) => {
 
   return (
     <div
-      className={cn("not-prose inline px-1 py-0.5 rounded bg-yellow-500/20 text-yellow-500 no-underline", {
-        "bg-custom-primary-100/20 text-custom-primary-100": id === currentUser?.id,
-      })}
+      className={cn(
+        "not-prose inline px-1 py-0.5 rounded bg-custom-primary-100/20 text-custom-primary-100 no-underline",
+        {
+          "bg-yellow-500/20 text-yellow-500": id === currentUser?.id,
+        }
+      )}
     >
       @{userDetails?.member__display_name}
     </div>

--- a/web/core/components/editor/embeds/mentions/user.tsx
+++ b/web/core/components/editor/embeds/mentions/user.tsx
@@ -58,9 +58,9 @@ export const EditorUserMention: React.FC<Props> = observer((props) => {
   return (
     <div
       className={cn(
-        "not-prose group/user-mention inline px-1 py-0.5 rounded bg-yellow-500/20 text-yellow-500 no-underline",
+        "not-prose group/user-mention inline px-1 py-0.5 rounded bg-custom-primary-100/20 text-custom-primary-100 no-underline",
         {
-          "bg-custom-primary-100/20 text-custom-primary-100": id === currentUser?.id,
+          "bg-yellow-500/20 text-yellow-500": id === currentUser?.id,
         }
       )}
     >


### PR DESCRIPTION
### Description

This PR fixes the following bugs-

1. User highlight color when mentioned(Yellow for slef mention, blue for other users).
2. Remove bot users from the list of users in the search endpoint.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced search functionality to exclude bot members from user mentions in results.
  
- **Style**
	- Updated visual representation of user mentions based on user status, improving clarity for active and deactivated users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->