### PR TITLE
feat: Enable issue comment link copy & smooth scroll to comment

### DIFF
--- a/web/core/components/issues/issue-detail/issue-activity/comments/comment-block.tsx
+++ b/web/core/components/issues/issue-detail/issue-activity/comments/comment-block.tsx
@@ -25,7 +25,10 @@ export const IssueCommentBlock: FC<TIssueCommentBlock> = observer((props) => {
 
   if (!comment) return <></>;
   return (
-    <div className={`relative flex gap-3 ${ends === "top" ? `pb-2` : ends === "bottom" ? `pt-2` : `py-2`}`}>
+    <div
+      id={`comment-${commentId}`}
+      className={`relative flex gap-3 ${ends === "top" ? `pb-2` : ends === "bottom" ? `pt-2` : `py-2`}`}
+    >
       <div className="absolute left-[13px] top-0 bottom-0 w-0.5 bg-custom-background-80" aria-hidden />
       <div className="flex-shrink-0 relative w-7 h-7 rounded-full flex justify-center items-center z-[3] bg-gray-500 text-white border border-white uppercase font-medium">
         {comment.actor_detail?.avatar_url && comment.actor_detail?.avatar_url !== "" ? (


### PR DESCRIPTION
### Description
This PR introduces the ability to copy a direct link to an issue comment and ensures smooth scrolling to the comment when accessed via a URL hash.
### Type of Change

- [x] Added an id to each comment block for direct navigation.
- [x] Implemented smooth scrolling when navigating to a comment via the hash in the URL.
- [x] Added a "Copy Link" option to issue comments, allowing users to copy a direct link to a comment.

### Screenshots and Media (if applicable)
https://github.com/user-attachments/assets/7bb7c2d6-d8bf-4dca-88f8-3eb8c94239d9



