### PR TITLE
fix: Remove AI Assistant Button from Tab Order to Prevent Focus

### DIFF
--- a/packages/constants/src/tab-indices.ts
+++ b/packages/constants/src/tab-indices.ts
@@ -2,7 +2,6 @@ export const ISSUE_FORM_TAB_INDICES = [
   "name",
   "description_html",
   "feeling_lucky",
-  "ai_assistant",
   "state_id",
   "priority",
   "assignee_ids",
@@ -54,14 +53,7 @@ export const PROJECT_CREATE_TAB_INDICES = [
   "logo_props",
 ];
 
-export const PROJECT_CYCLE_TAB_INDICES = [
-  "name",
-  "description",
-  "date_range",
-  "cancel",
-  "submit",
-  "project_id",
-];
+export const PROJECT_CYCLE_TAB_INDICES = ["name", "description", "date_range", "cancel", "submit", "project_id"];
 
 export const PROJECT_MODULE_TAB_INDICES = [
   "name",
@@ -74,21 +66,9 @@ export const PROJECT_MODULE_TAB_INDICES = [
   "submit",
 ];
 
-export const PROJECT_VIEW_TAB_INDICES = [
-  "name",
-  "description",
-  "filters",
-  "cancel",
-  "submit",
-];
+export const PROJECT_VIEW_TAB_INDICES = ["name", "description", "filters", "cancel", "submit"];
 
-export const PROJECT_PAGE_TAB_INDICES = [
-  "name",
-  "public",
-  "private",
-  "cancel",
-  "submit",
-];
+export const PROJECT_PAGE_TAB_INDICES = ["name", "public", "private", "cancel", "submit"];
 
 export enum ETabIndices {
   ISSUE_FORM = "issue-form",

--- a/packages/constants/src/tab-indices.ts
+++ b/packages/constants/src/tab-indices.ts
@@ -53,7 +53,14 @@ export const PROJECT_CREATE_TAB_INDICES = [
   "logo_props",
 ];
 
-export const PROJECT_CYCLE_TAB_INDICES = ["name", "description", "date_range", "cancel", "submit", "project_id"];
+export const PROJECT_CYCLE_TAB_INDICES = [
+  "name",
+  "description",
+  "date_range",
+  "cancel",
+  "submit",
+  "project_id",
+];
 
 export const PROJECT_MODULE_TAB_INDICES = [
   "name",
@@ -66,9 +73,21 @@ export const PROJECT_MODULE_TAB_INDICES = [
   "submit",
 ];
 
-export const PROJECT_VIEW_TAB_INDICES = ["name", "description", "filters", "cancel", "submit"];
+export const PROJECT_VIEW_TAB_INDICES = [
+  "name",
+  "description",
+  "filters",
+  "cancel",
+  "submit",
+];
 
-export const PROJECT_PAGE_TAB_INDICES = ["name", "public", "private", "cancel", "submit"];
+export const PROJECT_PAGE_TAB_INDICES = [
+  "name",
+  "public",
+  "private",
+  "cancel",
+  "submit",
+];
 
 export enum ETabIndices {
   ISSUE_FORM = "issue-form",

--- a/web/core/components/core/modals/gpt-assistant-popover.tsx
+++ b/web/core/components/core/modals/gpt-assistant-popover.tsx
@@ -188,7 +188,7 @@ export const GptAssistantPopover: React.FC<Props> = (props) => {
   return (
     <Popover as="div" className={`relative w-min text-left`}>
       <Popover.Button as={Fragment}>
-        <button ref={setReferenceElement} className="flex items-center">
+        <button ref={setReferenceElement} className="flex items-center" tabIndex={-1}>
           {button}
         </button>
       </Popover.Button>

--- a/web/core/components/issues/issue-modal/components/description-editor.tsx
+++ b/web/core/components/issues/issue-modal/components/description-editor.tsx
@@ -262,7 +262,7 @@ export const IssueDescriptionEditor: React.FC<TIssueDescriptionEditorProps> = ob
                     type="button"
                     className="flex items-center gap-1 rounded px-1.5 py-1 text-xs bg-custom-background-90 hover:bg-custom-background-80"
                     onClick={() => setGptAssistantModal((prevData) => !prevData)}
-                    tabIndex={getIndex("ai_assistant")}
+                    tabIndex={-1}
                   >
                     <Sparkle className="h-4 w-4" />
                     AI


### PR DESCRIPTION
This pull request includes several changes to the `tab-indices.ts` file and some updates to components in the `web/core/components` directory. The main changes involve the removal of certain tab indices and the setting of specific tab indices to `-1`.

Changes to tab indices:

* [`packages/constants/src/tab-indices.ts`](diffhunk://#diff-0b10fda420166fe57bd8fe7aaee39b73d5c8aebc2d916c3d8f94924dbc8f1b83L5): Removed the `ai_assistant` tab index from `ISSUE_FORM_TAB_INDICES` and reformatted other tab indices arrays to be on a single line. [[1]](diffhunk://#diff-0b10fda420166fe57bd8fe7aaee39b73d5c8aebc2d916c3d8f94924dbc8f1b83L5) [[2]](diffhunk://#diff-0b10fda420166fe57bd8fe7aaee39b73d5c8aebc2d916c3d8f94924dbc8f1b83L57-R56) [[3]](diffhunk://#diff-0b10fda420166fe57bd8fe7aaee39b73d5c8aebc2d916c3d8f94924dbc8f1b83L77-R71)

Updates to component tab indices:

* [`web/core/components/core/modals/gpt-assistant-popover.tsx`](diffhunk://#diff-6c3ee9fda7a56b62a2ea70e8e893fbb2ab7d28bf465342d64ebc16f2073ae717L191-R191): Set the `tabIndex` of the button in `GptAssistantPopover` to `-1` to remove it from the tab order.
* [`web/core/components/issues/issue-modal/components/description-editor.tsx`](diffhunk://#diff-a28ff7b64e27fc71e3ed7624f1251dc1405f6cb81a2f53902868a71387b8ea91L265-R265): Set the `tabIndex` of the AI assistant button in `IssueDescriptionEditor` to `-1` to remove it from the tab order.


https://github.com/user-attachments/assets/9357136e-ed99-426f-91cd-2f27ce063fb7



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
	- Improved keyboard navigation by removing an unnecessary focusable element from AI assistant interactions, ensuring smoother and more consistent tab order across pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->