### PR TITLE
[WEB-3194]fix: stickies modal close while redirection

### DIFF
--- a/web/core/components/stickies/layout/stickies-truncated.tsx
+++ b/web/core/components/stickies/layout/stickies-truncated.tsx
@@ -10,7 +10,12 @@ import { useSticky } from "@/hooks/use-stickies";
 import { ContentOverflowWrapper } from "../../core/content-overflow-HOC";
 import { StickiesLayout } from "./stickies-list";
 
-export const StickiesTruncated = observer(() => {
+type StickiesTruncatedProps = {
+  handleClose?: () => void;
+};
+
+export const StickiesTruncated = observer((props: StickiesTruncatedProps) => {
+  const { handleClose } = props;
   // navigation
   const { workspaceSlug } = useParams();
   // store hooks
@@ -33,6 +38,7 @@ export const StickiesTruncated = observer(() => {
           className={cn(
             "gap-1 w-full text-custom-primary-100 text-sm font-medium transition-opacity duration-300 bg-custom-background-90/20"
           )}
+          onClick={handleClose}
         >
           Show all
         </Link>

--- a/web/core/components/stickies/layout/stickies-truncated.tsx
+++ b/web/core/components/stickies/layout/stickies-truncated.tsx
@@ -15,7 +15,7 @@ type StickiesTruncatedProps = {
 };
 
 export const StickiesTruncated = observer((props: StickiesTruncatedProps) => {
-  const { handleClose } = props;
+  const { handleClose = () => {} } = props;
   // navigation
   const { workspaceSlug } = useParams();
   // store hooks

--- a/web/core/components/stickies/modal/stickies.tsx
+++ b/web/core/components/stickies/modal/stickies.tsx
@@ -67,7 +67,7 @@ export const Stickies = observer((props: TProps) => {
       </div>
       {/* content */}
       <div className="mb-4 max-h-[625px] overflow-scroll">
-        <StickiesTruncated />
+        <StickiesTruncated handleClose={handleClose} />
       </div>
     </div>
   );


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
This update fixes the modal close issue in stickies while redirecting.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### References
<!-- Link related issues if there are any -->
[WEB-3194](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/1ebc7595-76e9-46ef-b3ce-ae14cbed26c6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced `StickiesTruncated` component with a new `handleClose` prop.
	- Improved interaction between `Stickies` and `StickiesTruncated` components, allowing for better handling of close actions.

- **Improvements**
	- Added ability to handle close actions within the `StickiesTruncated` component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->