### PR TITLE
[PE-272] fix: prevent error on reload when page version history panel is open

### DIFF
--- a/packages/editor/src/core/hooks/use-editor.ts
+++ b/packages/editor/src/core/hooks/use-editor.ts
@@ -202,7 +202,7 @@ export const useEditor = (props: CustomEditorProps) => {
       getDocument: () => {
         const documentBinary = provider?.document ? Y.encodeStateAsUpdate(provider?.document) : null;
         const documentHTML = editor?.getHTML() ?? "<p></p>";
-        const documentJSON = editor.getJSON() ?? null;
+        const documentJSON = editor?.getJSON() ?? null;
 
         return {
           binary: documentBinary,


### PR DESCRIPTION
### Description
This PR fixes an issue where the app throws an error on reload when the version history panel is open. The error occurred because editor was potentially undefined, and calling editor.getJSON() directly resulted in a crash.

### Changes:
Updated the assignment of documentJSON to safely access editor using optional chaining (editor?.getJSON()), preventing the error when editor is undefined.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

### Test Scenarios 
- Reload the app with the version history panel open and verify that no error occurs.
- Ensure that the version history functionality remains unaffected.

### References
[[PE-272]](https://app.plane.so/plane/projects/b758d552-5a21-4c04-a145-7286c67b5b4b/issues/791a67e5-8243-4786-a879-cff33523be53)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling in editor content retrieval by adding optional chaining to prevent potential runtime errors when accessing editor methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->