### PR TITLE
fix: user config dependencies

### DIFF
--- a/web/core/components/pages/editor/editor-body.tsx
+++ b/web/core/components/pages/editor/editor-body.tsx
@@ -143,7 +143,7 @@ export const PageEditorBody: React.FC<Props> = observer((props) => {
       name: currentUser?.display_name ?? "",
       color: generateRandomColor(currentUser?.id ?? ""),
     }),
-    [currentUser]
+    [currentUser?.display_name, currentUser?.id]
   );
 
   if (pageId === undefined || !realtimeConfig) return <PageContentLoader />;


### PR DESCRIPTION
### Description

In this PR-

1. Updated the dependencies of the `userConfig` being passed to the document editor causing the HocuPocus provider to create multiple new providers without destroying the already existing ones.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)