### PR TITLE
[WEB 3053]feat: support LibreOffice file attachments in issues

### DIFF
--- a/apiserver/plane/app/views/issue/attachment.py
+++ b/apiserver/plane/app/views/issue/attachment.py
@@ -118,17 +118,14 @@ class IssueAttachmentV2Endpoint(BaseAPIView):
             entity_type=FileAsset.EntityTypeContext.ISSUE_ATTACHMENT,
         )
 
-        print(asset, "Print Assert")
-
         # Get the presigned URL
         storage = S3Storage(request=request)
-        print(storage, "Print Storage")
 
         # Generate a presigned URL to share an S3 object
         presigned_url = storage.generate_presigned_post(
             object_name=asset_key, file_type=type, file_size=size_limit
         )
-        print(presigned_url, "Print Presigned_URL")
+
         # Return the presigned URL
         return Response(
             {

--- a/apiserver/plane/app/views/issue/attachment.py
+++ b/apiserver/plane/app/views/issue/attachment.py
@@ -118,12 +118,17 @@ class IssueAttachmentV2Endpoint(BaseAPIView):
             entity_type=FileAsset.EntityTypeContext.ISSUE_ATTACHMENT,
         )
 
+        print(asset, "Print Assert")
+
         # Get the presigned URL
         storage = S3Storage(request=request)
+        print(storage, "Print Storage")
+
         # Generate a presigned URL to share an S3 object
         presigned_url = storage.generate_presigned_post(
             object_name=asset_key, file_type=type, file_size=size_limit
         )
+        print(presigned_url, "Print Presigned_URL")
         # Return the presigned URL
         return Response(
             {

--- a/apiserver/plane/settings/common.py
+++ b/apiserver/plane/settings/common.py
@@ -390,8 +390,6 @@ ATTACHMENT_MIME_TYPES = [
     "video/quicktime",
     "video/x-msvideo",
     "video/x-ms-wmv",
-    # Flash video
-    "video/x-flv",
     # Archives
     "application/zip",
     "application/x-rar-compressed",

--- a/apiserver/plane/settings/common.py
+++ b/apiserver/plane/settings/common.py
@@ -361,6 +361,7 @@ ATTACHMENT_MIME_TYPES = [
     "application/vnd.openxmlformats-officedocument.presentationml.presentation",
     "text/plain",
     "application/rtf",
+    "application/vnd.oasis.opendocument.spreadsheet",
     # Audio
     "audio/mpeg",
     "audio/wav",

--- a/apiserver/plane/settings/common.py
+++ b/apiserver/plane/settings/common.py
@@ -362,6 +362,17 @@ ATTACHMENT_MIME_TYPES = [
     "text/plain",
     "application/rtf",
     "application/vnd.oasis.opendocument.spreadsheet",
+    "application/vnd.oasis.opendocument.text",
+    "application/vnd.oasis.opendocument.presentation",
+    "application/vnd.oasis.opendocument.graphics",
+    # Microsoft Visio
+    "application/vnd.visio",
+    # Netpbm format
+    "image/x-portable-graymap",
+    "image/x-portable-bitmap",
+    "image/x-portable-pixmap",
+    # Open Office Bae
+    "application/vnd.oasis.opendocument.database",
     # Audio
     "audio/mpeg",
     "audio/wav",
@@ -379,6 +390,8 @@ ATTACHMENT_MIME_TYPES = [
     "video/quicktime",
     "video/x-msvideo",
     "video/x-ms-wmv",
+    # Flash video
+    "video/x-flv",
     # Archives
     "application/zip",
     "application/x-rar-compressed",


### PR DESCRIPTION
### Description
This PR allows LibreOffice, Microsoft Viseo, Netpbm, Open Office Bea files in the issue attachments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for new file types including OpenDocument formats, Microsoft Visio, and Netpbm image formats
  - Implemented new patch method for attachment updates
  - Enhanced attachment handling with file validation and presigned URL generation

- **Improvements**
  - Added soft delete functionality for file attachments
  - Improved asset retrieval with optional parameter support

- **Bug Fixes**
  - Added file type and size validation for attachments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->