### PR TITLE
[WEB-3347] fix: list layout stats indicator

### DIFF
--- a/web/core/components/issues/issue-layouts/list/block.tsx
+++ b/web/core/components/issues/issue-layouts/list/block.tsx
@@ -257,7 +257,7 @@ export const IssueBlock = observer((props: IssueBlockProps) => {
               disabled={isCurrentBlockDragging}
               renderByDefault={false}
             >
-              <p className="w-full truncate cursor-pointer text-sm text-custom-text-100">{issue.name}</p>
+              <p className="truncate cursor-pointer text-sm text-custom-text-100">{issue.name}</p>
             </Tooltip>
             {isEpic && <IssueStats issueId={issue.id} />}
           </div>


### PR DESCRIPTION
### Description
This PR fixes the placement of the stats indicator in the list layout items.

### Type of Change
- [x] Bug fix

### References
[[WEB-3347]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/8858de70-d981-4067-be74-01760f06fa6c)