### PR TITLE
[WEB-3152]fix: padding issue cycles menu

### DIFF
--- a/web/core/components/cycles/quick-actions.tsx
+++ b/web/core/components/cycles/quick-actions.tsx
@@ -183,7 +183,7 @@ export const CycleQuickActions: React.FC<Props> = observer((props) => {
         </div>
       )}
       <ContextMenu parentRef={parentRef} items={MENU_ITEMS} />
-      <CustomMenu ellipsis placement="bottom-end" closeOnSelect>
+      <CustomMenu ellipsis placement="bottom-end" closeOnSelect maxHeight="lg">
         {MENU_ITEMS.map((item) => {
           if (item.shouldRender === false) return null;
           return (


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
This update fixes active cycles issue in cycles action menu.
### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### References
<!-- Link related issues if there are any -->
[WEB-3152](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/895bff5f-3a98-4d85-9273-ab3ef46f9a0b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated the `CustomMenu` component to limit its maximum height, improving the visual layout and preventing excessive menu expansion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->