### PR TITLE
fix: provide working telemetry documentation url

### DIFF
--- a/admin/core/components/instance/setup-form.tsx
+++ b/admin/core/components/instance/setup-form.tsx
@@ -336,7 +336,7 @@ export const InstanceSetupForm: FC = (props) => {
             </label>
             <a
               tabIndex={-1}
-              href="https://docs.plane.so/telemetry"
+              href="https://developers.plane.so/self-hosting/telemetry"
               target="_blank"
               rel="noopener noreferrer"
               className="text-sm font-medium text-blue-500 hover:text-blue-600"


### PR DESCRIPTION
Closes #6613

### Description
Fix the url from one that 404s, to the one that works, and matches what's used in the general settings to as a pointer to "our Telemetry Policy."

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->
NA

### References
<!-- Link related issues if there are any -->
Closes #6613

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the telemetry link to redirect users to a dedicated self-hosting documentation page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->