### PR TITLE
fix: copying mentions as text

### DIFF
--- a/packages/editor/src/core/extensions/extensions.tsx
+++ b/packages/editor/src/core/extensions/extensions.tsx
@@ -137,7 +137,7 @@ export const CoreEditorExtensions = (args: TArguments): Extensions => {
     CustomCodeInlineExtension,
     Markdown.configure({
       html: true,
-      transformCopiedText: true,
+      transformCopiedText: false,
       transformPastedText: true,
       breaks: true,
     }),

--- a/packages/editor/src/core/extensions/mentions/extension-config.ts
+++ b/packages/editor/src/core/extensions/mentions/extension-config.ts
@@ -35,12 +35,19 @@ export const CustomMentionExtensionConfig = Mention.extend<TMentionExtensionOpti
     ];
   },
 
-  renderHTML({ HTMLAttributes }) {
+  renderHTML({ HTMLAttributes, node }) {
     return ["mention-component", mergeAttributes(HTMLAttributes)];
   },
 
   HTMLAttributes: {
     class: "mention",
+  },
+
+  renderText({ node }) {
+    const attrs = node.attrs as TMentionComponentAttributes;
+    const mentionEntityId = attrs[EMentionComponentAttributeNames.ENTITY_IDENTIFIER];
+    const mentionEntityDetails = this.options.getMentionComponentAttributes?.(mentionEntityId);
+    return `@${mentionEntityDetails.display_name ?? node.attrs.id}`;
   },
 
   addStorage() {

--- a/packages/editor/src/core/extensions/mentions/extension-config.ts
+++ b/packages/editor/src/core/extensions/mentions/extension-config.ts
@@ -35,7 +35,7 @@ export const CustomMentionExtensionConfig = Mention.extend<TMentionExtensionOpti
     ];
   },
 
-  renderHTML({ HTMLAttributes, node }) {
+  renderHTML({ HTMLAttributes }) {
     return ["mention-component", mergeAttributes(HTMLAttributes)];
   },
 
@@ -44,30 +44,25 @@ export const CustomMentionExtensionConfig = Mention.extend<TMentionExtensionOpti
   },
 
   renderText({ node }) {
-    const attrs = node.attrs as TMentionComponentAttributes;
-    const mentionEntityId = attrs[EMentionComponentAttributeNames.ENTITY_IDENTIFIER];
-    const mentionEntityDetails = this.options.getMentionComponentAttributes?.(mentionEntityId);
-    return `@${mentionEntityDetails.display_name ?? node.attrs.id}`;
+    return getMentionDisplayText(this.options, node);
   },
 
   addStorage() {
-    const getMentionComponentAttributes = this.options.getMentionComponentAttributes;
+    const options = this.options;
     return {
       mentionsOpen: false,
       markdown: {
         serialize(state: MarkdownSerializerState, node: NodeType) {
-          const attrs = node.attrs as TMentionComponentAttributes;
-          const mentionEntityId = attrs[EMentionComponentAttributeNames.ENTITY_IDENTIFIER];
-
-          const mentionEntityDetails = getMentionComponentAttributes?.(mentionEntityId);
-
-          if (mentionEntityDetails) {
-            state.write(`@${mentionEntityDetails.display_name}`);
-          } else {
-            state.write(`@${mentionEntityId}`);
-          }
+          state.write(getMentionDisplayText(options, node));
         },
       },
     };
   },
 });
+
+function getMentionDisplayText(options: TMentionExtensionOptions, node: NodeType): string {
+  const attrs = node.attrs as TMentionComponentAttributes;
+  const mentionEntityId = attrs[EMentionComponentAttributeNames.ENTITY_IDENTIFIER];
+  const mentionEntityDetails = options.getMentionComponentAttributes?.(mentionEntityId);
+  return `~${mentionEntityDetails?.display_name ?? attrs[EMentionComponentAttributeNames.ID] ?? mentionEntityId}`;
+}

--- a/packages/editor/src/core/extensions/mentions/extension.tsx
+++ b/packages/editor/src/core/extensions/mentions/extension.tsx
@@ -9,12 +9,13 @@ import { MentionNodeView } from "./mention-node-view";
 import { renderMentionsDropdown } from "./utils";
 
 export const CustomMentionExtension = (props: TMentionHandler) => {
-  const { searchCallback, renderComponent } = props;
+  const { searchCallback, renderComponent, getMentionComponentAttributes } = props;
   return CustomMentionExtensionConfig.extend({
     addOptions(this) {
       return {
         ...this.parent?.(),
         renderComponent,
+        getMentionComponentAttributes,
       };
     },
 

--- a/packages/editor/src/core/types/mention.ts
+++ b/packages/editor/src/core/types/mention.ts
@@ -1,5 +1,5 @@
 // plane types
-import { TSearchEntities } from "@plane/types";
+import { IUserLite, TSearchEntities } from "@plane/types";
 
 export type TMentionSuggestion = {
   entity_identifier: string;
@@ -20,6 +20,7 @@ export type TMentionComponentProps = Pick<TMentionSuggestion, "entity_identifier
 
 export type TReadOnlyMentionHandler = {
   renderComponent: (props: TMentionComponentProps) => React.ReactNode;
+  getMentionComponentAttributes?: (entity_identifier: string) => IUserLite | undefined;
 };
 
 export type TMentionHandler = TReadOnlyMentionHandler & {

--- a/web/core/components/pages/editor/editor-body.tsx
+++ b/web/core/components/pages/editor/editor-body.tsx
@@ -21,7 +21,7 @@ import { PageContentBrowser, PageContentLoader, PageEditorTitle } from "@/compon
 import { cn, LIVE_BASE_PATH, LIVE_BASE_URL } from "@/helpers/common.helper";
 import { generateRandomColor } from "@/helpers/string.helper";
 // hooks
-import { useUser } from "@/hooks/store";
+import { useMember, useUser } from "@/hooks/store";
 import { useEditorMention } from "@/hooks/use-editor-mention";
 import { usePageFilters } from "@/hooks/use-page-filters";
 // plane web components
@@ -66,6 +66,8 @@ export const PageEditorBody: React.FC<Props> = observer((props) => {
   } = props;
   // store hooks
   const { data: currentUser } = useUser();
+  const { getUserDetails } = useMember();
+
   // derived values
   const { id: pageId, name: pageTitle, isContentEditable, updateTitle } = page;
   // issue-embed
@@ -188,6 +190,7 @@ export const PageEditorBody: React.FC<Props> = observer((props) => {
                 return res;
               },
               renderComponent: (props) => <EditorMentionsRoot {...props} />,
+              getMentionComponentAttributes: (id: string) => getUserDetails(id),
             }}
             embedHandler={{
               issue: issueEmbedProps,


### PR DESCRIPTION
### Description
Before: The whole html of the mention node got copied

Now: The renderText method calculates and returns the correct the text properly as `@{userDisplayName}`

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
<!-- Link related issues if there are any -->