### PR TITLE
Fix:  padding for editor

### DIFF
--- a/web/core/components/editor/rich-text-editor/rich-text-editor.tsx
+++ b/web/core/components/editor/rich-text-editor/rich-text-editor.tsx
@@ -52,7 +52,7 @@ export const RichTextEditor = forwardRef<EditorRefApi, RichTextEditorWrapperProp
         renderComponent: (props) => <EditorMentionsRoot {...props} />,
       }}
       {...rest}
-      containerClassName={cn("relative pl-3", containerClassName)}
+      containerClassName={cn("relative pl-3 pb-3", containerClassName)}
     />
   );
 });


### PR DESCRIPTION
### Description  
Clicking at the bottom of the editor did not place the new node as expected due to the lack of padding.  

### Fix  
- [x] Added padding at the bottom to ensure proper node placement.

### Screenshots and Media (if applicable)

https://github.com/user-attachments/assets/f0c55cda-d668-4c58-98da-93f9bef385c8



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Adjusted the layout of the rich text editor by adding extra bottom padding for improved spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->