### PR TITLE
[WEB-3087] fix: project_id handling in cycle create write serializer

### DIFF
--- a/apiserver/plane/app/serializers/cycle.py
+++ b/apiserver/plane/app/serializers/cycle.py
@@ -20,7 +20,11 @@ class CycleWriteSerializer(BaseSerializer):
             data.get("start_date", None) is not None
             and data.get("end_date", None) is not None
         ):
-            project_id = self.initial_data.get("project_id") or self.instance.project_id
+            project_id = (
+                self.initial_data.get("project_id")
+                or self.instance.project_id
+                or self.context.get("project_id")
+            )
             is_start_date_end_date_equal = (
                 True
                 if str(data.get("start_date")) == str(data.get("end_date"))

--- a/apiserver/plane/app/views/cycle/base.py
+++ b/apiserver/plane/app/views/cycle/base.py
@@ -54,11 +54,7 @@ from plane.bgtasks.recent_visited_task import recent_visited_task
 # Module imports
 from .. import BaseAPIView, BaseViewSet
 from plane.bgtasks.webhook_task import model_activity
-from plane.utils.timezone_converter import (
-    convert_utc_to_project_timezone,
-    convert_to_utc,
-    user_timezone_converter,
-)
+from plane.utils.timezone_converter import convert_to_utc, user_timezone_converter
 
 
 class CycleViewSet(BaseViewSet):
@@ -270,7 +266,9 @@ class CycleViewSet(BaseViewSet):
             request.data.get("start_date", None) is not None
             and request.data.get("end_date", None) is not None
         ):
-            serializer = CycleWriteSerializer(data=request.data)
+            serializer = CycleWriteSerializer(
+                data=request.data, context={"project_id": project_id}
+            )
             if serializer.is_valid():
                 serializer.save(project_id=project_id, owned_by=request.user)
                 cycle = (
@@ -357,7 +355,9 @@ class CycleViewSet(BaseViewSet):
                     status=status.HTTP_400_BAD_REQUEST,
                 )
 
-        serializer = CycleWriteSerializer(cycle, data=request.data, partial=True)
+        serializer = CycleWriteSerializer(
+            cycle, data=request.data, partial=True, context={"project_id": project_id}
+        )
         if serializer.is_valid():
             serializer.save()
             cycle = queryset.values(


### PR DESCRIPTION
### Description
- Updated the cycle create write serializer to properly retrieve `project_id` from the current instance.  
- Ensured that `project_id` is correctly assigned and saved during cycle creation. 

### Type of Change
- [x] Improvement (change that would cause existing functionality to work as expected)  

### References
[[WEB-3087]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/f2d3e2a3-4f28-4bc4-ae6a-c018ac31d4f2)