### PR TITLE
[WEB-3198]fix: handled label overflow in modules

### DIFF
--- a/web/core/components/core/sidebar/single-progress-stats.tsx
+++ b/web/core/components/core/sidebar/single-progress-stats.tsx
@@ -21,8 +21,8 @@ export const SingleProgressStats: React.FC<TSingleProgressStatsProps> = ({
     } ${selected ? "bg-custom-background-90" : ""}`}
     onClick={onClick}
   >
-    <div className="w-1/2">{title}</div>
-    <div className="flex w-1/2 items-center justify-end gap-1 px-2">
+    <div className="w-4/6">{title}</div>
+    <div className="flex w-2/6 items-center justify-end gap-1 px-2">
       <div className="flex h-5 items-center justify-center gap-1">
         <span className="w-8 text-right">
           {isNaN(Math.round((completed / total) * 100)) ? "0" : Math.round((completed / total) * 100)}%

--- a/web/core/components/modules/analytics-sidebar/progress-stats.tsx
+++ b/web/core/components/modules/analytics-sidebar/progress-stats.tsx
@@ -135,14 +135,14 @@ export const LabelStatComponent = observer((props: TLabelStatComponent) => {
               <SingleProgressStats
                 key={label.id}
                 title={
-                  <div className="flex items-center gap-2">
-                    <span
-                      className="block h-3 w-3 rounded-full"
+                  <div className="flex items-center gap-2 truncate">
+                    <div
+                      className="h-3 w-3 rounded-full flex-shrink-0"
                       style={{
                         backgroundColor: label.color ?? "transparent",
                       }}
                     />
-                    <span className="text-xs">{label.title ?? "No labels"}</span>
+                    <p className="text-xs text-ellipsis truncate">{label.title ?? "No labels"}</p>
                   </div>
                 }
                 completed={label.completed}


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
This update handles the label overflow in the sidebar for Modules.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### References
<!-- Link related issues if there are any -->
[WEB-3198](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/7965b458-d66b-4e64-b27a-bbeb874d8417)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Improvements**
	- Enhanced layout of progress statistics component
	- Improved text handling and truncation for label statistics
	- Adjusted spacing and text display in sidebar components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->