### PR TITLE
[PE-257] fix: recent sticky collapse icon

### DIFF
--- a/web/core/components/stickies/sticky/root.tsx
+++ b/web/core/components/stickies/sticky/root.tsx
@@ -81,23 +81,25 @@ export const StickyNote = observer((props: TProps) => {
       >
         {/* {isStickiesPage && <StickyItemDragHandle isDragging={false} />}{" "} */}
         {onClose && (
-          <button type="button" className="flex w-full" onClick={onClose}>
-            <Minimize2 className="size-4 m-auto mr-0" />
+          <button type="button" className="flex-shrink-0 flex justify-end p-2.5" onClick={onClose}>
+            <Minimize2 className="size-4" />
           </button>
         )}
         {/* inputs */}
-        <StickyInput
-          stickyData={stickyData}
-          workspaceSlug={workspaceSlug}
-          handleUpdate={(payload) => {
-            handleLayout?.();
-            debouncedFormSave(payload);
-          }}
-          stickyId={stickyId}
-          handleDelete={() => setIsDeleteModalOpen(true)}
-          handleChange={handleChange}
-          showToolbar={showToolbar}
-        />
+        <div className="-mt-2">
+          <StickyInput
+            stickyData={stickyData}
+            workspaceSlug={workspaceSlug}
+            handleUpdate={(payload) => {
+              handleLayout?.();
+              debouncedFormSave(payload);
+            }}
+            stickyId={stickyId}
+            handleDelete={() => setIsDeleteModalOpen(true)}
+            handleChange={handleChange}
+            showToolbar={showToolbar}
+          />
+        </div>
       </div>
     </>
   );


### PR DESCRIPTION
### Description

This PR fixes the recent sticky collapse icon position

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### Screenshots and Media (if applicable)

| Before | After |
|--------|--------|
| <img width="412" alt="image" src="https://github.com/user-attachments/assets/ed145252-ebb5-4599-8a12-01623f20ae0d" /> | <img width="412" alt="image" src="https://github.com/user-attachments/assets/cea0d581-ece4-4fcf-84f6-869b8e897a7a" /> | 