### PR TITLE
fix: delete webhook for issues, issue_comments, projects

### DIFF
--- a/apiserver/plane/api/views/project.py
+++ b/apiserver/plane/api/views/project.py
@@ -28,7 +28,7 @@ from plane.db.models import (
     Workspace,
     UserFavorite,
 )
-from plane.bgtasks.webhook_task import model_activity
+from plane.bgtasks.webhook_task import model_activity, webhook_activity
 from .base import BaseAPIView
 
 
@@ -326,6 +326,19 @@ class ProjectAPIEndpoint(BaseAPIView):
             entity_type="project", entity_identifier=pk, project_id=pk
         ).delete()
         project.delete()
+        webhook_activity.delay(
+            event="project",
+            verb="deleted",
+            field=None,
+            old_value=None,
+            new_value=None,
+            actor_id=request.user.id,
+            slug=slug,
+            current_site=request.META.get("HTTP_ORIGIN"),
+            event_id=project.id,
+            old_identifier=None,
+            new_identifier=None,
+        )
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 

--- a/apiserver/plane/bgtasks/issue_activities_task.py
+++ b/apiserver/plane/bgtasks/issue_activities_task.py
@@ -738,8 +738,10 @@ def delete_comment_activity(
     issue_activities,
     epoch,
 ):
+    requested_data = json.loads(requested_data) if requested_data is not None else None
     issue_activities.append(
         IssueActivity(
+            issue_comment_id=requested_data.get("comment_id", None),
             issue_id=issue_id,
             project_id=project_id,
             workspace_id=workspace_id,

--- a/apiserver/plane/bgtasks/webhook_task.py
+++ b/apiserver/plane/bgtasks/webhook_task.py
@@ -387,7 +387,11 @@ def webhook_activity(
                 webhook=webhook.id,
                 slug=slug,
                 event=event,
-                event_data=get_model_data(event=event, event_id=event_id),
+                event_data=(
+                    {"id": event_id}
+                    if verb == "deleted"
+                    else get_model_data(event=event, event_id=event_id)
+                ),
                 action=verb,
                 current_site=current_site,
                 activity={


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
This PR fixes three issues:
1. Delete webhook failure caused by attempting to get deleted model data (dc78854db019fe7ec93163d14793c8cbe2240fd7)
3. event.id being null for issue_comment delete webhook (74b1623af5cd15b46d0ce1b9e050d4c18756c543)
4. Project delete not triggering a webhook, despite webhook page indicating it should (f04dc5d1ec78ff9395ace69a31b881e1a6940953)

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### References
<!-- Link related issues if there are any -->
close #6302

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Enhanced deletion logging to capture detailed audit data when projects are removed.
  - Integrated webhook notifications to streamline data communication during project deletions.
  - Improved activity logging for deleted comments to include specific identifiers.

- **Bug Fixes**
  - Improved processing of deletion data to ensure that comment removal details are accurately tracked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->