### PR TITLE
[RANTS-46] fix: modules list sidebar position

### DIFF
--- a/web/core/components/modules/modules-list-view.tsx
+++ b/web/core/components/modules/modules-list-view.tsx
@@ -90,20 +90,17 @@ export const ModulesListView: React.FC = observer(() => {
 
   return (
     <ContentWrapper variant={ERowVariant.HUGGING}>
-      {displayFilters?.layout === "list" && (
-        <div className="flex h-full w-full justify-between">
+      <div className="size-full flex justify-between">
+        {displayFilters?.layout === "list" && (
           <ListLayout>
             {filteredModuleIds.map((moduleId) => (
               <ModuleListItem key={moduleId} moduleId={moduleId} />
             ))}
           </ListLayout>
-          <ModulePeekOverview projectId={projectId?.toString() ?? ""} workspaceSlug={workspaceSlug?.toString() ?? ""} />
-        </div>
-      )}
-      {displayFilters?.layout === "board" && (
-        <Row className="flex h-full w-full justify-between py-page-y">
-          <div
-            className={`grid h-full w-full grid-cols-1 gap-6 overflow-y-auto ${
+        )}
+        {displayFilters?.layout === "board" && (
+          <Row
+            className={`size-full py-page-y grid grid-cols-1 gap-6 overflow-y-auto ${
               peekModule
                 ? "lg:grid-cols-1 xl:grid-cols-2 3xl:grid-cols-3"
                 : "lg:grid-cols-2 xl:grid-cols-3 3xl:grid-cols-4"
@@ -112,11 +109,17 @@ export const ModulesListView: React.FC = observer(() => {
             {filteredModuleIds.map((moduleId) => (
               <ModuleCardItem key={moduleId} moduleId={moduleId} />
             ))}
+          </Row>
+        )}
+        {displayFilters?.layout === "gantt" && (
+          <div className="size-full overflow-hidden">
+            <ModulesListGanttChartView />
           </div>
+        )}
+        <div className="flex-shrink-0">
           <ModulePeekOverview projectId={projectId?.toString() ?? ""} workspaceSlug={workspaceSlug?.toString() ?? ""} />
-        </Row>
-      )}
-      {displayFilters?.layout === "gantt" && <ModulesListGanttChartView />}
+        </div>
+      </div>
     </ContentWrapper>
   );
 });


### PR DESCRIPTION
### Description

This PR fixes the position of module info sidebar in the modules list page across different layouts.

### Type of Change

- [x] Improvement (change that would cause existing functionality to not work as expected)

### Media

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/3b47f1c4-f8b7-4895-9b26-ef89725dfa6c"></video> | <video src="https://github.com/user-attachments/assets/f11f6498-57f5-4b1a-b17d-2131e7ec9f86"></video> | 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined the layout display for modules, ensuring a consistent structure across list, board, and Gantt views.
  - Enhanced styling and spacing for a cleaner user experience while keeping the visual presentation intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->