### PR TITLE
fix: command palette search

### DIFF
--- a/web/core/components/command-palette/actions/search-results.tsx
+++ b/web/core/components/command-palette/actions/search-results.tsx
@@ -28,6 +28,7 @@ export const CommandPaletteSearchResults: React.FC<Props> = (props) => {
         const section = (results.results as any)[key];
         const currentSection = commandGroups[key];
 
+        if (!currentSection) return null;
         if (section.length > 0) {
           return (
             <Command.Group key={key} heading={`${currentSection.title} search`}>

--- a/web/core/components/command-palette/command-modal.tsx
+++ b/web/core/components/command-palette/command-modal.tsx
@@ -51,7 +51,7 @@ const workspaceService = new WorkspaceService();
 export const CommandModal: React.FC = observer(() => {
   // router
   const router = useAppRouter();
-  const { workspaceSlug, workItem } = useParams();
+  const { workspaceSlug, projectId: routerProjectId, workItem } = useParams();
   // states
   const [placeholder, setPlaceholder] = useState("Type a command or search...");
   const [resultsCount, setResultsCount] = useState(0);
@@ -91,7 +91,7 @@ export const CommandModal: React.FC = observer(() => {
   // derived values
   const issueDetails = workItemDetailsSWR ? getIssueById(workItemDetailsSWR?.id) : null;
   const issueId = issueDetails?.id;
-  const projectId = issueDetails?.project_id;
+  const projectId = issueDetails?.project_id ?? routerProjectId;
   const page = pages[pages.length - 1];
   const debouncedSearchTerm = useDebounce(searchTerm, 500);
   const { baseTabIndex } = getTabIndex(undefined, isMobile);
@@ -477,6 +477,7 @@ export const CommandModal: React.FC = observer(() => {
                     <ToggleSwitch
                       value={isWorkspaceLevel}
                       onChange={() => setIsWorkspaceLevel((prevData) => !prevData)}
+                      disabled={!projectId}
                       size="sm"
                     />
                   </div>


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
This PR, fixed an issue where workspace level search toggle was not working. This happened due to recent changes in the command palette where we update the project id from `router` to `workItemDetai.projectId`. Due to this change now the projectId was alway `undefined` until we are inside a work item detail page, breaking other logics which are dependent on projectId. To fix this, I have added `routerProjectId` as a fallback case. 

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
<!-- Link related issues if there are any -->