### PR TITLE
[WEB-3439] fix: work item attachment mutation

### DIFF
--- a/apiserver/plane/app/serializers/issue.py
+++ b/apiserver/plane/app/serializers/issue.py
@@ -522,6 +522,7 @@ class IssueAttachmentLiteSerializer(DynamicBaseSerializer):
             "asset",
             "attributes",
             # "issue_id",
+            "created_by",
             "updated_at",
             "updated_by",
             "asset_url",

--- a/web/core/store/issue/issue-details/attachment.store.ts
+++ b/web/core/store/issue/issue-details/attachment.store.ts
@@ -161,9 +161,6 @@ export class IssueAttachmentStore implements IIssueAttachmentStore {
         runInAction(() => {
           update(this.attachments, [issueId], (attachmentIds = []) => uniq(concat(attachmentIds, [response.id])));
           set(this.attachmentMap, response.id, response);
-          this.rootIssueStore.issues.updateIssue(issueId, {
-            attachment_count: issueAttachmentsCount + 1, // increment attachment count
-          });
         });
       }
 


### PR DESCRIPTION
### Description
This PR includes following changes:
- Fixed the work item attachment add mutation.
- Added "created_by" to the attachment response.

### Type of Change
- [x] Bug fix
- [x] Code refactoring

### References
[[WEB-3439]](https://app.plane.so/plane/browse/WEB-3439/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Issue attachments now include creator information in their details.

- **Bug Fixes**
  - Adjusted how attachment counts are updated when adding attachments, ensuring consistent display when attachments are removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->