### PR TITLE
[PE-254] fix: custom color extension markdown rule added

### DIFF
--- a/packages/editor/src/core/extensions/custom-color.ts
+++ b/packages/editor/src/core/extensions/custom-color.ts
@@ -93,6 +93,19 @@ export const CustomColorExtension = Mark.create({
     };
   },
 
+  addStorage() {
+    return {
+      markdown: {
+        serialize: {
+          open: "",
+          close: "",
+          mixable: true,
+          expelEnclosingWhitespace: true,
+        },
+      },
+    };
+  },
+
   parseHTML() {
     return [
       {


### PR DESCRIPTION
### Description
Added markdown rules for color and background color such that it doesn't get copy pasted while copying to editors that don't really support colors.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
<!-- Link related issues if there are any -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced markdown serialization capabilities for custom color extension in the editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->