### PR TITLE
[WEB-1964]chore: added current cycle to cycle dropdown

### DIFF
--- a/web/core/components/dropdowns/cycle/cycle-options.tsx
+++ b/web/core/components/dropdowns/cycle/cycle-options.tsx
@@ -31,10 +31,11 @@ type CycleOptionsProps = {
   placement: Placement | undefined;
   isOpen: boolean;
   canRemoveCycle: boolean;
+  currentCycleId?: string;
 };
 
 export const CycleOptions: FC<CycleOptionsProps> = observer((props) => {
-  const { projectId, isOpen, referenceElement, placement, canRemoveCycle } = props;
+  const { projectId, isOpen, referenceElement, placement, canRemoveCycle, currentCycleId } = props;
   //state hooks
   const [query, setQuery] = useState("");
   const [popperElement, setPopperElement] = useState<HTMLDivElement | null>(null);
@@ -68,6 +69,7 @@ export const CycleOptions: FC<CycleOptionsProps> = observer((props) => {
 
   const cycleIds = (getProjectCycleIds(projectId) ?? [])?.filter((cycleId) => {
     const cycleDetails = getCycleById(cycleId);
+    if (currentCycleId && currentCycleId === cycleId) return false;
     return cycleDetails?.status ? (cycleDetails?.status.toLowerCase() != "completed" ? true : false) : true;
   });
 

--- a/web/core/components/dropdowns/cycle/index.tsx
+++ b/web/core/components/dropdowns/cycle/index.tsx
@@ -26,6 +26,7 @@ type Props = TDropdownProps & {
   value: string | null;
   canRemoveCycle?: boolean;
   renderByDefault?: boolean;
+  currentCycleId?: string;
 };
 
 export const CycleDropdown: React.FC<Props> = observer((props) => {
@@ -49,6 +50,7 @@ export const CycleDropdown: React.FC<Props> = observer((props) => {
     value,
     canRemoveCycle = true,
     renderByDefault = true,
+    currentCycleId,
   } = props;
   // states
 
@@ -145,6 +147,7 @@ export const CycleDropdown: React.FC<Props> = observer((props) => {
           placement={placement}
           referenceElement={referenceElement}
           canRemoveCycle={canRemoveCycle}
+          currentCycleId={currentCycleId}
         />
       )}
     </ComboDropDown>


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
Added `currentCycleId` to the Cycle dropdown to exclude the current cycle from the dropdown.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [x] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update


### References
<!-- Link related issues if there are any -->
[WEB-1964](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/174a4f51-62d4-457e-961f-b4dccf2beb74)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced cycle dropdown functionality by introducing an optional `currentCycleId` property.
	- Improved cycle selection management with more flexible filtering logic to exclude the currently selected cycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->