### PR TITLE
[PE-97] chore: re-order pages options

### DIFF
--- a/web/core/components/pages/editor/header/options-dropdown.tsx
+++ b/web/core/components/pages/editor/header/options-dropdown.tsx
@@ -102,14 +102,14 @@ export const PageOptionsDropdown: React.FC<Props> = observer((props) => {
         extraOptions={EXTRA_MENU_OPTIONS}
         optionsOrder={[
           "full-screen",
-          "copy-markdown",
           "copy-link",
+          "make-a-copy",
           "toggle-lock",
           "toggle-access",
-          "make-a-copy",
           "archive-restore",
           "delete",
           "version-history",
+          "copy-markdown",
           "export",
         ]}
         page={page}

--- a/web/core/components/pages/list/block-item-action.tsx
+++ b/web/core/components/pages/list/block-item-action.tsx
@@ -29,13 +29,7 @@ export const BlockItemAction: FC<Props> = observer((props) => {
     page,
   });
   // derived values
-  const {
-    access,
-    created_at,
-    is_favorite,
-    owned_by,
-    canCurrentUserFavoritePage,
-  } = page;
+  const { access, created_at, is_favorite, owned_by, canCurrentUserFavoritePage } = page;
   const ownerDetails = owned_by ? getUserDetails(owned_by) : undefined;
 
   return (
@@ -76,11 +70,11 @@ export const BlockItemAction: FC<Props> = observer((props) => {
       {/* quick actions dropdown */}
       <PageActions
         optionsOrder={[
+          "copy-link",
+          "open-in-new-tab",
+          "make-a-copy",
           "toggle-lock",
           "toggle-access",
-          "open-in-new-tab",
-          "copy-link",
-          "make-a-copy",
           "archive-restore",
           "delete",
         ]}

--- a/web/core/components/pages/list/block-item-action.tsx
+++ b/web/core/components/pages/list/block-item-action.tsx
@@ -70,8 +70,8 @@ export const BlockItemAction: FC<Props> = observer((props) => {
       {/* quick actions dropdown */}
       <PageActions
         optionsOrder={[
-          "copy-link",
           "open-in-new-tab",
+          "copy-link",
           "make-a-copy",
           "toggle-lock",
           "toggle-access",


### PR DESCRIPTION
### Description

This PR updates the order of options for Pages' dropdowns.

### Type of Change

- [x] Improvement (change that would cause existing functionality to not work as expected)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Improvements**
	- Reordered dropdown menu options in the page options menu
	- Adjusted the sequence of page action options in the block item list
	- Maintained existing functionality while refining menu item placement

<!-- end of auto-generated comment: release notes by coderabbit.ai -->