### PR TITLE
[PE-208] fix: floating toolbar content

### DIFF
--- a/packages/editor/src/core/components/menus/bubble-menu/root.tsx
+++ b/packages/editor/src/core/components/menus/bubble-menu/root.tsx
@@ -87,12 +87,9 @@ export const EditorBubbleMenu: FC<EditorBubbleMenuProps> = (props: any) => {
   }, []);
 
   return (
-    <BubbleMenu
-      {...bubbleMenuProps}
-      className="flex py-2 divide-x divide-custom-border-200 rounded-lg border border-custom-border-200 bg-custom-background-100 shadow-custom-shadow-rg"
-    >
+    <BubbleMenu {...bubbleMenuProps}>
       {!isSelecting && (
-        <>
+        <div className="flex py-2 divide-x divide-custom-border-200 rounded-lg border border-custom-border-200 bg-custom-background-100 shadow-custom-shadow-rg">
           <div className="px-2">
             {!props.editor.isActive("table") && (
               <BubbleMenuNodeSelector
@@ -161,7 +158,7 @@ export const EditorBubbleMenu: FC<EditorBubbleMenuProps> = (props: any) => {
               editor.commands.setTextSelection(pos ?? 0);
             }}
           />
-        </>
+        </div>
       )}
     </BubbleMenu>
   );


### PR DESCRIPTION
### Description

This PR removes the CSS from the floating toolbar until it's ready to be visible.

With the CSS, toolbar appeared as a very small div with some border until the user was completely done making the selection.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Restructured the `BubbleMenu` component's rendering approach
	- Adjusted styling application method without changing core functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->