### PR TITLE
feat(translations): add Korean translation

### DIFF
--- a/packages/i18n/src/constants/language.ts
+++ b/packages/i18n/src/constants/language.ts
@@ -11,6 +11,7 @@ export const SUPPORTED_LANGUAGES: ILanguageOption[] = [
   { label: "Русский", value: "ru" },
   { label: "Italian", value: "it" },
   { label: "Čeština", value: "cs" },
+  { label: "한국어", value: "ko" },
 ];
 
 export const STORAGE_KEY = "userLanguage";

--- a/packages/i18n/src/hooks/use-translation.ts
+++ b/packages/i18n/src/hooks/use-translation.ts
@@ -1,8 +1,8 @@
-import { useContext } from 'react';
+import { useContext } from "react";
 // context
-import { TranslationContext } from '../context';
+import { TranslationContext } from "../context";
 // types
-import { ILanguageOption, TLanguage } from '../types';
+import { ILanguageOption, TLanguage } from "../types";
 
 export type TTranslationStore = {
   t: (key: string, params?: Record<string, any>) => string;
@@ -23,7 +23,7 @@ export type TTranslationStore = {
 export function useTranslation(): TTranslationStore {
   const store = useContext(TranslationContext);
   if (!store) {
-    throw new Error('useTranslation must be used within a TranslationProvider');
+    throw new Error("useTranslation must be used within a TranslationProvider");
   }
 
   return {

--- a/packages/i18n/src/locales/ko/translations.json
+++ b/packages/i18n/src/locales/ko/translations.json
@@ -1,0 +1,2371 @@
+{
+  "sidebar": {
+    "projects": "Projects",
+    "pages": "Pages",
+    "new_work_item": "New work item",
+    "home": "Home",
+    "your_work": "Your work",
+    "inbox": "Inbox",
+    "workspace": "Workspace",
+    "views": "Views",
+    "analytics": "Analytics",
+    "work_items": "Work Items",
+    "cycles": "Cycles",
+    "modules": "Modules",
+    "intake": "Intake",
+    "drafts": "Drafts",
+    "favorites": "Favorites",
+    "pro": "Pro",
+    "upgrade": "Upgrade"
+  },
+
+  "auth": {
+    "common": {
+      "email": {
+        "label": "Email",
+        "placeholder": "name@company.com",
+        "errors": {
+          "required": "Email is required",
+          "invalid": "Email is invalid"
+        }
+      },
+      "password": {
+        "label": "Password",
+        "set_password": "Set a password",
+        "placeholder": "Enter password",
+        "confirm_password": {
+          "label": "Confirm password",
+          "placeholder": "Confirm password"
+        },
+        "current_password": {
+          "label": "Current password"
+        },
+        "new_password": {
+          "label": "New password",
+          "placeholder": "Enter new password"
+        },
+        "change_password": {
+          "label": {
+            "default": "Change password",
+            "submitting": "Changing password"
+          }
+        },
+        "errors": {
+          "match": "Passwords don't match",
+          "empty": "Please enter your password",
+          "length": "Password length should me more than 8 characters",
+          "strength": {
+            "weak": "Password is weak",
+            "strong": "Password is strong"
+          }
+        },
+        "submit": "Set password",
+        "toast": {
+          "change_password": {
+            "success": {
+              "title": "Success!",
+              "message": "Password changed successfully."
+            },
+            "error": {
+              "title": "Error!",
+              "message": "Something went wrong. Please try again."
+            }
+          }
+        }
+      },
+      "unique_code": {
+        "label": "Unique code",
+        "placeholder": "gets-sets-flys",
+        "paste_code": "Paste the code sent to your email",
+        "requesting_new_code": "Requesting new code",
+        "sending_code": "Sending code"
+      },
+      "already_have_an_account": "Already have an account?",
+      "login": "Log in",
+      "create_account": "Create an account",
+      "new_to_plane": "New to Plane?",
+      "back_to_sign_in": "Back to sign in",
+      "resend_in": "Resend in {seconds} seconds",
+      "sign_in_with_unique_code": "Sign in with unique code",
+      "forgot_password": "Forgot your password?"
+    },
+    "sign_up": {
+      "header": {
+        "label": "Create an account to start managing work with your team.",
+        "step": {
+          "email": {
+            "header": "Sign up",
+            "sub_header": ""
+          },
+          "password": {
+            "header": "Sign up",
+            "sub_header": "Sign up using an email-password combination."
+          },
+          "unique_code": {
+            "header": "Sign up",
+            "sub_header": "Sign up using a unique code sent to the email address above."
+          }
+        }
+      },
+      "errors": {
+        "password": {
+          "strength": "Try setting-up a strong password to proceed"
+        }
+      }
+    },
+    "sign_in": {
+      "header": {
+        "label": "Log in to start managing work with your team.",
+        "step": {
+          "email": {
+            "header": "Log in or sign up",
+            "sub_header": ""
+          },
+          "password": {
+            "header": "Log in or sign up",
+            "sub_header": "Use your email-password combination to log in."
+          },
+          "unique_code": {
+            "header": "Log in or sign up",
+            "sub_header": "Log in using a unique code sent to the email address above."
+          }
+        }
+      }
+    },
+    "forgot_password": {
+      "title": "Reset your password",
+      "description": "Enter your user account's verified email address and we will send you a password reset link.",
+      "email_sent": "We sent the reset link to your email address",
+      "send_reset_link": "Send reset link",
+      "errors": {
+        "smtp_not_enabled": "We see that your god hasn't enabled SMTP, we will not be able to send a password reset link"
+      },
+      "toast": {
+        "success": {
+          "title": "Email sent",
+          "message": "Check your inbox for a link to reset your password. If it doesn't appear within a few minutes, check your spam folder."
+        },
+        "error": {
+          "title": "Error!",
+          "message": "Something went wrong. Please try again."
+        }
+      }
+    },
+    "reset_password": {
+      "title": "Set new password",
+      "description": "Secure your account with a strong password"
+    },
+    "set_password": {
+      "title": "Secure your account",
+      "description": "Setting password helps you login securely"
+    },
+    "sign_out": {
+      "toast": {
+        "error": {
+          "title": "Error!",
+          "message": "Failed to sign out. Please try again."
+        }
+      }
+    }
+  },
+
+  "submit": "Submit",
+  "cancel": "Cancel",
+  "loading": "Loading",
+  "error": "Error",
+  "success": "Success",
+  "warning": "Warning",
+  "info": "Info",
+  "close": "Close",
+  "yes": "Yes",
+  "no": "No",
+  "ok": "OK",
+  "name": "Name",
+  "description": "Description",
+  "search": "Search",
+  "add_member": "Add member",
+  "adding_members": "Adding members",
+  "remove_member": "Remove member",
+  "add_members": "Add members",
+  "adding_member": "Adding members",
+  "remove_members": "Remove members",
+  "add": "Add",
+  "adding": "Adding",
+  "remove": "Remove",
+  "add_new": "Add new",
+  "remove_selected": "Remove selected",
+  "first_name": "First name",
+  "last_name": "Last name",
+  "email": "Email",
+  "display_name": "Display name",
+  "role": "Role",
+  "timezone": "Timezone",
+  "avatar": "Avatar",
+  "cover_image": "Cover image",
+  "password": "Password",
+  "change_cover": "Change cover",
+  "language": "Language",
+  "saving": "Saving",
+  "save_changes": "Save changes",
+  "deactivate_account": "Deactivate account",
+  "deactivate_account_description": "When deactivating an account, all of the data and resources within that account will be permanently removed and cannot be recovered.",
+  "profile_settings": "Profile settings",
+  "your_account": "Your account",
+  "security": "Security",
+  "activity": "Activity",
+  "appearance": "Appearance",
+  "notifications": "Notifications",
+  "workspaces": "Workspaces",
+  "create_workspace": "Create workspace",
+  "invitations": "Invitations",
+  "summary": "Summary",
+  "assigned": "Assigned",
+  "created": "Created",
+  "subscribed": "Subscribed",
+  "you_do_not_have_the_permission_to_access_this_page": "You do not have the permission to access this page.",
+  "something_went_wrong_please_try_again": "Something went wrong. Please try again.",
+  "load_more": "Load more",
+  "select_or_customize_your_interface_color_scheme": "Select or customize your interface color scheme.",
+  "theme": "Theme",
+  "system_preference": "System preference",
+  "light": "Light",
+  "dark": "Dark",
+  "light_contrast": "Light high contrast",
+  "dark_contrast": "Dark high contrast",
+  "custom": "Custom theme",
+  "select_your_theme": "Select your theme",
+  "customize_your_theme": "Customize your theme",
+  "background_color": "Background color",
+  "text_color": "Text color",
+  "primary_color": "Primary(Theme) color",
+  "sidebar_background_color": "Sidebar background color",
+  "sidebar_text_color": "Sidebar text color",
+  "set_theme": "Set theme",
+  "enter_a_valid_hex_code_of_6_characters": "Enter a valid hex code of 6 characters",
+  "background_color_is_required": "Background color is required",
+  "text_color_is_required": "Text color is required",
+  "primary_color_is_required": "Primary color is required",
+  "sidebar_background_color_is_required": "Sidebar background color is required",
+  "sidebar_text_color_is_required": "Sidebar text color is required",
+  "updating_theme": "Updating theme",
+  "theme_updated_successfully": "Theme updated successfully",
+  "failed_to_update_the_theme": "Failed to update the theme",
+  "email_notifications": "Email notifications",
+  "stay_in_the_loop_on_issues_you_are_subscribed_to_enable_this_to_get_notified": "Stay in the loop on Work items you are subscribed to. Enable this to get notified.",
+  "email_notification_setting_updated_successfully": "Email notification setting updated successfully",
+  "failed_to_update_email_notification_setting": "Failed to update email notification setting",
+  "notify_me_when": "Notify me when",
+  "property_changes": "Property changes",
+  "property_changes_description": "Notify me when work items' properties like assignees, priority, estimates or anything else changes.",
+  "state_change": "State change",
+  "state_change_description": "Notify me when the work items moves to a different state",
+  "issue_completed": "Work item completed",
+  "issue_completed_description": "Notify me only when a work item is completed",
+  "comments": "Comments",
+  "comments_description": "Notify me when someone leaves a comment on the work item",
+  "mentions": "Mentions",
+  "mentions_description": "Notify me only when someone mentions me in the comments or description",
+  "old_password": "Old password",
+  "general_settings": "General settings",
+  "sign_out": "Sign out",
+  "signing_out": "Signing out",
+  "active_cycles": "Active cycles",
+  "active_cycles_description": "Monitor cycles across projects, track high-priority work items, and zoom in cycles that need attention.",
+  "on_demand_snapshots_of_all_your_cycles": "On-demand snapshots of all your cycles",
+  "upgrade": "Upgrade",
+  "10000_feet_view": "10,000-feet view of all active cycles.",
+  "10000_feet_view_description": "Zoom out to see running cycles across all your projects at once instead of going from Cycle to Cycle in each project.",
+  "get_snapshot_of_each_active_cycle": "Get a snapshot of each active cycle.",
+  "get_snapshot_of_each_active_cycle_description": "Track high-level metrics for all active cycles, see their state of progress, and get a sense of scope against deadlines.",
+  "compare_burndowns": "Compare burndowns.",
+  "compare_burndowns_description": "Monitor how each of your teams are performing with a peek into each cycle's burndown report.",
+  "quickly_see_make_or_break_issues": "Quickly see make-or-break work items.",
+  "quickly_see_make_or_break_issues_description": "Preview high-priority work items for each cycle against due dates. See all of them per cycle in one click.",
+  "zoom_into_cycles_that_need_attention": "Zoom into cycles that need attention.",
+  "zoom_into_cycles_that_need_attention_description": "Investigate the state of any cycle that doesn't conform to expectations in one click.",
+  "stay_ahead_of_blockers": "Stay ahead of blockers.",
+  "stay_ahead_of_blockers_description": "Spot challenges from one project to another and see inter-cycle dependencies that aren't obvious from any other view.",
+  "analytics": "Analytics",
+  "workspace_invites": "Workspace invites",
+  "enter_god_mode": "Enter god mode",
+  "workspace_logo": "Workspace logo",
+  "new_issue": "New work item",
+  "your_work": "Your work",
+  "drafts": "Drafts",
+  "projects": "Projects",
+  "views": "Views",
+  "workspace": "Workspace",
+  "archives": "Archives",
+  "settings": "Settings",
+  "failed_to_move_favorite": "Failed to move favorite",
+  "favorites": "Favorites",
+  "no_favorites_yet": "No favorites yet",
+  "create_folder": "Create folder",
+  "new_folder": "New folder",
+  "favorite_updated_successfully": "Favorite updated successfully",
+  "favorite_created_successfully": "Favorite created successfully",
+  "folder_already_exists": "Folder already exists",
+  "folder_name_cannot_be_empty": "Folder name cannot be empty",
+  "something_went_wrong": "Something went wrong",
+  "failed_to_reorder_favorite": "Failed to reorder favorite",
+  "favorite_removed_successfully": "Favorite removed successfully",
+  "failed_to_create_favorite": "Failed to create favorite",
+  "failed_to_rename_favorite": "Failed to rename favorite",
+  "project_link_copied_to_clipboard": "Project link copied to clipboard",
+  "link_copied": "Link copied",
+  "add_project": "Add project",
+  "create_project": "Create project",
+  "failed_to_remove_project_from_favorites": "Couldn't remove the project from favorites. Please try again.",
+  "project_created_successfully": "Project created successfully",
+  "project_created_successfully_description": "Project created successfully. You can now start adding work items to it.",
+  "project_cover_image_alt": "Project cover image",
+  "name_is_required": "Name is required",
+  "title_should_be_less_than_255_characters": "Title should be less than 255 characters",
+  "project_name": "Project name",
+  "project_id_must_be_at_least_1_character": "Project ID must at least be of 1 character",
+  "project_id_must_be_at_most_5_characters": "Project ID must at most be of 5 characters",
+  "project_id": "Project ID",
+  "project_id_tooltip_content": "Helps you identify work items in the project uniquely. Max 5 characters.",
+  "description_placeholder": "Description",
+  "only_alphanumeric_non_latin_characters_allowed": "Only Alphanumeric & Non-latin characters are allowed.",
+  "project_id_is_required": "Project ID is required",
+  "project_id_allowed_char": "Only Alphanumeric & Non-latin characters are allowed.",
+  "project_id_min_char": "Project ID must at least be of 1 character",
+  "project_id_max_char": "Project ID must at most be of 5 characters",
+  "project_description_placeholder": "Enter project description",
+  "select_network": "Select network",
+  "lead": "Lead",
+  "date_range": "Date range",
+  "private": "Private",
+  "public": "Public",
+  "accessible_only_by_invite": "Accessible only by invite",
+  "anyone_in_the_workspace_except_guests_can_join": "Anyone in the workspace except Guests can join",
+  "creating": "Creating",
+  "creating_project": "Creating project",
+  "adding_project_to_favorites": "Adding project to favorites",
+  "project_added_to_favorites": "Project added to favorites",
+  "couldnt_add_the_project_to_favorites": "Couldn't add the project to favorites. Please try again.",
+  "removing_project_from_favorites": "Removing project from favorites",
+  "project_removed_from_favorites": "Project removed from favorites",
+  "couldnt_remove_the_project_from_favorites": "Couldn't remove the project from favorites. Please try again.",
+  "add_to_favorites": "Add to favorites",
+  "remove_from_favorites": "Remove from favorites",
+  "publish_settings": "Publish settings",
+  "publish": "Publish",
+  "copy_link": "Copy link",
+  "leave_project": "Leave project",
+  "join_the_project_to_rearrange": "Join the project to rearrange",
+  "drag_to_rearrange": "Drag to rearrange",
+  "congrats": "Congrats!",
+  "open_project": "Open project",
+  "issues": "Work items",
+  "cycles": "Cycles",
+  "modules": "Modules",
+  "pages": "Pages",
+  "intake": "Intake",
+  "time_tracking": "Time Tracking",
+  "work_management": "Work management",
+  "projects_and_issues": "Projects and work items",
+  "projects_and_issues_description": "Toggle these on or off this project.",
+  "cycles_description": "Timebox work as you see fit per project and change frequency from one period to the next.",
+  "modules_description": "Group work into sub-project-like set-ups with their own leads and assignees.",
+  "views_description": "Save sorts, filters, and display options for later or share them.",
+  "pages_description": "Write anything like you write anything.",
+  "intake_description": "Stay in the loop on Work items you are subscribed to. Enable this to get notified.",
+  "time_tracking_description": "Track time spent on work items and projects.",
+  "work_management_description": "Manage your work and projects with ease.",
+  "documentation": "Documentation",
+  "message_support": "Message support",
+  "contact_sales": "Contact sales",
+  "hyper_mode": "Hyper Mode",
+  "keyboard_shortcuts": "Keyboard shortcuts",
+  "whats_new": "What's new?",
+  "version": "Version",
+  "we_are_having_trouble_fetching_the_updates": "We are having trouble fetching the updates.",
+  "our_changelogs": "our changelogs",
+  "for_the_latest_updates": "for the latest updates.",
+  "please_visit": "Please visit",
+  "docs": "Docs",
+  "full_changelog": "Full changelog",
+  "support": "Support",
+  "discord": "Discord",
+  "powered_by_plane_pages": "Powered by Plane Pages",
+  "please_select_at_least_one_invitation": "Please select at least one invitation.",
+  "please_select_at_least_one_invitation_description": "Please select at least one invitation to join the workspace.",
+  "we_see_that_someone_has_invited_you_to_join_a_workspace": "We see that someone has invited you to join a workspace",
+  "join_a_workspace": "Join a workspace",
+  "we_see_that_someone_has_invited_you_to_join_a_workspace_description": "We see that someone has invited you to join a workspace",
+  "join_a_workspace_description": "Join a workspace",
+  "accept_and_join": "Accept & Join",
+  "go_home": "Go Home",
+  "no_pending_invites": "No pending invites",
+  "you_can_see_here_if_someone_invites_you_to_a_workspace": "You can see here if someone invites you to a workspace",
+  "back_to_home": "Back to home",
+  "workspace_name": "workspace-name",
+  "deactivate_your_account": "Deactivate your account",
+  "deactivate_your_account_description": "Once deactivated, you can't be assigned work items and be billed for your workspace. To reactivate your account, you will need an invite to a workspace at this email address.",
+  "deactivating": "Deactivating",
+  "confirm": "Confirm",
+  "confirming": "Confirming",
+  "draft_created": "Draft created",
+  "issue_created_successfully": "Work item created successfully",
+  "draft_creation_failed": "Draft creation failed",
+  "issue_creation_failed": "Work item creation failed",
+  "draft_issue": "Draft work item",
+  "issue_updated_successfully": "Work item updated successfully",
+  "issue_could_not_be_updated": "Work item could not be updated",
+  "create_a_draft": "Create a draft",
+  "save_to_drafts": "Save to Drafts",
+  "save": "Save",
+  "update": "Update",
+  "updating": "Updating",
+  "create_new_issue": "Create new work item",
+  "editor_is_not_ready_to_discard_changes": "Editor is not ready to discard changes",
+  "failed_to_move_issue_to_project": "Failed to move work item to project",
+  "create_more": "Create more",
+  "add_to_project": "Add to project",
+  "discard": "Discard",
+  "duplicate_issue_found": "Duplicate work item found",
+  "duplicate_issues_found": "Duplicate work items found",
+  "no_matching_results": "No matching results",
+  "title_is_required": "Title is required",
+  "title": "Title",
+  "state": "State",
+  "priority": "Priority",
+  "none": "None",
+  "urgent": "Urgent",
+  "high": "High",
+  "medium": "Medium",
+  "low": "Low",
+  "members": "Members",
+  "assignee": "Assignee",
+  "assignees": "Assignees",
+  "you": "You",
+  "labels": "Labels",
+  "create_new_label": "Create new label",
+  "start_date": "Start date",
+  "end_date": "End date",
+  "due_date": "Due date",
+  "estimate": "Estimate",
+  "change_parent_issue": "Change parent work item",
+  "remove_parent_issue": "Remove parent work item",
+  "add_parent": "Add parent",
+  "loading_members": "Loading members",
+  "view_link_copied_to_clipboard": "View link copied to clipboard.",
+  "required": "Required",
+  "optional": "Optional",
+  "Cancel": "Cancel",
+  "edit": "Edit",
+  "archive": "Archive",
+  "restore": "Restore",
+  "open_in_new_tab": "Open in new tab",
+  "delete": "Delete",
+  "deleting": "Deleting",
+  "make_a_copy": "Make a copy",
+  "move_to_project": "Move to project",
+  "good": "Good",
+  "morning": "morning",
+  "afternoon": "afternoon",
+  "evening": "evening",
+  "show_all": "Show all",
+  "show_less": "Show less",
+  "no_data_yet": "No Data yet",
+  "syncing": "Syncing",
+  "add_work_item": "Add work item",
+  "advanced_description_placeholder": "Press '/' for commands",
+  "create_work_item": "Create work item",
+  "attachments": "Attachments",
+  "declining": "Declining",
+  "declined": "Declined",
+  "decline": "Decline",
+  "unassigned": "Unassigned",
+  "work_items": "Work items",
+  "add_link": "Add link",
+  "points": "Points",
+  "no_assignee": "No assignee",
+  "no_assignees_yet": "No assignees yet",
+  "no_labels_yet": "No labels yet",
+  "ideal": "Ideal",
+  "current": "Current",
+  "no_matching_members": "No matching members",
+  "leaving": "Leaving",
+  "removing": "Removing",
+  "leave": "Leave",
+  "refresh": "Refresh",
+  "refreshing": "Refreshing",
+  "refresh_status": "Refresh status",
+  "prev": "Prev",
+  "next": "Next",
+  "re_generating": "Re-generating",
+  "re_generate": "Re-generate",
+  "re_generate_key": "Re-generate key",
+  "export": "Export",
+  "member": "{count, plural, one{# member} other{# members}}",
+
+  "project_view": {
+    "sort_by": {
+      "created_at": "Created at",
+      "updated_at": "Updated at",
+      "name": "Name"
+    }
+  },
+
+  "toast": {
+    "success": "Success!",
+    "error": "Error!"
+  },
+
+  "links": {
+    "toasts": {
+      "created": {
+        "title": "Link created",
+        "message": "The link has been successfully created"
+      },
+      "not_created": {
+        "title": "Link not created",
+        "message": "The link could not be created"
+      },
+      "updated": {
+        "title": "Link updated",
+        "message": "The link has been successfully updated"
+      },
+      "not_updated": {
+        "title": "Link not updated",
+        "message": "The link could not be updated"
+      },
+      "removed": {
+        "title": "Link removed",
+        "message": "The link has been successfully removed"
+      },
+      "not_removed": {
+        "title": "Link not removed",
+        "message": "The link could not be removed"
+      }
+    }
+  },
+
+  "home": {
+    "empty": {
+      "quickstart_guide": "Your quickstart guide",
+      "not_right_now": "Not right now",
+      "create_project": {
+        "title": "Create a project",
+        "description": "Most things start with a project in Plane.",
+        "cta": "Get started"
+      },
+      "invite_team": {
+        "title": "Invite your team",
+        "description": "Build, ship, and manage with coworkers.",
+        "cta": "Get them in"
+      },
+      "configure_workspace": {
+        "title": "Set up your workspace.",
+        "description": "Turn features on or off or go beyond that.",
+        "cta": "Configure this workspace"
+      },
+      "personalize_account": {
+        "title": "Make Plane yours.",
+        "description": "Choose your picture, colors, and more.",
+        "cta": "Personalize now"
+      },
+      "widgets": {
+        "title": "It's Quiet Without Widgets, Turn Them On",
+        "description": "It looks like all your widgets are turned off. Enable them\nnow to enhance your experience!",
+        "primary_button": {
+          "text": "Manage widgets"
+        }
+      }
+    },
+    "quick_links": {
+      "empty": "Save links to work things that you'd like handy.",
+      "add": "Add quick Link",
+      "title": "Quicklink",
+      "title_plural": "Quicklinks"
+    },
+    "recents": {
+      "title": "Recents",
+      "empty": {
+        "project": "Your recent projects will appear here once you visit one.",
+        "page": "Your recent pages will appear here once you visit one.",
+        "issue": "Your recent work items will appear here once you visit one.",
+        "default": "You don't have any recents yet."
+      },
+      "filters": {
+        "all": "All items",
+        "projects": "Projects",
+        "pages": "Pages",
+        "issues": "Work items"
+      }
+    },
+    "new_at_plane": {
+      "title": "New at Plane"
+    },
+    "quick_tutorial": {
+      "title": "Quick tutorial"
+    },
+    "widget": {
+      "reordered_successfully": "Widget reordered successfully.",
+      "reordering_failed": "Error occurred while reordering widget."
+    },
+    "manage_widgets": "Manage widgets",
+    "title": "Home",
+    "star_us_on_github": "Star us on GitHub"
+  },
+
+  "link": {
+    "modal": {
+      "url": {
+        "text": "URL",
+        "required": "URL is invalid",
+        "placeholder": "Type or paste a URL"
+      },
+      "title": {
+        "text": "Display title",
+        "placeholder": "What you'd like to see this link as"
+      }
+    }
+  },
+
+  "common": {
+    "all": "All",
+    "states": "States",
+    "state": "State",
+    "state_groups": "State groups",
+    "state_group": "State group",
+    "priorities": "Priorities",
+    "priority": "Priority",
+    "team_project": "Team project",
+    "project": "Project",
+    "cycle": "Cycle",
+    "cycles": "Cycles",
+    "module": "Module",
+    "modules": "Modules",
+    "labels": "Labels",
+    "label": "Label",
+    "assignees": "Assignees",
+    "assignee": "Assignee",
+    "created_by": "Created by",
+    "none": "None",
+    "link": "Link",
+    "estimates": "Estimates",
+    "estimate": "Estimate",
+    "created_at": "Created at",
+    "completed_at": "Completed at",
+    "layout": "Layout",
+    "filters": "Filters",
+    "display": "Display",
+    "load_more": "Load more",
+    "activity": "Activity",
+    "analytics": "Analytics",
+    "dates": "Dates",
+    "success": "Success!",
+    "something_went_wrong": "Something went wrong",
+    "error": {
+      "label": "Error!",
+      "message": "Some error occurred. Please try again."
+    },
+    "group_by": "Group by",
+    "epic": "Epic",
+    "epics": "Epics",
+    "work_item": "Work item",
+    "work_items": "Work items",
+    "sub_work_item": "Sub-work item",
+    "add": "Add",
+    "warning": "Warning",
+    "updating": "Updating",
+    "adding": "Adding",
+    "update": "Update",
+    "creating": "Creating",
+    "create": "Create",
+    "cancel": "Cancel",
+    "description": "Description",
+    "title": "Title",
+    "attachment": "Attachment",
+    "general": "General",
+    "features": "Features",
+    "automation": "Automation",
+    "project_name": "Project name",
+    "project_id": "Project ID",
+    "project_timezone": "Project Timezone",
+    "created_on": "Created on",
+    "update_project": "Update project",
+    "identifier_already_exists": "Identifier already exists",
+    "add_more": "Add more",
+    "defaults": "Defaults",
+    "add_label": "Add label",
+    "customize_time_range": "Customize time range",
+    "loading": "Loading",
+    "attachments": "Attachments",
+    "property": "Property",
+    "properties": "Properties",
+    "parent": "Parent",
+    "page": "Page",
+    "remove": "Remove",
+    "archiving": "Archiving",
+    "archive": "Archive",
+    "access": {
+      "public": "Public",
+      "private": "Private"
+    },
+    "done": "Done",
+    "sub_work_items": "Sub-work items",
+    "comment": "Comment",
+    "workspace_level": "Workspace level",
+    "order_by": {
+      "label": "Order by",
+      "manual": "Manual",
+      "last_created": "Last created",
+      "last_updated": "Last updated",
+      "start_date": "Start date",
+      "due_date": "Due date",
+      "asc": "Ascending",
+      "desc": "Descending",
+      "updated_on": "Updated on"
+    },
+    "sort": {
+      "asc": "Ascending",
+      "desc": "Descending",
+      "created_on": "Created on",
+      "updated_on": "Updated on"
+    },
+    "comments": "Comments",
+    "updates": "Updates",
+    "clear_all": "Clear all",
+    "copied": "Copied!",
+    "link_copied": "Link copied!",
+    "link_copied_to_clipboard": "Link copied to clipboard",
+    "copied_to_clipboard": "Work item link copied to clipboard",
+    "is_copied_to_clipboard": "Work item is copied to clipboard",
+    "no_links_added_yet": "No links added yet",
+    "add_link": "Add link",
+    "links": "Links",
+    "go_to_workspace": "Go to workspace",
+    "progress": "Progress",
+    "optional": "Optional",
+    "join": "Join",
+    "go_back": "Go back",
+    "continue": "Continue",
+    "resend": "Resend",
+    "relations": "Relations",
+    "errors": {
+      "default": {
+        "title": "Error!",
+        "message": "Something went wrong. Please try again."
+      },
+      "required": "This field is required",
+      "entity_required": "{entity} is required"
+    },
+    "update_link": "Update link",
+    "attach": "Attach",
+    "create_new": "Create new",
+    "add_existing": "Add existing",
+    "type_or_paste_a_url": "Type or paste a URL",
+    "url_is_invalid": "URL is invalid",
+    "display_title": "Display title",
+    "link_title_placeholder": "What you'd like to see this link as",
+    "url": "URL",
+    "side_peek": "Side Peek",
+    "modal": "Modal",
+    "full_screen": "Full Screen",
+    "close_peek_view": "Close the peek view",
+    "toggle_peek_view_layout": "Toggle peek view layout",
+    "options": "Options",
+    "duration": "Duration",
+    "today": "Today",
+    "week": "Week",
+    "month": "Month",
+    "quarter": "Quarter",
+    "press_for_commands": "Press '/' for commands",
+    "click_to_add_description": "Click to add description",
+    "search": {
+      "label": "Search",
+      "placeholder": "Type to search",
+      "no_matches_found": "No matches found",
+      "no_matching_results": "No matching results"
+    },
+    "actions": {
+      "edit": "Edit",
+      "make_a_copy": "Make a copy",
+      "open_in_new_tab": "Open in new tab",
+      "copy_link": "Copy link",
+      "archive": "Archive",
+      "restore": "Restore",
+      "delete": "Delete",
+      "remove_relation": "Remove relation",
+      "subscribe": "Subscribe",
+      "unsubscribe": "Unsubscribe",
+      "clear_sorting": "Clear sorting",
+      "show_weekends": "Show weekends",
+      "enable": "Enable",
+      "disable": "Disable"
+    },
+    "name": "Name",
+    "discard": "Discard",
+    "confirm": "Confirm",
+    "confirming": "Confirming",
+    "read_the_docs": "Read the docs",
+    "default": "Default",
+    "active": "Active",
+    "enabled": "Enabled",
+    "disabled": "Disabled",
+    "mandate": "Mandate",
+    "mandatory": "Mandatory",
+    "yes": "Yes",
+    "no": "No",
+    "please_wait": "Please wait",
+    "enabling": "Enabling",
+    "disabling": "Disabling",
+    "beta": "Beta",
+    "or": "or",
+    "next": "Next",
+    "back": "Back",
+    "cancelling": "Cancelling",
+    "configuring": "Configuring",
+    "clear": "Clear",
+    "import": "Import",
+    "connect": "Connect",
+    "authorizing": "Authorizing",
+    "processing": "Processing",
+    "no_data_available": "No data available",
+    "from": "from {name}",
+    "authenticated": "Authenticated",
+    "select": "Select",
+    "upgrade": "Upgrade",
+    "add_seats": "Add Seats",
+    "projects": "Projects",
+    "workspace": "Workspace",
+    "workspaces": "Workspaces",
+    "team": "Team",
+    "teams": "Teams",
+    "entity": "Entity",
+    "entities": "Entities",
+    "task": "Task",
+    "tasks": "Tasks",
+    "section": "Section",
+    "sections": "Sections",
+    "edit": "Edit",
+    "connecting": "Connecting",
+    "connected": "Connected",
+    "disconnect": "Disconnect",
+    "disconnecting": "Disconnecting",
+    "installing": "Installing",
+    "install": "Install",
+    "reset": "Reset",
+    "live": "Live",
+    "change_history": "Change History",
+    "coming_soon": "Coming soon",
+    "members": "Members",
+    "you": "You",
+    "upgrade_cta": {
+      "higher_subscription": "Upgrade to higher subscription",
+      "talk_to_sales": "Talk to Sales"
+    },
+    "category": "Category",
+    "categories": "Categories",
+    "saving": "Saving",
+    "save_changes": "Save changes",
+    "delete": "Delete",
+    "deleting": "Deleting",
+    "pending": "Pending",
+    "invite": "Invite",
+    "view": "View"
+  },
+
+  "chart": {
+    "x_axis": "X-axis",
+    "y_axis": "Y-axis",
+    "metric": "Metric"
+  },
+
+  "form": {
+    "title": {
+      "required": "Title is required",
+      "max_length": "Title should be less than {length} characters"
+    }
+  },
+
+  "entity": {
+    "grouping_title": "{entity} Grouping",
+    "priority": "{entity} Priority",
+    "all": "All {entity}",
+    "drop_here_to_move": "Drop here to move the {entity}",
+    "delete": {
+      "label": "Delete {entity}",
+      "success": "{entity} deleted successfully",
+      "failed": "{entity} delete failed"
+    },
+    "update": {
+      "failed": "{entity} update failed",
+      "success": "{entity} updated successfully"
+    },
+    "link_copied_to_clipboard": "{entity} link copied to clipboard",
+    "fetch": {
+      "failed": "Error fetching {entity}"
+    },
+    "add": {
+      "success": "{entity} added successfully",
+      "failed": "Error adding {entity}"
+    }
+  },
+
+  "epic": {
+    "all": "All Epics",
+    "label": "{count, plural, one {Epic} other {Epics}}",
+    "new": "New Epic",
+    "adding": "Adding epic",
+    "create": {
+      "success": "Epic created successfully"
+    },
+    "add": {
+      "press_enter": "Press 'Enter' to add another epic",
+      "label": "Add Epic"
+    },
+    "title": {
+      "label": "Epic Title",
+      "required": "Epic title is required."
+    }
+  },
+
+  "issue": {
+    "label": "{count, plural, one {Work item} other {Work items}}",
+    "all": "All Work items",
+    "edit": "Edit work item",
+    "title": {
+      "label": "Work item title",
+      "required": "Work item title is required."
+    },
+    "add": {
+      "press_enter": "Press 'Enter' to add another work item",
+      "label": "Add work item",
+      "cycle": {
+        "failed": "Work item could not be added to the cycle. Please try again.",
+        "success": "{count, plural, one {Work item} other {Work items}} added to the cycle successfully.",
+        "loading": "Adding {count, plural, one {work item} other {work items}} to the cycle"
+      },
+      "assignee": "Add assignees",
+      "start_date": "Add start date",
+      "due_date": "Add due date",
+      "parent": "Add parent work item",
+      "sub_issue": "Add sub-work item",
+      "relation": "Add relation",
+      "link": "Add link",
+      "existing": "Add existing work item"
+    },
+    "remove": {
+      "label": "Remove work item",
+      "cycle": {
+        "loading": "Removing work item from the cycle",
+        "success": "Work item removed from the cycle successfully.",
+        "failed": "Work item could not be removed from the cycle. Please try again."
+      },
+      "module": {
+        "loading": "Removing work item from the module",
+        "success": "Work item removed from the module successfully.",
+        "failed": "Work item could not be removed from the module. Please try again."
+      },
+      "parent": {
+        "label": "Remove parent work item"
+      }
+    },
+    "new": "New Work item",
+    "adding": "Adding work item",
+    "create": {
+      "success": "Work item created successfully"
+    },
+    "priority": {
+      "urgent": "Urgent",
+      "high": "High",
+      "medium": "Medium",
+      "low": "Low"
+    },
+    "display": {
+      "properties": {
+        "label": "Display Properties",
+        "id": "ID",
+        "issue_type": "Work item Type",
+        "sub_issue_count": "Sub-work item count",
+        "attachment_count": "Attachment count",
+        "created_on": "Created on",
+        "sub_issue": "Sub-work item",
+        "work_item_count": "Work item count"
+      },
+      "extra": {
+        "show_sub_issues": "Show sub-work items",
+        "show_empty_groups": "Show empty groups"
+      }
+    },
+    "layouts": {
+      "ordered_by_label": "This layout is ordered by",
+      "list": "List",
+      "kanban": "Board",
+      "calendar": "Calendar",
+      "spreadsheet": "Table",
+      "gantt": "Timeline",
+      "title": {
+        "list": "List Layout",
+        "kanban": "Board Layout",
+        "calendar": "Calendar Layout",
+        "spreadsheet": "Table Layout",
+        "gantt": "Timeline Layout"
+      }
+    },
+    "states": {
+      "active": "Active",
+      "backlog": "Backlog"
+    },
+    "comments": {
+      "placeholder": "Add comment",
+      "switch": {
+        "private": "Switch to private comment",
+        "public": "Switch to public comment"
+      },
+      "create": {
+        "success": "Comment created successfully",
+        "error": "Comment creation failed. Please try again later."
+      },
+      "update": {
+        "success": "Comment updated successfully",
+        "error": "Comment update failed. Please try again later."
+      },
+      "remove": {
+        "success": "Comment removed successfully",
+        "error": "Comment remove failed. Please try again later."
+      },
+      "upload": {
+        "error": "Asset upload failed. Please try again later."
+      }
+    },
+    "empty_state": {
+      "issue_detail": {
+        "title": "Work item does not exist",
+        "description": "The work item you are looking for does not exist, has been archived, or has been deleted.",
+        "primary_button": {
+          "text": "View other work items"
+        }
+      }
+    },
+    "sibling": {
+      "label": "Sibling work items"
+    },
+    "archive": {
+      "description": "Only completed or canceled\nwork items can be archived",
+      "label": "Archive Work item",
+      "confirm_message": "Are you sure you want to archive the work item? All your archived work items can be restored later.",
+      "success": {
+        "label": "Archive success",
+        "message": "Your archives can be found in project archives."
+      },
+      "failed": {
+        "message": "Work item could not be archived. Please try again."
+      }
+    },
+    "restore": {
+      "success": {
+        "title": "Restore success",
+        "message": "Your work item can be found in project work items."
+      },
+      "failed": {
+        "message": "Work item could not be restored. Please try again."
+      }
+    },
+    "relation": {
+      "relates_to": "Relates to",
+      "duplicate": "Duplicate of",
+      "blocked_by": "Blocked by",
+      "blocking": "Blocking"
+    },
+    "copy_link": "Copy work item link",
+    "delete": {
+      "label": "Delete work item",
+      "error": "Error deleting work item"
+    },
+    "subscription": {
+      "actions": {
+        "subscribed": "Work item subscribed successfully",
+        "unsubscribed": "Work item unsubscribed successfully"
+      }
+    },
+    "select": {
+      "error": "Please select at least one work item",
+      "empty": "No work items selected",
+      "add_selected": "Add selected work items"
+    },
+    "open_in_full_screen": "Open work item in full screen"
+  },
+
+  "attachment": {
+    "error": "File could not be attached. Try uploading again.",
+    "only_one_file_allowed": "Only one file can be uploaded at a time.",
+    "file_size_limit": "File must be of {size}MB or less in size.",
+    "drag_and_drop": "Drag and drop anywhere to upload",
+    "delete": "Delete attachment"
+  },
+
+  "label": {
+    "select": "Select label",
+    "create": {
+      "success": "Label created successfully",
+      "failed": "Label creation failed",
+      "already_exists": "Label already exists",
+      "type": "Type to add a new label"
+    }
+  },
+
+  "sub_work_item": {
+    "update": {
+      "success": "Sub-work item updated successfully",
+      "error": "Error updating sub-work item"
+    },
+    "remove": {
+      "success": "Sub-work item removed successfully",
+      "error": "Error removing sub-work item"
+    }
+  },
+
+  "view": {
+    "label": "{count, plural, one {View} other {Views}}",
+    "create": {
+      "label": "Create View"
+    },
+    "update": {
+      "label": "Update View"
+    }
+  },
+
+  "inbox_issue": {
+    "status": {
+      "pending": {
+        "title": "Pending",
+        "description": "Pending"
+      },
+      "declined": {
+        "title": "Declined",
+        "description": "Declined"
+      },
+      "snoozed": {
+        "title": "Snoozed",
+        "description": "{days, plural, one{# day} other{# days}} to go"
+      },
+      "accepted": {
+        "title": "Accepted",
+        "description": "Accepted"
+      },
+      "duplicate": {
+        "title": "Duplicate",
+        "description": "Duplicate"
+      }
+    },
+    "modals": {
+      "decline": {
+        "title": "Decline work item",
+        "content": "Are you sure you want to decline work item {value}?"
+      },
+      "delete": {
+        "title": "Delete work item",
+        "content": "Are you sure you want to delete work item {value}?",
+        "success": "Work item deleted successfully"
+      }
+    },
+    "errors": {
+      "snooze_permission": "Only project admins can snooze/Un-snooze work items",
+      "accept_permission": "Only project admins can accept work items",
+      "decline_permission": "Only project admins can deny work items"
+    },
+    "actions": {
+      "accept": "Accept",
+      "decline": "Decline",
+      "snooze": "Snooze",
+      "unsnooze": "Un snooze",
+      "copy": "Copy work item link",
+      "delete": "Delete",
+      "open": "Open work item",
+      "mark_as_duplicate": "Mark as duplicate",
+      "move": "Move {value} to project work items"
+    },
+    "source": {
+      "in-app": "in-app"
+    },
+    "order_by": {
+      "created_at": "Created at",
+      "updated_at": "Updated at",
+      "id": "ID"
+    },
+    "label": "Intake",
+    "page_label": "{workspace} - Intake",
+    "modal": {
+      "title": "Create intake work item"
+    },
+    "tabs": {
+      "open": "Open",
+      "closed": "Closed"
+    },
+    "empty_state": {
+      "sidebar_open_tab": {
+        "title": "No open work items",
+        "description": "Find open work items here. Create new work item."
+      },
+      "sidebar_closed_tab": {
+        "title": "No closed work items",
+        "description": "All the work items whether accepted or declined can be found here."
+      },
+      "sidebar_filter": {
+        "title": "No matching work items",
+        "description": "No work item matches filter applied in intake. Create a new work item."
+      },
+      "detail": {
+        "title": "Select a work item to view its details."
+      }
+    }
+  },
+
+  "workspace_creation": {
+    "heading": "Create your workspace",
+    "subheading": "To start using Plane, you need to create or join a workspace.",
+    "form": {
+      "name": {
+        "label": "Name your workspace",
+        "placeholder": "Something familiar and recognizable is always best."
+      },
+      "url": {
+        "label": "Set your workspace's URL",
+        "placeholder": "Type or paste a URL",
+        "edit_slug": "You can only edit the slug of the URL"
+      },
+      "organization_size": {
+        "label": "How many people will use this workspace?",
+        "placeholder": "Select a range"
+      }
+    },
+    "errors": {
+      "creation_disabled": {
+        "title": "Only your instance admin can create workspaces",
+        "description": "If you know your instance admin's email address, click the button below to get in touch with them.",
+        "request_button": "Request instance admin"
+      },
+      "validation": {
+        "name_alphanumeric": "Workspaces names can contain only (' '), ('-'), ('_') and alphanumeric characters.",
+        "name_length": "Limit your name to 80 characters.",
+        "url_alphanumeric": "URLs can contain only ('-') and alphanumeric characters.",
+        "url_length": "Limit your URL to 48 characters.",
+        "url_already_taken": "Workspace URL is already taken!"
+      }
+    },
+    "request_email": {
+      "subject": "Requesting a new workspace",
+      "body": "Hi instance admin(s),\n\nPlease create a new workspace with the URL [/workspace-name] for [purpose of creating the workspace].\n\nThanks,\n{firstName} {lastName}\n{email}"
+    },
+    "button": {
+      "default": "Create workspace",
+      "loading": "Creating workspace"
+    },
+    "toast": {
+      "success": {
+        "title": "Success",
+        "message": "Workspace created successfully"
+      },
+      "error": {
+        "title": "Error",
+        "message": "Workspace could not be created. Please try again."
+      }
+    }
+  },
+
+  "workspace_dashboard": {
+    "empty_state": {
+      "general": {
+        "title": "Overview of your projects, activity, and metrics",
+        "description": "Welcome to Plane, we are excited to have you here. Create your first project and track your work items, and this page will transform into a space that helps you progress. Admins will also see items which help their team progress.",
+        "primary_button": {
+          "text": "Build your first project",
+          "comic": {
+            "title": "Everything starts with a project in Plane",
+            "description": "A project could be a product's roadmap, a marketing campaign, or launching a new car."
+          }
+        }
+      }
+    }
+  },
+
+  "workspace_analytics": {
+    "label": "Analytics",
+    "page_label": "{workspace} - Analytics",
+    "open_tasks": "Total open tasks",
+    "error": "There was some error in fetching the data.",
+    "work_items_closed_in": "Work items closed in",
+    "selected_projects": "Selected projects",
+    "total_members": "Total members",
+    "total_cycles": "Total cycles",
+    "total_modules": "Total modules",
+    "pending_work_items": {
+      "title": "Pending work items",
+      "empty_state": "Analysis of pending work items by co-workers appears here."
+    },
+    "work_items_closed_in_a_year": {
+      "title": "Work items closed in a year",
+      "empty_state": "Close work items to view analysis of the same in the form of a graph."
+    },
+    "most_work_items_created": {
+      "title": "Most work items created",
+      "empty_state": "Co-workers and the number of work items created by them appears here."
+    },
+    "most_work_items_closed": {
+      "title": "Most work items closed",
+      "empty_state": "Co-workers and the number of work items closed by them appears here."
+    },
+    "tabs": {
+      "scope_and_demand": "Scope and Demand",
+      "custom": "Custom Analytics"
+    },
+    "empty_state": {
+      "general": {
+        "title": "Track progress, workloads, and allocations. Spot trends, remove blockers, and move work faster",
+        "description": "See scope versus demand, estimates, and scope creep. Get performance by team members and teams, and make sure your project runs on time.",
+        "primary_button": {
+          "text": "Start your first project",
+          "comic": {
+            "title": "Analytics works best with Cycles + Modules",
+            "description": "First, timebox your work items into Cycles and, if you can, group work items that span more than a cycle into Modules. Check out both on the left nav."
+          }
+        }
+      }
+    }
+  },
+
+  "workspace_projects": {
+    "label": "{count, plural, one {Project} other {Projects}}",
+    "create": {
+      "label": "Add Project"
+    },
+    "network": {
+      "label": "Network",
+      "private": {
+        "title": "Private",
+        "description": "Accessible only by invite"
+      },
+      "public": {
+        "title": "Public",
+        "description": "Anyone in the workspace except Guests can join"
+      }
+    },
+    "error": {
+      "permission": "You don't have permission to perform this action.",
+      "cycle_delete": "Failed to delete cycle",
+      "module_delete": "Failed to delete module",
+      "issue_delete": "Failed to delete work item"
+    },
+    "state": {
+      "backlog": "Backlog",
+      "unstarted": "Unstarted",
+      "started": "Started",
+      "completed": "Completed",
+      "cancelled": "Cancelled"
+    },
+    "sort": {
+      "manual": "Manual",
+      "name": "Name",
+      "created_at": "Created date",
+      "members_length": "Number of members"
+    },
+    "scope": {
+      "my_projects": "My projects",
+      "archived_projects": "Archived"
+    },
+    "common": {
+      "months_count": "{months, plural, one{# month} other{# months}}"
+    },
+    "empty_state": {
+      "general": {
+        "title": "No active projects",
+        "description": "Think of each project as the parent for goal-oriented work. Projects are where Jobs, Cycles, and Modules live and, along with your colleagues, help you achieve that goal. Create a new project or filter for archived projects.",
+        "primary_button": {
+          "text": "Start your first project",
+          "comic": {
+            "title": "Everything starts with a project in Plane",
+            "description": "A project could be a product's roadmap, a marketing campaign, or launching a new car."
+          }
+        }
+      },
+      "no_projects": {
+        "title": "No project",
+        "description": "To create work items or manage your work, you need to create a project or be a part of one.",
+        "primary_button": {
+          "text": "Start your first project",
+          "comic": {
+            "title": "Everything starts with a project in Plane",
+            "description": "A project could be a product's roadmap, a marketing campaign, or launching a new car."
+          }
+        }
+      },
+      "filter": {
+        "title": "No matching projects",
+        "description": "No projects detected with the matching criteria. \n Create a new project instead."
+      },
+      "search": {
+        "description": "No projects detected with the matching criteria.\nCreate a new project instead"
+      }
+    }
+  },
+
+  "workspace_views": {
+    "add_view": "Add view",
+    "empty_state": {
+      "all-issues": {
+        "title": "No work items in the project",
+        "description": "First project done! Now, slice your work into trackable pieces with work items. Let's go!",
+        "primary_button": {
+          "text": "Create new work item"
+        }
+      },
+      "assigned": {
+        "title": "No work items yet",
+        "description": "Work items assigned to you can be tracked from here.",
+        "primary_button": {
+          "text": "Create new work item"
+        }
+      },
+      "created": {
+        "title": "No work items yet",
+        "description": "All work items created by you come here, track them here directly.",
+        "primary_button": {
+          "text": "Create new work item"
+        }
+      },
+      "subscribed": {
+        "title": "No work items yet",
+        "description": "Subscribe to work items you are interested in, track all of them here."
+      },
+      "custom-view": {
+        "title": "No work items yet",
+        "description": "Work items that applies to the filters, track all of them here."
+      }
+    }
+  },
+
+  "workspace_settings": {
+    "label": "Workspace settings",
+    "page_label": "{workspace} - General settings",
+    "key_created": "Key created",
+    "copy_key": "Copy and save this secret key in Plane Pages. You can't see this key after you hit Close. A CSV file containing the key has been downloaded.",
+    "token_copied": "Token copied to clipboard.",
+    "settings": {
+      "general": {
+        "title": "General",
+        "upload_logo": "Upload logo",
+        "edit_logo": "Edit logo",
+        "name": "Workspace name",
+        "company_size": "Company size",
+        "url": "Workspace URL",
+        "update_workspace": "Update workspace",
+        "delete_workspace": "Delete this workspace",
+        "delete_workspace_description": "When deleting a workspace, all of the data and resources within that workspace will be permanently removed and cannot be recovered.",
+        "delete_btn": "Delete this workspace",
+        "delete_modal": {
+          "title": "Are you sure you want to delete this workspace?",
+          "description": "You have an active trial to one of our paid plans. Please cancel it first to proceed.",
+          "dismiss": "Dismiss",
+          "cancel": "Cancel trial",
+          "success_title": "Workspace deleted.",
+          "success_message": "You will soon go to your profile page.",
+          "error_title": "That didn't work.",
+          "error_message": "Try again, please."
+        },
+        "errors": {
+          "name": {
+            "required": "Name is required",
+            "max_length": "Workspace name should not exceed 80 characters"
+          },
+          "company_size": {
+            "required": "Company size is required",
+            "select_a_range": "Select organization size"
+          }
+        }
+      },
+      "members": {
+        "title": "Members",
+        "add_member": "Add member",
+        "pending_invites": "Pending invites",
+        "invitations_sent_successfully": "Invitations sent successfully",
+        "leave_confirmation": "Are you sure you want to leave the workspace? You will no longer have access to this workspace. This action cannot be undone.",
+        "details": {
+          "full_name": "Full name",
+          "display_name": "Display name",
+          "email_address": "Email address",
+          "account_type": "Account type",
+          "authentication": "Authentication",
+          "joining_date": "Joining date"
+        },
+        "modal": {
+          "title": "Invite people to collaborate",
+          "description": "Invite people to collaborate on your workspace.",
+          "button": "Send invitations",
+          "button_loading": "Sending invitations",
+          "placeholder": "name@company.com",
+          "errors": {
+            "required": "We need an email address to invite them.",
+            "invalid": "Email is invalid"
+          }
+        }
+      },
+      "billing_and_plans": {
+        "title": "Billing & Plans",
+        "current_plan": "Current plan",
+        "free_plan": "You are currently using the free plan",
+        "view_plans": "View plans"
+      },
+      "exports": {
+        "title": "Exports",
+        "exporting": "Exporting",
+        "previous_exports": "Previous exports",
+        "export_separate_files": "Export the data into separate files",
+        "modal": {
+          "title": "Export to",
+          "toasts": {
+            "success": {
+              "title": "Export successful",
+              "message": "You will be able to download the exported {entity} from the previous export."
+            },
+            "error": {
+              "title": "Export failed",
+              "message": "Export was unsuccessful. Please try again."
+            }
+          }
+        }
+      },
+      "webhooks": {
+        "title": "Webhooks",
+        "add_webhook": "Add webhook",
+        "modal": {
+          "title": "Create webhook",
+          "details": "Webhook details",
+          "payload": "Payload URL",
+          "question": "Which events would you like to trigger this webhook?",
+          "error": "URL is required"
+        },
+        "secret_key": {
+          "title": "Secret key",
+          "message": "Generate a token to sign-in to the webhook payload"
+        },
+        "options": {
+          "all": "Send me everything",
+          "individual": "Select individual events"
+        },
+        "toasts": {
+          "created": {
+            "title": "Webhook created",
+            "message": "The webhook has been successfully created"
+          },
+          "not_created": {
+            "title": "Webhook not created",
+            "message": "The webhook could not be created"
+          },
+          "updated": {
+            "title": "Webhook updated",
+            "message": "The webhook has been successfully updated"
+          },
+          "not_updated": {
+            "title": "Webhook not updated",
+            "message": "The webhook could not be updated"
+          },
+          "removed": {
+            "title": "Webhook removed",
+            "message": "The webhook has been successfully removed"
+          },
+          "not_removed": {
+            "title": "Webhook not removed",
+            "message": "The webhook could not be removed"
+          },
+          "secret_key_copied": {
+            "message": "Secret key copied to clipboard."
+          },
+          "secret_key_not_copied": {
+            "message": "Error occurred while copying secret key."
+          }
+        }
+      },
+      "api_tokens": {
+        "title": "API Tokens",
+        "add_token": "Add API token",
+        "create_token": "Create token",
+        "never_expires": "Never expires",
+        "generate_token": "Generate token",
+        "generating": "Generating",
+        "delete": {
+          "title": "Delete API token",
+          "description": "Any application using this token will no longer have the access to Plane data. This action cannot be undone.",
+          "success": {
+            "title": "Success!",
+            "message": "The API token has been successfully deleted"
+          },
+          "error": {
+            "title": "Error!",
+            "message": "The API token could not be deleted"
+          }
+        }
+      }
+    },
+    "empty_state": {
+      "api_tokens": {
+        "title": "No API tokens created",
+        "description": "Plane APIs can be used to integrate your data in Plane with any external system. Create a token to get started."
+      },
+      "webhooks": {
+        "title": "No webhooks added",
+        "description": "Create webhooks to receive real-time updates and automate actions."
+      },
+      "exports": {
+        "title": "No exports yet",
+        "description": "Anytime you export, you will also have a copy here for reference."
+      },
+      "imports": {
+        "title": "No imports yet",
+        "description": "Find all your previous imports here and download them."
+      }
+    }
+  },
+
+  "profile": {
+    "label": "Profile",
+    "page_label": "Your work",
+    "work": "Work",
+    "details": {
+      "joined_on": "Joined on",
+      "time_zone": "Timezone"
+    },
+    "stats": {
+      "workload": "Workload",
+      "overview": "Overview",
+      "created": "Work items created",
+      "assigned": "Work items assigned",
+      "subscribed": "Work items subscribed",
+      "state_distribution": {
+        "title": "Work items by state",
+        "empty": "Create work items to view the them by states in the graph for better analysis."
+      },
+      "priority_distribution": {
+        "title": "Work items by Priority",
+        "empty": "Create work items to view the them by priority in the graph for better analysis."
+      },
+      "recent_activity": {
+        "title": "Recent activity",
+        "empty": "We couldn't find data. Kindly view your inputs",
+        "button": "Download today's activity",
+        "button_loading": "Downloading"
+      }
+    },
+    "actions": {
+      "profile": "Profile",
+      "security": "Security",
+      "activity": "Activity",
+      "appearance": "Appearance",
+      "notifications": "Notifications"
+    },
+    "tabs": {
+      "summary": "Summary",
+      "assigned": "Assigned",
+      "created": "Created",
+      "subscribed": "Subscribed",
+      "activity": "Activity"
+    },
+    "empty_state": {
+      "activity": {
+        "title": "No activities yet",
+        "description": "Get started by creating a new work item! Add details and properties to it. Explore more in Plane to see your activity."
+      },
+      "assigned": {
+        "title": "No work items are assigned to you",
+        "description": "Work items assigned to you can be tracked from here."
+      },
+      "created": {
+        "title": "No work items yet",
+        "description": "All work items created by you come here, track them here directly."
+      },
+      "subscribed": {
+        "title": "No work items yet",
+        "description": "Subscribe to work items you are interested in, track all of them here."
+      }
+    }
+  },
+
+  "project_settings": {
+    "general": {
+      "enter_project_id": "Enter project ID",
+      "please_select_a_timezone": "Please select a timezone",
+      "archive_project": {
+        "title": "Archive project",
+        "description": "Archiving a project will unlist your project from your side navigation although you will still be able to access it from your projects page. You can restore the project or delete it whenever you want.",
+        "button": "Archive project"
+      },
+      "delete_project": {
+        "title": "Delete project",
+        "description": "When deleting a project, all of the data and resources within that project will be permanently removed and cannot be recovered.",
+        "button": "Delete my project"
+      },
+      "toast": {
+        "success": "Project updated successfully",
+        "error": "Project could not be updated. Please try again."
+      }
+    },
+    "members": {
+      "label": "Members",
+      "project_lead": "Project lead",
+      "default_assignee": "Default assignee",
+      "guest_super_permissions": {
+        "title": "Grant view access to all work items for guest users:",
+        "sub_heading": "This will allow guests to have view access to all the project work items."
+      },
+      "invite_members": {
+        "title": "Invite members",
+        "sub_heading": "Invite members to work on your project.",
+        "select_co_worker": "Select co-worker"
+      }
+    },
+    "states": {
+      "describe_this_state_for_your_members": "Describe this state for your members.",
+      "empty_state": {
+        "title": "No states available for the {groupKey} group",
+        "description": "Please create a new state"
+      }
+    },
+    "labels": {
+      "label_title": "Label title",
+      "label_title_is_required": "Label title is required",
+      "label_max_char": "Label name should not exceed 255 characters",
+      "toast": {
+        "error": "Error while updating the label"
+      }
+    },
+    "estimates": {
+      "title": "Enable estimates for my project",
+      "description": "They help you in communicating complexity and workload of the team."
+    },
+    "automations": {
+      "label": "Automations",
+      "auto-archive": {
+        "title": "Auto-archive closed work items",
+        "description": "Plane will auto archive work items that have been completed or canceled.",
+        "duration": "Auto-archive work items that are closed for"
+      },
+      "auto-close": {
+        "title": "Auto-close work items",
+        "description": "Plane will automatically close work items that haven't been completed or canceled.",
+        "duration": "Auto-close work items that are inactive for",
+        "auto_close_status": "Auto-close status"
+      }
+    },
+
+    "empty_state": {
+      "labels": {
+        "title": "No labels yet",
+        "description": "Create labels to help organize and filter work items in you project."
+      },
+      "estimates": {
+        "title": "No estimate systems yet",
+        "description": "Create a set of estimates to communicate the amount of work per work item.",
+        "primary_button": "Add estimate system"
+      }
+    }
+  },
+
+  "project_cycles": {
+    "add_cycle": "Add cycle",
+    "more_details": "More details",
+    "cycle": "Cycle",
+    "update_cycle": "Update cycle",
+    "create_cycle": "Create cycle",
+    "no_matching_cycles": "No matching cycles",
+    "remove_filters_to_see_all_cycles": "Remove the filters to see all cycles",
+    "remove_search_criteria_to_see_all_cycles": "Remove the search criteria to see all cycles",
+    "only_completed_cycles_can_be_archived": "Only completed cycles can be archived",
+    "active_cycle": {
+      "label": "Active cycle",
+      "progress": "Progress",
+      "chart": "Burndown chart",
+      "priority_issue": "Priority work items",
+      "assignees": "Assignees",
+      "issue_burndown": "Work item burndown",
+      "ideal": "Ideal",
+      "current": "Current",
+      "labels": "Labels"
+    },
+    "upcoming_cycle": {
+      "label": "Upcoming cycle"
+    },
+    "completed_cycle": {
+      "label": "Completed cycle"
+    },
+    "status": {
+      "days_left": "Days left",
+      "completed": "Completed",
+      "yet_to_start": "Yet to start",
+      "in_progress": "In progress",
+      "draft": "Draft"
+    },
+    "action": {
+      "restore": {
+        "title": "Restore cycle",
+        "success": {
+          "title": "Cycle restored",
+          "description": "The cycle has been restored."
+        },
+        "failed": {
+          "title": "Cycle restore failed",
+          "description": "The cycle could not be restored. Please try again."
+        }
+      },
+      "favorite": {
+        "loading": "Adding cycle to favorites",
+        "success": {
+          "description": "Cycle added to favorites.",
+          "title": "Success!"
+        },
+        "failed": {
+          "description": "Couldn't add the cycle to favorites. Please try again.",
+          "title": "Error!"
+        }
+      },
+      "unfavorite": {
+        "loading": "Removing cycle from favorites",
+        "success": {
+          "description": "Cycle removed from favorites.",
+          "title": "Success!"
+        },
+        "failed": {
+          "description": "Couldn't remove the cycle from favorites. Please try again.",
+          "title": "Error!"
+        }
+      },
+      "update": {
+        "loading": "Updating cycle",
+        "success": {
+          "description": "Cycle updated successfully.",
+          "title": "Success!"
+        },
+        "failed": {
+          "description": "Error updating the cycle. Please try again.",
+          "title": "Error!"
+        },
+        "error": {
+          "already_exists": "You already have a cycle on the given dates, if you want to create a draft cycle, you can do that by removing both the dates."
+        }
+      }
+    },
+    "empty_state": {
+      "general": {
+        "title": "Group and timebox your work in Cycles.",
+        "description": "Break work down by timeboxed chunks, work backwards from your project deadline to set dates, and make tangible progress as a team.",
+        "primary_button": {
+          "text": "Set your first cycle",
+          "comic": {
+            "title": "Cycles are repetitive time-boxes.",
+            "description": "A sprint, an iteration, and or any other term you use for weekly or fortnightly tracking of work is a cycle."
+          }
+        }
+      },
+      "no_issues": {
+        "title": "No work items added to the cycle",
+        "description": "Add or create work items you wish to timebox and deliver within this cycle",
+        "primary_button": {
+          "text": "Create new work item"
+        },
+        "secondary_button": {
+          "text": "Add existing work item"
+        }
+      },
+      "completed_no_issues": {
+        "title": "No work items in the cycle",
+        "description": "No work items in the cycle. Work items are either transferred or hidden. To see hidden work items if any, update your display properties accordingly."
+      },
+      "active": {
+        "title": "No active cycle",
+        "description": "An active cycle includes any period that encompasses today's date within its range. Find the progress and details of the active cycle here."
+      },
+      "archived": {
+        "title": "No archived cycles yet",
+        "description": "To tidy up your project, archive completed cycles. Find them here once archived."
+      }
+    }
+  },
+
+  "project_issues": {
+    "empty_state": {
+      "no_issues": {
+        "title": "Create a work item and assign it to someone, even yourself",
+        "description": "Think of work items as jobs, tasks, work, or JTBD. Which we like. A work item and its sub-work items are usually time-based actionables assigned to members of your team. Your team creates, assigns, and completes work items to move your project towards its goal.",
+        "primary_button": {
+          "text": "Create your first work item",
+          "comic": {
+            "title": "Work items are building blocks in Plane.",
+            "description": "Redesign the Plane UI, Rebrand the company, or Launch the new fuel injection system are examples of work items that likely have sub-work items."
+          }
+        }
+      },
+      "no_archived_issues": {
+        "title": "No archived work items yet",
+        "description": "Manually or through automation, you can archive work items that are completed or cancelled. Find them here once archived.",
+        "primary_button": {
+          "text": "Set automation"
+        }
+      },
+      "issues_empty_filter": {
+        "title": "No work items found matching the filters applied",
+        "secondary_button": {
+          "text": "Clear all filters"
+        }
+      }
+    }
+  },
+
+  "project_module": {
+    "add_module": "Add Module",
+    "update_module": "Update Module",
+    "create_module": "Create Module",
+    "archive_module": "Archive Module",
+    "restore_module": "Restore Module",
+    "delete_module": "Delete module",
+    "empty_state": {
+      "general": {
+        "title": "Map your project milestones to Modules and track aggregated work easily.",
+        "description": "A group of work items that belong to a logical, hierarchical parent form a module. Think of them as a way to track work by project milestones. They have their own periods and deadlines as well as analytics to help you see how close or far you are from a milestone.",
+        "primary_button": {
+          "text": "Build your first module",
+          "comic": {
+            "title": "Modules help group work by hierarchy.",
+            "description": "A cart module, a chassis module, and a warehouse module are all good example of this grouping."
+          }
+        }
+      },
+      "no_issues": {
+        "title": "No work items in the module",
+        "description": "Create or add work items which you want to accomplish as part of this module",
+        "primary_button": {
+          "text": "Create new work items"
+        },
+        "secondary_button": {
+          "text": "Add an existing work item"
+        }
+      },
+      "archived": {
+        "title": "No archived Modules yet",
+        "description": "To tidy up your project, archive completed or cancelled modules. Find them here once archived."
+      },
+      "sidebar": {
+        "in_active": "This module isn't active yet.",
+        "invalid_date": "Invalid date. Please enter valid date."
+      }
+    },
+    "quick_actions": {
+      "archive_module": "Archive module",
+      "archive_module_description": "Only completed or canceled\nmodule can be archived.",
+      "delete_module": "Delete module"
+    },
+    "toast": {
+      "copy": {
+        "success": "Module link copied to clipboard"
+      },
+      "delete": {
+        "success": "Module deleted successfully",
+        "error": "Failed to delete module"
+      }
+    }
+  },
+
+  "project_views": {
+    "empty_state": {
+      "general": {
+        "title": "Save filtered views for your project. Create as many as you need",
+        "description": "Views are a set of saved filters that you use frequently or want easy access to. All your colleagues in a project can see everyone’s views and choose whichever suits their needs best.",
+        "primary_button": {
+          "text": "Create your first view",
+          "comic": {
+            "title": "Views work atop Work item properties.",
+            "description": "You can create a view from here with as many properties as filters as you see fit."
+          }
+        }
+      },
+      "filter": {
+        "title": "No matching views",
+        "description": "No views match the search criteria. \n Create a new view instead."
+      }
+    }
+  },
+
+  "project_page": {
+    "empty_state": {
+      "general": {
+        "title": "Write a note, a doc, or a full knowledge base. Get Galileo, Plane's AI assistant, to help you get started",
+        "description": "Pages are thoughts potting space in Plane. Take down meeting notes, format them easily, embed work items, lay them out using a library of components, and keep them all in your project's context. To make short work of any doc, invoke Galileo, Plane's AI, with a shortcut or the click of a button.",
+        "primary_button": {
+          "text": "Create your first page"
+        }
+      },
+      "private": {
+        "title": "No private pages yet",
+        "description": "Keep your private thoughts here. When you're ready to share, the team's just a click away.",
+        "primary_button": {
+          "text": "Create your first page"
+        }
+      },
+      "public": {
+        "title": "No public pages yet",
+        "description": "See pages shared with everyone in your project right here.",
+        "primary_button": {
+          "text": "Create your first page"
+        }
+      },
+      "archived": {
+        "title": "No archived pages yet",
+        "description": "Archive pages not on your radar. Access them here when needed."
+      }
+    }
+  },
+
+  "command_k": {
+    "empty_state": {
+      "search": {
+        "title": "No results found"
+      }
+    }
+  },
+
+  "issue_relation": {
+    "empty_state": {
+      "search": {
+        "title": "No matching work items found"
+      },
+      "no_issues": {
+        "title": "No work items found"
+      }
+    }
+  },
+
+  "issue_comment": {
+    "empty_state": {
+      "general": {
+        "title": "No comments yet",
+        "description": "Comments can be used as a discussion and follow-up space for the work items"
+      }
+    }
+  },
+
+  "notification": {
+    "label": "Inbox",
+    "page_label": "{workspace} - Inbox",
+    "options": {
+      "mark_all_as_read": "Mark all as read",
+      "mark_read": "Mark as read",
+      "mark_unread": "Mark as unread",
+      "refresh": "Refresh",
+      "filters": "Inbox Filters",
+      "show_unread": "Show unread",
+      "show_snoozed": "Show snoozed",
+      "show_archived": "Show archived",
+      "mark_archive": "Archive",
+      "mark_unarchive": "Un archive",
+      "mark_snooze": "Snooze",
+      "mark_unsnooze": "Un snooze"
+    },
+    "toasts": {
+      "read": "Notification marked as read",
+      "unread": "Notification marked as unread",
+      "archived": "Notification marked as archived",
+      "unarchived": "Notification marked as un archived",
+      "snoozed": "Notification snoozed",
+      "unsnoozed": "Notification un snoozed"
+    },
+    "empty_state": {
+      "detail": {
+        "title": "Select to view details."
+      },
+      "all": {
+        "title": "No work items assigned",
+        "description": "Updates for work items assigned to you can be \n seen here"
+      },
+      "mentions": {
+        "title": "No work items assigned",
+        "description": "Updates for work items assigned to you can be \n seen here"
+      }
+    },
+    "tabs": {
+      "all": "All",
+      "mentions": "Mentions"
+    },
+    "filter": {
+      "assigned": "Assigned to me",
+      "created": "Created by me",
+      "subscribed": "Subscribed by me"
+    },
+    "snooze": {
+      "1_day": "1 day",
+      "3_days": "3 days",
+      "5_days": "5 days",
+      "1_week": "1 week",
+      "2_weeks": "2 weeks",
+      "custom": "Custom"
+    }
+  },
+
+  "active_cycle": {
+    "empty_state": {
+      "progress": {
+        "title": "Add work items to the cycle to view it's progress"
+      },
+      "chart": {
+        "title": "Add work items to the cycle to view the burndown chart."
+      },
+      "priority_issue": {
+        "title": "Observe high priority work items tackled in the cycle at a glance."
+      },
+      "assignee": {
+        "title": "Add assignees to work items to see a breakdown of work by assignees."
+      },
+      "label": {
+        "title": "Add labels to work items to see the breakdown of work by labels."
+      }
+    }
+  },
+
+  "disabled_project": {
+    "empty_state": {
+      "inbox": {
+        "title": "Intake is not enabled for the project.",
+        "description": "Intake helps you manage incoming requests to your project and add them as work items in your workflow. Enable intake from project settings to manage requests.",
+        "primary_button": {
+          "text": "Manage features"
+        }
+      },
+      "cycle": {
+        "title": "Cycles is not enabled for this project.",
+        "description": "Break work down by timeboxed chunks, work backwards from your project deadline to set dates, and make tangible progress as a team. Enable the cycles feature for your project to start using them.",
+        "primary_button": {
+          "text": "Manage features"
+        }
+      },
+      "module": {
+        "title": "Modules are not enabled for the project.",
+        "description": "Modules are the building blocks of your project. Enable modules from project settings to start using them.",
+        "primary_button": {
+          "text": "Manage features"
+        }
+      },
+      "page": {
+        "title": "Pages are not enabled for the project.",
+        "description": "Pages are the building blocks of your project. Enable pages from project settings to start using them.",
+        "primary_button": {
+          "text": "Manage features"
+        }
+      },
+      "view": {
+        "title": "Views are not enabled for the project.",
+        "description": "Views are the building blocks of your project. Enable views from project settings to start using them.",
+        "primary_button": {
+          "text": "Manage features"
+        }
+      }
+    }
+  },
+  "workspace_draft_issues": {
+    "draft_an_issue": "Draft a work item",
+    "empty_state": {
+      "title": "Half-written work items, and soon, comments will show up here.",
+      "description": "To try this out, start adding a work item and leave it mid-way or create your first draft below. 😉",
+      "primary_button": {
+        "text": "Create your first draft"
+      }
+    },
+    "delete_modal": {
+      "title": "Delete draft",
+      "description": "Are you sure you want to delete this draft? This can't be undone."
+    },
+    "toasts": {
+      "created": {
+        "success": "Draft created",
+        "error": "Work item could not be created. Please try again."
+      },
+      "deleted": {
+        "success": "Draft deleted"
+      }
+    }
+  },
+
+  "stickies": {
+    "title": "Your stickies",
+    "placeholder": "click to type here",
+    "all": "All stickies",
+    "no-data": "Jot down an idea, capture an aha, or record a brainwave. Add a sticky to get started.",
+    "add": "Add sticky",
+    "search_placeholder": "Search by title",
+    "delete": "Delete sticky",
+    "delete_confirmation": "Are you sure you want to delete this sticky?",
+    "empty_state": {
+      "simple": "Jot down an idea, capture an aha, or record a brainwave. Add a sticky to get started.",
+      "general": {
+        "title": "Stickies are quick notes and to-dos you take down on the fly.",
+        "description": "Capture your thoughts and ideas effortlessly by creating stickies that you can access anytime and from anywhere.",
+        "primary_button": {
+          "text": "Add sticky"
+        }
+      },
+      "search": {
+        "title": "That doesn't match any of your stickies.",
+        "description": "Try a different term or let us know\nif you are sure your search is right. ",
+        "primary_button": {
+          "text": "Add sticky"
+        }
+      }
+    },
+    "toasts": {
+      "errors": {
+        "wrong_name": "The sticky name cannot be longer than 100 characters.",
+        "already_exists": "There already exists a sticky with no description"
+      },
+      "created": {
+        "title": "Sticky created",
+        "message": "The sticky has been successfully created"
+      },
+      "not_created": {
+        "title": "Sticky not created",
+        "message": "The sticky could not be created"
+      },
+      "updated": {
+        "title": "Sticky updated",
+        "message": "The sticky has been successfully updated"
+      },
+      "not_updated": {
+        "title": "Sticky not updated",
+        "message": "The sticky could not be updated"
+      },
+      "removed": {
+        "title": "Sticky removed",
+        "message": "The sticky has been successfully removed"
+      },
+      "not_removed": {
+        "title": "Sticky not removed",
+        "message": "The sticky could not be removed"
+      }
+    }
+  },
+
+  "role_details": {
+    "guest": {
+      "title": "Guest",
+      "description": "External members of organizations can be invited as guests."
+    },
+    "member": {
+      "title": "Member",
+      "description": "Ability to read, write, edit, and delete entities inside projects, cycles, and modules"
+    },
+    "admin": {
+      "title": "Admin",
+      "description": "All permissions set to true within the workspace."
+    }
+  },
+
+  "user_roles": {
+    "product_or_project_manager": "Product / Project Manager",
+    "development_or_engineering": "Development / Engineering",
+    "founder_or_executive": "Founder / Executive",
+    "freelancer_or_consultant": "Freelancer / Consultant",
+    "marketing_or_growth": "Marketing / Growth",
+    "sales_or_business_development": "Sales / Business Development",
+    "support_or_operations": "Support / Operations",
+    "student_or_professor": "Student / Professor",
+    "human_resources": "Human / Resources",
+    "other": "Other"
+  },
+
+  "importer": {
+    "github": {
+      "title": "Github",
+      "description": "Import work items from GitHub repositories and sync them."
+    },
+    "jira": {
+      "title": "Jira",
+      "description": "Import work items and epics from Jira projects and epics."
+    }
+  },
+
+  "exporter": {
+    "csv": {
+      "title": "CSV",
+      "description": "Export work items to a CSV file.",
+      "short_description": "Export as csv"
+    },
+    "excel": {
+      "title": "Excel",
+      "description": "Export work items to a Excel file.",
+      "short_description": "Export as excel"
+    },
+    "xlsx": {
+      "title": "Excel",
+      "description": "Export work items to a Excel file.",
+      "short_description": "Export as excel"
+    },
+    "json": {
+      "title": "JSON",
+      "description": "Export work items to a JSON file.",
+      "short_description": "Export as json"
+    }
+  },
+  "default_global_view": {
+    "all_issues": "All work items",
+    "assigned": "Assigned",
+    "created": "Created",
+    "subscribed": "Subscribed"
+  },
+
+  "themes": {
+    "theme_options": {
+      "system_preference": {
+        "label": "System preference"
+      },
+      "light": {
+        "label": "Light"
+      },
+      "dark": {
+        "label": "Dark"
+      },
+      "light_contrast": {
+        "label": "Light high contrast"
+      },
+      "dark_contrast": {
+        "label": "Dark high contrast"
+      },
+      "custom": {
+        "label": "Custom theme"
+      }
+    }
+  },
+  "project_modules": {
+    "status": {
+      "backlog": "Backlog",
+      "planned": "Planned",
+      "in_progress": "In Progress",
+      "paused": "Paused",
+      "completed": "Completed",
+      "cancelled": "Cancelled"
+    },
+    "layout": {
+      "list": "List layout",
+      "board": "Gallery layout",
+      "timeline": "Timeline layout"
+    },
+    "order_by": {
+      "name": "Name",
+      "progress": "Progress",
+      "issues": "Number of work items",
+      "due_date": "Due date",
+      "created_at": "Created date",
+      "manual": "Manual"
+    }
+  },
+
+  "cycle": {
+    "label": "{count, plural, one {Cycle} other {Cycles}}",
+    "no_cycle": "No cycle"
+  },
+
+  "module": {
+    "label": "{count, plural, one {Module} other {Modules}}",
+    "no_module": "No module"
+  }
+}

--- a/packages/i18n/src/locales/ko/translations.json
+++ b/packages/i18n/src/locales/ko/translations.json
@@ -1,1271 +1,1271 @@
 {
   "sidebar": {
-    "projects": "Projects",
-    "pages": "Pages",
-    "new_work_item": "New work item",
-    "home": "Home",
-    "your_work": "Your work",
-    "inbox": "Inbox",
-    "workspace": "Workspace",
-    "views": "Views",
-    "analytics": "Analytics",
-    "work_items": "Work Items",
-    "cycles": "Cycles",
-    "modules": "Modules",
-    "intake": "Intake",
-    "drafts": "Drafts",
-    "favorites": "Favorites",
-    "pro": "Pro",
-    "upgrade": "Upgrade"
+    "projects": "프로젝트",
+    "pages": "페이지",
+    "new_work_item": "새 작업 항목",
+    "home": "홈",
+    "your_work": "나의 작업",
+    "inbox": "받은 편지함",
+    "workspace": "작업 공간",
+    "views": "보기",
+    "analytics": "분석",
+    "work_items": "작업 항목",
+    "cycles": "주기",
+    "modules": "모듈",
+    "intake": "접수",
+    "drafts": "초안",
+    "favorites": "즐겨찾기",
+    "pro": "프로",
+    "upgrade": "업그레이드"
   },
 
   "auth": {
     "common": {
       "email": {
-        "label": "Email",
+        "label": "이메일",
         "placeholder": "name@company.com",
         "errors": {
-          "required": "Email is required",
-          "invalid": "Email is invalid"
+          "required": "이메일이 필요합니다",
+          "invalid": "유효하지 않은 이메일입니다"
         }
       },
       "password": {
-        "label": "Password",
-        "set_password": "Set a password",
-        "placeholder": "Enter password",
+        "label": "비밀번호",
+        "set_password": "비밀번호 설정",
+        "placeholder": "비밀번호 입력",
         "confirm_password": {
-          "label": "Confirm password",
-          "placeholder": "Confirm password"
+          "label": "비밀번호 확인",
+          "placeholder": "비밀번호 확인"
         },
         "current_password": {
-          "label": "Current password"
+          "label": "현재 비밀번호"
         },
         "new_password": {
-          "label": "New password",
-          "placeholder": "Enter new password"
+          "label": "새 비밀번호",
+          "placeholder": "새 비밀번호 입력"
         },
         "change_password": {
           "label": {
-            "default": "Change password",
-            "submitting": "Changing password"
+            "default": "비밀번호 변경",
+            "submitting": "비밀번호 변경 중"
           }
         },
         "errors": {
-          "match": "Passwords don't match",
-          "empty": "Please enter your password",
-          "length": "Password length should me more than 8 characters",
+          "match": "비밀번호가 일치하지 않습니다",
+          "empty": "비밀번호를 입력해주세요",
+          "length": "비밀번호는 8자 이상이어야 합니다",
           "strength": {
-            "weak": "Password is weak",
-            "strong": "Password is strong"
+            "weak": "비밀번호가 약합니다",
+            "strong": "비밀번호가 강합니다"
           }
         },
-        "submit": "Set password",
+        "submit": "비밀번호 설정",
         "toast": {
           "change_password": {
             "success": {
-              "title": "Success!",
-              "message": "Password changed successfully."
+              "title": "성공!",
+              "message": "비밀번호가 성공적으로 변경되었습니다."
             },
             "error": {
-              "title": "Error!",
-              "message": "Something went wrong. Please try again."
+              "title": "오류!",
+              "message": "문제가 발생했습니다. 다시 시도해주세요."
             }
           }
         }
       },
       "unique_code": {
-        "label": "Unique code",
+        "label": "고유 코드",
         "placeholder": "gets-sets-flys",
-        "paste_code": "Paste the code sent to your email",
-        "requesting_new_code": "Requesting new code",
-        "sending_code": "Sending code"
+        "paste_code": "이메일로 전송된 코드를 붙여넣기",
+        "requesting_new_code": "새 코드 요청 중",
+        "sending_code": "코드 전송 중"
       },
-      "already_have_an_account": "Already have an account?",
-      "login": "Log in",
-      "create_account": "Create an account",
-      "new_to_plane": "New to Plane?",
-      "back_to_sign_in": "Back to sign in",
-      "resend_in": "Resend in {seconds} seconds",
-      "sign_in_with_unique_code": "Sign in with unique code",
-      "forgot_password": "Forgot your password?"
+      "already_have_an_account": "이미 계정이 있으신가요?",
+      "login": "로그인",
+      "create_account": "계정 만들기",
+      "new_to_plane": "Plane을 처음 사용하시나요?",
+      "back_to_sign_in": "로그인으로 돌아가기",
+      "resend_in": "{seconds}초 후 다시 전송",
+      "sign_in_with_unique_code": "고유 코드로 로그인",
+      "forgot_password": "비밀번호를 잊으셨나요?"
     },
     "sign_up": {
       "header": {
-        "label": "Create an account to start managing work with your team.",
+        "label": "팀과 함께 작업을 관리하려면 계정을 만드세요.",
         "step": {
           "email": {
-            "header": "Sign up",
+            "header": "가입",
             "sub_header": ""
           },
           "password": {
-            "header": "Sign up",
-            "sub_header": "Sign up using an email-password combination."
+            "header": "가입",
+            "sub_header": "이메일-비밀번호 조합으로 가입하세요."
           },
           "unique_code": {
-            "header": "Sign up",
-            "sub_header": "Sign up using a unique code sent to the email address above."
+            "header": "가입",
+            "sub_header": "위 이메일 주소로 전송된 고유 코드로 가입하세요."
           }
         }
       },
       "errors": {
         "password": {
-          "strength": "Try setting-up a strong password to proceed"
+          "strength": "강력한 비밀번호를 설정하여 진행하세요"
         }
       }
     },
     "sign_in": {
       "header": {
-        "label": "Log in to start managing work with your team.",
+        "label": "팀과 함께 작업을 관리하려면 로그인하세요.",
         "step": {
           "email": {
-            "header": "Log in or sign up",
+            "header": "로그인 또는 가입",
             "sub_header": ""
           },
           "password": {
-            "header": "Log in or sign up",
-            "sub_header": "Use your email-password combination to log in."
+            "header": "로그인 또는 가입",
+            "sub_header": "이메일-비밀번호 조합을 사용하여 로그인하세요."
           },
           "unique_code": {
-            "header": "Log in or sign up",
-            "sub_header": "Log in using a unique code sent to the email address above."
+            "header": "로그인 또는 가입",
+            "sub_header": "위 이메일 주소로 전송된 고유 코드로 로그인하세요."
           }
         }
       }
     },
     "forgot_password": {
-      "title": "Reset your password",
-      "description": "Enter your user account's verified email address and we will send you a password reset link.",
-      "email_sent": "We sent the reset link to your email address",
-      "send_reset_link": "Send reset link",
+      "title": "비밀번호 재설정",
+      "description": "사용자 계정의 인증된 이메일 주소를 입력하면 비밀번호 재설정 링크를 보내드립니다.",
+      "email_sent": "이메일 주소로 재설정 링크를 보냈습니다",
+      "send_reset_link": "재설정 링크 보내기",
       "errors": {
-        "smtp_not_enabled": "We see that your god hasn't enabled SMTP, we will not be able to send a password reset link"
+        "smtp_not_enabled": "SMTP가 활성화되지 않았습니다. 비밀번호 재설정 링크를 보낼 수 없습니다."
       },
       "toast": {
         "success": {
-          "title": "Email sent",
-          "message": "Check your inbox for a link to reset your password. If it doesn't appear within a few minutes, check your spam folder."
+          "title": "이메일 전송됨",
+          "message": "비밀번호 재설정 링크를 확인하세요. 몇 분 내에 나타나지 않으면 스팸 폴더를 확인하세요."
         },
         "error": {
-          "title": "Error!",
-          "message": "Something went wrong. Please try again."
+          "title": "오류!",
+          "message": "문제가 발생했습니다. 다시 시도해주세요."
         }
       }
     },
     "reset_password": {
-      "title": "Set new password",
-      "description": "Secure your account with a strong password"
+      "title": "새 비밀번호 설정",
+      "description": "강력한 비밀번호로 계정을 보호하세요"
     },
     "set_password": {
-      "title": "Secure your account",
-      "description": "Setting password helps you login securely"
+      "title": "계정 보호",
+      "description": "비밀번호 설정은 안전한 로그인을 도와줍니다"
     },
     "sign_out": {
       "toast": {
         "error": {
-          "title": "Error!",
-          "message": "Failed to sign out. Please try again."
+          "title": "오류!",
+          "message": "로그아웃에 실패했습니다. 다시 시도해주세요."
         }
       }
     }
   },
 
-  "submit": "Submit",
-  "cancel": "Cancel",
-  "loading": "Loading",
-  "error": "Error",
-  "success": "Success",
-  "warning": "Warning",
-  "info": "Info",
-  "close": "Close",
-  "yes": "Yes",
-  "no": "No",
-  "ok": "OK",
-  "name": "Name",
-  "description": "Description",
-  "search": "Search",
-  "add_member": "Add member",
-  "adding_members": "Adding members",
-  "remove_member": "Remove member",
-  "add_members": "Add members",
-  "adding_member": "Adding members",
-  "remove_members": "Remove members",
-  "add": "Add",
-  "adding": "Adding",
-  "remove": "Remove",
-  "add_new": "Add new",
-  "remove_selected": "Remove selected",
-  "first_name": "First name",
-  "last_name": "Last name",
-  "email": "Email",
-  "display_name": "Display name",
-  "role": "Role",
-  "timezone": "Timezone",
-  "avatar": "Avatar",
-  "cover_image": "Cover image",
-  "password": "Password",
-  "change_cover": "Change cover",
-  "language": "Language",
-  "saving": "Saving",
-  "save_changes": "Save changes",
-  "deactivate_account": "Deactivate account",
-  "deactivate_account_description": "When deactivating an account, all of the data and resources within that account will be permanently removed and cannot be recovered.",
-  "profile_settings": "Profile settings",
-  "your_account": "Your account",
-  "security": "Security",
-  "activity": "Activity",
-  "appearance": "Appearance",
-  "notifications": "Notifications",
-  "workspaces": "Workspaces",
-  "create_workspace": "Create workspace",
-  "invitations": "Invitations",
-  "summary": "Summary",
-  "assigned": "Assigned",
-  "created": "Created",
-  "subscribed": "Subscribed",
-  "you_do_not_have_the_permission_to_access_this_page": "You do not have the permission to access this page.",
-  "something_went_wrong_please_try_again": "Something went wrong. Please try again.",
-  "load_more": "Load more",
-  "select_or_customize_your_interface_color_scheme": "Select or customize your interface color scheme.",
-  "theme": "Theme",
-  "system_preference": "System preference",
-  "light": "Light",
-  "dark": "Dark",
-  "light_contrast": "Light high contrast",
-  "dark_contrast": "Dark high contrast",
-  "custom": "Custom theme",
-  "select_your_theme": "Select your theme",
-  "customize_your_theme": "Customize your theme",
-  "background_color": "Background color",
-  "text_color": "Text color",
-  "primary_color": "Primary(Theme) color",
-  "sidebar_background_color": "Sidebar background color",
-  "sidebar_text_color": "Sidebar text color",
-  "set_theme": "Set theme",
-  "enter_a_valid_hex_code_of_6_characters": "Enter a valid hex code of 6 characters",
-  "background_color_is_required": "Background color is required",
-  "text_color_is_required": "Text color is required",
-  "primary_color_is_required": "Primary color is required",
-  "sidebar_background_color_is_required": "Sidebar background color is required",
-  "sidebar_text_color_is_required": "Sidebar text color is required",
-  "updating_theme": "Updating theme",
-  "theme_updated_successfully": "Theme updated successfully",
-  "failed_to_update_the_theme": "Failed to update the theme",
-  "email_notifications": "Email notifications",
-  "stay_in_the_loop_on_issues_you_are_subscribed_to_enable_this_to_get_notified": "Stay in the loop on Work items you are subscribed to. Enable this to get notified.",
-  "email_notification_setting_updated_successfully": "Email notification setting updated successfully",
-  "failed_to_update_email_notification_setting": "Failed to update email notification setting",
-  "notify_me_when": "Notify me when",
-  "property_changes": "Property changes",
-  "property_changes_description": "Notify me when work items' properties like assignees, priority, estimates or anything else changes.",
-  "state_change": "State change",
-  "state_change_description": "Notify me when the work items moves to a different state",
-  "issue_completed": "Work item completed",
-  "issue_completed_description": "Notify me only when a work item is completed",
-  "comments": "Comments",
-  "comments_description": "Notify me when someone leaves a comment on the work item",
-  "mentions": "Mentions",
-  "mentions_description": "Notify me only when someone mentions me in the comments or description",
-  "old_password": "Old password",
-  "general_settings": "General settings",
-  "sign_out": "Sign out",
-  "signing_out": "Signing out",
-  "active_cycles": "Active cycles",
-  "active_cycles_description": "Monitor cycles across projects, track high-priority work items, and zoom in cycles that need attention.",
-  "on_demand_snapshots_of_all_your_cycles": "On-demand snapshots of all your cycles",
-  "upgrade": "Upgrade",
-  "10000_feet_view": "10,000-feet view of all active cycles.",
-  "10000_feet_view_description": "Zoom out to see running cycles across all your projects at once instead of going from Cycle to Cycle in each project.",
-  "get_snapshot_of_each_active_cycle": "Get a snapshot of each active cycle.",
-  "get_snapshot_of_each_active_cycle_description": "Track high-level metrics for all active cycles, see their state of progress, and get a sense of scope against deadlines.",
-  "compare_burndowns": "Compare burndowns.",
-  "compare_burndowns_description": "Monitor how each of your teams are performing with a peek into each cycle's burndown report.",
-  "quickly_see_make_or_break_issues": "Quickly see make-or-break work items.",
-  "quickly_see_make_or_break_issues_description": "Preview high-priority work items for each cycle against due dates. See all of them per cycle in one click.",
-  "zoom_into_cycles_that_need_attention": "Zoom into cycles that need attention.",
-  "zoom_into_cycles_that_need_attention_description": "Investigate the state of any cycle that doesn't conform to expectations in one click.",
-  "stay_ahead_of_blockers": "Stay ahead of blockers.",
-  "stay_ahead_of_blockers_description": "Spot challenges from one project to another and see inter-cycle dependencies that aren't obvious from any other view.",
-  "analytics": "Analytics",
-  "workspace_invites": "Workspace invites",
-  "enter_god_mode": "Enter god mode",
-  "workspace_logo": "Workspace logo",
-  "new_issue": "New work item",
-  "your_work": "Your work",
-  "drafts": "Drafts",
-  "projects": "Projects",
-  "views": "Views",
-  "workspace": "Workspace",
-  "archives": "Archives",
-  "settings": "Settings",
-  "failed_to_move_favorite": "Failed to move favorite",
-  "favorites": "Favorites",
-  "no_favorites_yet": "No favorites yet",
-  "create_folder": "Create folder",
-  "new_folder": "New folder",
-  "favorite_updated_successfully": "Favorite updated successfully",
-  "favorite_created_successfully": "Favorite created successfully",
-  "folder_already_exists": "Folder already exists",
-  "folder_name_cannot_be_empty": "Folder name cannot be empty",
-  "something_went_wrong": "Something went wrong",
-  "failed_to_reorder_favorite": "Failed to reorder favorite",
-  "favorite_removed_successfully": "Favorite removed successfully",
-  "failed_to_create_favorite": "Failed to create favorite",
-  "failed_to_rename_favorite": "Failed to rename favorite",
-  "project_link_copied_to_clipboard": "Project link copied to clipboard",
-  "link_copied": "Link copied",
-  "add_project": "Add project",
-  "create_project": "Create project",
-  "failed_to_remove_project_from_favorites": "Couldn't remove the project from favorites. Please try again.",
-  "project_created_successfully": "Project created successfully",
-  "project_created_successfully_description": "Project created successfully. You can now start adding work items to it.",
-  "project_cover_image_alt": "Project cover image",
-  "name_is_required": "Name is required",
-  "title_should_be_less_than_255_characters": "Title should be less than 255 characters",
-  "project_name": "Project name",
-  "project_id_must_be_at_least_1_character": "Project ID must at least be of 1 character",
-  "project_id_must_be_at_most_5_characters": "Project ID must at most be of 5 characters",
-  "project_id": "Project ID",
-  "project_id_tooltip_content": "Helps you identify work items in the project uniquely. Max 5 characters.",
-  "description_placeholder": "Description",
-  "only_alphanumeric_non_latin_characters_allowed": "Only Alphanumeric & Non-latin characters are allowed.",
-  "project_id_is_required": "Project ID is required",
-  "project_id_allowed_char": "Only Alphanumeric & Non-latin characters are allowed.",
-  "project_id_min_char": "Project ID must at least be of 1 character",
-  "project_id_max_char": "Project ID must at most be of 5 characters",
-  "project_description_placeholder": "Enter project description",
-  "select_network": "Select network",
-  "lead": "Lead",
-  "date_range": "Date range",
-  "private": "Private",
-  "public": "Public",
-  "accessible_only_by_invite": "Accessible only by invite",
-  "anyone_in_the_workspace_except_guests_can_join": "Anyone in the workspace except Guests can join",
-  "creating": "Creating",
-  "creating_project": "Creating project",
-  "adding_project_to_favorites": "Adding project to favorites",
-  "project_added_to_favorites": "Project added to favorites",
-  "couldnt_add_the_project_to_favorites": "Couldn't add the project to favorites. Please try again.",
-  "removing_project_from_favorites": "Removing project from favorites",
-  "project_removed_from_favorites": "Project removed from favorites",
-  "couldnt_remove_the_project_from_favorites": "Couldn't remove the project from favorites. Please try again.",
-  "add_to_favorites": "Add to favorites",
-  "remove_from_favorites": "Remove from favorites",
-  "publish_settings": "Publish settings",
-  "publish": "Publish",
-  "copy_link": "Copy link",
-  "leave_project": "Leave project",
-  "join_the_project_to_rearrange": "Join the project to rearrange",
-  "drag_to_rearrange": "Drag to rearrange",
-  "congrats": "Congrats!",
-  "open_project": "Open project",
-  "issues": "Work items",
-  "cycles": "Cycles",
-  "modules": "Modules",
-  "pages": "Pages",
-  "intake": "Intake",
-  "time_tracking": "Time Tracking",
-  "work_management": "Work management",
-  "projects_and_issues": "Projects and work items",
-  "projects_and_issues_description": "Toggle these on or off this project.",
-  "cycles_description": "Timebox work as you see fit per project and change frequency from one period to the next.",
-  "modules_description": "Group work into sub-project-like set-ups with their own leads and assignees.",
-  "views_description": "Save sorts, filters, and display options for later or share them.",
-  "pages_description": "Write anything like you write anything.",
-  "intake_description": "Stay in the loop on Work items you are subscribed to. Enable this to get notified.",
-  "time_tracking_description": "Track time spent on work items and projects.",
-  "work_management_description": "Manage your work and projects with ease.",
-  "documentation": "Documentation",
-  "message_support": "Message support",
-  "contact_sales": "Contact sales",
-  "hyper_mode": "Hyper Mode",
-  "keyboard_shortcuts": "Keyboard shortcuts",
-  "whats_new": "What's new?",
-  "version": "Version",
-  "we_are_having_trouble_fetching_the_updates": "We are having trouble fetching the updates.",
-  "our_changelogs": "our changelogs",
-  "for_the_latest_updates": "for the latest updates.",
-  "please_visit": "Please visit",
-  "docs": "Docs",
-  "full_changelog": "Full changelog",
-  "support": "Support",
-  "discord": "Discord",
-  "powered_by_plane_pages": "Powered by Plane Pages",
-  "please_select_at_least_one_invitation": "Please select at least one invitation.",
-  "please_select_at_least_one_invitation_description": "Please select at least one invitation to join the workspace.",
-  "we_see_that_someone_has_invited_you_to_join_a_workspace": "We see that someone has invited you to join a workspace",
-  "join_a_workspace": "Join a workspace",
-  "we_see_that_someone_has_invited_you_to_join_a_workspace_description": "We see that someone has invited you to join a workspace",
-  "join_a_workspace_description": "Join a workspace",
-  "accept_and_join": "Accept & Join",
-  "go_home": "Go Home",
-  "no_pending_invites": "No pending invites",
-  "you_can_see_here_if_someone_invites_you_to_a_workspace": "You can see here if someone invites you to a workspace",
-  "back_to_home": "Back to home",
-  "workspace_name": "workspace-name",
-  "deactivate_your_account": "Deactivate your account",
-  "deactivate_your_account_description": "Once deactivated, you can't be assigned work items and be billed for your workspace. To reactivate your account, you will need an invite to a workspace at this email address.",
-  "deactivating": "Deactivating",
-  "confirm": "Confirm",
-  "confirming": "Confirming",
-  "draft_created": "Draft created",
-  "issue_created_successfully": "Work item created successfully",
-  "draft_creation_failed": "Draft creation failed",
-  "issue_creation_failed": "Work item creation failed",
-  "draft_issue": "Draft work item",
-  "issue_updated_successfully": "Work item updated successfully",
-  "issue_could_not_be_updated": "Work item could not be updated",
-  "create_a_draft": "Create a draft",
-  "save_to_drafts": "Save to Drafts",
-  "save": "Save",
-  "update": "Update",
-  "updating": "Updating",
-  "create_new_issue": "Create new work item",
-  "editor_is_not_ready_to_discard_changes": "Editor is not ready to discard changes",
-  "failed_to_move_issue_to_project": "Failed to move work item to project",
-  "create_more": "Create more",
-  "add_to_project": "Add to project",
-  "discard": "Discard",
-  "duplicate_issue_found": "Duplicate work item found",
-  "duplicate_issues_found": "Duplicate work items found",
-  "no_matching_results": "No matching results",
-  "title_is_required": "Title is required",
-  "title": "Title",
-  "state": "State",
-  "priority": "Priority",
-  "none": "None",
-  "urgent": "Urgent",
-  "high": "High",
-  "medium": "Medium",
-  "low": "Low",
-  "members": "Members",
-  "assignee": "Assignee",
-  "assignees": "Assignees",
-  "you": "You",
-  "labels": "Labels",
-  "create_new_label": "Create new label",
-  "start_date": "Start date",
-  "end_date": "End date",
-  "due_date": "Due date",
-  "estimate": "Estimate",
-  "change_parent_issue": "Change parent work item",
-  "remove_parent_issue": "Remove parent work item",
-  "add_parent": "Add parent",
-  "loading_members": "Loading members",
-  "view_link_copied_to_clipboard": "View link copied to clipboard.",
-  "required": "Required",
-  "optional": "Optional",
-  "Cancel": "Cancel",
-  "edit": "Edit",
-  "archive": "Archive",
-  "restore": "Restore",
-  "open_in_new_tab": "Open in new tab",
-  "delete": "Delete",
-  "deleting": "Deleting",
-  "make_a_copy": "Make a copy",
-  "move_to_project": "Move to project",
-  "good": "Good",
-  "morning": "morning",
-  "afternoon": "afternoon",
-  "evening": "evening",
-  "show_all": "Show all",
-  "show_less": "Show less",
-  "no_data_yet": "No Data yet",
-  "syncing": "Syncing",
-  "add_work_item": "Add work item",
-  "advanced_description_placeholder": "Press '/' for commands",
-  "create_work_item": "Create work item",
-  "attachments": "Attachments",
-  "declining": "Declining",
-  "declined": "Declined",
-  "decline": "Decline",
-  "unassigned": "Unassigned",
-  "work_items": "Work items",
-  "add_link": "Add link",
-  "points": "Points",
-  "no_assignee": "No assignee",
-  "no_assignees_yet": "No assignees yet",
-  "no_labels_yet": "No labels yet",
-  "ideal": "Ideal",
-  "current": "Current",
-  "no_matching_members": "No matching members",
-  "leaving": "Leaving",
-  "removing": "Removing",
-  "leave": "Leave",
-  "refresh": "Refresh",
-  "refreshing": "Refreshing",
-  "refresh_status": "Refresh status",
-  "prev": "Prev",
-  "next": "Next",
-  "re_generating": "Re-generating",
-  "re_generate": "Re-generate",
-  "re_generate_key": "Re-generate key",
-  "export": "Export",
-  "member": "{count, plural, one{# member} other{# members}}",
+  "submit": "제출",
+  "cancel": "취소",
+  "loading": "로딩 중",
+  "error": "오류",
+  "success": "성공",
+  "warning": "경고",
+  "info": "정보",
+  "close": "닫기",
+  "yes": "예",
+  "no": "아니오",
+  "ok": "확인",
+  "name": "이름",
+  "description": "설명",
+  "search": "검색",
+  "add_member": "멤버 추가",
+  "adding_members": "멤버 추가 중",
+  "remove_member": "멤버 제거",
+  "add_members": "멤버 추가",
+  "adding_member": "멤버 추가 중",
+  "remove_members": "멤버 제거",
+  "add": "추가",
+  "adding": "추가 중",
+  "remove": "제거",
+  "add_new": "새로 추가",
+  "remove_selected": "선택 제거",
+  "first_name": "이름",
+  "last_name": "성",
+  "email": "이메일",
+  "display_name": "표시 이름",
+  "role": "역할",
+  "timezone": "시간대",
+  "avatar": "아바타",
+  "cover_image": "커버 이미지",
+  "password": "비밀번호",
+  "change_cover": "커버 변경",
+  "language": "언어",
+  "saving": "저장 중",
+  "save_changes": "변경 사항 저장",
+  "deactivate_account": "계정 비활성화",
+  "deactivate_account_description": "계정을 비활성화하면 해당 계정 내의 모든 데이터와 리소스가 영구적으로 삭제되며 복구할 수 없습니다.",
+  "profile_settings": "프로필 설정",
+  "your_account": "나의 계정",
+  "security": "보안",
+  "activity": "활동",
+  "appearance": "외관",
+  "notifications": "알림",
+  "workspaces": "작업 공간",
+  "create_workspace": "작업 공간 생성",
+  "invitations": "초대",
+  "summary": "요약",
+  "assigned": "할당됨",
+  "created": "생성됨",
+  "subscribed": "구독됨",
+  "you_do_not_have_the_permission_to_access_this_page": "이 페이지에 접근할 권한이 없습니다.",
+  "something_went_wrong_please_try_again": "문제가 발생했습니다. 다시 시도해주세요.",
+  "load_more": "더 보기",
+  "select_or_customize_your_interface_color_scheme": "인터페이스 색상 테마를 선택하거나 사용자 정의하세요.",
+  "theme": "테마",
+  "system_preference": "시스템 기본값",
+  "light": "라이트",
+  "dark": "다크",
+  "light_contrast": "라이트 고대비",
+  "dark_contrast": "다크 고대비",
+  "custom": "사용자 정의 테마",
+  "select_your_theme": "테마 선택",
+  "customize_your_theme": "테마 사용자 정의",
+  "background_color": "배경 색상",
+  "text_color": "텍스트 색상",
+  "primary_color": "기본(테마) 색상",
+  "sidebar_background_color": "사이드바 배경 색상",
+  "sidebar_text_color": "사이드바 텍스트 색상",
+  "set_theme": "테마 설정",
+  "enter_a_valid_hex_code_of_6_characters": "유효한 6자리 헥스 코드를 입력하세요",
+  "background_color_is_required": "배경 색상이 필요합니다",
+  "text_color_is_required": "텍스트 색상이 필요합니다",
+  "primary_color_is_required": "기본 색상이 필요합니다",
+  "sidebar_background_color_is_required": "사이드바 배경 색상이 필요합니다",
+  "sidebar_text_color_is_required": "사이드바 텍스트 색상이 필요합니다",
+  "updating_theme": "테마 업데이트 중",
+  "theme_updated_successfully": "테마가 성공적으로 업데이트되었습니다",
+  "failed_to_update_the_theme": "테마 업데이트에 실패했습니다",
+  "email_notifications": "이메일 알림",
+  "stay_in_the_loop_on_issues_you_are_subscribed_to_enable_this_to_get_notified": "구독한 작업 항목에 대한 최신 정보를 유지하세요. 알림을 받으려면 이 기능을 활성화하세요.",
+  "email_notification_setting_updated_successfully": "이메일 알림 설정이 성공적으로 업데이트되었습니다",
+  "failed_to_update_email_notification_setting": "이메일 알림 설정 업데이트에 실패했습니다",
+  "notify_me_when": "다음 경우 알림",
+  "property_changes": "속성 변경",
+  "property_changes_description": "작업 항목의 속성(담당자, 우선순위, 추정치 등)이 변경될 때 알림을 받습니다.",
+  "state_change": "상태 변경",
+  "state_change_description": "작업 항목이 다른 상태로 이동할 때 알림을 받습니다",
+  "issue_completed": "작업 항목 완료",
+  "issue_completed_description": "작업 항목이 완료될 때만 알림을 받습니다",
+  "comments": "댓글",
+  "comments_description": "작업 항목에 누군가 댓글을 남길 때 알림을 받습니다",
+  "mentions": "멘션",
+  "mentions_description": "댓글이나 설명에서 누군가 나를 멘션할 때만 알림을 받습니다",
+  "old_password": "기존 비밀번호",
+  "general_settings": "일반 설정",
+  "sign_out": "로그아웃",
+  "signing_out": "로그아웃 중",
+  "active_cycles": "활성 주기",
+  "active_cycles_description": "프로젝트 전반의 주기를 모니터링하고, 고우선 작업 항목을 추적하며, 주의가 필요한 주기를 확대합니다.",
+  "on_demand_snapshots_of_all_your_cycles": "모든 주기의 주문형 스냅샷",
+  "upgrade": "업그레이드",
+  "10000_feet_view": "10,000피트 뷰",
+  "10000_feet_view_description": "모든 프로젝트의 주기를 한 번에 확인할 수 있습니다.",
+  "get_snapshot_of_each_active_cycle": "각 활성 주기의 스냅샷을 얻으세요.",
+  "get_snapshot_of_each_active_cycle_description": "모든 활성 주기의 고수준 메트릭을 추적하고, 진행 상태를 확인하며, 마감일에 대한 범위를 파악합니다.",
+  "compare_burndowns": "버다운 비교",
+  "compare_burndowns_description": "각 팀의 성과를 모니터링하고 각 주기의 버다운 보고서를 확인합니다.",
+  "quickly_see_make_or_break_issues": "빠르게 중요한 작업 항목을 확인하세요.",
+  "quickly_see_make_or_break_issues_description": "각 주기의 고우선 작업 항목을 미리 보고 마감일에 대한 모든 작업 항목을 한 번에 확인합니다.",
+  "zoom_into_cycles_that_need_attention": "주의가 필요한 주기를 확대하세요.",
+  "zoom_into_cycles_that_need_attention_description": "기대에 부합하지 않는 주기의 상태를 한 번에 조사합니다.",
+  "stay_ahead_of_blockers": "차단 요소를 미리 파악하세요.",
+  "stay_ahead_of_blockers_description": "프로젝트 간의 문제를 파악하고 다른 뷰에서 명확하지 않은 주기 간의 종속성을 확인합니다.",
+  "analytics": "분석",
+  "workspace_invites": "작업 공간 초대",
+  "enter_god_mode": "갓 모드로 전환",
+  "workspace_logo": "작업 공간 로고",
+  "new_issue": "새 작업 항목",
+  "your_work": "나의 작업",
+  "drafts": "초안",
+  "projects": "프로젝트",
+  "views": "보기",
+  "workspace": "작업 공간",
+  "archives": "아카이브",
+  "settings": "설정",
+  "failed_to_move_favorite": "즐겨찾기 이동 실패",
+  "favorites": "즐겨찾기",
+  "no_favorites_yet": "아직 즐겨찾기가 없습니다",
+  "create_folder": "폴더 생성",
+  "new_folder": "새 폴더",
+  "favorite_updated_successfully": "즐겨찾기가 성공적으로 업데이트되었습니다",
+  "favorite_created_successfully": "즐겨찾기가 성공적으로 생성되었습니다",
+  "folder_already_exists": "폴더가 이미 존재합니다",
+  "folder_name_cannot_be_empty": "폴더 이름은 비워둘 수 없습니다",
+  "something_went_wrong": "문제가 발생했습니다",
+  "failed_to_reorder_favorite": "즐겨찾기 재정렬 실패",
+  "favorite_removed_successfully": "즐겨찾기가 성공적으로 제거되었습니다",
+  "failed_to_create_favorite": "즐겨찾기 생성 실패",
+  "failed_to_rename_favorite": "즐겨찾기 이름 변경 실패",
+  "project_link_copied_to_clipboard": "프로젝트 링크가 클립보드에 복사되었습니다",
+  "link_copied": "링크 복사됨",
+  "add_project": "프로젝트 추가",
+  "create_project": "프로젝트 생성",
+  "failed_to_remove_project_from_favorites": "프로젝트를 즐겨찾기에서 제거하지 못했습니다. 다시 시도해주세요.",
+  "project_created_successfully": "프로젝트가 성공적으로 생성되었습니다",
+  "project_created_successfully_description": "프로젝트가 성공적으로 생성되었습니다. 이제 작업 항목을 추가할 수 있습니다.",
+  "project_cover_image_alt": "프로젝트 커버 이미지",
+  "name_is_required": "이름이 필요합니다",
+  "title_should_be_less_than_255_characters": "제목은 255자 미만이어야 합니다",
+  "project_name": "프로젝트 이름",
+  "project_id_must_be_at_least_1_character": "프로젝트 ID는 최소 1자 이상이어야 합니다",
+  "project_id_must_be_at_most_5_characters": "프로젝트 ID는 최대 5자 이하여야 합니다",
+  "project_id": "프로젝트 ID",
+  "project_id_tooltip_content": "작업 항목을 고유하게 식별하는 데 도움이 됩니다. 최대 5자.",
+  "description_placeholder": "설명",
+  "only_alphanumeric_non_latin_characters_allowed": "영숫자 및 비라틴 문자만 허용됩니다.",
+  "project_id_is_required": "프로젝트 ID가 필요합니다",
+  "project_id_allowed_char": "영숫자 및 비라틴 문자만 허용됩니다.",
+  "project_id_min_char": "프로젝트 ID는 최소 1자 이상이어야 합니다",
+  "project_id_max_char": "프로젝트 ID는 최대 5자 이하여야 합니다",
+  "project_description_placeholder": "프로젝트 설명 입력",
+  "select_network": "네트워크 선택",
+  "lead": "리드",
+  "date_range": "날짜 범위",
+  "private": "비공개",
+  "public": "공개",
+  "accessible_only_by_invite": "초대에 의해서만 접근 가능",
+  "anyone_in_the_workspace_except_guests_can_join": "게스트를 제외한 작업 공간의 모든 사람이 참여할 수 있습니다",
+  "creating": "생성 중",
+  "creating_project": "프로젝트 생성 중",
+  "adding_project_to_favorites": "프로젝트를 즐겨찾기에 추가 중",
+  "project_added_to_favorites": "프로젝트가 즐겨찾기에 추가되었습니다",
+  "couldnt_add_the_project_to_favorites": "프로젝트를 즐겨찾기에 추가하지 못했습니다. 다시 시도해주세요.",
+  "removing_project_from_favorites": "프로젝트를 즐겨찾기에서 제거 중",
+  "project_removed_from_favorites": "프로젝트가 즐겨찾기에서 제거되었습니다",
+  "couldnt_remove_the_project_from_favorites": "프로젝트를 즐겨찾기에서 제거하지 못했습니다. 다시 시도해주세요.",
+  "add_to_favorites": "즐겨찾기에 추가",
+  "remove_from_favorites": "즐겨찾기에서 제거",
+  "publish_settings": "설정 게시",
+  "publish": "게시",
+  "copy_link": "링크 복사",
+  "leave_project": "프로젝트 떠나기",
+  "join_the_project_to_rearrange": "프로젝트에 참여하여 재정렬",
+  "drag_to_rearrange": "드래그하여 재정렬",
+  "congrats": "축하합니다!",
+  "open_project": "프로젝트 열기",
+  "issues": "작업 항목",
+  "cycles": "주기",
+  "modules": "모듈",
+  "pages": "페이지",
+  "intake": "접수",
+  "time_tracking": "시간 추적",
+  "work_management": "작업 관리",
+  "projects_and_issues": "프로젝트 및 작업 항목",
+  "projects_and_issues_description": "이 프로젝트에서 이들을 켜거나 끕니다.",
+  "cycles_description": "프로젝트별로 작업을 시간 상자로 나누고, 한 기간에서 다음 기간으로 빈도를 변경합니다.",
+  "modules_description": "작업을 하위 프로젝트와 같은 설정으로 그룹화하고, 각 설정에 리드와 담당자를 지정합니다.",
+  "views_description": "정렬, 필터 및 표시 옵션을 나중에 저장하거나 공유합니다.",
+  "pages_description": "무엇이든 작성하세요.",
+  "intake_description": "구독한 작업 항목에 대한 최신 정보를 유지하세요. 알림을 받으려면 이 기능을 활성화하세요.",
+  "time_tracking_description": "작업 항목 및 프로젝트에 소요된 시간을 추적합니다.",
+  "work_management_description": "작업 및 프로젝트를 쉽게 관리합니다.",
+  "documentation": "문서",
+  "message_support": "지원 메시지",
+  "contact_sales": "영업 문의",
+  "hyper_mode": "하이퍼 모드",
+  "keyboard_shortcuts": "키보드 단축키",
+  "whats_new": "새로운 기능",
+  "version": "버전",
+  "we_are_having_trouble_fetching_the_updates": "업데이트를 가져오는 데 문제가 발생했습니다.",
+  "our_changelogs": "우리의 변경 로그",
+  "for_the_latest_updates": "최신 업데이트를 위해",
+  "please_visit": "방문해주세요",
+  "docs": "문서",
+  "full_changelog": "전체 변경 로그",
+  "support": "지원",
+  "discord": "디스코드",
+  "powered_by_plane_pages": "Plane Pages 제공",
+  "please_select_at_least_one_invitation": "최소 하나의 초대를 선택하세요.",
+  "please_select_at_least_one_invitation_description": "작업 공간에 참여하려면 최소 하나의 초대를 선택하세요.",
+  "we_see_that_someone_has_invited_you_to_join_a_workspace": "누군가가 작업 공간에 참여하도록 초대했습니다",
+  "join_a_workspace": "작업 공간 참여",
+  "we_see_that_someone_has_invited_you_to_join_a_workspace_description": "누군가가 작업 공간에 참여하도록 초대했습니다",
+  "join_a_workspace_description": "작업 공간 참여",
+  "accept_and_join": "수락하고 참여",
+  "go_home": "홈으로 이동",
+  "no_pending_invites": "보류 중인 초대 없음",
+  "you_can_see_here_if_someone_invites_you_to_a_workspace": "누군가가 작업 공간에 초대하면 여기에 표시됩니다",
+  "back_to_home": "홈으로 돌아가기",
+  "workspace_name": "작업 공간 이름",
+  "deactivate_your_account": "계정 비활성화",
+  "deactivate_your_account_description": "계정을 비활성화하면 작업 항목에 할당될 수 없으며 작업 공간에 대한 청구가 발생하지 않습니다. 계정을 다시 활성화하려면 이 이메일 주소로 작업 공간 초대가 필요합니다.",
+  "deactivating": "비활성화 중",
+  "confirm": "확인",
+  "confirming": "확인 중",
+  "draft_created": "초안 생성됨",
+  "issue_created_successfully": "작업 항목이 성공적으로 생성되었습니다",
+  "draft_creation_failed": "초안 생성 실패",
+  "issue_creation_failed": "작업 항목 생성 실패",
+  "draft_issue": "초안 작업 항목",
+  "issue_updated_successfully": "작업 항목이 성공적으로 업데이트되었습니다",
+  "issue_could_not_be_updated": "작업 항목을 업데이트할 수 없습니다",
+  "create_a_draft": "초안 생성",
+  "save_to_drafts": "초안에 저장",
+  "save": "저장",
+  "update": "업데이트",
+  "updating": "업데이트 중",
+  "create_new_issue": "새 작업 항목 생성",
+  "editor_is_not_ready_to_discard_changes": "편집기가 변경 사항을 폐기할 준비가 되지 않았습니다",
+  "failed_to_move_issue_to_project": "작업 항목을 프로젝트로 이동하지 못했습니다",
+  "create_more": "더 많이 생성",
+  "add_to_project": "프로젝트에 추가",
+  "discard": "폐기",
+  "duplicate_issue_found": "중복된 작업 항목 발견",
+  "duplicate_issues_found": "중복된 작업 항목 발견",
+  "no_matching_results": "일치하는 결과 없음",
+  "title_is_required": "제목이 필요합니다",
+  "title": "제목",
+  "state": "상태",
+  "priority": "우선순위",
+  "none": "없음",
+  "urgent": "긴급",
+  "high": "높음",
+  "medium": "중간",
+  "low": "낮음",
+  "members": "멤버",
+  "assignee": "담당자",
+  "assignees": "담당자",
+  "you": "나",
+  "labels": "레이블",
+  "create_new_label": "새 레이블 생성",
+  "start_date": "시작 날짜",
+  "end_date": "종료 날짜",
+  "due_date": "마감일",
+  "estimate": "추정",
+  "change_parent_issue": "상위 작업 항목 변경",
+  "remove_parent_issue": "상위 작업 항목 제거",
+  "add_parent": "상위 항목 추가",
+  "loading_members": "멤버 로딩 중",
+  "view_link_copied_to_clipboard": "뷰 링크가 클립보드에 복사되었습니다.",
+  "required": "필수",
+  "optional": "선택",
+  "Cancel": "취소",
+  "edit": "편집",
+  "archive": "아카이브",
+  "restore": "복원",
+  "open_in_new_tab": "새 탭에서 열기",
+  "delete": "삭제",
+  "deleting": "삭제 중",
+  "make_a_copy": "복사본 만들기",
+  "move_to_project": "프로젝트로 이동",
+  "good": "좋은",
+  "morning": "아침",
+  "afternoon": "오후",
+  "evening": "저녁",
+  "show_all": "모두 보기",
+  "show_less": "간략히 보기",
+  "no_data_yet": "아직 데이터 없음",
+  "syncing": "동기화 중",
+  "add_work_item": "작업 항목 추가",
+  "advanced_description_placeholder": "명령어를 위해 '/'를 누르세요",
+  "create_work_item": "작업 항목 생성",
+  "attachments": "첨부 파일",
+  "declining": "거절 중",
+  "declined": "거절됨",
+  "decline": "거절",
+  "unassigned": "미할당",
+  "work_items": "작업 항목",
+  "add_link": "링크 추가",
+  "points": "포인트",
+  "no_assignee": "담당자 없음",
+  "no_assignees_yet": "아직 담당자 없음",
+  "no_labels_yet": "아직 레이블 없음",
+  "ideal": "이상적인",
+  "current": "현재",
+  "no_matching_members": "일치하는 멤버 없음",
+  "leaving": "떠나는 중",
+  "removing": "제거 중",
+  "leave": "떠나기",
+  "refresh": "새로 고침",
+  "refreshing": "새로 고침 중",
+  "refresh_status": "상태 새로 고침",
+  "prev": "이전",
+  "next": "다음",
+  "re_generating": "다시 생성 중",
+  "re_generate": "다시 생성",
+  "re_generate_key": "키 다시 생성",
+  "export": "내보내기",
+  "member": "{count, plural, one{# 멤버} other{# 멤버}}",
 
   "project_view": {
     "sort_by": {
-      "created_at": "Created at",
-      "updated_at": "Updated at",
-      "name": "Name"
+      "created_at": "생성일",
+      "updated_at": "업데이트일",
+      "name": "이름"
     }
   },
 
   "toast": {
-    "success": "Success!",
-    "error": "Error!"
+    "success": "성공!",
+    "error": "오류!"
   },
 
   "links": {
     "toasts": {
       "created": {
-        "title": "Link created",
-        "message": "The link has been successfully created"
+        "title": "링크 생성됨",
+        "message": "링크가 성공적으로 생성되었습니다"
       },
       "not_created": {
-        "title": "Link not created",
-        "message": "The link could not be created"
+        "title": "링크 생성되지 않음",
+        "message": "링크를 생성할 수 없습니다"
       },
       "updated": {
-        "title": "Link updated",
-        "message": "The link has been successfully updated"
+        "title": "링크 업데이트됨",
+        "message": "링크가 성공적으로 업데이트되었습니다"
       },
       "not_updated": {
-        "title": "Link not updated",
-        "message": "The link could not be updated"
+        "title": "링크 업데이트되지 않음",
+        "message": "링크를 업데이트할 수 없습니다"
       },
       "removed": {
-        "title": "Link removed",
-        "message": "The link has been successfully removed"
+        "title": "링크 제거됨",
+        "message": "링크가 성공적으로 제거되었습니다"
       },
       "not_removed": {
-        "title": "Link not removed",
-        "message": "The link could not be removed"
+        "title": "링크 제거되지 않음",
+        "message": "링크를 제거할 수 없습니다"
       }
     }
   },
 
   "home": {
     "empty": {
-      "quickstart_guide": "Your quickstart guide",
-      "not_right_now": "Not right now",
+      "quickstart_guide": "빠른 시작 가이드",
+      "not_right_now": "지금은 안 함",
       "create_project": {
-        "title": "Create a project",
-        "description": "Most things start with a project in Plane.",
-        "cta": "Get started"
+        "title": "프로젝트 생성",
+        "description": "Plane에서 대부분의 작업은 프로젝트로 시작됩니다.",
+        "cta": "시작하기"
       },
       "invite_team": {
-        "title": "Invite your team",
-        "description": "Build, ship, and manage with coworkers.",
-        "cta": "Get them in"
+        "title": "팀 초대",
+        "description": "동료와 함께 빌드, 배포 및 관리하세요.",
+        "cta": "초대하기"
       },
       "configure_workspace": {
-        "title": "Set up your workspace.",
-        "description": "Turn features on or off or go beyond that.",
-        "cta": "Configure this workspace"
+        "title": "작업 공간 설정",
+        "description": "기능을 켜거나 끄거나 그 이상을 수행하세요.",
+        "cta": "이 작업 공간 설정"
       },
       "personalize_account": {
-        "title": "Make Plane yours.",
-        "description": "Choose your picture, colors, and more.",
-        "cta": "Personalize now"
+        "title": "Plane을 개인화하세요.",
+        "description": "사진, 색상 등을 선택하세요.",
+        "cta": "지금 개인화"
       },
       "widgets": {
-        "title": "It's Quiet Without Widgets, Turn Them On",
-        "description": "It looks like all your widgets are turned off. Enable them\nnow to enhance your experience!",
+        "title": "위젯이 없으면 조용합니다. 켜세요",
+        "description": "모든 위젯이 꺼져 있는 것 같습니다. 지금 활성화하여 경험을 향상시키세요!",
         "primary_button": {
-          "text": "Manage widgets"
+          "text": "위젯 관리"
         }
       }
     },
     "quick_links": {
-      "empty": "Save links to work things that you'd like handy.",
-      "add": "Add quick Link",
-      "title": "Quicklink",
-      "title_plural": "Quicklinks"
+      "empty": "작업과 관련된 링크를 저장하세요.",
+      "add": "빠른 링크 추가",
+      "title": "빠른 링크",
+      "title_plural": "빠른 링크"
     },
     "recents": {
-      "title": "Recents",
+      "title": "최근 항목",
       "empty": {
-        "project": "Your recent projects will appear here once you visit one.",
-        "page": "Your recent pages will appear here once you visit one.",
-        "issue": "Your recent work items will appear here once you visit one.",
-        "default": "You don't have any recents yet."
+        "project": "최근 방문한 프로젝트가 여기에 표시됩니다.",
+        "page": "최근 방문한 페이지가 여기에 표시됩니다.",
+        "issue": "최근 방문한 작업 항목이 여기에 표시됩니다.",
+        "default": "아직 최근 항목이 없습니다."
       },
       "filters": {
-        "all": "All items",
-        "projects": "Projects",
-        "pages": "Pages",
-        "issues": "Work items"
+        "all": "모든 항목",
+        "projects": "프로젝트",
+        "pages": "페이지",
+        "issues": "작업 항목"
       }
     },
     "new_at_plane": {
-      "title": "New at Plane"
+      "title": "Plane의 새로운 기능"
     },
     "quick_tutorial": {
-      "title": "Quick tutorial"
+      "title": "빠른 튜토리얼"
     },
     "widget": {
-      "reordered_successfully": "Widget reordered successfully.",
-      "reordering_failed": "Error occurred while reordering widget."
+      "reordered_successfully": "위젯이 성공적으로 재정렬되었습니다.",
+      "reordering_failed": "위젯 재정렬 중 오류가 발생했습니다."
     },
-    "manage_widgets": "Manage widgets",
-    "title": "Home",
-    "star_us_on_github": "Star us on GitHub"
+    "manage_widgets": "위젯 관리",
+    "title": "홈",
+    "star_us_on_github": "GitHub에서 별표"
   },
 
   "link": {
     "modal": {
       "url": {
         "text": "URL",
-        "required": "URL is invalid",
-        "placeholder": "Type or paste a URL"
+        "required": "URL이 유효하지 않습니다",
+        "placeholder": "URL 입력 또는 붙여넣기"
       },
       "title": {
-        "text": "Display title",
-        "placeholder": "What you'd like to see this link as"
+        "text": "표시 제목",
+        "placeholder": "이 링크를 어떻게 표시할지 입력하세요"
       }
     }
   },
 
   "common": {
-    "all": "All",
-    "states": "States",
-    "state": "State",
-    "state_groups": "State groups",
-    "state_group": "State group",
-    "priorities": "Priorities",
-    "priority": "Priority",
-    "team_project": "Team project",
-    "project": "Project",
-    "cycle": "Cycle",
-    "cycles": "Cycles",
-    "module": "Module",
-    "modules": "Modules",
-    "labels": "Labels",
-    "label": "Label",
-    "assignees": "Assignees",
-    "assignee": "Assignee",
-    "created_by": "Created by",
-    "none": "None",
-    "link": "Link",
-    "estimates": "Estimates",
-    "estimate": "Estimate",
-    "created_at": "Created at",
-    "completed_at": "Completed at",
-    "layout": "Layout",
-    "filters": "Filters",
-    "display": "Display",
-    "load_more": "Load more",
-    "activity": "Activity",
-    "analytics": "Analytics",
-    "dates": "Dates",
-    "success": "Success!",
-    "something_went_wrong": "Something went wrong",
+    "all": "모두",
+    "states": "상태",
+    "state": "상태",
+    "state_groups": "상태 그룹",
+    "state_group": "상태 그룹",
+    "priorities": "우선순위",
+    "priority": "우선순위",
+    "team_project": "팀 프로젝트",
+    "project": "프로젝트",
+    "cycle": "주기",
+    "cycles": "주기",
+    "module": "모듈",
+    "modules": "모듈",
+    "labels": "레이블",
+    "label": "레이블",
+    "assignees": "담당자",
+    "assignee": "담당자",
+    "created_by": "생성자",
+    "none": "없음",
+    "link": "링크",
+    "estimates": "추정",
+    "estimate": "추정",
+    "created_at": "생성일",
+    "completed_at": "완료일",
+    "layout": "레이아웃",
+    "filters": "필터",
+    "display": "디스플레이",
+    "load_more": "더 보기",
+    "activity": "활동",
+    "analytics": "분석",
+    "dates": "날짜",
+    "success": "성공!",
+    "something_went_wrong": "문제가 발생했습니다",
     "error": {
-      "label": "Error!",
-      "message": "Some error occurred. Please try again."
+      "label": "오류!",
+      "message": "오류가 발생했습니다. 다시 시도해주세요."
     },
-    "group_by": "Group by",
-    "epic": "Epic",
-    "epics": "Epics",
-    "work_item": "Work item",
-    "work_items": "Work items",
-    "sub_work_item": "Sub-work item",
-    "add": "Add",
-    "warning": "Warning",
-    "updating": "Updating",
-    "adding": "Adding",
-    "update": "Update",
-    "creating": "Creating",
-    "create": "Create",
-    "cancel": "Cancel",
-    "description": "Description",
-    "title": "Title",
-    "attachment": "Attachment",
-    "general": "General",
-    "features": "Features",
-    "automation": "Automation",
-    "project_name": "Project name",
-    "project_id": "Project ID",
-    "project_timezone": "Project Timezone",
-    "created_on": "Created on",
-    "update_project": "Update project",
-    "identifier_already_exists": "Identifier already exists",
-    "add_more": "Add more",
-    "defaults": "Defaults",
-    "add_label": "Add label",
-    "customize_time_range": "Customize time range",
-    "loading": "Loading",
-    "attachments": "Attachments",
-    "property": "Property",
-    "properties": "Properties",
-    "parent": "Parent",
-    "page": "Page",
-    "remove": "Remove",
-    "archiving": "Archiving",
-    "archive": "Archive",
+    "group_by": "그룹화 기준",
+    "epic": "에픽",
+    "epics": "에픽",
+    "work_item": "작업 항목",
+    "work_items": "작업 항목",
+    "sub_work_item": "하위 작업 항목",
+    "add": "추가",
+    "warning": "경고",
+    "updating": "업데이트 중",
+    "adding": "추가 중",
+    "update": "업데이트",
+    "creating": "생성 중",
+    "create": "생성",
+    "cancel": "취소",
+    "description": "설명",
+    "title": "제목",
+    "attachment": "첨부 파일",
+    "general": "일반",
+    "features": "기능",
+    "automation": "자동화",
+    "project_name": "프로젝트 이름",
+    "project_id": "프로젝트 ID",
+    "project_timezone": "프로젝트 시간대",
+    "created_on": "생성일",
+    "update_project": "프로젝트 업데이트",
+    "identifier_already_exists": "식별자가 이미 존재합니다",
+    "add_more": "더 추가",
+    "defaults": "기본값",
+    "add_label": "레이블 추가",
+    "customize_time_range": "시간 범위 사용자 정의",
+    "loading": "로딩 중",
+    "attachments": "첨부 파일",
+    "property": "속성",
+    "properties": "속성",
+    "parent": "상위 항목",
+    "page": "페이지",
+    "remove": "제거",
+    "archiving": "아카이브 중",
+    "archive": "아카이브",
     "access": {
-      "public": "Public",
-      "private": "Private"
+      "public": "공개",
+      "private": "비공개"
     },
-    "done": "Done",
-    "sub_work_items": "Sub-work items",
-    "comment": "Comment",
-    "workspace_level": "Workspace level",
+    "done": "완료",
+    "sub_work_items": "하위 작업 항목",
+    "comment": "댓글",
+    "workspace_level": "작업 공간 수준",
     "order_by": {
-      "label": "Order by",
-      "manual": "Manual",
-      "last_created": "Last created",
-      "last_updated": "Last updated",
-      "start_date": "Start date",
-      "due_date": "Due date",
-      "asc": "Ascending",
-      "desc": "Descending",
-      "updated_on": "Updated on"
+      "label": "정렬 기준",
+      "manual": "수동",
+      "last_created": "마지막 생성",
+      "last_updated": "마지막 업데이트",
+      "start_date": "시작 날짜",
+      "due_date": "마감일",
+      "asc": "오름차순",
+      "desc": "내림차순",
+      "updated_on": "업데이트일"
     },
     "sort": {
-      "asc": "Ascending",
-      "desc": "Descending",
-      "created_on": "Created on",
-      "updated_on": "Updated on"
+      "asc": "오름차순",
+      "desc": "내림차순",
+      "created_on": "생성일",
+      "updated_on": "업데이트일"
     },
-    "comments": "Comments",
-    "updates": "Updates",
-    "clear_all": "Clear all",
-    "copied": "Copied!",
-    "link_copied": "Link copied!",
-    "link_copied_to_clipboard": "Link copied to clipboard",
-    "copied_to_clipboard": "Work item link copied to clipboard",
-    "is_copied_to_clipboard": "Work item is copied to clipboard",
-    "no_links_added_yet": "No links added yet",
-    "add_link": "Add link",
-    "links": "Links",
-    "go_to_workspace": "Go to workspace",
-    "progress": "Progress",
-    "optional": "Optional",
-    "join": "Join",
-    "go_back": "Go back",
-    "continue": "Continue",
-    "resend": "Resend",
-    "relations": "Relations",
+    "comments": "댓글",
+    "updates": "업데이트",
+    "clear_all": "모두 지우기",
+    "copied": "복사됨!",
+    "link_copied": "링크 복사됨!",
+    "link_copied_to_clipboard": "링크가 클립보드에 복사되었습니다",
+    "copied_to_clipboard": "작업 항목 링크가 클립보드에 복사되었습니다",
+    "is_copied_to_clipboard": "작업 항목이 클립보드에 복사되었습니다",
+    "no_links_added_yet": "아직 추가된 링크 없음",
+    "add_link": "링크 추가",
+    "links": "링크",
+    "go_to_workspace": "작업 공간으로 이동",
+    "progress": "진행",
+    "optional": "선택",
+    "join": "참여",
+    "go_back": "뒤로 가기",
+    "continue": "계속",
+    "resend": "다시 보내기",
+    "relations": "관계",
     "errors": {
       "default": {
-        "title": "Error!",
-        "message": "Something went wrong. Please try again."
+        "title": "오류!",
+        "message": "문제가 발생했습니다. 다시 시도해주세요."
       },
-      "required": "This field is required",
-      "entity_required": "{entity} is required"
+      "required": "이 필드는 필수입니다",
+      "entity_required": "{entity}가 필요합니다"
     },
-    "update_link": "Update link",
-    "attach": "Attach",
-    "create_new": "Create new",
-    "add_existing": "Add existing",
-    "type_or_paste_a_url": "Type or paste a URL",
-    "url_is_invalid": "URL is invalid",
-    "display_title": "Display title",
-    "link_title_placeholder": "What you'd like to see this link as",
+    "update_link": "링크 업데이트",
+    "attach": "첨부",
+    "create_new": "새로 생성",
+    "add_existing": "기존 항목 추가",
+    "type_or_paste_a_url": "URL 입력 또는 붙여넣기",
+    "url_is_invalid": "URL이 유효하지 않습니다",
+    "display_title": "표시 제목",
+    "link_title_placeholder": "이 링크를 어떻게 표시할지 입력하세요",
     "url": "URL",
-    "side_peek": "Side Peek",
-    "modal": "Modal",
-    "full_screen": "Full Screen",
-    "close_peek_view": "Close the peek view",
-    "toggle_peek_view_layout": "Toggle peek view layout",
-    "options": "Options",
-    "duration": "Duration",
-    "today": "Today",
-    "week": "Week",
-    "month": "Month",
-    "quarter": "Quarter",
-    "press_for_commands": "Press '/' for commands",
-    "click_to_add_description": "Click to add description",
+    "side_peek": "사이드 피크",
+    "modal": "모달",
+    "full_screen": "전체 화면",
+    "close_peek_view": "피크 뷰 닫기",
+    "toggle_peek_view_layout": "피크 뷰 레이아웃 전환",
+    "options": "옵션",
+    "duration": "기간",
+    "today": "오늘",
+    "week": "주",
+    "month": "월",
+    "quarter": "분기",
+    "press_for_commands": "명령어를 위해 '/'를 누르세요",
+    "click_to_add_description": "설명 추가를 위해 클릭하세요",
     "search": {
-      "label": "Search",
-      "placeholder": "Type to search",
-      "no_matches_found": "No matches found",
-      "no_matching_results": "No matching results"
+      "label": "검색",
+      "placeholder": "검색어 입력",
+      "no_matches_found": "일치하는 항목 없음",
+      "no_matching_results": "일치하는 결과 없음"
     },
     "actions": {
-      "edit": "Edit",
-      "make_a_copy": "Make a copy",
-      "open_in_new_tab": "Open in new tab",
-      "copy_link": "Copy link",
-      "archive": "Archive",
-      "restore": "Restore",
-      "delete": "Delete",
-      "remove_relation": "Remove relation",
-      "subscribe": "Subscribe",
-      "unsubscribe": "Unsubscribe",
-      "clear_sorting": "Clear sorting",
-      "show_weekends": "Show weekends",
-      "enable": "Enable",
-      "disable": "Disable"
+      "edit": "편집",
+      "make_a_copy": "복사본 만들기",
+      "open_in_new_tab": "새 탭에서 열기",
+      "copy_link": "링크 복사",
+      "archive": "아카이브",
+      "restore": "복원",
+      "delete": "삭제",
+      "remove_relation": "관계 제거",
+      "subscribe": "구독",
+      "unsubscribe": "구독 취소",
+      "clear_sorting": "정렬 지우기",
+      "show_weekends": "주말 표시",
+      "enable": "활성화",
+      "disable": "비활성화"
     },
-    "name": "Name",
-    "discard": "Discard",
-    "confirm": "Confirm",
-    "confirming": "Confirming",
-    "read_the_docs": "Read the docs",
-    "default": "Default",
-    "active": "Active",
-    "enabled": "Enabled",
-    "disabled": "Disabled",
-    "mandate": "Mandate",
-    "mandatory": "Mandatory",
-    "yes": "Yes",
-    "no": "No",
-    "please_wait": "Please wait",
-    "enabling": "Enabling",
-    "disabling": "Disabling",
-    "beta": "Beta",
-    "or": "or",
-    "next": "Next",
-    "back": "Back",
-    "cancelling": "Cancelling",
-    "configuring": "Configuring",
-    "clear": "Clear",
-    "import": "Import",
-    "connect": "Connect",
-    "authorizing": "Authorizing",
-    "processing": "Processing",
-    "no_data_available": "No data available",
-    "from": "from {name}",
-    "authenticated": "Authenticated",
-    "select": "Select",
-    "upgrade": "Upgrade",
-    "add_seats": "Add Seats",
-    "projects": "Projects",
-    "workspace": "Workspace",
-    "workspaces": "Workspaces",
-    "team": "Team",
-    "teams": "Teams",
-    "entity": "Entity",
-    "entities": "Entities",
-    "task": "Task",
-    "tasks": "Tasks",
-    "section": "Section",
-    "sections": "Sections",
-    "edit": "Edit",
-    "connecting": "Connecting",
-    "connected": "Connected",
-    "disconnect": "Disconnect",
-    "disconnecting": "Disconnecting",
-    "installing": "Installing",
-    "install": "Install",
-    "reset": "Reset",
-    "live": "Live",
-    "change_history": "Change History",
-    "coming_soon": "Coming soon",
-    "members": "Members",
-    "you": "You",
+    "name": "이름",
+    "discard": "폐기",
+    "confirm": "확인",
+    "confirming": "확인 중",
+    "read_the_docs": "문서 읽기",
+    "default": "기본값",
+    "active": "활성",
+    "enabled": "활성화됨",
+    "disabled": "비활성화됨",
+    "mandate": "의무",
+    "mandatory": "필수",
+    "yes": "예",
+    "no": "아니오",
+    "please_wait": "기다려주세요",
+    "enabling": "활성화 중",
+    "disabling": "비활성화 중",
+    "beta": "베타",
+    "or": "또는",
+    "next": "다음",
+    "back": "뒤로",
+    "cancelling": "취소 중",
+    "configuring": "구성 중",
+    "clear": "지우기",
+    "import": "가져오기",
+    "connect": "연결",
+    "authorizing": "인증 중",
+    "processing": "처리 중",
+    "no_data_available": "사용 가능한 데이터 없음",
+    "from": "{name}에서",
+    "authenticated": "인증됨",
+    "select": "선택",
+    "upgrade": "업그레이드",
+    "add_seats": "좌석 추가",
+    "projects": "프로젝트",
+    "workspace": "작업 공간",
+    "workspaces": "작업 공간",
+    "team": "팀",
+    "teams": "팀",
+    "entity": "엔티티",
+    "entities": "엔티티",
+    "task": "작업",
+    "tasks": "작업",
+    "section": "섹션",
+    "sections": "섹션",
+    "edit": "편집",
+    "connecting": "연결 중",
+    "connected": "연결됨",
+    "disconnect": "연결 해제",
+    "disconnecting": "연결 해제 중",
+    "installing": "설치 중",
+    "install": "설치",
+    "reset": "재설정",
+    "live": "라이브",
+    "change_history": "변경 기록",
+    "coming_soon": "곧 출시",
+    "members": "멤버",
+    "you": "나",
     "upgrade_cta": {
-      "higher_subscription": "Upgrade to higher subscription",
-      "talk_to_sales": "Talk to Sales"
+      "higher_subscription": "더 높은 구독으로 업그레이드",
+      "talk_to_sales": "영업팀과 상담"
     },
-    "category": "Category",
-    "categories": "Categories",
-    "saving": "Saving",
-    "save_changes": "Save changes",
-    "delete": "Delete",
-    "deleting": "Deleting",
-    "pending": "Pending",
-    "invite": "Invite",
-    "view": "View"
+    "category": "카테고리",
+    "categories": "카테고리",
+    "saving": "저장 중",
+    "save_changes": "변경 사항 저장",
+    "delete": "삭제",
+    "deleting": "삭제 중",
+    "pending": "보류 중",
+    "invite": "초대",
+    "view": "보기"
   },
 
   "chart": {
-    "x_axis": "X-axis",
-    "y_axis": "Y-axis",
-    "metric": "Metric"
+    "x_axis": "X축",
+    "y_axis": "Y축",
+    "metric": "메트릭"
   },
 
   "form": {
     "title": {
-      "required": "Title is required",
-      "max_length": "Title should be less than {length} characters"
+      "required": "제목이 필요합니다",
+      "max_length": "제목은 {length}자 미만이어야 합니다"
     }
   },
 
   "entity": {
-    "grouping_title": "{entity} Grouping",
-    "priority": "{entity} Priority",
-    "all": "All {entity}",
-    "drop_here_to_move": "Drop here to move the {entity}",
+    "grouping_title": "{entity} 그룹화",
+    "priority": "{entity} 우선순위",
+    "all": "모든 {entity}",
+    "drop_here_to_move": "{entity}를 이동하려면 여기에 드롭하세요",
     "delete": {
-      "label": "Delete {entity}",
-      "success": "{entity} deleted successfully",
-      "failed": "{entity} delete failed"
+      "label": "{entity} 삭제",
+      "success": "{entity}가 성공적으로 삭제되었습니다",
+      "failed": "{entity} 삭제 실패"
     },
     "update": {
-      "failed": "{entity} update failed",
-      "success": "{entity} updated successfully"
+      "failed": "{entity} 업데이트 실패",
+      "success": "{entity}가 성공적으로 업데이트되었습니다"
     },
-    "link_copied_to_clipboard": "{entity} link copied to clipboard",
+    "link_copied_to_clipboard": "{entity} 링크가 클립보드에 복사되었습니다",
     "fetch": {
-      "failed": "Error fetching {entity}"
+      "failed": "{entity}를 가져오는 중 오류 발생"
     },
     "add": {
-      "success": "{entity} added successfully",
-      "failed": "Error adding {entity}"
+      "success": "{entity}가 성공적으로 추가되었습니다",
+      "failed": "{entity} 추가 중 오류 발생"
     }
   },
 
   "epic": {
-    "all": "All Epics",
-    "label": "{count, plural, one {Epic} other {Epics}}",
-    "new": "New Epic",
-    "adding": "Adding epic",
+    "all": "모든 에픽",
+    "label": "{count, plural, one {에픽} other {에픽}}",
+    "new": "새 에픽",
+    "adding": "에픽 추가 중",
     "create": {
-      "success": "Epic created successfully"
+      "success": "에픽이 성공적으로 생성되었습니다"
     },
     "add": {
-      "press_enter": "Press 'Enter' to add another epic",
-      "label": "Add Epic"
+      "press_enter": "다른 에픽을 추가하려면 'Enter'를 누르세요",
+      "label": "에픽 추가"
     },
     "title": {
-      "label": "Epic Title",
-      "required": "Epic title is required."
+      "label": "에픽 제목",
+      "required": "에픽 제목이 필요합니다."
     }
   },
 
   "issue": {
-    "label": "{count, plural, one {Work item} other {Work items}}",
-    "all": "All Work items",
-    "edit": "Edit work item",
+    "label": "{count, plural, one {작업 항목} other {작업 항목}}",
+    "all": "모든 작업 항목",
+    "edit": "작업 항목 편집",
     "title": {
-      "label": "Work item title",
-      "required": "Work item title is required."
+      "label": "작업 항목 제목",
+      "required": "작업 항목 제목이 필요합니다."
     },
     "add": {
-      "press_enter": "Press 'Enter' to add another work item",
-      "label": "Add work item",
+      "press_enter": "다른 작업 항목을 추가하려면 'Enter'를 누르세요",
+      "label": "작업 항목 추가",
       "cycle": {
-        "failed": "Work item could not be added to the cycle. Please try again.",
-        "success": "{count, plural, one {Work item} other {Work items}} added to the cycle successfully.",
-        "loading": "Adding {count, plural, one {work item} other {work items}} to the cycle"
+        "failed": "작업 항목을 주기에 추가할 수 없습니다. 다시 시도해주세요.",
+        "success": "{count, plural, one {작업 항목} other {작업 항목}}이 주기에 성공적으로 추가되었습니다.",
+        "loading": "{count, plural, one {작업 항목} other {작업 항목}}을 주기에 추가 중"
       },
-      "assignee": "Add assignees",
-      "start_date": "Add start date",
-      "due_date": "Add due date",
-      "parent": "Add parent work item",
-      "sub_issue": "Add sub-work item",
-      "relation": "Add relation",
-      "link": "Add link",
-      "existing": "Add existing work item"
+      "assignee": "담당자 추가",
+      "start_date": "시작 날짜 추가",
+      "due_date": "마감일 추가",
+      "parent": "상위 작업 항목 추가",
+      "sub_issue": "하위 작업 항목 추가",
+      "relation": "관계 추가",
+      "link": "링크 추가",
+      "existing": "기존 작업 항목 추가"
     },
     "remove": {
-      "label": "Remove work item",
+      "label": "작업 항목 제거",
       "cycle": {
-        "loading": "Removing work item from the cycle",
-        "success": "Work item removed from the cycle successfully.",
-        "failed": "Work item could not be removed from the cycle. Please try again."
+        "loading": "작업 항목을 주기에서 제거 중",
+        "success": "작업 항목이 주기에서 성공적으로 제거되었습니다.",
+        "failed": "작업 항목을 주기에서 제거할 수 없습니다. 다시 시도해주세요."
       },
       "module": {
-        "loading": "Removing work item from the module",
-        "success": "Work item removed from the module successfully.",
-        "failed": "Work item could not be removed from the module. Please try again."
+        "loading": "작업 항목을 모듈에서 제거 중",
+        "success": "작업 항목이 모듈에서 성공적으로 제거되었습니다.",
+        "failed": "작업 항목을 모듈에서 제거할 수 없습니다. 다시 시도해주세요."
       },
       "parent": {
-        "label": "Remove parent work item"
+        "label": "상위 작업 항목 제거"
       }
     },
-    "new": "New Work item",
-    "adding": "Adding work item",
+    "new": "새 작업 항목",
+    "adding": "작업 항목 추가 중",
     "create": {
-      "success": "Work item created successfully"
+      "success": "작업 항목이 성공적으로 생성되었습니다"
     },
     "priority": {
-      "urgent": "Urgent",
-      "high": "High",
-      "medium": "Medium",
-      "low": "Low"
+      "urgent": "긴급",
+      "high": "높음",
+      "medium": "중간",
+      "low": "낮음"
     },
     "display": {
       "properties": {
-        "label": "Display Properties",
+        "label": "디스플레이 속성",
         "id": "ID",
-        "issue_type": "Work item Type",
-        "sub_issue_count": "Sub-work item count",
-        "attachment_count": "Attachment count",
-        "created_on": "Created on",
-        "sub_issue": "Sub-work item",
-        "work_item_count": "Work item count"
+        "issue_type": "작업 항목 유형",
+        "sub_issue_count": "하위 작업 항목 수",
+        "attachment_count": "첨부 파일 수",
+        "created_on": "생성일",
+        "sub_issue": "하위 작업 항목",
+        "work_item_count": "작업 항목 수"
       },
       "extra": {
-        "show_sub_issues": "Show sub-work items",
-        "show_empty_groups": "Show empty groups"
+        "show_sub_issues": "하위 작업 항목 표시",
+        "show_empty_groups": "빈 그룹 표시"
       }
     },
     "layouts": {
-      "ordered_by_label": "This layout is ordered by",
-      "list": "List",
-      "kanban": "Board",
-      "calendar": "Calendar",
-      "spreadsheet": "Table",
-      "gantt": "Timeline",
+      "ordered_by_label": "이 레이아웃은 다음 기준으로 정렬됩니다",
+      "list": "목록",
+      "kanban": "보드",
+      "calendar": "캘린더",
+      "spreadsheet": "테이블",
+      "gantt": "타임라인",
       "title": {
-        "list": "List Layout",
-        "kanban": "Board Layout",
-        "calendar": "Calendar Layout",
-        "spreadsheet": "Table Layout",
-        "gantt": "Timeline Layout"
+        "list": "목록 레이아웃",
+        "kanban": "보드 레이아웃",
+        "calendar": "캘린더 레이아웃",
+        "spreadsheet": "테이블 레이아웃",
+        "gantt": "타임라인 레이아웃"
       }
     },
     "states": {
-      "active": "Active",
-      "backlog": "Backlog"
+      "active": "활성",
+      "backlog": "백로그"
     },
     "comments": {
-      "placeholder": "Add comment",
+      "placeholder": "댓글 추가",
       "switch": {
-        "private": "Switch to private comment",
-        "public": "Switch to public comment"
+        "private": "비공개 댓글로 전환",
+        "public": "공개 댓글로 전환"
       },
       "create": {
-        "success": "Comment created successfully",
-        "error": "Comment creation failed. Please try again later."
+        "success": "댓글이 성공적으로 생성되었습니다",
+        "error": "댓글 생성 실패. 나중에 다시 시도해주세요."
       },
       "update": {
-        "success": "Comment updated successfully",
-        "error": "Comment update failed. Please try again later."
+        "success": "댓글이 성공적으로 업데이트되었습니다",
+        "error": "댓글 업데이트 실패. 나중에 다시 시도해주세요."
       },
       "remove": {
-        "success": "Comment removed successfully",
-        "error": "Comment remove failed. Please try again later."
+        "success": "댓글이 성공적으로 제거되었습니다",
+        "error": "댓글 제거 실패. 나중에 다시 시도해주세요."
       },
       "upload": {
-        "error": "Asset upload failed. Please try again later."
+        "error": "자산 업로드 실패. 나중에 다시 시도해주세요."
       }
     },
     "empty_state": {
       "issue_detail": {
-        "title": "Work item does not exist",
-        "description": "The work item you are looking for does not exist, has been archived, or has been deleted.",
+        "title": "작업 항목이 존재하지 않습니다",
+        "description": "찾고 있는 작업 항목이 존재하지 않거나, 아카이브되었거나, 삭제되었습니다.",
         "primary_button": {
-          "text": "View other work items"
+          "text": "다른 작업 항목 보기"
         }
       }
     },
     "sibling": {
-      "label": "Sibling work items"
+      "label": "형제 작업 항목"
     },
     "archive": {
-      "description": "Only completed or canceled\nwork items can be archived",
-      "label": "Archive Work item",
-      "confirm_message": "Are you sure you want to archive the work item? All your archived work items can be restored later.",
+      "description": "완료되거나 취소된 작업 항목만 아카이브할 수 있습니다",
+      "label": "작업 항목 아카이브",
+      "confirm_message": "작업 항목을 아카이브하시겠습니까? 모든 아카이브된 작업 항목은 나중에 복원할 수 있습니다.",
       "success": {
-        "label": "Archive success",
-        "message": "Your archives can be found in project archives."
+        "label": "아카이브 성공",
+        "message": "아카이브된 항목은 프로젝트 아카이브에서 찾을 수 있습니다."
       },
       "failed": {
-        "message": "Work item could not be archived. Please try again."
+        "message": "작업 항목을 아카이브할 수 없습니다. 다시 시도해주세요."
       }
     },
     "restore": {
       "success": {
-        "title": "Restore success",
-        "message": "Your work item can be found in project work items."
+        "title": "복원 성공",
+        "message": "작업 항목을 프로젝트 작업 항목에서 찾을 수 있습니다."
       },
       "failed": {
-        "message": "Work item could not be restored. Please try again."
+        "message": "작업 항목을 복원할 수 없습니다. 다시 시도해주세요."
       }
     },
     "relation": {
-      "relates_to": "Relates to",
-      "duplicate": "Duplicate of",
-      "blocked_by": "Blocked by",
-      "blocking": "Blocking"
+      "relates_to": "관련 있음",
+      "duplicate": "중복",
+      "blocked_by": "차단됨",
+      "blocking": "차단 중"
     },
-    "copy_link": "Copy work item link",
+    "copy_link": "작업 항목 링크 복사",
     "delete": {
-      "label": "Delete work item",
-      "error": "Error deleting work item"
+      "label": "작업 항목 삭제",
+      "error": "작업 항목 삭제 중 오류 발생"
     },
     "subscription": {
       "actions": {
-        "subscribed": "Work item subscribed successfully",
-        "unsubscribed": "Work item unsubscribed successfully"
+        "subscribed": "작업 항목이 성공적으로 구독되었습니다",
+        "unsubscribed": "작업 항목 구독이 성공적으로 취소되었습니다"
       }
     },
     "select": {
-      "error": "Please select at least one work item",
-      "empty": "No work items selected",
-      "add_selected": "Add selected work items"
+      "error": "최소 하나의 작업 항목을 선택하세요",
+      "empty": "선택된 작업 항목 없음",
+      "add_selected": "선택된 작업 항목 추가"
     },
-    "open_in_full_screen": "Open work item in full screen"
+    "open_in_full_screen": "작업 항목을 전체 화면으로 열기"
   },
 
   "attachment": {
-    "error": "File could not be attached. Try uploading again.",
-    "only_one_file_allowed": "Only one file can be uploaded at a time.",
-    "file_size_limit": "File must be of {size}MB or less in size.",
-    "drag_and_drop": "Drag and drop anywhere to upload",
-    "delete": "Delete attachment"
+    "error": "파일을 첨부할 수 없습니다. 다시 업로드하세요.",
+    "only_one_file_allowed": "한 번에 하나의 파일만 업로드할 수 있습니다.",
+    "file_size_limit": "파일 크기는 {size}MB 이하이어야 합니다.",
+    "drag_and_drop": "업로드하려면 아무 곳에나 드래그 앤 드롭하세요",
+    "delete": "첨부 파일 삭제"
   },
 
   "label": {
-    "select": "Select label",
+    "select": "레이블 선택",
     "create": {
-      "success": "Label created successfully",
-      "failed": "Label creation failed",
-      "already_exists": "Label already exists",
-      "type": "Type to add a new label"
+      "success": "레이블이 성공적으로 생성되었습니다",
+      "failed": "레이블 생성 실패",
+      "already_exists": "레이블이 이미 존재합니다",
+      "type": "새 레이블을 추가하려면 입력하세요"
     }
   },
 
   "sub_work_item": {
     "update": {
-      "success": "Sub-work item updated successfully",
-      "error": "Error updating sub-work item"
+      "success": "하위 작업 항목이 성공적으로 업데이트되었습니다",
+      "error": "하위 작업 항목 업데이트 중 오류 발생"
     },
     "remove": {
-      "success": "Sub-work item removed successfully",
-      "error": "Error removing sub-work item"
+      "success": "하위 작업 항목이 성공적으로 제거되었습니다",
+      "error": "하위 작업 항목 제거 중 오류 발생"
     }
   },
 
   "view": {
-    "label": "{count, plural, one {View} other {Views}}",
+    "label": "{count, plural, one {뷰} other {뷰}}",
     "create": {
-      "label": "Create View"
+      "label": "뷰 생성"
     },
     "update": {
-      "label": "Update View"
+      "label": "뷰 업데이트"
     }
   },
 
   "inbox_issue": {
     "status": {
       "pending": {
-        "title": "Pending",
-        "description": "Pending"
+        "title": "보류 중",
+        "description": "보류 중"
       },
       "declined": {
-        "title": "Declined",
-        "description": "Declined"
+        "title": "거절됨",
+        "description": "거절됨"
       },
       "snoozed": {
-        "title": "Snoozed",
-        "description": "{days, plural, one{# day} other{# days}} to go"
+        "title": "미루기",
+        "description": "{days, plural, one{# 일} other{# 일}} 남음"
       },
       "accepted": {
-        "title": "Accepted",
-        "description": "Accepted"
+        "title": "수락됨",
+        "description": "수락됨"
       },
       "duplicate": {
-        "title": "Duplicate",
-        "description": "Duplicate"
+        "title": "중복",
+        "description": "중복"
       }
     },
     "modals": {
       "decline": {
-        "title": "Decline work item",
-        "content": "Are you sure you want to decline work item {value}?"
+        "title": "작업 항목 거절",
+        "content": "작업 항목 {value}을(를) 거절하시겠습니까?"
       },
       "delete": {
-        "title": "Delete work item",
-        "content": "Are you sure you want to delete work item {value}?",
-        "success": "Work item deleted successfully"
+        "title": "작업 항목 삭제",
+        "content": "작업 항목 {value}을(를) 삭제하시겠습니까?",
+        "success": "작업 항목이 성공적으로 삭제되었습니다"
       }
     },
     "errors": {
-      "snooze_permission": "Only project admins can snooze/Un-snooze work items",
-      "accept_permission": "Only project admins can accept work items",
-      "decline_permission": "Only project admins can deny work items"
+      "snooze_permission": "프로젝트 관리자만 작업 항목을 미루거나 미루기 해제할 수 있습니다",
+      "accept_permission": "프로젝트 관리자만 작업 항목을 수락할 수 있습니다",
+      "decline_permission": "프로젝트 관리자만 작업 항목을 거절할 수 있습니다"
     },
     "actions": {
-      "accept": "Accept",
-      "decline": "Decline",
-      "snooze": "Snooze",
-      "unsnooze": "Un snooze",
-      "copy": "Copy work item link",
-      "delete": "Delete",
-      "open": "Open work item",
-      "mark_as_duplicate": "Mark as duplicate",
-      "move": "Move {value} to project work items"
+      "accept": "수락",
+      "decline": "거절",
+      "snooze": "미루기",
+      "unsnooze": "미루기 해제",
+      "copy": "작업 항목 링크 복사",
+      "delete": "삭제",
+      "open": "작업 항목 열기",
+      "mark_as_duplicate": "중복으로 표시",
+      "move": "{value}을(를) 프로젝트 작업 항목으로 이동"
     },
     "source": {
-      "in-app": "in-app"
+      "in-app": "앱 내"
     },
     "order_by": {
-      "created_at": "Created at",
-      "updated_at": "Updated at",
+      "created_at": "생성일",
+      "updated_at": "업데이트일",
       "id": "ID"
     },
-    "label": "Intake",
-    "page_label": "{workspace} - Intake",
+    "label": "접수",
+    "page_label": "{workspace} - 접수",
     "modal": {
-      "title": "Create intake work item"
+      "title": "접수 작업 항목 생성"
     },
     "tabs": {
-      "open": "Open",
-      "closed": "Closed"
+      "open": "열기",
+      "closed": "닫기"
     },
     "empty_state": {
       "sidebar_open_tab": {
-        "title": "No open work items",
-        "description": "Find open work items here. Create new work item."
+        "title": "열린 작업 항목 없음",
+        "description": "여기에서 열린 작업 항목을 찾을 수 있습니다. 새 작업 항목을 생성하세요."
       },
       "sidebar_closed_tab": {
-        "title": "No closed work items",
-        "description": "All the work items whether accepted or declined can be found here."
+        "title": "닫힌 작업 항목 없음",
+        "description": "수락되거나 거절된 모든 작업 항목을 여기에서 찾을 수 있습니다."
       },
       "sidebar_filter": {
-        "title": "No matching work items",
-        "description": "No work item matches filter applied in intake. Create a new work item."
+        "title": "일치하는 작업 항목 없음",
+        "description": "적용된 필터와 일치하는 작업 항목이 없습니다. 새 작업 항목을 생성하세요."
       },
       "detail": {
-        "title": "Select a work item to view its details."
+        "title": "작업 항목의 세부 정보를 보려면 선택하세요."
       }
     }
   },
 
   "workspace_creation": {
-    "heading": "Create your workspace",
-    "subheading": "To start using Plane, you need to create or join a workspace.",
+    "heading": "작업 공간 생성",
+    "subheading": "Plane을 사용하려면 작업 공간을 생성하거나 참여해야 합니다.",
     "form": {
       "name": {
-        "label": "Name your workspace",
-        "placeholder": "Something familiar and recognizable is always best."
+        "label": "작업 공간 이름",
+        "placeholder": "익숙하고 인식 가능한 이름이 가장 좋습니다."
       },
       "url": {
-        "label": "Set your workspace's URL",
-        "placeholder": "Type or paste a URL",
-        "edit_slug": "You can only edit the slug of the URL"
+        "label": "작업 공간 URL 설정",
+        "placeholder": "URL 입력 또는 붙여넣기",
+        "edit_slug": "URL의 슬러그만 편집할 수 있습니다"
       },
       "organization_size": {
-        "label": "How many people will use this workspace?",
-        "placeholder": "Select a range"
+        "label": "이 작업 공간을 사용할 사람 수",
+        "placeholder": "범위 선택"
       }
     },
     "errors": {
       "creation_disabled": {
-        "title": "Only your instance admin can create workspaces",
-        "description": "If you know your instance admin's email address, click the button below to get in touch with them.",
-        "request_button": "Request instance admin"
+        "title": "작업 공간은 인스턴스 관리자만 생성할 수 있습니다",
+        "description": "인스턴스 관리자 이메일 주소를 알고 있다면 아래 버튼을 클릭하여 연락하세요.",
+        "request_button": "인스턴스 관리자 요청"
       },
       "validation": {
-        "name_alphanumeric": "Workspaces names can contain only (' '), ('-'), ('_') and alphanumeric characters.",
-        "name_length": "Limit your name to 80 characters.",
-        "url_alphanumeric": "URLs can contain only ('-') and alphanumeric characters.",
-        "url_length": "Limit your URL to 48 characters.",
-        "url_already_taken": "Workspace URL is already taken!"
+        "name_alphanumeric": "작업 공간 이름에는 (' '), ('-'), ('_') 및 영숫자 문자만 포함될 수 있습니다.",
+        "name_length": "이름은 80자 이내로 제한하세요.",
+        "url_alphanumeric": "URL에는 ('-') 및 영숫자 문자만 포함될 수 있습니다.",
+        "url_length": "URL은 48자 이내로 제한하세요.",
+        "url_already_taken": "작업 공간 URL이 이미 사용 중입니다!"
       }
     },
     "request_email": {
-      "subject": "Requesting a new workspace",
-      "body": "Hi instance admin(s),\n\nPlease create a new workspace with the URL [/workspace-name] for [purpose of creating the workspace].\n\nThanks,\n{firstName} {lastName}\n{email}"
+      "subject": "새 작업 공간 요청",
+      "body": "안녕하세요 인스턴스 관리자님,\n\n[목적]을 위해 [/workspace-name] URL로 새 작업 공간을 생성해 주세요.\n\n감사합니다,\n{firstName} {lastName}\n{email}"
     },
     "button": {
-      "default": "Create workspace",
-      "loading": "Creating workspace"
+      "default": "작업 공간 생성",
+      "loading": "작업 공간 생성 중"
     },
     "toast": {
       "success": {
-        "title": "Success",
-        "message": "Workspace created successfully"
+        "title": "성공",
+        "message": "작업 공간이 성공적으로 생성되었습니다"
       },
       "error": {
-        "title": "Error",
-        "message": "Workspace could not be created. Please try again."
+        "title": "오류",
+        "message": "작업 공간을 생성할 수 없습니다. 다시 시도해주세요."
       }
     }
   },
@@ -1273,13 +1273,13 @@
   "workspace_dashboard": {
     "empty_state": {
       "general": {
-        "title": "Overview of your projects, activity, and metrics",
-        "description": "Welcome to Plane, we are excited to have you here. Create your first project and track your work items, and this page will transform into a space that helps you progress. Admins will also see items which help their team progress.",
+        "title": "프로젝트, 활동 및 메트릭 개요",
+        "description": "Plane에 오신 것을 환영합니다. 첫 번째 프로젝트를 생성하고 작업 항목을 추적하면 이 페이지가 진행 상황을 돕는 공간으로 변합니다. 관리자도 팀의 진행을 돕는 항목을 볼 수 있습니다.",
         "primary_button": {
-          "text": "Build your first project",
+          "text": "첫 번째 프로젝트 생성",
           "comic": {
-            "title": "Everything starts with a project in Plane",
-            "description": "A project could be a product's roadmap, a marketing campaign, or launching a new car."
+            "title": "Plane에서 모든 것은 프로젝트로 시작됩니다",
+            "description": "프로젝트는 제품 로드맵, 마케팅 캠페인 또는 새로운 자동차 출시일 수 있습니다."
           }
         }
       }
@@ -1287,44 +1287,44 @@
   },
 
   "workspace_analytics": {
-    "label": "Analytics",
-    "page_label": "{workspace} - Analytics",
-    "open_tasks": "Total open tasks",
-    "error": "There was some error in fetching the data.",
-    "work_items_closed_in": "Work items closed in",
-    "selected_projects": "Selected projects",
-    "total_members": "Total members",
-    "total_cycles": "Total cycles",
-    "total_modules": "Total modules",
+    "label": "분석",
+    "page_label": "{workspace} - 분석",
+    "open_tasks": "열린 작업 항목",
+    "error": "데이터를 가져오는 중 오류가 발생했습니다.",
+    "work_items_closed_in": "닫힌 작업 항목",
+    "selected_projects": "선택된 프로젝트",
+    "total_members": "총 멤버",
+    "total_cycles": "총 주기",
+    "total_modules": "총 모듈",
     "pending_work_items": {
-      "title": "Pending work items",
-      "empty_state": "Analysis of pending work items by co-workers appears here."
+      "title": "보류 중인 작업 항목",
+      "empty_state": "동료의 보류 중인 작업 항목 분석이 여기에 표시됩니다."
     },
     "work_items_closed_in_a_year": {
-      "title": "Work items closed in a year",
-      "empty_state": "Close work items to view analysis of the same in the form of a graph."
+      "title": "1년 동안 닫힌 작업 항목",
+      "empty_state": "작업 항목을 닫아 그래프에서 분석을 확인하세요."
     },
     "most_work_items_created": {
-      "title": "Most work items created",
-      "empty_state": "Co-workers and the number of work items created by them appears here."
+      "title": "가장 많은 작업 항목 생성",
+      "empty_state": "동료와 그들이 생성한 작업 항목 수가 여기에 표시됩니다."
     },
     "most_work_items_closed": {
-      "title": "Most work items closed",
-      "empty_state": "Co-workers and the number of work items closed by them appears here."
+      "title": "가장 많은 작업 항목 닫힘",
+      "empty_state": "동료와 그들이 닫은 작업 항목 수가 여기에 표시됩니다."
     },
     "tabs": {
-      "scope_and_demand": "Scope and Demand",
-      "custom": "Custom Analytics"
+      "scope_and_demand": "범위 및 수요",
+      "custom": "맞춤형 분석"
     },
     "empty_state": {
       "general": {
-        "title": "Track progress, workloads, and allocations. Spot trends, remove blockers, and move work faster",
-        "description": "See scope versus demand, estimates, and scope creep. Get performance by team members and teams, and make sure your project runs on time.",
+        "title": "진행 상황, 작업량 및 할당을 추적하세요. 트렌드를 파악하고, 차단 요소를 제거하며, 작업을 더 빠르게 진행하세요",
+        "description": "범위 대 수요, 추정치 및 범위 크리프를 확인하세요. 팀원과 팀의 성과를 확인하고 프로젝트가 제시간에 진행되도록 하세요.",
         "primary_button": {
-          "text": "Start your first project",
+          "text": "첫 번째 프로젝트 시작",
           "comic": {
-            "title": "Analytics works best with Cycles + Modules",
-            "description": "First, timebox your work items into Cycles and, if you can, group work items that span more than a cycle into Modules. Check out both on the left nav."
+            "title": "분석은 주기 + 모듈과 함께 작동합니다",
+            "description": "먼저 작업 항목을 주기로 시간 상자화하고, 주기를 초과하는 작업 항목을 모듈로 그룹화하세요. 왼쪽 탐색에서 둘 다 확인하세요."
           }
         }
       }
@@ -1332,556 +1332,556 @@
   },
 
   "workspace_projects": {
-    "label": "{count, plural, one {Project} other {Projects}}",
+    "label": "{count, plural, one {프로젝트} other {프로젝트}}",
     "create": {
-      "label": "Add Project"
+      "label": "프로젝트 추가"
     },
     "network": {
-      "label": "Network",
+      "label": "네트워크",
       "private": {
-        "title": "Private",
-        "description": "Accessible only by invite"
+        "title": "비공개",
+        "description": "초대에 의해서만 접근 가능"
       },
       "public": {
-        "title": "Public",
-        "description": "Anyone in the workspace except Guests can join"
+        "title": "공개",
+        "description": "게스트를 제외한 작업 공간의 모든 사람이 참여할 수 있습니다"
       }
     },
     "error": {
-      "permission": "You don't have permission to perform this action.",
-      "cycle_delete": "Failed to delete cycle",
-      "module_delete": "Failed to delete module",
-      "issue_delete": "Failed to delete work item"
+      "permission": "이 작업을 수행할 권한이 없습니다.",
+      "cycle_delete": "주기 삭제 실패",
+      "module_delete": "모듈 삭제 실패",
+      "issue_delete": "작업 항목 삭제 실패"
     },
     "state": {
-      "backlog": "Backlog",
-      "unstarted": "Unstarted",
-      "started": "Started",
-      "completed": "Completed",
-      "cancelled": "Cancelled"
+      "backlog": "백로그",
+      "unstarted": "시작되지 않음",
+      "started": "시작됨",
+      "completed": "완료됨",
+      "cancelled": "취소됨"
     },
     "sort": {
-      "manual": "Manual",
-      "name": "Name",
-      "created_at": "Created date",
-      "members_length": "Number of members"
+      "manual": "수동",
+      "name": "이름",
+      "created_at": "생성일",
+      "members_length": "멤버 수"
     },
     "scope": {
-      "my_projects": "My projects",
-      "archived_projects": "Archived"
+      "my_projects": "내 프로젝트",
+      "archived_projects": "아카이브"
     },
     "common": {
-      "months_count": "{months, plural, one{# month} other{# months}}"
+      "months_count": "{months, plural, one{# 개월} other{# 개월}}"
     },
     "empty_state": {
       "general": {
-        "title": "No active projects",
-        "description": "Think of each project as the parent for goal-oriented work. Projects are where Jobs, Cycles, and Modules live and, along with your colleagues, help you achieve that goal. Create a new project or filter for archived projects.",
+        "title": "활성 프로젝트 없음",
+        "description": "각 프로젝트를 목표 지향 작업의 부모로 생각하세요. 프로젝트는 작업, 주기 및 모듈이 존재하는 곳이며, 동료와 함께 목표를 달성하는 데 도움이 됩니다. 새 프로젝트를 생성하거나 아카이브된 프로젝트를 필터링하세요.",
         "primary_button": {
-          "text": "Start your first project",
+          "text": "첫 번째 프로젝트 시작",
           "comic": {
-            "title": "Everything starts with a project in Plane",
-            "description": "A project could be a product's roadmap, a marketing campaign, or launching a new car."
+            "title": "Plane에서 모든 것은 프로젝트로 시작됩니다",
+            "description": "프로젝트는 제품 로드맵, 마케팅 캠페인 또는 새로운 자동차 출시일 수 있습니다."
           }
         }
       },
       "no_projects": {
-        "title": "No project",
-        "description": "To create work items or manage your work, you need to create a project or be a part of one.",
+        "title": "프로젝트 없음",
+        "description": "작업 항목을 생성하거나 작업을 관리하려면 프로젝트를 생성하거나 참여해야 합니다.",
         "primary_button": {
-          "text": "Start your first project",
+          "text": "첫 번째 프로젝트 시작",
           "comic": {
-            "title": "Everything starts with a project in Plane",
-            "description": "A project could be a product's roadmap, a marketing campaign, or launching a new car."
+            "title": "Plane에서 모든 것은 프로젝트로 시작됩니다",
+            "description": "프로젝트는 제품 로드맵, 마케팅 캠페인 또는 새로운 자동차 출시일 수 있습니다."
           }
         }
       },
       "filter": {
-        "title": "No matching projects",
-        "description": "No projects detected with the matching criteria. \n Create a new project instead."
+        "title": "일치하는 프로젝트 없음",
+        "description": "일치하는 프로젝트가 없습니다. 대신 새 프로젝트를 생성하세요."
       },
       "search": {
-        "description": "No projects detected with the matching criteria.\nCreate a new project instead"
+        "description": "일치하는 프로젝트가 없습니다. 대신 새 프로젝트를 생성하세요"
       }
     }
   },
 
   "workspace_views": {
-    "add_view": "Add view",
+    "add_view": "뷰 추가",
     "empty_state": {
       "all-issues": {
-        "title": "No work items in the project",
-        "description": "First project done! Now, slice your work into trackable pieces with work items. Let's go!",
+        "title": "프로젝트에 작업 항목 없음",
+        "description": "첫 번째 프로젝트 완료! 이제 작업 항목을 추적 가능한 조각으로 나누세요. 시작합시다!",
         "primary_button": {
-          "text": "Create new work item"
+          "text": "새 작업 항목 생성"
         }
       },
       "assigned": {
-        "title": "No work items yet",
-        "description": "Work items assigned to you can be tracked from here.",
+        "title": "작업 항목 없음",
+        "description": "할당된 작업 항목을 여기에서 추적할 수 있습니다.",
         "primary_button": {
-          "text": "Create new work item"
+          "text": "새 작업 항목 생성"
         }
       },
       "created": {
-        "title": "No work items yet",
-        "description": "All work items created by you come here, track them here directly.",
+        "title": "작업 항목 없음",
+        "description": "생성한 모든 작업 항목이 여기에 표시됩니다. 여기에서 직접 추적하세요.",
         "primary_button": {
-          "text": "Create new work item"
+          "text": "새 작업 항목 생성"
         }
       },
       "subscribed": {
-        "title": "No work items yet",
-        "description": "Subscribe to work items you are interested in, track all of them here."
+        "title": "작업 항목 없음",
+        "description": "관심 있는 작업 항목을 구독하고 여기에서 모두 추적하세요."
       },
       "custom-view": {
-        "title": "No work items yet",
-        "description": "Work items that applies to the filters, track all of them here."
+        "title": "작업 항목 없음",
+        "description": "필터가 적용된 작업 항목을 여기에서 모두 추적하세요."
       }
     }
   },
 
   "workspace_settings": {
-    "label": "Workspace settings",
-    "page_label": "{workspace} - General settings",
-    "key_created": "Key created",
-    "copy_key": "Copy and save this secret key in Plane Pages. You can't see this key after you hit Close. A CSV file containing the key has been downloaded.",
-    "token_copied": "Token copied to clipboard.",
+    "label": "작업 공간 설정",
+    "page_label": "{workspace} - 일반 설정",
+    "key_created": "키 생성됨",
+    "copy_key": "이 비밀 키를 Plane Pages에 복사하고 저장하세요. 닫기 버튼을 누른 후에는 이 키를 볼 수 없습니다. 키가 포함된 CSV 파일이 다운로드되었습니다.",
+    "token_copied": "토큰이 클립보드에 복사되었습니다.",
     "settings": {
       "general": {
-        "title": "General",
-        "upload_logo": "Upload logo",
-        "edit_logo": "Edit logo",
-        "name": "Workspace name",
-        "company_size": "Company size",
-        "url": "Workspace URL",
-        "update_workspace": "Update workspace",
-        "delete_workspace": "Delete this workspace",
-        "delete_workspace_description": "When deleting a workspace, all of the data and resources within that workspace will be permanently removed and cannot be recovered.",
-        "delete_btn": "Delete this workspace",
+        "title": "일반",
+        "upload_logo": "로고 업로드",
+        "edit_logo": "로고 편집",
+        "name": "작업 공간 이름",
+        "company_size": "회사 규모",
+        "url": "작업 공간 URL",
+        "update_workspace": "작업 공간 업데이트",
+        "delete_workspace": "이 작업 공간 삭제",
+        "delete_workspace_description": "작업 공간을 삭제하면 해당 작업 공간 내의 모든 데이터와 리소스가 영구적으로 삭제되며 복구할 수 없습니다.",
+        "delete_btn": "이 작업 공간 삭제",
         "delete_modal": {
-          "title": "Are you sure you want to delete this workspace?",
-          "description": "You have an active trial to one of our paid plans. Please cancel it first to proceed.",
-          "dismiss": "Dismiss",
-          "cancel": "Cancel trial",
-          "success_title": "Workspace deleted.",
-          "success_message": "You will soon go to your profile page.",
-          "error_title": "That didn't work.",
-          "error_message": "Try again, please."
+          "title": "이 작업 공간을 삭제하시겠습니까?",
+          "description": "유료 플랜의 활성화된 평가판이 있습니다. 먼저 취소해야 진행할 수 있습니다.",
+          "dismiss": "무시",
+          "cancel": "평가판 취소",
+          "success_title": "작업 공간 삭제됨.",
+          "success_message": "곧 프로필 페이지로 이동합니다.",
+          "error_title": "작업이 실패했습니다.",
+          "error_message": "다시 시도해주세요."
         },
         "errors": {
           "name": {
-            "required": "Name is required",
-            "max_length": "Workspace name should not exceed 80 characters"
+            "required": "이름이 필요합니다",
+            "max_length": "작업 공간 이름은 80자를 초과할 수 없습니다"
           },
           "company_size": {
-            "required": "Company size is required",
-            "select_a_range": "Select organization size"
+            "required": "회사 규모가 필요합니다",
+            "select_a_range": "조직 규모 선택"
           }
         }
       },
       "members": {
-        "title": "Members",
-        "add_member": "Add member",
-        "pending_invites": "Pending invites",
-        "invitations_sent_successfully": "Invitations sent successfully",
-        "leave_confirmation": "Are you sure you want to leave the workspace? You will no longer have access to this workspace. This action cannot be undone.",
+        "title": "멤버",
+        "add_member": "멤버 추가",
+        "pending_invites": "보류 중인 초대",
+        "invitations_sent_successfully": "초대가 성공적으로 전송되었습니다",
+        "leave_confirmation": "작업 공간을 떠나시겠습니까? 더 이상 이 작업 공간에 접근할 수 없습니다. 이 작업은 되돌릴 수 없습니다.",
         "details": {
-          "full_name": "Full name",
-          "display_name": "Display name",
-          "email_address": "Email address",
-          "account_type": "Account type",
-          "authentication": "Authentication",
-          "joining_date": "Joining date"
+          "full_name": "전체 이름",
+          "display_name": "표시 이름",
+          "email_address": "이메일 주소",
+          "account_type": "계정 유형",
+          "authentication": "인증",
+          "joining_date": "가입 날짜"
         },
         "modal": {
-          "title": "Invite people to collaborate",
-          "description": "Invite people to collaborate on your workspace.",
-          "button": "Send invitations",
-          "button_loading": "Sending invitations",
+          "title": "사람들을 초대하여 협업하세요",
+          "description": "작업 공간에서 협업할 사람들을 초대하세요.",
+          "button": "초대 전송",
+          "button_loading": "초대 전송 중",
           "placeholder": "name@company.com",
           "errors": {
-            "required": "We need an email address to invite them.",
-            "invalid": "Email is invalid"
+            "required": "초대하려면 이메일 주소가 필요합니다.",
+            "invalid": "이메일이 유효하지 않습니다"
           }
         }
       },
       "billing_and_plans": {
-        "title": "Billing & Plans",
-        "current_plan": "Current plan",
-        "free_plan": "You are currently using the free plan",
-        "view_plans": "View plans"
+        "title": "청구 및 플랜",
+        "current_plan": "현재 플랜",
+        "free_plan": "현재 무료 플랜을 사용 중입니다",
+        "view_plans": "플랜 보기"
       },
       "exports": {
-        "title": "Exports",
-        "exporting": "Exporting",
-        "previous_exports": "Previous exports",
-        "export_separate_files": "Export the data into separate files",
+        "title": "내보내기",
+        "exporting": "내보내기 중",
+        "previous_exports": "이전 내보내기",
+        "export_separate_files": "데이터를 별도의 파일로 내보내기",
         "modal": {
-          "title": "Export to",
+          "title": "내보내기",
           "toasts": {
             "success": {
-              "title": "Export successful",
-              "message": "You will be able to download the exported {entity} from the previous export."
+              "title": "내보내기 성공",
+              "message": "이전 내보내기에서 내보낸 {entity}를 다운로드할 수 있습니다."
             },
             "error": {
-              "title": "Export failed",
-              "message": "Export was unsuccessful. Please try again."
+              "title": "내보내기 실패",
+              "message": "내보내기가 실패했습니다. 다시 시도해주세요."
             }
           }
         }
       },
       "webhooks": {
-        "title": "Webhooks",
-        "add_webhook": "Add webhook",
+        "title": "웹훅",
+        "add_webhook": "웹훅 추가",
         "modal": {
-          "title": "Create webhook",
-          "details": "Webhook details",
-          "payload": "Payload URL",
-          "question": "Which events would you like to trigger this webhook?",
-          "error": "URL is required"
+          "title": "웹훅 생성",
+          "details": "웹훅 세부 정보",
+          "payload": "페이로드 URL",
+          "question": "어떤 이벤트가 이 웹훅을 트리거하길 원하십니까?",
+          "error": "URL이 필요합니다"
         },
         "secret_key": {
-          "title": "Secret key",
-          "message": "Generate a token to sign-in to the webhook payload"
+          "title": "비밀 키",
+          "message": "웹훅 페이로드에 로그인하려면 토큰을 생성하세요"
         },
         "options": {
-          "all": "Send me everything",
-          "individual": "Select individual events"
+          "all": "모든 항목 보내기",
+          "individual": "개별 이벤트 선택"
         },
         "toasts": {
           "created": {
-            "title": "Webhook created",
-            "message": "The webhook has been successfully created"
+            "title": "웹훅 생성됨",
+            "message": "웹훅이 성공적으로 생성되었습니다"
           },
           "not_created": {
-            "title": "Webhook not created",
-            "message": "The webhook could not be created"
+            "title": "웹훅 생성되지 않음",
+            "message": "웹훅을 생성할 수 없습니다"
           },
           "updated": {
-            "title": "Webhook updated",
-            "message": "The webhook has been successfully updated"
+            "title": "웹훅 업데이트됨",
+            "message": "웹훅이 성공적으로 업데이트되었습니다"
           },
           "not_updated": {
-            "title": "Webhook not updated",
-            "message": "The webhook could not be updated"
+            "title": "웹훅 업데이트되지 않음",
+            "message": "웹훅을 업데이트할 수 없습니다"
           },
           "removed": {
-            "title": "Webhook removed",
-            "message": "The webhook has been successfully removed"
+            "title": "웹훅 제거됨",
+            "message": "웹훅이 성공적으로 제거되었습니다"
           },
           "not_removed": {
-            "title": "Webhook not removed",
-            "message": "The webhook could not be removed"
+            "title": "웹훅 제거되지 않음",
+            "message": "웹훅을 제거할 수 없습니다"
           },
           "secret_key_copied": {
-            "message": "Secret key copied to clipboard."
+            "message": "비밀 키가 클립보드에 복사되었습니다."
           },
           "secret_key_not_copied": {
-            "message": "Error occurred while copying secret key."
+            "message": "비밀 키를 복사하는 중 오류가 발생했습니다."
           }
         }
       },
       "api_tokens": {
-        "title": "API Tokens",
-        "add_token": "Add API token",
-        "create_token": "Create token",
-        "never_expires": "Never expires",
-        "generate_token": "Generate token",
-        "generating": "Generating",
+        "title": "API 토큰",
+        "add_token": "API 토큰 추가",
+        "create_token": "토큰 생성",
+        "never_expires": "만료되지 않음",
+        "generate_token": "토큰 생성",
+        "generating": "생성 중",
         "delete": {
-          "title": "Delete API token",
-          "description": "Any application using this token will no longer have the access to Plane data. This action cannot be undone.",
+          "title": "API 토큰 삭제",
+          "description": "이 토큰을 사용하는 애플리케이션은 더 이상 Plane 데이터에 접근할 수 없습니다. 이 작업은 되돌릴 수 없습니다.",
           "success": {
-            "title": "Success!",
-            "message": "The API token has been successfully deleted"
+            "title": "성공!",
+            "message": "API 토큰이 성공적으로 삭제되었습니다"
           },
           "error": {
-            "title": "Error!",
-            "message": "The API token could not be deleted"
+            "title": "오류!",
+            "message": "API 토큰을 삭제할 수 없습니다"
           }
         }
       }
     },
     "empty_state": {
       "api_tokens": {
-        "title": "No API tokens created",
-        "description": "Plane APIs can be used to integrate your data in Plane with any external system. Create a token to get started."
+        "title": "생성된 API 토큰 없음",
+        "description": "Plane API를 사용하여 Plane의 데이터를 외부 시스템과 통합할 수 있습니다. 토큰을 생성하여 시작하세요."
       },
       "webhooks": {
-        "title": "No webhooks added",
-        "description": "Create webhooks to receive real-time updates and automate actions."
+        "title": "추가된 웹훅 없음",
+        "description": "실시간 업데이트를 받고 작업을 자동화하려면 웹훅을 생성하세요."
       },
       "exports": {
-        "title": "No exports yet",
-        "description": "Anytime you export, you will also have a copy here for reference."
+        "title": "아직 내보내기 없음",
+        "description": "내보낼 때마다 참조용으로 여기에 복사본이 있습니다."
       },
       "imports": {
-        "title": "No imports yet",
-        "description": "Find all your previous imports here and download them."
+        "title": "아직 가져오기 없음",
+        "description": "이전 가져오기를 모두 여기에서 찾고 다운로드하세요."
       }
     }
   },
 
   "profile": {
-    "label": "Profile",
-    "page_label": "Your work",
-    "work": "Work",
+    "label": "프로필",
+    "page_label": "나의 작업",
+    "work": "작업",
     "details": {
-      "joined_on": "Joined on",
-      "time_zone": "Timezone"
+      "joined_on": "가입일",
+      "time_zone": "시간대"
     },
     "stats": {
-      "workload": "Workload",
-      "overview": "Overview",
-      "created": "Work items created",
-      "assigned": "Work items assigned",
-      "subscribed": "Work items subscribed",
+      "workload": "작업량",
+      "overview": "개요",
+      "created": "생성된 작업 항목",
+      "assigned": "할당된 작업 항목",
+      "subscribed": "구독된 작업 항목",
       "state_distribution": {
-        "title": "Work items by state",
-        "empty": "Create work items to view the them by states in the graph for better analysis."
+        "title": "상태별 작업 항목",
+        "empty": "작업 항목을 생성하여 상태별 그래프에서 분석을 확인하세요."
       },
       "priority_distribution": {
-        "title": "Work items by Priority",
-        "empty": "Create work items to view the them by priority in the graph for better analysis."
+        "title": "우선순위별 작업 항목",
+        "empty": "작업 항목을 생성하여 우선순위별 그래프에서 분석을 확인하세요."
       },
       "recent_activity": {
-        "title": "Recent activity",
-        "empty": "We couldn't find data. Kindly view your inputs",
-        "button": "Download today's activity",
-        "button_loading": "Downloading"
+        "title": "최근 활동",
+        "empty": "데이터를 찾을 수 없습니다. 입력을 확인하세요",
+        "button": "오늘의 활동 다운로드",
+        "button_loading": "다운로드 중"
       }
     },
     "actions": {
-      "profile": "Profile",
-      "security": "Security",
-      "activity": "Activity",
-      "appearance": "Appearance",
-      "notifications": "Notifications"
+      "profile": "프로필",
+      "security": "보안",
+      "activity": "활동",
+      "appearance": "외관",
+      "notifications": "알림"
     },
     "tabs": {
-      "summary": "Summary",
-      "assigned": "Assigned",
-      "created": "Created",
-      "subscribed": "Subscribed",
-      "activity": "Activity"
+      "summary": "요약",
+      "assigned": "할당됨",
+      "created": "생성됨",
+      "subscribed": "구독됨",
+      "activity": "활동"
     },
     "empty_state": {
       "activity": {
-        "title": "No activities yet",
-        "description": "Get started by creating a new work item! Add details and properties to it. Explore more in Plane to see your activity."
+        "title": "아직 활동 없음",
+        "description": "새 작업 항목을 생성하여 시작하세요! 세부 정보와 속성을 추가하세요. Plane에서 더 많은 것을 탐색하여 활동을 확인하세요."
       },
       "assigned": {
-        "title": "No work items are assigned to you",
-        "description": "Work items assigned to you can be tracked from here."
+        "title": "할당된 작업 항목 없음",
+        "description": "할당된 작업 항목을 여기에서 추적할 수 있습니다."
       },
       "created": {
-        "title": "No work items yet",
-        "description": "All work items created by you come here, track them here directly."
+        "title": "작업 항목 없음",
+        "description": "생성한 모든 작업 항목이 여기에 표시됩니다. 여기에서 직접 추적하세요."
       },
       "subscribed": {
-        "title": "No work items yet",
-        "description": "Subscribe to work items you are interested in, track all of them here."
+        "title": "작업 항목 없음",
+        "description": "관심 있는 작업 항목을 구독하고 여기에서 모두 추적하세요."
       }
     }
   },
 
   "project_settings": {
     "general": {
-      "enter_project_id": "Enter project ID",
-      "please_select_a_timezone": "Please select a timezone",
+      "enter_project_id": "프로젝트 ID 입력",
+      "please_select_a_timezone": "시간대를 선택하세요",
       "archive_project": {
-        "title": "Archive project",
-        "description": "Archiving a project will unlist your project from your side navigation although you will still be able to access it from your projects page. You can restore the project or delete it whenever you want.",
-        "button": "Archive project"
+        "title": "프로젝트 아카이브",
+        "description": "프로젝트를 아카이브하면 사이드 내비게이션에서 프로젝트가 목록에서 제외되지만 프로젝트 페이지에서 여전히 접근할 수 있습니다. 언제든지 프로젝트를 복원하거나 삭제할 수 있습니다.",
+        "button": "프로젝트 아카이브"
       },
       "delete_project": {
-        "title": "Delete project",
-        "description": "When deleting a project, all of the data and resources within that project will be permanently removed and cannot be recovered.",
-        "button": "Delete my project"
+        "title": "프로젝트 삭제",
+        "description": "프로젝트를 삭제하면 해당 프로젝트 내의 모든 데이터와 리소스가 영구적으로 삭제되며 복구할 수 없습니다.",
+        "button": "프로젝트 삭제"
       },
       "toast": {
-        "success": "Project updated successfully",
-        "error": "Project could not be updated. Please try again."
+        "success": "프로젝트가 성공적으로 업데이트되었습니다",
+        "error": "프로젝트를 업데이트할 수 없습니다. 다시 시도해주세요."
       }
     },
     "members": {
-      "label": "Members",
-      "project_lead": "Project lead",
-      "default_assignee": "Default assignee",
+      "label": "멤버",
+      "project_lead": "프로젝트 리드",
+      "default_assignee": "기본 담당자",
       "guest_super_permissions": {
-        "title": "Grant view access to all work items for guest users:",
-        "sub_heading": "This will allow guests to have view access to all the project work items."
+        "title": "게스트 사용자에게 모든 작업 항목에 대한 보기 권한 부여:",
+        "sub_heading": "이렇게 하면 게스트가 모든 프로젝트 작업 항목에 대한 보기 권한을 갖게 됩니다."
       },
       "invite_members": {
-        "title": "Invite members",
-        "sub_heading": "Invite members to work on your project.",
-        "select_co_worker": "Select co-worker"
+        "title": "멤버 초대",
+        "sub_heading": "프로젝트에서 작업할 멤버를 초대하세요.",
+        "select_co_worker": "동료 선택"
       }
     },
     "states": {
-      "describe_this_state_for_your_members": "Describe this state for your members.",
+      "describe_this_state_for_your_members": "멤버를 위해 이 상태를 설명하세요.",
       "empty_state": {
-        "title": "No states available for the {groupKey} group",
-        "description": "Please create a new state"
+        "title": "{groupKey} 그룹에 사용할 수 있는 상태 없음",
+        "description": "새 상태를 생성하세요"
       }
     },
     "labels": {
-      "label_title": "Label title",
-      "label_title_is_required": "Label title is required",
-      "label_max_char": "Label name should not exceed 255 characters",
+      "label_title": "레이블 제목",
+      "label_title_is_required": "레이블 제목이 필요합니다",
+      "label_max_char": "레이블 이름은 255자를 초과할 수 없습니다",
       "toast": {
-        "error": "Error while updating the label"
+        "error": "레이블 업데이트 중 오류 발생"
       }
     },
     "estimates": {
-      "title": "Enable estimates for my project",
-      "description": "They help you in communicating complexity and workload of the team."
+      "title": "프로젝트에 대한 추정 활성화",
+      "description": "팀의 복잡성과 작업량을 전달하는 데 도움이 됩니다."
     },
     "automations": {
-      "label": "Automations",
+      "label": "자동화",
       "auto-archive": {
-        "title": "Auto-archive closed work items",
-        "description": "Plane will auto archive work items that have been completed or canceled.",
-        "duration": "Auto-archive work items that are closed for"
+        "title": "닫힌 작업 항목 자동 아카이브",
+        "description": "Plane은 완료되거나 취소된 작업 항목을 자동으로 아카이브합니다.",
+        "duration": "닫힌 작업 항목을 자동 아카이브"
       },
       "auto-close": {
-        "title": "Auto-close work items",
-        "description": "Plane will automatically close work items that haven't been completed or canceled.",
-        "duration": "Auto-close work items that are inactive for",
-        "auto_close_status": "Auto-close status"
+        "title": "작업 항목 자동 닫기",
+        "description": "Plane은 완료되거나 취소되지 않은 작업 항목을 자동으로 닫습니다.",
+        "duration": "비활성 상태인 작업 항목 자동 닫기",
+        "auto_close_status": "자동 닫기 상태"
       }
     },
 
     "empty_state": {
       "labels": {
-        "title": "No labels yet",
-        "description": "Create labels to help organize and filter work items in you project."
+        "title": "레이블 없음",
+        "description": "프로젝트에서 작업 항목을 구성하고 필터링하는 데 도움이 되는 레이블을 생성하세요."
       },
       "estimates": {
-        "title": "No estimate systems yet",
-        "description": "Create a set of estimates to communicate the amount of work per work item.",
-        "primary_button": "Add estimate system"
+        "title": "추정 시스템 없음",
+        "description": "작업 항목당 작업량을 전달하는 추정 세트를 생성하세요.",
+        "primary_button": "추정 시스템 추가"
       }
     }
   },
 
   "project_cycles": {
-    "add_cycle": "Add cycle",
-    "more_details": "More details",
-    "cycle": "Cycle",
-    "update_cycle": "Update cycle",
-    "create_cycle": "Create cycle",
-    "no_matching_cycles": "No matching cycles",
-    "remove_filters_to_see_all_cycles": "Remove the filters to see all cycles",
-    "remove_search_criteria_to_see_all_cycles": "Remove the search criteria to see all cycles",
-    "only_completed_cycles_can_be_archived": "Only completed cycles can be archived",
+    "add_cycle": "주기 추가",
+    "more_details": "자세히 보기",
+    "cycle": "주기",
+    "update_cycle": "주기 업데이트",
+    "create_cycle": "주기 생성",
+    "no_matching_cycles": "일치하는 주기 없음",
+    "remove_filters_to_see_all_cycles": "모든 주기를 보려면 필터를 제거하세요",
+    "remove_search_criteria_to_see_all_cycles": "모든 주기를 보려면 검색 기준을 제거하세요",
+    "only_completed_cycles_can_be_archived": "완료된 주기만 아카이브할 수 있습니다",
     "active_cycle": {
-      "label": "Active cycle",
-      "progress": "Progress",
-      "chart": "Burndown chart",
-      "priority_issue": "Priority work items",
-      "assignees": "Assignees",
-      "issue_burndown": "Work item burndown",
-      "ideal": "Ideal",
-      "current": "Current",
-      "labels": "Labels"
+      "label": "활성 주기",
+      "progress": "진행",
+      "chart": "버다운 차트",
+      "priority_issue": "우선순위 작업 항목",
+      "assignees": "담당자",
+      "issue_burndown": "작업 항목 버다운",
+      "ideal": "이상적인",
+      "current": "현재",
+      "labels": "레이블"
     },
     "upcoming_cycle": {
-      "label": "Upcoming cycle"
+      "label": "다가오는 주기"
     },
     "completed_cycle": {
-      "label": "Completed cycle"
+      "label": "완료된 주기"
     },
     "status": {
-      "days_left": "Days left",
-      "completed": "Completed",
-      "yet_to_start": "Yet to start",
-      "in_progress": "In progress",
-      "draft": "Draft"
+      "days_left": "남은 일수",
+      "completed": "완료됨",
+      "yet_to_start": "시작되지 않음",
+      "in_progress": "진행 중",
+      "draft": "초안"
     },
     "action": {
       "restore": {
-        "title": "Restore cycle",
+        "title": "주기 복원",
         "success": {
-          "title": "Cycle restored",
-          "description": "The cycle has been restored."
+          "title": "주기 복원됨",
+          "description": "주기가 복원되었습니다."
         },
         "failed": {
-          "title": "Cycle restore failed",
-          "description": "The cycle could not be restored. Please try again."
+          "title": "주기 복원 실패",
+          "description": "주기를 복원할 수 없습니다. 다시 시도해주세요."
         }
       },
       "favorite": {
-        "loading": "Adding cycle to favorites",
+        "loading": "주기를 즐겨찾기에 추가 중",
         "success": {
-          "description": "Cycle added to favorites.",
-          "title": "Success!"
+          "description": "주기가 즐겨찾기에 추가되었습니다.",
+          "title": "성공!"
         },
         "failed": {
-          "description": "Couldn't add the cycle to favorites. Please try again.",
-          "title": "Error!"
+          "description": "주기를 즐겨찾기에 추가할 수 없습니다. 다시 시도해주세요.",
+          "title": "오류!"
         }
       },
       "unfavorite": {
-        "loading": "Removing cycle from favorites",
+        "loading": "주기를 즐겨찾기에서 제거 중",
         "success": {
-          "description": "Cycle removed from favorites.",
-          "title": "Success!"
+          "description": "주기가 즐겨찾기에서 제거되었습니다.",
+          "title": "성공!"
         },
         "failed": {
-          "description": "Couldn't remove the cycle from favorites. Please try again.",
-          "title": "Error!"
+          "description": "주기를 즐겨찾기에서 제거할 수 없습니다. 다시 시도해주세요.",
+          "title": "오류!"
         }
       },
       "update": {
-        "loading": "Updating cycle",
+        "loading": "주기 업데이트 중",
         "success": {
-          "description": "Cycle updated successfully.",
-          "title": "Success!"
+          "description": "주기가 성공적으로 업데이트되었습니다.",
+          "title": "성공!"
         },
         "failed": {
-          "description": "Error updating the cycle. Please try again.",
-          "title": "Error!"
+          "description": "주기 업데이트 중 오류 발생. 다시 시도해주세요.",
+          "title": "오류!"
         },
         "error": {
-          "already_exists": "You already have a cycle on the given dates, if you want to create a draft cycle, you can do that by removing both the dates."
+          "already_exists": "주어진 날짜에 이미 주기가 있습니다. 초안 주기를 생성하려면 두 날짜를 모두 제거하세요."
         }
       }
     },
     "empty_state": {
       "general": {
-        "title": "Group and timebox your work in Cycles.",
-        "description": "Break work down by timeboxed chunks, work backwards from your project deadline to set dates, and make tangible progress as a team.",
+        "title": "작업을 주기로 그룹화하고 시간 상자화하세요.",
+        "description": "작업을 시간 상자로 나누고, 프로젝트 마감일에서 역으로 날짜를 설정하며, 팀으로서 실질적인 진전을 이루세요.",
         "primary_button": {
-          "text": "Set your first cycle",
+          "text": "첫 번째 주기 설정",
           "comic": {
-            "title": "Cycles are repetitive time-boxes.",
-            "description": "A sprint, an iteration, and or any other term you use for weekly or fortnightly tracking of work is a cycle."
+            "title": "주기는 반복적인 시간 상자입니다.",
+            "description": "스프린트, 반복 또는 주간 또는 격주로 작업을 추적하는 데 사용하는 다른 용어는 모두 주기입니다."
           }
         }
       },
       "no_issues": {
-        "title": "No work items added to the cycle",
-        "description": "Add or create work items you wish to timebox and deliver within this cycle",
+        "title": "주기에 추가된 작업 항목 없음",
+        "description": "이 주기 내에서 시간 상자화하고 전달하려는 작업 항목을 추가하거나 생성하세요",
         "primary_button": {
-          "text": "Create new work item"
+          "text": "새 작업 항목 생성"
         },
         "secondary_button": {
-          "text": "Add existing work item"
+          "text": "기존 작업 항목 추가"
         }
       },
       "completed_no_issues": {
-        "title": "No work items in the cycle",
-        "description": "No work items in the cycle. Work items are either transferred or hidden. To see hidden work items if any, update your display properties accordingly."
+        "title": "주기에 작업 항목 없음",
+        "description": "주기에 작업 항목이 없습니다. 작업 항목이 전송되었거나 숨겨져 있습니다. 숨겨진 작업 항목을 보려면 표시 속성을 적절히 업데이트하세요."
       },
       "active": {
-        "title": "No active cycle",
-        "description": "An active cycle includes any period that encompasses today's date within its range. Find the progress and details of the active cycle here."
+        "title": "활성 주기 없음",
+        "description": "활성 주기에는 오늘 날짜가 범위 내에 포함된 모든 기간이 포함됩니다. 여기에서 활성 주기의 진행 상황과 세부 정보를 확인하세요."
       },
       "archived": {
-        "title": "No archived cycles yet",
-        "description": "To tidy up your project, archive completed cycles. Find them here once archived."
+        "title": "아카이브된 주기 없음",
+        "description": "프로젝트를 정리하려면 완료된 주기를 아카이브하세요. 아카이브된 주기는 여기에서 찾을 수 있습니다."
       }
     }
   },
@@ -1889,82 +1889,82 @@
   "project_issues": {
     "empty_state": {
       "no_issues": {
-        "title": "Create a work item and assign it to someone, even yourself",
-        "description": "Think of work items as jobs, tasks, work, or JTBD. Which we like. A work item and its sub-work items are usually time-based actionables assigned to members of your team. Your team creates, assigns, and completes work items to move your project towards its goal.",
+        "title": "작업 항목을 생성하고 누군가에게 할당하세요, 심지어 자신에게도",
+        "description": "작업 항목을 작업, 작업, 작업 또는 JTBD로 생각하세요. 작업 항목과 하위 작업 항목은 일반적으로 팀원에게 할당된 시간 기반 작업입니다. 팀은 작업 항목을 생성, 할당 및 완료하여 프로젝트 목표를 향해 나아갑니다.",
         "primary_button": {
-          "text": "Create your first work item",
+          "text": "첫 번째 작업 항목 생성",
           "comic": {
-            "title": "Work items are building blocks in Plane.",
-            "description": "Redesign the Plane UI, Rebrand the company, or Launch the new fuel injection system are examples of work items that likely have sub-work items."
+            "title": "작업 항목은 Plane의 구성 요소입니다.",
+            "description": "Plane UI 재설계, 회사 리브랜딩 또는 새로운 연료 주입 시스템 출시와 같은 작업 항목은 하위 작업 항목이 있을 가능성이 큽니다."
           }
         }
       },
       "no_archived_issues": {
-        "title": "No archived work items yet",
-        "description": "Manually or through automation, you can archive work items that are completed or cancelled. Find them here once archived.",
+        "title": "아카이브된 작업 항목 없음",
+        "description": "수동으로 또는 자동화를 통해 완료되거나 취소된 작업 항목을 아카이브할 수 있습니다. 아카이브된 항목은 여기에서 찾을 수 있습니다.",
         "primary_button": {
-          "text": "Set automation"
+          "text": "자동화 설정"
         }
       },
       "issues_empty_filter": {
-        "title": "No work items found matching the filters applied",
+        "title": "적용된 필터와 일치하는 작업 항목 없음",
         "secondary_button": {
-          "text": "Clear all filters"
+          "text": "모든 필터 지우기"
         }
       }
     }
   },
 
   "project_module": {
-    "add_module": "Add Module",
-    "update_module": "Update Module",
-    "create_module": "Create Module",
-    "archive_module": "Archive Module",
-    "restore_module": "Restore Module",
-    "delete_module": "Delete module",
+    "add_module": "모듈 추가",
+    "update_module": "모듈 업데이트",
+    "create_module": "모듈 생성",
+    "archive_module": "모듈 아카이브",
+    "restore_module": "모듈 복원",
+    "delete_module": "모듈 삭제",
     "empty_state": {
       "general": {
-        "title": "Map your project milestones to Modules and track aggregated work easily.",
-        "description": "A group of work items that belong to a logical, hierarchical parent form a module. Think of them as a way to track work by project milestones. They have their own periods and deadlines as well as analytics to help you see how close or far you are from a milestone.",
+        "title": "프로젝트 마일스톤을 모듈로 매핑하고 집계된 작업을 쉽게 추적하세요.",
+        "description": "논리적이고 계층적인 부모에 속하는 작업 항목 그룹이 모듈을 형성합니다. 이를 프로젝트 마일스톤별로 작업을 추적하는 방법으로 생각하세요. 모듈은 자체 기간과 마감일을 가지며, 마일스톤에 얼마나 가까운지 또는 먼지를 확인하는 데 도움이 되는 분석을 제공합니다.",
         "primary_button": {
-          "text": "Build your first module",
+          "text": "첫 번째 모듈 생성",
           "comic": {
-            "title": "Modules help group work by hierarchy.",
-            "description": "A cart module, a chassis module, and a warehouse module are all good example of this grouping."
+            "title": "모듈은 계층별로 작업을 그룹화하는 데 도움이 됩니다.",
+            "description": "카트 모듈, 섀시 모듈 및 창고 모듈은 모두 이 그룹화의 좋은 예입니다."
           }
         }
       },
       "no_issues": {
-        "title": "No work items in the module",
-        "description": "Create or add work items which you want to accomplish as part of this module",
+        "title": "모듈에 작업 항목 없음",
+        "description": "이 모듈의 일부로 완료하려는 작업 항목을 생성하거나 추가하세요",
         "primary_button": {
-          "text": "Create new work items"
+          "text": "새 작업 항목 생성"
         },
         "secondary_button": {
-          "text": "Add an existing work item"
+          "text": "기존 작업 항목 추가"
         }
       },
       "archived": {
-        "title": "No archived Modules yet",
-        "description": "To tidy up your project, archive completed or cancelled modules. Find them here once archived."
+        "title": "아카이브된 모듈 없음",
+        "description": "프로젝트를 정리하려면 완료되거나 취소된 모듈을 아카이브하세요. 아카이브된 모듈은 여기에서 찾을 수 있습니다."
       },
       "sidebar": {
-        "in_active": "This module isn't active yet.",
-        "invalid_date": "Invalid date. Please enter valid date."
+        "in_active": "이 모듈은 아직 활성화되지 않았습니다.",
+        "invalid_date": "유효하지 않은 날짜입니다. 유효한 날짜를 입력하세요."
       }
     },
     "quick_actions": {
-      "archive_module": "Archive module",
-      "archive_module_description": "Only completed or canceled\nmodule can be archived.",
-      "delete_module": "Delete module"
+      "archive_module": "모듈 아카이브",
+      "archive_module_description": "완료되거나 취소된 모듈만 아카이브할 수 있습니다.",
+      "delete_module": "모듈 삭제"
     },
     "toast": {
       "copy": {
-        "success": "Module link copied to clipboard"
+        "success": "모듈 링크가 클립보드에 복사되었습니다"
       },
       "delete": {
-        "success": "Module deleted successfully",
-        "error": "Failed to delete module"
+        "success": "모듈이 성공적으로 삭제되었습니다",
+        "error": "모듈 삭제 실패"
       }
     }
   },
@@ -1972,19 +1972,19 @@
   "project_views": {
     "empty_state": {
       "general": {
-        "title": "Save filtered views for your project. Create as many as you need",
-        "description": "Views are a set of saved filters that you use frequently or want easy access to. All your colleagues in a project can see everyone’s views and choose whichever suits their needs best.",
+        "title": "프로젝트에 대한 필터링된 뷰를 저장하세요. 필요한 만큼 생성하세요",
+        "description": "뷰는 자주 사용하는 필터 또는 쉽게 접근하고 싶은 필터 세트입니다. 프로젝트의 모든 동료가 모든 사람의 뷰를 보고 자신에게 가장 적합한 뷰를 선택할 수 있습니다.",
         "primary_button": {
-          "text": "Create your first view",
+          "text": "첫 번째 뷰 생성",
           "comic": {
-            "title": "Views work atop Work item properties.",
-            "description": "You can create a view from here with as many properties as filters as you see fit."
+            "title": "뷰는 작업 항목 속성 위에서 작동합니다.",
+            "description": "여기에서 원하는 만큼의 속성을 필터로 사용하여 뷰를 생성할 수 있습니다."
           }
         }
       },
       "filter": {
-        "title": "No matching views",
-        "description": "No views match the search criteria. \n Create a new view instead."
+        "title": "일치하는 뷰 없음",
+        "description": "검색 기준과 일치하는 뷰가 없습니다. 대신 새 뷰를 생성하세요."
       }
     }
   },
@@ -1992,29 +1992,29 @@
   "project_page": {
     "empty_state": {
       "general": {
-        "title": "Write a note, a doc, or a full knowledge base. Get Galileo, Plane's AI assistant, to help you get started",
-        "description": "Pages are thoughts potting space in Plane. Take down meeting notes, format them easily, embed work items, lay them out using a library of components, and keep them all in your project's context. To make short work of any doc, invoke Galileo, Plane's AI, with a shortcut or the click of a button.",
+        "title": "메모, 문서 또는 전체 지식 기반을 작성하세요. Galileo, Plane의 AI 도우미가 시작을 도와줍니다",
+        "description": "페이지는 Plane에서 생각을 정리하는 공간입니다. 회의 메모를 작성하고, 쉽게 형식을 지정하고, 작업 항목을 포함하고, 구성 요소 라이브러리를 사용하여 레이아웃을 작성하고, 모든 것을 프로젝트의 맥락에서 유지하세요. 문서를 빠르게 작성하려면 단축키나 버튼 클릭으로 Galileo, Plane의 AI를 호출하세요.",
         "primary_button": {
-          "text": "Create your first page"
+          "text": "첫 번째 페이지 생성"
         }
       },
       "private": {
-        "title": "No private pages yet",
-        "description": "Keep your private thoughts here. When you're ready to share, the team's just a click away.",
+        "title": "비공개 페이지 없음",
+        "description": "비공개 생각을 여기에 보관하세요. 공유할 준비가 되면 팀이 클릭 한 번으로 접근할 수 있습니다.",
         "primary_button": {
-          "text": "Create your first page"
+          "text": "첫 번째 페이지 생성"
         }
       },
       "public": {
-        "title": "No public pages yet",
-        "description": "See pages shared with everyone in your project right here.",
+        "title": "공개 페이지 없음",
+        "description": "프로젝트의 모든 사람과 공유된 페이지를 여기에서 확인하세요.",
         "primary_button": {
-          "text": "Create your first page"
+          "text": "첫 번째 페이지 생성"
         }
       },
       "archived": {
-        "title": "No archived pages yet",
-        "description": "Archive pages not on your radar. Access them here when needed."
+        "title": "아카이브된 페이지 없음",
+        "description": "레이더에 없는 페이지를 아카이브하세요. 필요할 때 여기에서 접근하세요."
       }
     }
   },
@@ -2022,7 +2022,7 @@
   "command_k": {
     "empty_state": {
       "search": {
-        "title": "No results found"
+        "title": "결과 없음"
       }
     }
   },
@@ -2030,10 +2030,10 @@
   "issue_relation": {
     "empty_state": {
       "search": {
-        "title": "No matching work items found"
+        "title": "일치하는 작업 항목 없음"
       },
       "no_issues": {
-        "title": "No work items found"
+        "title": "작업 항목 없음"
       }
     }
   },
@@ -2041,85 +2041,85 @@
   "issue_comment": {
     "empty_state": {
       "general": {
-        "title": "No comments yet",
-        "description": "Comments can be used as a discussion and follow-up space for the work items"
+        "title": "댓글 없음",
+        "description": "댓글은 작업 항목에 대한 토론 및 후속 공간으로 사용할 수 있습니다"
       }
     }
   },
 
   "notification": {
-    "label": "Inbox",
-    "page_label": "{workspace} - Inbox",
+    "label": "받은 편지함",
+    "page_label": "{workspace} - 받은 편지함",
     "options": {
-      "mark_all_as_read": "Mark all as read",
-      "mark_read": "Mark as read",
-      "mark_unread": "Mark as unread",
-      "refresh": "Refresh",
-      "filters": "Inbox Filters",
-      "show_unread": "Show unread",
-      "show_snoozed": "Show snoozed",
-      "show_archived": "Show archived",
-      "mark_archive": "Archive",
-      "mark_unarchive": "Un archive",
-      "mark_snooze": "Snooze",
-      "mark_unsnooze": "Un snooze"
+      "mark_all_as_read": "모두 읽음으로 표시",
+      "mark_read": "읽음으로 표시",
+      "mark_unread": "읽지 않음으로 표시",
+      "refresh": "새로 고침",
+      "filters": "받은 편지함 필터",
+      "show_unread": "읽지 않음 표시",
+      "show_snoozed": "미루기 표시",
+      "show_archived": "아카이브 표시",
+      "mark_archive": "아카이브",
+      "mark_unarchive": "아카이브 해제",
+      "mark_snooze": "미루기",
+      "mark_unsnooze": "미루기 해제"
     },
     "toasts": {
-      "read": "Notification marked as read",
-      "unread": "Notification marked as unread",
-      "archived": "Notification marked as archived",
-      "unarchived": "Notification marked as un archived",
-      "snoozed": "Notification snoozed",
-      "unsnoozed": "Notification un snoozed"
+      "read": "알림이 읽음으로 표시되었습니다",
+      "unread": "알림이 읽지 않음으로 표시되었습니다",
+      "archived": "알림이 아카이브되었습니다",
+      "unarchived": "알림이 아카이브 해제되었습니다",
+      "snoozed": "알림이 미루기되었습니다",
+      "unsnoozed": "알림이 미루기 해제되었습니다"
     },
     "empty_state": {
       "detail": {
-        "title": "Select to view details."
+        "title": "세부 정보를 보려면 선택하세요."
       },
       "all": {
-        "title": "No work items assigned",
-        "description": "Updates for work items assigned to you can be \n seen here"
+        "title": "할당된 작업 항목 없음",
+        "description": "할당된 작업 항목의 업데이트를 여기에서 확인할 수 있습니다"
       },
       "mentions": {
-        "title": "No work items assigned",
-        "description": "Updates for work items assigned to you can be \n seen here"
+        "title": "할당된 작업 항목 없음",
+        "description": "할당된 작업 항목의 업데이트를 여기에서 확인할 수 있습니다"
       }
     },
     "tabs": {
-      "all": "All",
-      "mentions": "Mentions"
+      "all": "모두",
+      "mentions": "멘션"
     },
     "filter": {
-      "assigned": "Assigned to me",
-      "created": "Created by me",
-      "subscribed": "Subscribed by me"
+      "assigned": "나에게 할당됨",
+      "created": "내가 생성함",
+      "subscribed": "내가 구독함"
     },
     "snooze": {
-      "1_day": "1 day",
-      "3_days": "3 days",
-      "5_days": "5 days",
-      "1_week": "1 week",
-      "2_weeks": "2 weeks",
-      "custom": "Custom"
+      "1_day": "1일",
+      "3_days": "3일",
+      "5_days": "5일",
+      "1_week": "1주",
+      "2_weeks": "2주",
+      "custom": "사용자 정의"
     }
   },
 
   "active_cycle": {
     "empty_state": {
       "progress": {
-        "title": "Add work items to the cycle to view it's progress"
+        "title": "주기에 작업 항목을 추가하여 진행 상황을 확인하세요"
       },
       "chart": {
-        "title": "Add work items to the cycle to view the burndown chart."
+        "title": "주기에 작업 항목을 추가하여 버다운 차트를 확인하세요."
       },
       "priority_issue": {
-        "title": "Observe high priority work items tackled in the cycle at a glance."
+        "title": "주기에서 처리된 고우선 작업 항목을 한눈에 확인하세요."
       },
       "assignee": {
-        "title": "Add assignees to work items to see a breakdown of work by assignees."
+        "title": "작업 항목에 담당자를 추가하여 담당자별 작업 분포를 확인하세요."
       },
       "label": {
-        "title": "Add labels to work items to see the breakdown of work by labels."
+        "title": "작업 항목에 레이블을 추가하여 레이블별 작업 분포를 확인하세요."
       }
     }
   },
@@ -2127,245 +2127,245 @@
   "disabled_project": {
     "empty_state": {
       "inbox": {
-        "title": "Intake is not enabled for the project.",
-        "description": "Intake helps you manage incoming requests to your project and add them as work items in your workflow. Enable intake from project settings to manage requests.",
+        "title": "프로젝트에 접수가 활성화되지 않았습니다.",
+        "description": "접수는 프로젝트로 들어오는 요청을 관리하고 이를 워크플로우의 작업 항목으로 추가하는 데 도움이 됩니다. 프로젝트 설정에서 접수를 활성화하여 요청을 관리하세요.",
         "primary_button": {
-          "text": "Manage features"
+          "text": "기능 관리"
         }
       },
       "cycle": {
-        "title": "Cycles is not enabled for this project.",
-        "description": "Break work down by timeboxed chunks, work backwards from your project deadline to set dates, and make tangible progress as a team. Enable the cycles feature for your project to start using them.",
+        "title": "이 프로젝트에 주기가 활성화되지 않았습니다.",
+        "description": "작업을 시간 상자로 나누고, 프로젝트 마감일에서 역으로 날짜를 설정하며, 팀으로서 실질적인 진전을 이루세요. 프로젝트에 주기 기능을 활성화하여 사용하세요.",
         "primary_button": {
-          "text": "Manage features"
+          "text": "기능 관리"
         }
       },
       "module": {
-        "title": "Modules are not enabled for the project.",
-        "description": "Modules are the building blocks of your project. Enable modules from project settings to start using them.",
+        "title": "프로젝트에 모듈이 활성화되지 않았습니다.",
+        "description": "모듈은 프로젝트의 구성 요소입니다. 프로젝트 설정에서 모듈을 활성화하여 사용하세요.",
         "primary_button": {
-          "text": "Manage features"
+          "text": "기능 관리"
         }
       },
       "page": {
-        "title": "Pages are not enabled for the project.",
-        "description": "Pages are the building blocks of your project. Enable pages from project settings to start using them.",
+        "title": "프로젝트에 페이지가 활성화되지 않았습니다.",
+        "description": "페이지는 프로젝트의 구성 요소입니다. 프로젝트 설정에서 페이지를 활성화하여 사용하세요.",
         "primary_button": {
-          "text": "Manage features"
+          "text": "기능 관리"
         }
       },
       "view": {
-        "title": "Views are not enabled for the project.",
-        "description": "Views are the building blocks of your project. Enable views from project settings to start using them.",
+        "title": "프로젝트에 뷰가 활성화되지 않았습니다.",
+        "description": "뷰는 프로젝트의 구성 요소입니다. 프로젝트 설정에서 뷰를 활성화하여 사용하세요.",
         "primary_button": {
-          "text": "Manage features"
+          "text": "기능 관리"
         }
       }
     }
   },
   "workspace_draft_issues": {
-    "draft_an_issue": "Draft a work item",
+    "draft_an_issue": "작업 항목 초안",
     "empty_state": {
-      "title": "Half-written work items, and soon, comments will show up here.",
-      "description": "To try this out, start adding a work item and leave it mid-way or create your first draft below. 😉",
+      "title": "작성 중인 작업 항목과 곧 댓글이 여기에 표시됩니다.",
+      "description": "이 기능을 사용해 보려면 작업 항목을 추가하고 중간에 멈추거나 아래에서 첫 번째 초안을 생성하세요. 😉",
       "primary_button": {
-        "text": "Create your first draft"
+        "text": "첫 번째 초안 생성"
       }
     },
     "delete_modal": {
-      "title": "Delete draft",
-      "description": "Are you sure you want to delete this draft? This can't be undone."
+      "title": "초안 삭제",
+      "description": "이 초안을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
     },
     "toasts": {
       "created": {
-        "success": "Draft created",
-        "error": "Work item could not be created. Please try again."
+        "success": "초안 생성됨",
+        "error": "작업 항목을 생성할 수 없습니다. 다시 시도해주세요."
       },
       "deleted": {
-        "success": "Draft deleted"
+        "success": "초안 삭제됨"
       }
     }
   },
 
   "stickies": {
-    "title": "Your stickies",
-    "placeholder": "click to type here",
-    "all": "All stickies",
-    "no-data": "Jot down an idea, capture an aha, or record a brainwave. Add a sticky to get started.",
-    "add": "Add sticky",
-    "search_placeholder": "Search by title",
-    "delete": "Delete sticky",
-    "delete_confirmation": "Are you sure you want to delete this sticky?",
+    "title": "나의 스티키",
+    "placeholder": "여기에 입력하려면 클릭하세요",
+    "all": "모든 스티키",
+    "no-data": "아이디어를 적어두거나, 유레카를 기록하거나, 영감을 기록하세요. 스티키를 추가하여 시작하세요.",
+    "add": "스티키 추가",
+    "search_placeholder": "제목으로 검색",
+    "delete": "스티키 삭제",
+    "delete_confirmation": "이 스티키를 삭제하시겠습니까?",
     "empty_state": {
-      "simple": "Jot down an idea, capture an aha, or record a brainwave. Add a sticky to get started.",
+      "simple": "아이디어를 적어두거나, 유레카를 기록하거나, 영감을 기록하세요. 스티키를 추가하여 시작하세요.",
       "general": {
-        "title": "Stickies are quick notes and to-dos you take down on the fly.",
-        "description": "Capture your thoughts and ideas effortlessly by creating stickies that you can access anytime and from anywhere.",
+        "title": "스티키는 즉석에서 작성하는 빠른 메모와 할 일입니다.",
+        "description": "스티키를 생성하여 생각과 아이디어를 쉽게 캡처하고 언제 어디서나 접근할 수 있습니다.",
         "primary_button": {
-          "text": "Add sticky"
+          "text": "스티키 추가"
         }
       },
       "search": {
-        "title": "That doesn't match any of your stickies.",
-        "description": "Try a different term or let us know\nif you are sure your search is right. ",
+        "title": "일치하는 스티키가 없습니다.",
+        "description": "다른 용어를 시도하거나 검색이 올바른지 확신하는 경우 알려주세요.",
         "primary_button": {
-          "text": "Add sticky"
+          "text": "스티키 추가"
         }
       }
     },
     "toasts": {
       "errors": {
-        "wrong_name": "The sticky name cannot be longer than 100 characters.",
-        "already_exists": "There already exists a sticky with no description"
+        "wrong_name": "스티키 이름은 100자를 초과할 수 없습니다.",
+        "already_exists": "설명이 없는 스티키가 이미 존재합니다"
       },
       "created": {
-        "title": "Sticky created",
-        "message": "The sticky has been successfully created"
+        "title": "스티키 생성됨",
+        "message": "스티키가 성공적으로 생성되었습니다"
       },
       "not_created": {
-        "title": "Sticky not created",
-        "message": "The sticky could not be created"
+        "title": "스티키 생성되지 않음",
+        "message": "스티키를 생성할 수 없습니다"
       },
       "updated": {
-        "title": "Sticky updated",
-        "message": "The sticky has been successfully updated"
+        "title": "스티키 업데이트됨",
+        "message": "스티키가 성공적으로 업데이트되었습니다"
       },
       "not_updated": {
-        "title": "Sticky not updated",
-        "message": "The sticky could not be updated"
+        "title": "스티키 업데이트되지 않음",
+        "message": "스티키를 업데이트할 수 없습니다"
       },
       "removed": {
-        "title": "Sticky removed",
-        "message": "The sticky has been successfully removed"
+        "title": "스티키 제거됨",
+        "message": "스티키가 성공적으로 제거되었습니다"
       },
       "not_removed": {
-        "title": "Sticky not removed",
-        "message": "The sticky could not be removed"
+        "title": "스티키 제거되지 않음",
+        "message": "스티키를 제거할 수 없습니다"
       }
     }
   },
 
   "role_details": {
     "guest": {
-      "title": "Guest",
-      "description": "External members of organizations can be invited as guests."
+      "title": "게스트",
+      "description": "조직의 외부 멤버는 게스트로 초대될 수 있습니다."
     },
     "member": {
-      "title": "Member",
-      "description": "Ability to read, write, edit, and delete entities inside projects, cycles, and modules"
+      "title": "멤버",
+      "description": "프로젝트, 주기 및 모듈 내에서 엔티티를 읽고, 쓰고, 편집하고, 삭제할 수 있는 권한"
     },
     "admin": {
-      "title": "Admin",
-      "description": "All permissions set to true within the workspace."
+      "title": "관리자",
+      "description": "작업 공간 내에서 모든 권한이 true로 설정됨."
     }
   },
 
   "user_roles": {
-    "product_or_project_manager": "Product / Project Manager",
-    "development_or_engineering": "Development / Engineering",
-    "founder_or_executive": "Founder / Executive",
-    "freelancer_or_consultant": "Freelancer / Consultant",
-    "marketing_or_growth": "Marketing / Growth",
-    "sales_or_business_development": "Sales / Business Development",
-    "support_or_operations": "Support / Operations",
-    "student_or_professor": "Student / Professor",
-    "human_resources": "Human / Resources",
-    "other": "Other"
+    "product_or_project_manager": "제품 / 프로젝트 관리자",
+    "development_or_engineering": "개발 / 엔지니어링",
+    "founder_or_executive": "창립자 / 임원",
+    "freelancer_or_consultant": "프리랜서 / 컨설턴트",
+    "marketing_or_growth": "마케팅 / 성장",
+    "sales_or_business_development": "영업 / 비즈니스 개발",
+    "support_or_operations": "지원 / 운영",
+    "student_or_professor": "학생 / 교수",
+    "human_resources": "인사 / 자원",
+    "other": "기타"
   },
 
   "importer": {
     "github": {
       "title": "Github",
-      "description": "Import work items from GitHub repositories and sync them."
+      "description": "GitHub 저장소에서 작업 항목을 가져오고 동기화합니다."
     },
     "jira": {
       "title": "Jira",
-      "description": "Import work items and epics from Jira projects and epics."
+      "description": "Jira 프로젝트 및 에픽에서 작업 항목과 에픽을 가져옵니다."
     }
   },
 
   "exporter": {
     "csv": {
       "title": "CSV",
-      "description": "Export work items to a CSV file.",
-      "short_description": "Export as csv"
+      "description": "작업 항목을 CSV 파일로 내보냅니다.",
+      "short_description": "CSV로 내보내기"
     },
     "excel": {
       "title": "Excel",
-      "description": "Export work items to a Excel file.",
-      "short_description": "Export as excel"
+      "description": "작업 항목을 Excel 파일로 내보냅니다.",
+      "short_description": "Excel로 내보내기"
     },
     "xlsx": {
       "title": "Excel",
-      "description": "Export work items to a Excel file.",
-      "short_description": "Export as excel"
+      "description": "작업 항목을 Excel 파일로 내보냅니다.",
+      "short_description": "Excel로 내보내기"
     },
     "json": {
       "title": "JSON",
-      "description": "Export work items to a JSON file.",
-      "short_description": "Export as json"
+      "description": "작업 항목을 JSON 파일로 내보냅니다.",
+      "short_description": "JSON으로 내보내기"
     }
   },
   "default_global_view": {
-    "all_issues": "All work items",
-    "assigned": "Assigned",
-    "created": "Created",
-    "subscribed": "Subscribed"
+    "all_issues": "모든 작업 항목",
+    "assigned": "할당됨",
+    "created": "생성됨",
+    "subscribed": "구독됨"
   },
 
   "themes": {
     "theme_options": {
       "system_preference": {
-        "label": "System preference"
+        "label": "시스템 기본값"
       },
       "light": {
-        "label": "Light"
+        "label": "라이트"
       },
       "dark": {
-        "label": "Dark"
+        "label": "다크"
       },
       "light_contrast": {
-        "label": "Light high contrast"
+        "label": "라이트 고대비"
       },
       "dark_contrast": {
-        "label": "Dark high contrast"
+        "label": "다크 고대비"
       },
       "custom": {
-        "label": "Custom theme"
+        "label": "사용자 정의 테마"
       }
     }
   },
   "project_modules": {
     "status": {
-      "backlog": "Backlog",
-      "planned": "Planned",
-      "in_progress": "In Progress",
-      "paused": "Paused",
-      "completed": "Completed",
-      "cancelled": "Cancelled"
+      "backlog": "백로그",
+      "planned": "계획됨",
+      "in_progress": "진행 중",
+      "paused": "일시 중지됨",
+      "completed": "완료됨",
+      "cancelled": "취소됨"
     },
     "layout": {
-      "list": "List layout",
-      "board": "Gallery layout",
-      "timeline": "Timeline layout"
+      "list": "목록 레이아웃",
+      "board": "갤러리 레이아웃",
+      "timeline": "타임라인 레이아웃"
     },
     "order_by": {
-      "name": "Name",
-      "progress": "Progress",
-      "issues": "Number of work items",
-      "due_date": "Due date",
-      "created_at": "Created date",
-      "manual": "Manual"
+      "name": "이름",
+      "progress": "진행",
+      "issues": "작업 항목 수",
+      "due_date": "마감일",
+      "created_at": "생성일",
+      "manual": "수동"
     }
   },
 
   "cycle": {
-    "label": "{count, plural, one {Cycle} other {Cycles}}",
-    "no_cycle": "No cycle"
+    "label": "{count, plural, one {주기} other {주기}}",
+    "no_cycle": "주기 없음"
   },
 
   "module": {
-    "label": "{count, plural, one {Module} other {Modules}}",
-    "no_module": "No module"
+    "label": "{count, plural, one {모듈} other {모듈}}",
+    "no_module": "모듈 없음"
   }
 }

--- a/packages/i18n/src/store/index.ts
+++ b/packages/i18n/src/store/index.ts
@@ -153,6 +153,8 @@ export class TranslationStore {
         return import("../locales/it/translations.json");
       case "cs":
         return import("../locales/cs/translations.json");
+      case "ko":
+        return import("../locales/ko/translations.json");
       default:
         throw new Error(`Unsupported language: ${language}`);
     }

--- a/packages/i18n/src/types/language.ts
+++ b/packages/i18n/src/types/language.ts
@@ -1,4 +1,4 @@
-export type TLanguage = "en" | "fr" | "es" | "ja" | "zh-CN" | "ru" | "it" | "cs";
+export type TLanguage = "en" | "fr" | "es" | "ja" | "zh-CN" | "ru" | "it" | "cs" | "ko";
 
 export interface ILanguageOption {
   label: string;


### PR DESCRIPTION
### **Description**  
This PR introduces Korean translations for UI labels used across the application.  
It ensures consistency, improves readability, and aligns with common Korean UI conventions.

---

### **Translation Guidelines**  

#### **1. Prioritising natural translation over word-for-word conversion**  
Korean translations focus on fluency rather than direct word-for-word accuracy.  
For example:  
- `"Your account"` → `"나의 계정"`  
  - The word "Your" is commonly used in English UI, but "My" ("나의") provides a more natural user experience in Korean.  

#### **2. Maintaining polite and formal language**  
Korean UI texts generally adopt a polite tone.  
For example:  
- `"Forgot your password?"` → `"비밀번호를 잊으셨나요?"`  
  - The verb ending `-셨나요?` is an honorific form, enhancing user-friendliness.  

#### **3. Avoiding direct second-person pronouns ("You")**  
Unlike English, Korean UI rarely uses direct second-person pronouns ("You"). Instead, sentences are restructured.  
For example:  
- `"Your workspace"` → `"작업 공간"` (instead of `"너의 작업 공간"`)  
  - Personal pronouns like "너의" are typically avoided in formal UI contexts.  

#### **4. Using functional and role-based translations**  
Translations prioritise clarity and align with standard terminology in development and project management.  
For example:  
- `"Work Items"` → `"작업 항목"`  
  - The term "항목" (item) is widely used in project management and development tools.  

---

### **Key Changes**  
✅ Added Korean translations to `ko/translations.json`, based on `en/translations.json`.  
✅ Ensured all keys were translated with no missing entries (automated validation passed).  
✅ Adjusted direct translations to improve readability and contextual accuracy.  

---

### **Consistency Check**  
To maintain a uniform translation approach, key terms were consistently translated:

| **English**          | **Korean Translation**   | **Notes** |
|----------------------|------------------------|-----------|
| Your account        | 나의 계정                | "너의" replaced with "나의" for better UX |
| Work Item(s)        | 작업 항목                | Unified across all references |
| Sign in             | 로그인                   | Consistently translated as "로그인" |
| Sign up             | 가입                     | Preferred over "회원가입" for simplicity |
| Forgot your password? | 비밀번호를 잊으셨나요? | Polite form applied |
| Reset password      | 비밀번호 재설정           | UI-friendly translation |
| Home               | 홈                      | Commonly used in Korean UI |
| Inbox              | 받은 편지함               | Matches email and notification context |
| Analytics          | 분석                     | Standard translation for data-related contexts |
| Projects          | 프로젝트                  | Retained in original form |
| Modules           | 모듈                     | Retained in original form |
| Cycles            | 주기                     | Contextually appropriate in development terminology |
| Upgrade           | 업그레이드                | Kept as "업그레이드" for familiarity |
| Settings          | 설정                     | Common UI term in Korean |

---

### **Concerns & Review Requests**  

#### **1. Phrases that may feel unnatural in Korean**  
- Expressions like `"Good morning"` and `"Good afternoon"` were translated as `"좋은 아침"` and `"좋은 오후"`, respectively.  
- However, such expressions are rarely used in everyday Korean and may need alternative translations based on UI placement.  

#### **2. Contextual Accuracy in UI**  
- `"Sign in"` is translated as `"로그인"`, but `"Sign in to your account"` is adapted as `"내 계정에 로그인"` for clarity.  
- Reviewers should verify whether these translations fit naturally within the UI context.  

📌 **Reviewers, please confirm whether the translations feel natural within the UI.**  
📌 **Feedback on any awkward or inconsistent expressions would be greatly appreciated.**  

Thank you! 🙏🚀  


### **Additional Notes**  

#### **1. Translation Scope**  
Currently, only the **Community Edition** has been translated into Korean.  
For translations of other versions, please reach out individually for further discussion.  

#### **2. Development Environment Issues**  
Due to persistent 502 errors from the next build process, fine-tuning is completely blocked at this stage
This issue has significantly impacted progress, and further adjustments will be required once the environment stabilises.  

Thank you for your understanding.  

---

### **Type of Change**  
<!-- Put an 'x' in the boxes that apply -->  
- [ ] Bug fix (non-breaking change that fixes an issue)  
- [x] Feature (non-breaking change that adds functionality)  
- [ ] Improvement (change that alters existing functionality)  
- [ ] Code refactoring  
- [ ] Performance improvements  
- [ ] Documentation update  

---

### **Screenshots and Media (if applicable)**  
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->  

---

### **Test Scenarios**  
<!-- Please describe the tests performed to verify the changes -->  
- Automated validation to check for missing translation keys.  
- Manual verification of key translations for consistency.  
- Pending UI review to assess natural language flow.  

---

### **References**  
<!-- Link related issues if applicable -->  
N/A  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced Korean language support to expand the list of available languages.
	- Delivered comprehensive Korean translations across the user interface, enhancing the overall localization experience including navigation, authentication, error messages, and other UI components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->