### PR TITLE
fix: removing self from private project error 404

### DIFF
--- a/web/core/components/project/member-list-item.tsx
+++ b/web/core/components/project/member-list-item.tsx
@@ -9,7 +9,7 @@ import { ConfirmProjectMemberRemove } from "@/components/project";
 // constants
 
 // hooks
-import { useEventTracker, useMember, useProject, useUser, useUserPermissions } from "@/hooks/store";
+import { useEventTracker, useMember, useUser, useUserPermissions } from "@/hooks/store";
 import { useAppRouter } from "@/hooks/use-app-router";
 import { useProjectColumns } from "@/plane-web/components/projects/settings/useProjectColumns";
 import { IProjectMemberDetails } from "@/store/member/project-member.store";
@@ -27,7 +27,6 @@ export const ProjectMemberListItem: React.FC<Props> = observer((props) => {
   // store hooks
   const { leaveProject } = useUserPermissions();
   const { data: currentUser } = useUser();
-  const { fetchProjectDetails } = useProject();
   const {
     project: { removeMemberFromProject },
   } = useMember();
@@ -45,7 +44,6 @@ export const ProjectMemberListItem: React.FC<Props> = observer((props) => {
             state: "SUCCESS",
             element: "Project settings members page",
           });
-          await fetchProjectDetails(workspaceSlug.toString(), projectId.toString());
         })
         .catch((err) =>
           setToast({


### PR DESCRIPTION
### Description
We were getting a 404 error when removing ourselves from a project because we were fetching project details. Since we are no longer part of the project, the error occurred. I removed that part of code, and there was no change in the app's behavior.

### Screenshots and Media 
[Issue]( https://drive.google.com/file/d/1Fc0i6j3n6R27X5wATgbdfSDF12jxyVi3/view)

Fix: 

https://github.com/user-attachments/assets/f3c27da8-b861-4e19-b662-90de89e9a9ca




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined the member removal process by eliminating an unnecessary data refresh after a removal action.
- **Bug Fixes**
  - Preserved clear error notifications during member removal operations to ensure reliable feedback in case of issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->