### PR TITLE
[WEB-3110] chore: changed the creator of page when duplicated

### DIFF
--- a/apiserver/plane/app/views/page/base.py
+++ b/apiserver/plane/app/views/page/base.py
@@ -573,6 +573,8 @@ class PageDuplicateEndpoint(BaseAPIView):
         page.name = f"{page.name} (Copy)"
         page.description_binary = None
         page.owned_by = request.user
+        page.created_by = request.user
+        page.updated_by = request.user
         page.save()
 
         for project_id in project_ids:


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
- The creator of the page is changed when the page is duplicated.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced page duplication process to track the user who creates a duplicate page
- **Bug Fixes**
  - Improved user attribution when duplicating pages by setting `created_by` and `updated_by` fields

<!-- end of auto-generated comment: release notes by coderabbit.ai -->