### PR TITLE
[WEB-3271] fix: adjust z-index to prevent overlap issue with version history panel

### DIFF
--- a/web/core/components/pages/version/root.tsx
+++ b/web/core/components/pages/version/root.tsx
@@ -40,7 +40,7 @@ export const PageVersionsOverlay: React.FC<Props> = observer((props) => {
   return (
     <div
       className={cn(
-        "absolute inset-0 z-20 size-full bg-custom-background-100 flex overflow-hidden opacity-0 pointer-events-none transition-opacity",
+        "absolute inset-0 z-[16] size-full bg-custom-background-100 flex overflow-hidden opacity-0 pointer-events-none transition-opacity",
         {
           "opacity-100 pointer-events-auto": isOpen,
         }


### PR DESCRIPTION
### Description
This PR resolves a z-index issue where clicking on the page emoji in the header was causing an unintended overlap when the version history panel was open.

### Changes:
Updated the z-index from z-20 to z-[16] to properly manage layering and prevent the version history panel from interfering with the emoji picker.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

### Screenshots and Media (if applicable)
| Before | After |
|--------|--------|
| ![before](https://github.com/user-attachments/assets/48c3cda0-539c-4a57-88f1-4d021e29b6fa) | ![after](https://github.com/user-attachments/assets/9a33373c-ba0c-47cd-810d-8a9908e7cda0) |

### Test Scenarios 
- Open the version history panel and click on the page emoji in the header.
- Ensure that the emoji picker appears correctly without being obstructed.
- Verify that other UI elements remain unaffected.

### References
[[WEB-3271]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/94b78a76-8a3f-4800-b4af-4b90a6454118/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated z-index styling for the page versions overlay component to adjust its stacking order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->