### PR TITLE
[ PE-294 ] fix : route back on page delete

### DIFF
--- a/web/core/components/pages/modals/delete-page-modal.tsx
+++ b/web/core/components/pages/modals/delete-page-modal.tsx
@@ -3,12 +3,14 @@
 import React, { useState } from "react";
 import { observer } from "mobx-react";
 // ui
+import { useParams } from "next/navigation";
 import { PAGE_DELETED } from "@plane/constants";
 import { AlertModalCore, TOAST_TYPE, setToast } from "@plane/ui";
 // constants
 // hooks
 import { useEventTracker } from "@/hooks/store";
 // plane web hooks
+import { useAppRouter } from "@/hooks/use-app-router";
 import { EPageStoreType, usePageStore } from "@/plane-web/hooks/store";
 // store
 import { TPageInstance } from "@/store/pages/base-page";
@@ -36,6 +38,9 @@ export const DeletePageModal: React.FC<TConfirmPageDeletionProps> = observer((pr
     onClose();
   };
 
+  const router = useAppRouter();
+  const { pageId: routePageId } = useParams();
+
   const handleDelete = async () => {
     setIsDeleting(true);
     await removePage(pageId)
@@ -53,6 +58,10 @@ export const DeletePageModal: React.FC<TConfirmPageDeletionProps> = observer((pr
           title: "Success!",
           message: "Page deleted successfully.",
         });
+
+        if (routePageId) {
+          router.back();
+        }
       })
       .catch(() => {
         capturePageEvent({


### PR DESCRIPTION
### Description
Deleting a page from within doesn’t redirect the user, leading to a fetch error. This fix ensures proper redirection.

### Type of Change
- [x]  Check pageId and redirect user to previous page if needed.


### Screenshots and Media (if applicable)
### Before 
https://github.com/user-attachments/assets/6d7ee8cd-5a69-4d85-a19c-e403bb663e77

### After
https://github.com/user-attachments/assets/61278335-7b3a-424a-8ef6-3250c1a1d5ea





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the page deletion process by automatically navigating back to the previous view after a successful deletion, ensuring a smoother user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->