### PR TITLE
[WEB-3377] fix: attachment item avatar

### DIFF
--- a/packages/types/src/issues/issue_attachment.d.ts
+++ b/packages/types/src/issues/issue_attachment.d.ts
@@ -11,6 +11,7 @@ export type TIssueAttachment = {
   // required
   updated_at: string;
   updated_by: string;
+  created_by: string;
 };
 
 export type TIssueAttachmentUploadResponse = TFileSignedURLResponse & {

--- a/web/core/components/issues/attachment/attachment-list-item.tsx
+++ b/web/core/components/issues/attachment/attachment-list-item.tsx
@@ -71,11 +71,11 @@ export const IssueAttachmentsListItem: FC<TIssueAttachmentsListItem> = observer(
                 <Tooltip
                   isMobile={isMobile}
                   tooltipContent={`${
-                    getUserDetails(attachment.updated_by)?.display_name ?? ""
+                    getUserDetails(attachment?.created_by)?.display_name ?? ""
                   } uploaded on ${renderFormattedDate(attachment.updated_at)}`}
                 >
                   <div className="flex items-center justify-center">
-                    <ButtonAvatars showTooltip userIds={attachment?.updated_by} />
+                    <ButtonAvatars showTooltip userIds={attachment?.created_by} />
                   </div>
                 </Tooltip>
               </>


### PR DESCRIPTION
### Description
This PR fixes an issue where the attachment item created by was not displaying correctly.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

### References
[[WEB-3377]](https://app.plane.so/plane/browse/PE-286/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Attachments now include and display the creator’s information.
  - The user tooltip on attachment avatars has been updated to reflect the creator’s name instead of the previous user detail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->