### PR TITLE
[WEB-3050] fix: removed the unused triage state

### DIFF
--- a/apiserver/plane/api/views/project.py
+++ b/apiserver/plane/api/views/project.py
@@ -288,16 +288,6 @@ class ProjectAPIEndpoint(BaseAPIView):
                             is_default=True,
                         )
 
-                    # Create the triage state in Backlog group
-                    State.objects.get_or_create(
-                        name="Triage",
-                        group="triage",
-                        description="Default state for managing all Intake Issues",
-                        project_id=pk,
-                        color="#ff7700",
-                        is_triage=True,
-                    )
-
                 project = self.get_queryset().filter(pk=serializer.data["id"]).first()
 
                 model_activity.delay(

--- a/apiserver/plane/app/views/project/base.py
+++ b/apiserver/plane/app/views/project/base.py
@@ -416,16 +416,6 @@ class ProjectViewSet(BaseViewSet):
                             is_default=True,
                         )
 
-                    # Create the triage state in Backlog group
-                    State.objects.get_or_create(
-                        name="Triage",
-                        group="triage",
-                        description="Default state for managing all Intake Issues",
-                        project_id=pk,
-                        color="#ff7700",
-                        is_triage=True,
-                    )
-
                 project = self.get_queryset().filter(pk=serializer.data["id"]).first()
 
                 model_activity.delay(

--- a/apiserver/plane/space/views/intake.py
+++ b/apiserver/plane/space/views/intake.py
@@ -130,15 +130,6 @@ class IntakeIssuePublicViewSet(BaseViewSet):
                 {"error": "Invalid priority"}, status=status.HTTP_400_BAD_REQUEST
             )
 
-        # Create or get state
-        state, _ = State.objects.get_or_create(
-            name="Triage",
-            group="backlog",
-            description="Default state for managing all Intake Issues",
-            project_id=project_deploy_board.project_id,
-            color="#ff7700",
-        )
-
         # create an issue
         issue = Issue.objects.create(
             name=request.data.get("issue", {}).get("name"),
@@ -148,7 +139,6 @@ class IntakeIssuePublicViewSet(BaseViewSet):
             ),
             priority=request.data.get("issue", {}).get("priority", "low"),
             project_id=project_deploy_board.project_id,
-            state=state,
         )
 
         # Create an Issue Activity


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
this pull request removes the unused triage states in the project.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [x] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Removed Features**
	- Removed automatic "Triage" state creation when updating or creating projects and issues
	- Eliminated default state assignment for new issues

The changes suggest a modification in how project states and issue management are handled, potentially requiring manual state configuration or introducing a different workflow for issue intake and project setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->