### PR TITLE
[WEB-3513] fix: return cycle start and end dates in project's timezone

### DIFF
--- a/apiserver/plane/api/serializers/cycle.py
+++ b/apiserver/plane/api/serializers/cycle.py
@@ -1,4 +1,5 @@
 # Third party imports
+import pytz
 from rest_framework import serializers
 
 # Module imports
@@ -17,6 +18,14 @@ class CycleSerializer(BaseSerializer):
     total_estimates = serializers.FloatField(read_only=True)
     completed_estimates = serializers.FloatField(read_only=True)
     started_estimates = serializers.FloatField(read_only=True)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        project = self.context.get("project")
+        if project and project.timezone:
+            project_timezone = pytz.timezone(project.timezone)
+            self.fields["start_date"].timezone = project_timezone
+            self.fields["end_date"].timezone = project_timezone
 
     def validate(self, data):
         if (

--- a/apiserver/plane/api/views/cycle.py
+++ b/apiserver/plane/api/views/cycle.py
@@ -137,10 +137,12 @@ class CycleAPIEndpoint(BaseAPIView):
         )
 
     def get(self, request, slug, project_id, pk=None):
+        project = Project.objects.get(workspace__slug=slug, pk=project_id)
         if pk:
             queryset = self.get_queryset().filter(archived_at__isnull=True).get(pk=pk)
             data = CycleSerializer(
-                queryset, fields=self.fields, expand=self.expand
+                queryset, fields=self.fields,
+                expand=self.expand, context={"project": project}
             ).data
             return Response(data, status=status.HTTP_200_OK)
         queryset = self.get_queryset().filter(archived_at__isnull=True)
@@ -152,7 +154,8 @@ class CycleAPIEndpoint(BaseAPIView):
                 start_date__lte=timezone.now(), end_date__gte=timezone.now()
             )
             data = CycleSerializer(
-                queryset, many=True, fields=self.fields, expand=self.expand
+                queryset, many=True, fields=self.fields,
+                expand=self.expand, context={"project": project}
             ).data
             return Response(data, status=status.HTTP_200_OK)
 
@@ -163,7 +166,8 @@ class CycleAPIEndpoint(BaseAPIView):
                 request=request,
                 queryset=(queryset),
                 on_results=lambda cycles: CycleSerializer(
-                    cycles, many=True, fields=self.fields, expand=self.expand
+                    cycles, many=True, fields=self.fields,
+                    expand=self.expand, context={"project": project}
                 ).data,
             )
 
@@ -174,7 +178,8 @@ class CycleAPIEndpoint(BaseAPIView):
                 request=request,
                 queryset=(queryset),
                 on_results=lambda cycles: CycleSerializer(
-                    cycles, many=True, fields=self.fields, expand=self.expand
+                    cycles, many=True, fields=self.fields,
+                    expand=self.expand, context={"project": project}
                 ).data,
             )
 
@@ -185,7 +190,8 @@ class CycleAPIEndpoint(BaseAPIView):
                 request=request,
                 queryset=(queryset),
                 on_results=lambda cycles: CycleSerializer(
-                    cycles, many=True, fields=self.fields, expand=self.expand
+                    cycles, many=True, fields=self.fields,
+                    expand=self.expand, context={"project": project}
                 ).data,
             )
 
@@ -198,14 +204,16 @@ class CycleAPIEndpoint(BaseAPIView):
                 request=request,
                 queryset=(queryset),
                 on_results=lambda cycles: CycleSerializer(
-                    cycles, many=True, fields=self.fields, expand=self.expand
+                    cycles, many=True, fields=self.fields,
+                    expand=self.expand, context={"project": project}
                 ).data,
             )
         return self.paginate(
             request=request,
             queryset=(queryset),
             on_results=lambda cycles: CycleSerializer(
-                cycles, many=True, fields=self.fields, expand=self.expand
+                cycles, many=True, fields=self.fields,
+                expand=self.expand, context={"project": project}
             ).data,
         )
 

--- a/apiserver/plane/app/views/cycle/base.py
+++ b/apiserver/plane/app/views/cycle/base.py
@@ -268,7 +268,7 @@ class CycleViewSet(BaseViewSet):
         )
         datetime_fields = ["start_date", "end_date"]
         data = user_timezone_converter(
-            data, datetime_fields, request.user.user_timezone
+            data, datetime_fields, project_timezone
         )
         return Response(data, status=status.HTTP_200_OK)
 
@@ -318,9 +318,13 @@ class CycleViewSet(BaseViewSet):
                     .first()
                 )
 
+                # Fetch the project timezone
+                project = Project.objects.get(id=self.kwargs.get("project_id"))
+                project_timezone = project.timezone
+
                 datetime_fields = ["start_date", "end_date"]
                 cycle = user_timezone_converter(
-                    cycle, datetime_fields, request.user.user_timezone
+                    cycle, datetime_fields, project_timezone
                 )
 
                 # Send the model activity
@@ -407,9 +411,13 @@ class CycleViewSet(BaseViewSet):
                 "created_by",
             ).first()
 
+            # Fetch the project timezone
+            project = Project.objects.get(id=self.kwargs.get("project_id"))
+            project_timezone = project.timezone
+
             datetime_fields = ["start_date", "end_date"]
             cycle = user_timezone_converter(
-                cycle, datetime_fields, request.user.user_timezone
+                cycle, datetime_fields, project_timezone
             )
 
             # Send the model activity
@@ -480,10 +488,11 @@ class CycleViewSet(BaseViewSet):
             )
 
         queryset = queryset.first()
+        # Fetch the project timezone
+        project = Project.objects.get(id=self.kwargs.get("project_id"))
+        project_timezone = project.timezone
         datetime_fields = ["start_date", "end_date"]
-        data = user_timezone_converter(
-            data, datetime_fields, request.user.user_timezone
-        )
+        data = user_timezone_converter(data, datetime_fields, project_timezone)
 
         recent_visited_task.delay(
             slug=slug,


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
Updated the API responces to return the start_date and end_date in the project's timezone instead of user's timezone

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
<!-- Link related issues if there are any -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Cycle start and end dates are now automatically adjusted based on your project's timezone settings. This update ensures that all cycle-related operations—whether viewing, creating, or editing—display date and time information consistently and accurately across the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->