### PR TITLE
[WEB-3345] fix: work item form tab index

### DIFF
--- a/web/core/components/issues/issue-modal/components/title-input.tsx
+++ b/web/core/components/issues/issue-modal/components/title-input.tsx
@@ -37,7 +37,7 @@ export const IssueTitleInput: React.FC<TIssueTitleInputProps> = observer((props)
     return undefined;
   };
   return (
-    <div tabIndex={getIndex("name")}>
+    <div>
       <Controller
         control={control}
         name="name"
@@ -64,6 +64,7 @@ export const IssueTitleInput: React.FC<TIssueTitleInputProps> = observer((props)
             placeholder={t("title")}
             className="w-full text-base"
             autoFocus
+            tabIndex={getIndex("name")}
           />
         )}
       />


### PR DESCRIPTION
### Description
This PR fixes the tab index issue in the work item modal, where the focus was not set on the title input field upon opening.

### Type of Change
- [x] Bug fix

### References
[[WEB-3345]](https://app.plane.so/plane/projects/02c3e1d5-d7e2-401d-a773-45ecba45d745/issues/d7ad687d-d5d3-4c35-a692-76edf96b9b22/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved keyboard navigation for the issue title input, ensuring that pressing the tab key now directly focuses the input field.
  - Retained robust input validation to promptly alert users of any errors.
  - Enhanced overall usability for a smoother and more intuitive issue entry experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->