### PR TITLE
improvement: add timeout before resetting data in workspace delete form

### DIFF
--- a/web/core/components/workspace/delete-workspace-form.tsx
+++ b/web/core/components/workspace/delete-workspace-form.tsx
@@ -46,8 +46,12 @@ export const DeleteWorkspaceForm: React.FC<Props> = observer((props) => {
   const canDelete = watch("workspaceName") === data?.name && watch("confirmDelete") === "delete my workspace";
 
   const handleClose = () => {
+    const timer = setTimeout(() => {
+      reset(defaultValues);
+      clearTimeout(timer);
+    }, 350);
+
     onClose();
-    reset(defaultValues);
   };
 
   const onSubmit = async () => {


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
<!-- Link related issues if there are any -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The delete workspace form now delays resetting its values after closure, allowing confirmation messages or UI feedback to be displayed clearly for a smoother user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->