### PR TITLE
[WEB-3201] improvement: minor enhancements for tree map text size and color

### DIFF
--- a/web/core/components/core/charts/tree-map/map-content.tsx
+++ b/web/core/components/core/charts/tree-map/map-content.tsx
@@ -241,8 +241,8 @@ export const CustomTreeMapContent: React.FC<any> = ({
                 y={pY + pHeight - LAYOUT.TEXT.PADDING_LEFT}
                 textAnchor="start"
                 className={cn(
-                  "text-xs font-extralight tracking-wider select-none",
-                  textClassName || "text-custom-text-400"
+                  "text-sm font-extralight tracking-wider select-none",
+                  textClassName || "text-custom-text-300"
                 )}
                 fill="currentColor"
               >
@@ -252,8 +252,8 @@ export const CustomTreeMapContent: React.FC<any> = ({
                     {bottom.labelTruncated
                       ? truncateText(
                           label,
-                          availableTextWidth - calculateContentWidth(value, LAYOUT.TEXT.FONT_SIZES.XS) - 4,
-                          LAYOUT.TEXT.FONT_SIZES.XS
+                        availableTextWidth - calculateContentWidth(value, LAYOUT.TEXT.FONT_SIZES.SM) - 4,
+                        LAYOUT.TEXT.FONT_SIZES.SM
                         )
                       : label}
                   </tspan>


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
<!-- Link related issues if there are any -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated font size for tree map chart values from extra small to small
	- Modified text color for chart labels
	- Adjusted label truncation logic to accommodate larger font size

<!-- end of auto-generated comment: release notes by coderabbit.ai -->