### PR TITLE
chore: remove unnecessary useEffect for setting default image

### DIFF
--- a/web/core/components/core/image-picker-popover.tsx
+++ b/web/core/components/core/image-picker-popover.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useState, useRef, useCallback } from "react";
+import React, { useState, useRef, useCallback } from "react";
 import { observer } from "mobx-react";
 import Image from "next/image";
 import { useParams } from "next/navigation";
@@ -129,12 +129,6 @@ export const ImagePickerPopover: React.FC<Props> = observer((props) => {
         .then((res) => uploadCallback(res.asset_url));
     }
   };
-
-  useEffect(() => {
-    if (!unsplashImages || value !== null) return;
-
-    onChange(unsplashImages[0]?.urls.regular);
-  }, [value, onChange, unsplashImages]);
 
   const handleClose = () => {
     if (isOpen) setIsOpen(false);


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
Removed an unnecessary useEffect that set the default Unsplash image. 

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated image selection behavior: the component no longer auto-selects an image when none is specified. Users will now need to manually choose their desired image, while all other image interactions remain consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->