### PR TITLE
[PE-228] chore: update `@tiptap/extension-task-item` version and required css

### DIFF
--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -48,7 +48,7 @@
     "@tiptap/extension-list-item": "2.11.0",
     "@tiptap/extension-mention": "2.11.0",
     "@tiptap/extension-placeholder": "2.11.0",
-    "@tiptap/extension-task-item": "2.10.4",
+    "@tiptap/extension-task-item": "2.11.0",
     "@tiptap/extension-task-list": "2.11.0",
     "@tiptap/extension-text-align": "2.11.0",
     "@tiptap/extension-text-style": "2.11.0",

--- a/packages/editor/src/styles/editor.css
+++ b/packages/editor/src/styles/editor.css
@@ -119,13 +119,13 @@ ul[data-type="taskList"] li > label input[type="checkbox"] {
   pointer-events: none;
 }
 
-ul[data-type="taskList"] li > label input[type="checkbox"][checked] {
+ul[data-type="taskList"] li > label input[type="checkbox"]:checked {
   background-color: rgba(var(--color-primary-100)) !important;
   border-color: rgba(var(--color-primary-100)) !important;
   color: white !important;
 }
 
-ul[data-type="taskList"] li > label input[type="checkbox"][checked]:hover {
+ul[data-type="taskList"] li > label input[type="checkbox"]:checked:hover {
   background-color: rgba(var(--color-primary-300)) !important;
   border-color: rgba(var(--color-primary-300)) !important;
 }
@@ -174,7 +174,7 @@ ul[data-type="taskList"] li > label input[type="checkbox"] {
     clip-path: polygon(14% 44%, 0 65%, 50% 100%, 100% 16%, 80% 0%, 43% 62%);
   }
 
-  &[checked]::before {
+  &:checked::before {
     transform: scale(1) translate(-50%, -50%);
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3546,10 +3546,10 @@
   resolved "https://registry.yarnpkg.com/@tiptap/extension-strike/-/extension-strike-2.11.0.tgz#8507cfb501f4950d869f8ddd1adb47b66680765f"
   integrity sha512-71i2IZT58kY2ohlhyO+ucyAioNNCkNkuPkrVERc9lXhmcCKOff5y6ekDHQHO2jNjnejkVE5ibyDO3Z7RUXjh1A==
 
-"@tiptap/extension-task-item@2.10.4":
-  version "2.10.4"
-  resolved "https://registry.yarnpkg.com/@tiptap/extension-task-item/-/extension-task-item-2.10.4.tgz#afc59e1632db1d7d1d8c2ff4e897a638337a949f"
-  integrity sha512-ucKGXdHdHCBanIJTB/nhmQ3iIL6BcSVKr7mN5BGEu6sSLYROflX7lmnMPVIRcTKJz+FGJeR6AqPFVagZAXVkGQ==
+"@tiptap/extension-task-item@2.11.0":
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/@tiptap/extension-task-item/-/extension-task-item-2.11.0.tgz#ff97f10bf39d6c27fd3f3f1ee3987d7015304c11"
+  integrity sha512-qu6VuRc8qF80Bwr82CItFcrKtC67LJkwpxESLEIi42zWZ5sXF/3DJEPPS/4Kk+nAc9UCBoEMFAULibPq7rRl/w==
 
 "@tiptap/extension-task-list@2.11.0":
   version "2.11.0"


### PR DESCRIPTION
### Description

This PR updates the `@tiptap/extension-task-item` version to the latest.

In addition, CSS for checked item is also updated to accommodate the latest changes made to the task item extension which no longer adds the `checked` attribute to the checkbox input, instead handles it programmatically.

### Type of Change

- [x] Improvement (change that would cause existing functionality to not work as expected)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Dependencies**
	- Updated `@tiptap/extension-task-item` package to version 2.11.0

- **Style**
	- Refined CSS selectors for task list checkboxes, improving selector syntax and maintainability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->