### PR TITLE
[PE-83] fix: reset text and background color in issue description

### DIFF
--- a/packages/editor/src/core/components/menus/bubble-menu/color-selector.tsx
+++ b/packages/editor/src/core/components/menus/bubble-menu/color-selector.tsx
@@ -71,7 +71,7 @@ export const BubbleMenuColorSelector: FC<Props> = (props) => {
               <button
                 type="button"
                 className="flex-shrink-0 size-6 grid place-items-center rounded text-custom-text-300 border-[0.5px] border-custom-border-400 hover:bg-custom-background-80 transition-colors"
-                onClick={() => TextColorItem(editor).command(undefined)}
+                onClick={() => TextColorItem(editor).command({ color: undefined })}
               >
                 <Ban className="size-4" />
               </button>
@@ -94,7 +94,7 @@ export const BubbleMenuColorSelector: FC<Props> = (props) => {
               <button
                 type="button"
                 className="flex-shrink-0 size-6 grid place-items-center rounded text-custom-text-300 border-[0.5px] border-custom-border-400 hover:bg-custom-background-80 transition-colors"
-                onClick={() => BackgroundColorItem(editor).command(undefined)}
+                onClick={() => BackgroundColorItem(editor).command({ color: undefined })}
               >
                 <Ban className="size-4" />
               </button>


### PR DESCRIPTION
### Description

This PR fixes reset text and background color bug on issue descriptions.

**Cause of the bug-** Wrong argument being passed to the text and background color handlers.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved color reset functionality in the editor's bubble menu color selector to ensure consistent color command handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->