### PR TITLE
[WEB-3166] chore: global empty state components

### DIFF
--- a/web/core/components/empty-state/detailed-empty-state-root.tsx
+++ b/web/core/components/empty-state/detailed-empty-state-root.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import React from "react";
+import { observer } from "mobx-react";
+import Image from "next/image";
+// ui
+import { Button } from "@plane/ui/src/button";
+// utils
+import { cn } from "@plane/utils";
+
+type EmptyStateSize = "sm" | "md" | "lg";
+
+type ButtonConfig = {
+  text: string;
+  prependIcon?: React.ReactNode;
+  appendIcon?: React.ReactNode;
+  onClick?: () => void;
+  disabled?: boolean;
+};
+
+type Props = {
+  title: string;
+  description?: string;
+  assetPath?: string;
+  size?: EmptyStateSize;
+  primaryButton?: ButtonConfig;
+  secondaryButton?: ButtonConfig;
+  customPrimaryButton?: React.ReactNode;
+  customSecondaryButton?: React.ReactNode;
+};
+
+const sizeClasses = {
+  sm: "md:min-w-[24rem] max-w-[45rem]",
+  md: "md:min-w-[28rem] max-w-[50rem]",
+  lg: "md:min-w-[30rem] max-w-[60rem]",
+} as const;
+
+const CustomButton = ({
+  config,
+  variant,
+  size,
+}: {
+  config: ButtonConfig;
+  variant: "primary" | "neutral-primary";
+  size: EmptyStateSize;
+}) => (
+  <Button
+    variant={variant}
+    size={size}
+    onClick={config.onClick}
+    prependIcon={config.prependIcon}
+    appendIcon={config.appendIcon}
+    disabled={config.disabled}
+  >
+    {config.text}
+  </Button>
+);
+
+export const DetailedEmptyState: React.FC<Props> = observer((props) => {
+  const {
+    title,
+    description,
+    size = "lg",
+    primaryButton,
+    secondaryButton,
+    customPrimaryButton,
+    customSecondaryButton,
+    assetPath,
+  } = props;
+
+  const hasButtons = primaryButton || secondaryButton || customPrimaryButton || customSecondaryButton;
+
+  return (
+    <div className="flex items-center justify-center min-h-full min-w-full overflow-y-auto py-10 md:px-20 px-5">
+      <div className={cn("flex flex-col gap-5", sizeClasses[size])}>
+        <div className="flex flex-col gap-1.5 flex-shrink">
+          <h3 className={cn("text-xl font-semibold", { "font-medium": !description })}>{title}</h3>
+          {description && <p className="text-sm">{description}</p>}
+        </div>
+
+        {assetPath && (
+          <Image src={assetPath} alt={title} width={384} height={250} layout="responsive" lazyBoundary="100%" />
+        )}
+
+        {hasButtons && (
+          <div className="relative flex items-center justify-center gap-2 flex-shrink-0 w-full">
+            {/* primary button */}
+            {customPrimaryButton ??
+              (primaryButton?.text && <CustomButton config={primaryButton} variant="primary" size={size} />)}
+            {/* secondary button */}
+            {customSecondaryButton ??
+              (secondaryButton?.text && (
+                <CustomButton config={secondaryButton} variant="neutral-primary" size={size} />
+              ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+});

--- a/web/core/components/empty-state/index.ts
+++ b/web/core/components/empty-state/index.ts
@@ -1,3 +1,5 @@
 export * from "./empty-state";
 export * from "./helper";
 export * from "./comic-box-button";
+export * from "./detailed-empty-state-root";
+export * from "./simple-empty-state-root";

--- a/web/core/components/empty-state/index.ts
+++ b/web/core/components/empty-state/index.ts
@@ -3,3 +3,4 @@ export * from "./helper";
 export * from "./comic-box-button";
 export * from "./detailed-empty-state-root";
 export * from "./simple-empty-state-root";
+export * from "./section-empty-state-root";

--- a/web/core/components/empty-state/section-empty-state-root.tsx
+++ b/web/core/components/empty-state/section-empty-state-root.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { FC } from "react";
+
+type Props = {
+  icon: React.ReactNode;
+  title: string;
+  description?: string;
+  actionElement?: React.ReactNode;
+};
+
+export const SectionEmptyState: FC<Props> = (props) => {
+  const { title, description, icon, actionElement } = props;
+  return (
+    <div className="flex flex-col gap-4 items-center justify-center rounded-md border border-custom-border-200 p-10">
+      <div className="flex flex-col items-center gap-2">
+        <div className="flex items-center justify-center size-8 bg-custom-background-80 rounded">{icon}</div>
+        <span className="text-sm font-medium">{title}</span>
+        {description && <span className="text-xs text-custom-text-300">{description}</span>}
+      </div>
+      {actionElement && <>{actionElement}</>}
+    </div>
+  );
+};

--- a/web/core/components/empty-state/simple-empty-state-root.tsx
+++ b/web/core/components/empty-state/simple-empty-state-root.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import React from "react";
+import { observer } from "mobx-react";
+import Image from "next/image";
+// utils
+import { cn } from "@plane/utils";
+
+type EmptyStateSize = "sm" | "md" | "lg";
+
+type Props = {
+  title: string;
+  description?: string;
+  assetPath?: string;
+  size?: EmptyStateSize;
+};
+
+const sizeConfig = {
+  sm: {
+    container: "size-20",
+    dimensions: 78,
+  },
+  md: {
+    container: "size-24",
+    dimensions: 80,
+  },
+  lg: {
+    container: "size-28",
+    dimensions: 96,
+  },
+} as const;
+
+const getTitleClassName = (hasDescription: boolean) =>
+  cn("font-medium whitespace-pre-line", {
+    "text-sm text-custom-text-400": !hasDescription,
+    "text-lg text-custom-text-300": hasDescription,
+  });
+
+export const SimpleEmptyState = observer((props: Props) => {
+  const { title, description, size = "sm", assetPath } = props;
+
+  return (
+    <div className="text-center flex flex-col gap-2.5 items-center">
+      {assetPath && (
+        <div className={sizeConfig[size].container}>
+          <Image
+            src={assetPath}
+            alt={title}
+            height={sizeConfig[size].dimensions}
+            width={sizeConfig[size].dimensions}
+            layout="responsive"
+            lazyBoundary="100%"
+          />
+        </div>
+      )}
+
+      <h3 className={getTitleClassName(!!description)}>{title}</h3>
+
+      {description && <p className="text-base font-medium text-custom-text-400 whitespace-pre-line">{description}</p>}
+    </div>
+  );
+});

--- a/web/core/hooks/use-resolved-asset-path.tsx
+++ b/web/core/hooks/use-resolved-asset-path.tsx
@@ -1,0 +1,17 @@
+import { useTheme } from "next-themes";
+
+type AssetPathConfig = {
+  basePath: string;
+  additionalPath?: string;
+  extension?: string;
+};
+
+export const useResolvedAssetPath = ({ basePath, additionalPath = "", extension = "webp" }: AssetPathConfig) => {
+  // hooks
+  const { resolvedTheme } = useTheme();
+
+  // resolved theme
+  const theme = resolvedTheme === "light" ? "light" : "dark";
+
+  return `${additionalPath && additionalPath !== "" ? `${basePath}${additionalPath}` : basePath}-${theme}.${extension}`;
+};


### PR DESCRIPTION
### Description
This PR includes following changes:
- Global empty state component added.
   - Detailed screen
   - Simple screen
   - Section screen
- Asset path helper function added.

### Type of Change
- [x] Improvement
- [x] Code refactoring

### References
[[WEB-3166]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/91e76fbe-026a-484f-8568-a2dc8c103a4d/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced three new empty state components: `DetailedEmptyState`, `SimpleEmptyState`, and `SectionEmptyState`
	- Added a new hook `useResolvedAssetPath` for dynamic asset path resolution
	- Expanded empty state component library with customizable UI options for different scenarios

- **Documentation**
	- Updated module exports to include new empty state components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->