### PR TITLE
[WEB-3112] fix: Remove default timezone and use user-specific timezone in timezone select

### DIFF
--- a/web/core/components/global/timezone-select.tsx
+++ b/web/core/components/global/timezone-select.tsx
@@ -37,7 +37,7 @@ export const TimezoneSelect: FC<TTimezoneSelect> = observer((props) => {
     <div>
       <CustomSearchSelect
         value={value}
-        label={selectedValue ? selectedValue(value) : label}
+        label={value && selectedValue ? selectedValue(value) : label}
         options={isDisabled || disabled ? [] : timezones}
         onChange={onChange}
         buttonClassName={cn(buttonClassName, {

--- a/web/core/components/profile/form.tsx
+++ b/web/core/components/profile/form.tsx
@@ -62,7 +62,7 @@ export const ProfileForm = observer((props: TProfileFormProps) => {
       email: user.email || "",
       role: profile.role || "Product / Project Manager",
       language: profile.language || "en",
-      user_timezone: "Asia/Kolkata",
+      user_timezone: user.user_timezone || "Asia/Kolkata",
     },
   });
   // derived values


### PR DESCRIPTION
### Description  
- Removed the default timezone setting and now the timezone value is derived from user details.  
- Updated the timezone select dropdown to handle and display the user's timezone properly.  

### Type of Change  
- [x] Bug fix (non-breaking change which fixes an issue)

### References
[[WEB-3112]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/9d729a11-7977-4cce-801b-da57c9206f44)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved timezone selection logic in `TimezoneSelect` component to prevent potential undefined behavior
  - Enhanced `ProfileForm` to use user's existing timezone as default, with fallback to "Asia/Kolkata"

<!-- end of auto-generated comment: release notes by coderabbit.ai -->