### PR TITLE
[WEB-3122] fix: error handling for workspace invite bg task

### DIFF
--- a/apiserver/plane/bgtasks/workspace_invitation_task.py
+++ b/apiserver/plane/bgtasks/workspace_invitation_task.py
@@ -16,9 +16,9 @@ from plane.utils.exception_logger import log_exception
 
 
 @shared_task
-def workspace_invitation(email, workspace_id, token, current_site, invitor):
+def workspace_invitation(email, workspace_id, token, current_site, inviter):
     try:
-        user = User.objects.get(email=invitor)
+        user = User.objects.get(email=inviter)
 
         workspace = Workspace.objects.get(pk=workspace_id)
         workspace_member_invite = WorkspaceMemberInvite.objects.get(
@@ -26,7 +26,7 @@ def workspace_invitation(email, workspace_id, token, current_site, invitor):
         )
 
         # Relative link
-        relative_link = f"/workspace-invitations/?invitation_id={workspace_member_invite.id}&email={email}&slug={workspace.slug}"
+        relative_link = f"/workspace-invitations/?invitation_id={workspace_member_invite.id}&email={email}&slug={workspace.slug}"  # noqa: E501
 
         # The complete url including the domain
         abs_url = str(current_site) + relative_link
@@ -42,7 +42,7 @@ def workspace_invitation(email, workspace_id, token, current_site, invitor):
         ) = get_email_configuration()
 
         # Subject of the email
-        subject = f"{user.first_name or user.display_name or user.email} has invited you to join them in {workspace.name} on Plane"
+        subject = f"{user.first_name or user.display_name or user.email} has invited you to join them in {workspace.name} on Plane"  # noqa: E501
 
         context = {
             "email": email,
@@ -78,11 +78,9 @@ def workspace_invitation(email, workspace_id, token, current_site, invitor):
         )
         msg.attach_alternative(html_content, "text/html")
         msg.send()
-        logging.getLogger("plane").info("Email sent succesfully")
-
+        logging.getLogger("plane").info("Email sent successfully")
         return
-    except (Workspace.DoesNotExist, WorkspaceMemberInvite.DoesNotExist) as e:
-        log_exception(e)
+    except (Workspace.DoesNotExist, WorkspaceMemberInvite.DoesNotExist):
         return
     except Exception as e:
         log_exception(e)


### PR DESCRIPTION
### Description
Error handling for workspace invites when workspace or invite doesn't exist.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected spelling of "successfully" in email sending log message
  - Fixed parameter naming from `invitor` to `inviter`

- **Chores**
  - Refined exception handling for workspace-related database queries

<!-- end of auto-generated comment: release notes by coderabbit.ai -->