### PR TITLE
[WEB-2903] fix: active cycle update payload

### DIFF
--- a/web/core/components/cycles/modal.tsx
+++ b/web/core/components/cycles/modal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useEffect, useState } from "react";
+import { format } from "date-fns";
 import { mutate } from "swr";
 // types
 import type { CycleDateCheckData, ICycle, TCycleTabOptions } from "@plane/types";
@@ -131,8 +132,8 @@ export const CycleCreateUpdateModal: React.FC<CycleModalProps> = (props) => {
     if (payload.start_date && payload.end_date) {
       if (data?.start_date && data?.end_date)
         isDateValid = await dateChecker(payload.project_id ?? projectId, {
-          start_date: payload.start_date,
-          end_date: payload.end_date,
+          start_date: format(payload.start_date, "yyyy-MM-dd"),
+          end_date: format(payload.end_date, "yyyy-MM-dd"),
           cycle_id: data.id,
         });
       else


### PR DESCRIPTION
### Description
This PR resolves the issue with updating the active cycle. Previously, users were unable to update the active cycle due to a mismatch in the expected payload format. The start_date and end_date fields now updated in this YYYY-MM-DD format. 

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

### References
[[WEB-2903]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/ef7f55d2-e018-49ec-9d69-717915377c33/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved date handling in cycle creation and update processes by ensuring dates are consistently formatted.
  
- **New Features**
	- Enhanced date validation logic for better reliability when checking against existing cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->