### PR TITLE
[PE-219] chore: add missing tiptap/html package to the editor

### DIFF
--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -53,6 +53,7 @@
     "@tiptap/extension-text-align": "^2.8.0",
     "@tiptap/extension-text-style": "^2.7.1",
     "@tiptap/extension-underline": "^2.1.13",
+    "@tiptap/html": "^2.1.13",
     "@tiptap/pm": "^2.1.13",
     "@tiptap/react": "^2.1.13",
     "@tiptap/starter-kit": "^2.1.13",


### PR DESCRIPTION
### Description

This PR adds the missing package, `@tiptap/html`, to the editor package.json.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Added `@tiptap/html` library as a dependency for the editor package, which may improve text processing and HTML handling capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->