### PR TITLE
[PE-269] fix: table flicker during resize

### DIFF
--- a/packages/editor/src/styles/editor.css
+++ b/packages/editor/src/styles/editor.css
@@ -412,7 +412,7 @@ p.editor-paragraph-block {
     padding-bottom: 4px;
   }
 
-  &:not(:last-child) {
+  &:not(td p.editor-paragraph-block):not(:last-child) {
     padding-bottom: 8px;
   }
 

--- a/packages/editor/src/styles/table.css
+++ b/packages/editor/src/styles/table.css
@@ -48,7 +48,7 @@
 /* table dropdown */
 .table-wrapper table .column-resize-handle {
   position: absolute;
-  right: -2px;
+  right: 0;
   top: 0;
   width: 2px;
   height: 100%;


### PR DESCRIPTION
### Description

This PR fixes the bug where resizing a column of a table causes a bad flicker of the whole table.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### Screenshots and Media (if applicable)

https://github.com/user-attachments/assets/a041c18f-88ee-4af8-9b7e-2b7094ade25e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Refined paragraph spacing rules in the editor
	- Adjusted column resize handle positioning in table styling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->