### PR TITLE
[WEB-2588]fix: enabling guest user to use filters on their own views 

### DIFF
--- a/web/app/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/views/(detail)/[viewId]/header.tsx
+++ b/web/app/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/views/(detail)/[viewId]/header.tsx
@@ -31,6 +31,7 @@ import {
   useProject,
   useProjectState,
   useProjectView,
+  useUser,
   useUserPermissions,
 } from "@/hooks/store";
 import { EUserPermissions, EUserPermissionsLevel } from "@/plane-web/constants/user-permissions";
@@ -45,6 +46,7 @@ export const ProjectViewIssuesHeader: React.FC = observer(() => {
   const { setTrackElement } = useEventTracker();
   const { toggleCreateIssueModal } = useCommandPalette();
   const { allowPermissions } = useUserPermissions();
+  const { data } = useUser();
 
   const { currentProjectDetails, loader } = useProject();
   const { projectViewIds, getViewById } = useProjectView();
@@ -126,6 +128,10 @@ export const ProjectViewIssuesHeader: React.FC = observer(() => {
   );
 
   const viewDetails = viewId ? getViewById(viewId.toString()) : null;
+
+  // auth
+  const isOwner = viewDetails?.owned_by === data?.id;
+  const isAdmin = allowPermissions([EUserPermissions.ADMIN], EUserPermissionsLevel.PROJECT);
 
   const canUserCreateIssue = allowPermissions(
     [EUserPermissions.ADMIN, EUserPermissions.MEMBER],
@@ -247,7 +253,7 @@ export const ProjectViewIssuesHeader: React.FC = observer(() => {
             <FiltersDropdown
               title="Filters"
               placement="bottom-end"
-              disabled={!canUserCreateIssue}
+              disabled={!isOwner && !isAdmin}
               isFiltersApplied={isIssueFilterActive(issueFilters)}
             >
               <FilterSelection


### PR DESCRIPTION
### Description
This update modifies the permissions to allow guest users to edit views if they are the owners. Additionally, it ensures that admins or owners continue to have editing permissions.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [x] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### References
[WEB-2588](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/f732e070-c8cc-4e38-80aa-90714400cfab)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced user permission checks for project views.
	- Integrated user data to determine ownership and admin status.

- **Bug Fixes**
	- Improved logic for enabling/disabling the FiltersDropdown based on user permissions.

- **Documentation**
	- Updated method signatures for clarity on user data retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->