### PR TITLE
[WEB-3104] chore: removed extra permission in stickies

### DIFF
--- a/apiserver/plane/app/views/workspace/sticky.py
+++ b/apiserver/plane/app/views/workspace/sticky.py
@@ -4,7 +4,7 @@ from rest_framework import status
 
 # Module imports
 from plane.app.views.base import BaseViewSet
-from plane.app.permissions import WorkSpaceBasePermission, ROLE, allow_permission
+from plane.app.permissions import ROLE, allow_permission
 from plane.db.models import Sticky, Workspace
 from plane.app.serializers import StickySerializer
 
@@ -12,7 +12,6 @@ from plane.app.serializers import StickySerializer
 class WorkspaceStickyViewSet(BaseViewSet):
     serializer_class = StickySerializer
     model = Sticky
-    permission_classes = [WorkSpaceBasePermission]
 
     def get_queryset(self):
         return self.filter_queryset(


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
- removed extra permission in stickies
### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
	- Updated permission handling for workspace sticky notes
	- Refined access control mechanisms for specific view actions
	- Maintained role-based permissions for create, list, update, and delete operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->