### PR TITLE
fix: cache invalidation for workspace labels endpoint

### DIFF
--- a/apiserver/plane/app/views/issue/label.py
+++ b/apiserver/plane/app/views/issue/label.py
@@ -35,7 +35,9 @@ class LabelViewSet(BaseViewSet):
             .order_by("sort_order")
         )
 
-    @invalidate_cache(path="/api/workspaces/:slug/labels/", url_params=True, user=False)
+    @invalidate_cache(
+        path="/api/workspaces/:slug/labels/", url_params=True, user=False, multiple=True
+    )
     @allow_permission([ROLE.ADMIN])
     def create(self, request, slug, project_id):
         try:


### PR DESCRIPTION
fix:
- cache invalidation by adding `multiple` True to remove all instances of the workspace label cache on creating a label.