### PR TITLE
[WEB-3134] fix: plane logo rendering issue in safari

### DIFF
--- a/web/core/layouts/auth-layout/workspace-wrapper.tsx
+++ b/web/core/layouts/auth-layout/workspace-wrapper.tsx
@@ -150,7 +150,7 @@ export const WorkspaceAuthWrapper: FC<IWorkspaceAuthWrapper> = observer((props) 
         <div className="container relative mx-auto flex h-full w-full flex-col overflow-hidden overflow-y-auto px-5 py-14 md:px-0">
           <div className="relative flex flex-shrink-0 items-center justify-between gap-4">
             <div className="z-10 flex-shrink-0 bg-custom-background-90 py-4">
-              <Image src={planeLogo} className="h-[26px] w-full" alt="Plane logo" />
+              <Image src={planeLogo} height={26} className="h-[26px]" alt="Plane logo" />
             </div>
             <div className="relative flex items-center gap-2">
               <div className="text-sm font-medium">{currentUser?.email}</div>


### PR DESCRIPTION
### Description
This PR fixes the issue where the plane logo in the workspace wrapper was not rendering properly in Safari.

### Type of Change
- [x] Bug fix

### References
[[WEB-3134]](https://app.plane.so/plane/browse/WEB-3134/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Enhanced the display of the application logo by adjusting its dimensions for a more consistent and refined visual experience. The logo now maintains a fixed height while its width adapts to the surrounding container, ensuring improved responsiveness and a cleaner layout. This update enhances the overall visual consistency on relevant screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->