### PR TITLE
[WEB-3087] fix: handle cycle start and end timezone conversion in list, create, and update

### DIFF
--- a/apiserver/plane/app/serializers/cycle.py
+++ b/apiserver/plane/app/serializers/cycle.py
@@ -22,7 +22,7 @@ class CycleWriteSerializer(BaseSerializer):
         ):
             project_id = (
                 self.initial_data.get("project_id", None)
-                or (self.instance and self.instance.get("project_id", None))
+                or (self.instance and self.instance.project_id)
                 or self.context.get("project_id", None)
             )
             is_start_date_end_date_equal = (

--- a/apiserver/plane/app/views/cycle/base.py
+++ b/apiserver/plane/app/views/cycle/base.py
@@ -303,6 +303,11 @@ class CycleViewSet(BaseViewSet):
                     .first()
                 )
 
+                datetime_fields = ["start_date", "end_date"]
+                cycle = user_timezone_converter(
+                    cycle, datetime_fields, request.user.user_timezone
+                )
+
                 # Send the model activity
                 model_activity.delay(
                     model_name="cycle",
@@ -386,6 +391,11 @@ class CycleViewSet(BaseViewSet):
                 "status",
                 "created_by",
             ).first()
+
+            datetime_fields = ["start_date", "end_date"]
+            cycle = user_timezone_converter(
+                cycle, datetime_fields, request.user.user_timezone
+            )
 
             # Send the model activity
             model_activity.delay(

--- a/yarn.lock
+++ b/yarn.lock
@@ -3576,11 +3576,7 @@
   resolved "https://registry.yarnpkg.com/@tiptap/extension-underline/-/extension-underline-2.11.0.tgz#473025d3ed01953fb2c23f8060ea90be4c231faa"
   integrity sha512-DE1piq441y1+9Aj1pvvuq1dcc5B2HZ2d1SPtO4DTMjCxrhok12biTkMxxq0q1dzA5/BouLlUW6WTPpinhmrUWA==
 
-<<<<<<< Updated upstream
 "@tiptap/html@2.11.0":
-=======
-"@tiptap/html@^2.1.13", "@tiptap/html@^2.3.0":
->>>>>>> Stashed changes
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/@tiptap/html/-/html-2.11.0.tgz#dd0b4195a07bbdca27aa13325b8ebac41480a6a0"
   integrity sha512-9+8eSeey3gm6vMtbt+uKZfkvtwsWr577lhtTeGUsoThim9zyBnbhzHc1dQw2m1RefOoPcODrnnQPvi5nvA84Cw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3576,7 +3576,11 @@
   resolved "https://registry.yarnpkg.com/@tiptap/extension-underline/-/extension-underline-2.11.0.tgz#473025d3ed01953fb2c23f8060ea90be4c231faa"
   integrity sha512-DE1piq441y1+9Aj1pvvuq1dcc5B2HZ2d1SPtO4DTMjCxrhok12biTkMxxq0q1dzA5/BouLlUW6WTPpinhmrUWA==
 
+<<<<<<< Updated upstream
 "@tiptap/html@2.11.0":
+=======
+"@tiptap/html@^2.1.13", "@tiptap/html@^2.3.0":
+>>>>>>> Stashed changes
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/@tiptap/html/-/html-2.11.0.tgz#dd0b4195a07bbdca27aa13325b8ebac41480a6a0"
   integrity sha512-9+8eSeey3gm6vMtbt+uKZfkvtwsWr577lhtTeGUsoThim9zyBnbhzHc1dQw2m1RefOoPcODrnnQPvi5nvA84Cw==


### PR DESCRIPTION
### Description  
- Fixed timezone conversion issues for `start_date` and `end_date` in cycles.  
- Ensured proper handling of timezone-aware dates in the cycle list, create, and update operations.  

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

### References
[[WEB-3087]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/f2d3e2a3-4f28-4bc4-ae6a-c018ac31d4f2)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed a syntax error in the `read_only_fields` declaration for `CycleUserPropertiesSerializer`
  - Corrected `project_id` access method in `CycleWriteSerializer`

- **New Features**
  - Added timezone conversion for `start_date` and `end_date` fields in cycle operations
  - Improved handling of date fields to support user's local timezone

<!-- end of auto-generated comment: release notes by coderabbit.ai -->