### PR TITLE
[WEB-2915] fix: Modules reordering through drag and drop

### DIFF
--- a/web/core/components/gantt-chart/sidebar/modules/sidebar.tsx
+++ b/web/core/components/gantt-chart/sidebar/modules/sidebar.tsx
@@ -1,9 +1,14 @@
 "use client";
 
+import { observer } from "mobx-react";
 // ui
 import { Loader } from "@plane/ui";
 // components
-import { ChartDataType, IBlockUpdateData, IGanttBlock } from "@/components/gantt-chart";
+import { IBlockUpdateData } from "@/components/gantt-chart";
+// hooks
+import { useTimeLineChart } from "@/hooks/use-timeline-chart";
+//
+import { ETimeLineTypeType } from "../../contexts";
 import { GanttDnDHOC } from "../gantt-dnd-HOC";
 import { handleOrderChange } from "../utils";
 import { ModulesSidebarBlock } from "./block";
@@ -12,13 +17,14 @@ import { ModulesSidebarBlock } from "./block";
 type Props = {
   title: string;
   blockUpdateHandler: (block: any, payload: IBlockUpdateData) => void;
-  getBlockById: (id: string, currentViewData?: ChartDataType | undefined) => IGanttBlock;
   blockIds: string[];
   enableReorder: boolean;
 };
 
-export const ModuleGanttSidebar: React.FC<Props> = (props) => {
-  const { blockUpdateHandler, blockIds, getBlockById, enableReorder } = props;
+export const ModuleGanttSidebar: React.FC<Props> = observer((props) => {
+  const { blockUpdateHandler, blockIds, enableReorder } = props;
+
+  const { getBlockById } = useTimeLineChart(ETimeLineTypeType.MODULE);
 
   const handleOnDrop = (
     draggingBlockId: string | undefined,
@@ -52,4 +58,4 @@ export const ModuleGanttSidebar: React.FC<Props> = (props) => {
       )}
     </div>
   );
-};
+});


### PR DESCRIPTION
### Description

This PR makes change to use `getBlockById` from the module timeline store instead of the props being passed down to fix the re ordering of modules in timeline chart

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced Gantt chart sidebar with improved state management
	- Integrated new timeline chart hook for more dynamic data retrieval

- **Refactor**
	- Updated component to use MobX observer for reactive state updates
	- Simplified component props and data fetching mechanism

<!-- end of auto-generated comment: release notes by coderabbit.ai -->