### PR TITLE
[WEB-3035] chore: add labels to treemap chart

### DIFF
--- a/packages/types/src/charts.d.ts
+++ b/packages/types/src/charts.d.ts
@@ -35,6 +35,7 @@ export type TStackedBarChartProps<K extends string, T extends string> = {
 export type TreeMapItem = {
   name: string;
   value: number;
+  label?: string;
   textClassName?: string;
   icon?: React.ReactElement;
 } & (

--- a/web/core/components/core/charts/tree-map/map-content.tsx
+++ b/web/core/components/core/charts/tree-map/map-content.tsx
@@ -31,6 +31,7 @@ export const CustomTreeMapContent = ({
   height,
   name,
   value,
+  label,
   fillColor,
   fillClassName,
   textClassName,
@@ -109,10 +110,11 @@ export const CustomTreeMapContent = ({
         x={pX + TEXT_PADDING_LEFT}
         y={pY + pHeight - TEXT_PADDING_LEFT}
         textAnchor="start"
-        className={cn("text-xs", textClassName || "text-custom-text-300")}
+        className={cn("text-xs font-light tracking-wider", textClassName || "text-custom-text-300")}
         fill="currentColor"
       >
         {value?.toLocaleString()}
+        {label && ` ${label}`}
       </text>
     </g>
   );


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [x] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added optional `label` property to tree map items
	- Enhanced tree map chart content with additional labeling capabilities

- **Style**
	- Updated text styling for tree map chart labels with `font-light` and `tracking-wider` classes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->