### PR TITLE
[PE-269] fix: table flicker on resize

### DIFF
--- a/packages/editor/src/styles/editor.css
+++ b/packages/editor/src/styles/editor.css
@@ -408,12 +408,14 @@ p.editor-paragraph-block {
     padding-top: 4px;
   }
 
-  &:last-child {
-    padding-bottom: 4px;
-  }
+  &:not(td p.editor-paragraph-block, th p.editor-paragraph-block) {
+    &:last-child {
+      padding-bottom: 4px;
+    }
 
-  &:not(td p.editor-paragraph-block):not(:last-child) {
-    padding-bottom: 8px;
+    &:not(:last-child) {
+      padding-bottom: 8px;
+    }
   }
 
   font-size: var(--font-size-regular);


### PR DESCRIPTION
### Description

This PR fixes the table flicker effect on resizing in case any table cell has multiple cells or table has a header row.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated paragraph styling in the editor to improve spacing and layout
	- Refined padding rules for paragraphs, especially within table contexts
	- Adjusted bottom padding for paragraph elements to enhance visual consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->