### PR TITLE
[ PE-262 ] Fix : page name overflow in delete modal

### DIFF
--- a/web/core/components/pages/modals/delete-page-modal.tsx
+++ b/web/core/components/pages/modals/delete-page-modal.tsx
@@ -91,8 +91,8 @@ export const DeletePageModal: React.FC<TConfirmPageDeletionProps> = observer((pr
       content={
         <>
           Are you sure you want to delete page-{" "}
-          <span className="break-words font-medium text-custom-text-100">{name}</span>? The Page will be deleted
-          permanently. This action cannot be undone.
+          <span className="break-words font-medium text-custom-text-100 break-all">{name}</span> ? The Page will be
+          deleted permanently. This action cannot be undone.
         </>
       }
     />


### PR DESCRIPTION
### Description
Added `break-all` to prevent long words from overflowing the delete modal.  

### Screenshots and Media (if applicable)
### before
![image](https://github.com/user-attachments/assets/a241f487-4d6c-4f8f-9f58-03cc747de6c1)

### after 
![image](https://github.com/user-attachments/assets/e7648bdd-793b-4062-96cf-447f57d29d35)

