### PR TITLE
[WEB-3477] fix: mutation issue on moving work items for a manually ended cycle

### DIFF
--- a/web/core/store/cycle.store.ts
+++ b/web/core/store/cycle.store.ts
@@ -179,7 +179,9 @@ export class CycleStore implements ICycleStore {
       const endDate = getDate(c.end_date);
       const hasEndDatePassed = endDate && isPast(endDate);
       const isEndDateToday = endDate && isToday(endDate);
-      return c.project_id === projectId && hasEndDatePassed && !isEndDateToday && !c?.archived_at;
+      return (
+        c.project_id === projectId && ((hasEndDatePassed && !isEndDateToday) || c.status?.toLowerCase() === "completed")
+      );
     });
     completedCycles = sortBy(completedCycles, [(c) => c.sort_order]);
     const completedCycleIds = completedCycles.map((c) => c.id);
@@ -195,7 +197,9 @@ export class CycleStore implements ICycleStore {
     let incompleteCycles = Object.values(this.cycleMap ?? {}).filter((c) => {
       const endDate = getDate(c.end_date);
       const hasEndDatePassed = endDate && isPast(endDate);
-      return c.project_id === projectId && !hasEndDatePassed && !c?.archived_at;
+      return (
+        c.project_id === projectId && !hasEndDatePassed && !c?.archived_at && c.status?.toLowerCase() !== "completed"
+      );
     });
     incompleteCycles = sortBy(incompleteCycles, [(c) => c.sort_order]);
     const incompleteCycleIds = incompleteCycles.map((c) => c.id);


### PR DESCRIPTION
### Description
This PR restricts the users from editing work items in completed cycle

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved cycle filtering so that cycles marked as "completed" appear correctly in the completed list, regardless of end date conditions.
	- Adjusted the logic to ensure these cycles are excluded from the incomplete list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->