### PR TITLE
[WEB-2889] fix: global views sorting when hyper model is enabled.

### DIFF
--- a/web/core/components/workspace/views/form.tsx
+++ b/web/core/components/workspace/views/form.tsx
@@ -3,6 +3,8 @@
 import { useEffect } from "react";
 import { observer } from "mobx-react";
 import { Controller, useForm } from "react-hook-form";
+// constant
+import { EIssueLayoutTypes } from "@plane/constants";
 // types
 import { IIssueDisplayFilterOptions, IIssueDisplayProperties, IIssueFilterOptions, IWorkspaceView } from "@plane/types";
 // ui
@@ -30,7 +32,9 @@ const defaultValues: Partial<IWorkspaceView> = {
   description: "",
   access: EViewAccess.PUBLIC,
   display_properties: getComputedDisplayProperties(),
-  display_filters: getComputedDisplayFilters(),
+  display_filters: getComputedDisplayFilters({
+    layout: EIssueLayoutTypes.SPREADSHEET,
+  }),
 };
 
 export const WorkspaceViewForm: React.FC<Props> = observer((props) => {

--- a/web/core/store/issue/helpers/base-issues.store.ts
+++ b/web/core/store/issue/helpers/base-issues.store.ts
@@ -297,6 +297,7 @@ export abstract class BaseIssuesStore implements IBaseIssuesStore {
     // Temporary code to fix no load order by
     if (
       this.rootIssueStore.rootStore.user.localDBEnabled &&
+      this.rootIssueStore.rootStore.router.projectId &&
       layout !== EIssueLayoutTypes.SPREADSHEET &&
       orderBy &&
       Object.keys(SPECIAL_ORDER_BY).includes(orderBy)


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
In this PR, I have fixed the issue with sorting in global views when hyper mode is enabled. 

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->
* Before

https://github.com/user-attachments/assets/c18ae31b-d897-4f28-89ef-8544f2689297


* After

https://github.com/user-attachments/assets/a4280814-84b7-4156-aa12-bf25d505242c



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced initial state for display filters in the Workspace View Form to align with the spreadsheet layout.
	- Improved issue ordering logic based on project context in the Base Issues Store.

- **Bug Fixes**
	- Addressed issues with display filters and ordering when specific layout types are applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->