### PR TITLE
[WEB-2830]fix: create view modal - layout drop down close

### DIFF
--- a/packages/ui/src/dropdown/single-select.tsx
+++ b/packages/ui/src/dropdown/single-select.tsx
@@ -110,7 +110,7 @@ export const Dropdown: FC<ISingleSelectDropdown> = (props) => {
   // hooks
   const handleKeyDown = useDropdownKeyPressed(toggleDropdown, handleClose);
 
-  useOutsideClickDetector(dropdownRef, handleClose);
+  useOutsideClickDetector(dropdownRef, handleClose, true);
 
   return (
     <Combobox


### PR DESCRIPTION
### Description
This update modifies the dropdown component to ensure it closes when a click is detected on the popover element.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update



### References
[WEB-2830](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/11cccf75-fbfa-40a7-9bb6-00f0a1c6fc88)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved event handling for the dropdown component's outside click detection, enhancing user experience when interacting with the dropdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->