### PR TITLE
[WEB-3042]fix: added tooltips for truncated favorites

### DIFF
--- a/web/core/components/workspace/sidebar/favorites/favorite-folder.tsx
+++ b/web/core/components/workspace/sidebar/favorites/favorite-folder.tsx
@@ -188,12 +188,7 @@ export const FavoriteFolder: React.FC<Props> = (props) => {
                 </div>
               ) : (
                 <>
-                  <Tooltip
-                    tooltipContent={`${favorite.name}`}
-                    position="right"
-                    disabled={!isSidebarCollapsed}
-                    isMobile={isMobile}
-                  >
+                  <Tooltip tooltipContent={`${favorite.name}`} position="right" className="ml-8" isMobile={isMobile}>
                     <div className="flex-grow flex truncate">
                       <Disclosure.Button
                         as="button"

--- a/web/core/components/workspace/sidebar/favorites/favorite-items/common/favorite-item-title.tsx
+++ b/web/core/components/workspace/sidebar/favorites/favorite-items/common/favorite-item-title.tsx
@@ -3,6 +3,7 @@ import React, { FC } from "react";
 import { observer } from "mobx-react";
 import Link from "next/link";
 import { Tooltip } from "@plane/ui";
+import { cn } from "@plane/utils";
 import { useAppTheme } from "@/hooks/store";
 import { usePlatformOS } from "@/hooks/use-platform-os";
 
@@ -28,7 +29,7 @@ export const FavoriteItemTitle: FC<Props> = observer((props) => {
   };
 
   return (
-    <Tooltip tooltipContent={title} isMobile={isMobile} disabled={!isSidebarCollapsed} position="right">
+    <Tooltip tooltipContent={title} isMobile={isMobile} position="right" className={cn(!isSidebarCollapsed && "ml-8")}>
       <Link href={href} className={isSidebarCollapsed ? collapsedClass : linkClass} draggable onClick={handleOnClick}>
         <span className="flex items-center justify-center size-5">{icon}</span>
         {!isSidebarCollapsed && <span className="text-sm leading-5 font-medium flex-1 truncate">{title}</span>}


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
Added tooltips for truncated favorite items.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update


### References
<!-- Link related issues if there are any -->
[WEB-3042](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/1e0892d3-9f0c-4320-9d60-94b84f06e43b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated `Tooltip` component styling in favorite folder and favorite item title components
	- Added left margin to tooltip when sidebar is not collapsed

<!-- end of auto-generated comment: release notes by coderabbit.ai -->