### PR TITLE
[WEB-3049] fix: Resolve start and end date comparison issue in cycle create and update

### DIFF
--- a/apiserver/plane/api/serializers/cycle.py
+++ b/apiserver/plane/api/serializers/cycle.py
@@ -32,7 +32,9 @@ class CycleSerializer(BaseSerializer):
         ):
             project_id = self.initial_data.get("project_id") or self.instance.project_id
             is_start_date_end_date_equal = (
-                True if data.get("start_date") == data.get("end_date") else False
+                True
+                if str(data.get("start_date")) == str(data.get("end_date"))
+                else False
             )
             data["start_date"] = convert_to_utc(
                 date=str(data.get("start_date").date()),

--- a/apiserver/plane/app/serializers/cycle.py
+++ b/apiserver/plane/app/serializers/cycle.py
@@ -22,7 +22,9 @@ class CycleWriteSerializer(BaseSerializer):
         ):
             project_id = self.initial_data.get("project_id") or self.instance.project_id
             is_start_date_end_date_equal = (
-                True if data.get("start_date") == data.get("end_date") else False
+                True
+                if str(data.get("start_date")) == str(data.get("end_date"))
+                else False
             )
             data["start_date"] = convert_to_utc(
                 date=str(data.get("start_date").date()),

--- a/apiserver/plane/app/views/cycle/base.py
+++ b/apiserver/plane/app/views/cycle/base.py
@@ -535,7 +535,7 @@ class CycleDateCheckEndpoint(BaseAPIView):
             )
 
         is_start_date_end_date_equal = (
-            True if str("start_date") == str("end_date") else False
+            True if str(start_date) == str(end_date) else False
         )
         start_date = convert_to_utc(
             date=str(start_date), project_id=project_id, is_start_date=True


### PR DESCRIPTION
### Description  
- Fixed the comparison logic for `start_date` and `end_date` during cycle creation and updates.  
- Ensures proper validation and handling of date ranges to avoid invalid or conflicting cycle configurations.  

### Type of Change  
- [x] Bug fix (non-breaking change which fixes an issue)

### References
[[WEB-3049]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/0bf646a6-6331-4a55-a41b-f369304cdd39)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed date comparison logic in cycle serializers and views to ensure accurate start and end date validation
  - Corrected a potential syntax error in the `CycleUserPropertiesSerializer` by adding a missing comma in `read_only_fields`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->