### PR TITLE
[WEB-3045] fix: sticky placeholder, gray color value

### DIFF
--- a/web/core/components/editor/sticky-editor/color-palette.tsx
+++ b/web/core/components/editor/sticky-editor/color-palette.tsx
@@ -8,7 +8,7 @@ export const STICKY_COLORS_LIST: {
   {
     key: "gray",
     label: "Gray",
-    backgroundColor: "var(--editor-colors-gray-background)",
+    backgroundColor: "rgba(var(--color-background-90))",
   },
   {
     key: "peach",

--- a/web/core/components/editor/sticky-editor/editor.tsx
+++ b/web/core/components/editor/sticky-editor/editor.tsx
@@ -43,7 +43,6 @@ export const StickyEditor = React.forwardRef<EditorRefApi, StickyEditorWrapperPr
     showToolbarInitially = true,
     showToolbar = true,
     parentClassName = "",
-    placeholder = "Add comment...",
     uploadFile,
     ...rest
   } = props;
@@ -78,7 +77,6 @@ export const StickyEditor = React.forwardRef<EditorRefApi, StickyEditorWrapperPr
         mentionHandler={{
           renderComponent: () => <></>,
         }}
-        placeholder={placeholder}
         containerClassName={cn(containerClassName, "relative")}
         {...rest}
       />

--- a/web/core/components/stickies/sticky/inputs.tsx
+++ b/web/core/components/stickies/sticky/inputs.tsx
@@ -4,6 +4,8 @@ import { Controller, useForm } from "react-hook-form";
 import { EditorRefApi } from "@plane/editor";
 // plane types
 import { TSticky } from "@plane/types";
+// plane utils
+import { isCommentEmpty } from "@plane/utils";
 // hooks
 import { useWorkspace } from "@/hooks/store";
 // components
@@ -67,7 +69,11 @@ export const StickyInput = (props: TProps) => {
               onChange(description_html);
               handleSubmit(handleFormSubmit)();
             }}
-            placeholder="Click to type here"
+            placeholder={(_, value) => {
+              const isContentEmpty = isCommentEmpty(value);
+              if (!isContentEmpty) return "";
+              return "Click to type here";
+            }}
             containerClassName="px-0 text-base min-h-[250px] w-full"
             uploadFile={async () => ""}
             showToolbar={showToolbar}


### PR DESCRIPTION
### Description

This PR improves on the following things-

1. Enhanced the gray background color.
2. Removed the placeholder from sticky if content is already added.

### Type of Change

- [x] Improvement (change that would cause existing functionality to not work as expected)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Changes**
	- Removed default placeholder text from sticky editor
	- Updated color palette for gray background color

- **Utility Updates**
	- Added new utility function to dynamically check comment emptiness

The changes subtly modify the visual and interactive aspects of the sticky editor and color palette, focusing on improving the user interface and content handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->