### PR TITLE
fix: command modal mutation

### DIFF
--- a/web/core/components/command-palette/command-modal.tsx
+++ b/web/core/components/command-palette/command-modal.tsx
@@ -80,7 +80,7 @@ export const CommandModal: React.FC = observer(() => {
   const { setTrackElement } = useEventTracker();
   const projectIdentifier = workItem?.toString().split("-")[0];
   const sequence_id = workItem?.toString().split("-")[1];
-  // fetch issue details using identifier
+  // fetch work item details using identifier
   const { data: workItemDetailsSWR } = useSWR(
     workspaceSlug && workItem ? `ISSUE_DETAIL_${workspaceSlug}_${projectIdentifier}_${sequence_id}` : null,
     workspaceSlug && workItem

--- a/web/core/components/command-palette/command-modal.tsx
+++ b/web/core/components/command-palette/command-modal.tsx
@@ -67,7 +67,10 @@ export const CommandModal: React.FC = observer(() => {
   // plane hooks
   const { t } = useTranslation();
   // hooks
-  const { fetchIssueWithIdentifier } = useIssueDetail();
+  const {
+    issue: { getIssueById },
+    fetchIssueWithIdentifier,
+  } = useIssueDetail();
   const { workspaceProjectIds } = useProject();
   const { platform, isMobile } = usePlatformOS();
   const { canPerformAnyCreateAction } = useUser();
@@ -75,11 +78,10 @@ export const CommandModal: React.FC = observer(() => {
     useCommandPalette();
   const { allowPermissions } = useUserPermissions();
   const { setTrackElement } = useEventTracker();
-
   const projectIdentifier = workItem?.toString().split("-")[0];
   const sequence_id = workItem?.toString().split("-")[1];
-
-  const { data: issueDetails } = useSWR(
+  // fetch issue details using identifier
+  const { data: workItemDetailsSWR } = useSWR(
     workspaceSlug && workItem ? `ISSUE_DETAIL_${workspaceSlug}_${projectIdentifier}_${sequence_id}` : null,
     workspaceSlug && workItem
       ? () => fetchIssueWithIdentifier(workspaceSlug.toString(), projectIdentifier, sequence_id)
@@ -87,6 +89,7 @@ export const CommandModal: React.FC = observer(() => {
   );
 
   // derived values
+  const issueDetails = workItemDetailsSWR ? getIssueById(workItemDetailsSWR?.id) : null;
   const issueId = issueDetails?.id;
   const projectId = issueDetails?.project_id;
   const page = pages[pages.length - 1];


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
In this PR, I have fixed a mutation issue on command modal actions. This issue was observer when we were updating the work item detail from the command modal, the properties of the work item was updated but the command modal still showed stale data.
 
To Fix this issue, I have update the component to use data from `mobx` store instead of relying on the initial `SWR` call. 

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->
* Before

https://github.com/user-attachments/assets/dbba3056-5faa-455a-9642-657e2ce173e2


* After

https://github.com/user-attachments/assets/877dc524-762c-48b7-a08c-55c7bb623293



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the command interface’s data retrieval process for issue details, ensuring more reliable and consistent display of information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->