### PR TITLE
chore: added estimate point value in expand issues

### DIFF
--- a/apiserver/plane/api/serializers/__init__.py
+++ b/apiserver/plane/api/serializers/__init__.py
@@ -15,3 +15,4 @@ from .state import StateLiteSerializer, StateSerializer
 from .cycle import CycleSerializer, CycleIssueSerializer, CycleLiteSerializer
 from .module import ModuleSerializer, ModuleIssueSerializer, ModuleLiteSerializer
 from .intake import IntakeIssueSerializer
+from .estimate import EstimatePointSerializer

--- a/apiserver/plane/api/serializers/base.py
+++ b/apiserver/plane/api/serializers/base.py
@@ -72,6 +72,7 @@ class BaseSerializer(serializers.ModelSerializer):
                         StateLiteSerializer,
                         UserLiteSerializer,
                         WorkspaceLiteSerializer,
+                        EstimatePointSerializer,
                     )
 
                     # Expansion mapper
@@ -88,6 +89,7 @@ class BaseSerializer(serializers.ModelSerializer):
                         "owned_by": UserLiteSerializer,
                         "members": UserLiteSerializer,
                         "parent": IssueLiteSerializer,
+                        "estimate_point": EstimatePointSerializer,
                     }
                     # Check if field in expansion  then expand the field
                     if expand in expansion:

--- a/apiserver/plane/api/serializers/estimate.py
+++ b/apiserver/plane/api/serializers/estimate.py
@@ -1,0 +1,10 @@
+# Module imports
+from plane.db.models import EstimatePoint
+from .base import BaseSerializer
+
+
+class EstimatePointSerializer(BaseSerializer):
+    class Meta:
+        model = EstimatePoint
+        fields = ["id", "value"]
+        read_only_fields = fields


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
added `value` in the expand query param of the issues endpoint in the external api.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `EstimatePointSerializer` for handling estimate point data
	- Enhanced serialization capabilities to support nested estimate point information

- **Improvements**
	- Updated base serializer to expand and process estimate point fields
	- Added support for reading estimate point details with read-only fields

<!-- end of auto-generated comment: release notes by coderabbit.ai -->