### PR TITLE
[WEB-3079]fix: copy module link

### DIFF
--- a/web/core/components/modules/links/list-item.tsx
+++ b/web/core/components/modules/links/list-item.tsx
@@ -66,7 +66,7 @@ export const ModulesLinksListItem: React.FC<Props> = observer((props) => {
             </button>
           )}
           <span
-            onClick={() => copyToClipboard(link.title && link.title !== "" ? link.title : link.url)}
+            onClick={() => copyToClipboard(link.url)}
             className="grid place-items-center p-1 hover:bg-custom-background-80 cursor-pointer"
           >
             <Copy className="h-3.5 w-3.5 stroke-[1.5]" />


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
Fixed the issue where the title is copied instead of link in modules.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update


### References
<!-- Link related issues if there are any -->
[WEB-3079](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/9ea9ab63-ea21-4b63-be90-a8065062e9d0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated link copying behavior to always copy the link's URL when clicked, simplifying the clipboard interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->