### PR TITLE
[WEB-3580] fix: automations settings translation

### DIFF
--- a/packages/constants/src/project.ts
+++ b/packages/constants/src/project.ts
@@ -1,8 +1,5 @@
 // icons
-import {
-  TProjectAppliedDisplayFilterKeys,
-  TProjectOrderByOptions,
-} from "@plane/types";
+import { TProjectAppliedDisplayFilterKeys, TProjectOrderByOptions } from "@plane/types";
 
 export type TNetworkChoiceIconKey = "Lock" | "Globe2";
 
@@ -55,11 +52,11 @@ export const GROUP_CHOICES = {
 };
 
 export const PROJECT_AUTOMATION_MONTHS = [
-  { i18n_label: "common.months_count", value: 1 },
-  { i18n_label: "common.months_count", value: 3 },
-  { i18n_label: "common.months_count", value: 6 },
-  { i18n_label: "common.months_count", value: 9 },
-  { i18n_label: "common.months_count", value: 12 },
+  { i18n_label: "workspace_projects.common.months_count", value: 1 },
+  { i18n_label: "workspace_projects.common.months_count", value: 3 },
+  { i18n_label: "workspace_projects.common.months_count", value: 6 },
+  { i18n_label: "workspace_projects.common.months_count", value: 9 },
+  { i18n_label: "workspace_projects.common.months_count", value: 12 },
 ];
 
 export const PROJECT_UNSPLASH_COVERS = [

--- a/web/core/components/automation/auto-archive-automation.tsx
+++ b/web/core/components/automation/auto-archive-automation.tsx
@@ -97,7 +97,7 @@ export const AutoArchiveAutomation: React.FC<Props> = observer((props) => {
                     <>
                       {PROJECT_AUTOMATION_MONTHS.map((month) => (
                         <CustomSelect.Option key={month.i18n_label} value={month.value}>
-                          <span className="text-sm">{t(month.i18n_label, { month: month.value })}</span>
+                          <span className="text-sm">{t(month.i18n_label, { months: month.value })}</span>
                         </CustomSelect.Option>
                       ))}
 
@@ -106,7 +106,7 @@ export const AutoArchiveAutomation: React.FC<Props> = observer((props) => {
                         className="flex w-full select-none items-center rounded px-1 py-1.5 text-sm text-custom-text-200 hover:bg-custom-background-80"
                         onClick={() => setmonthModal(true)}
                       >
-                        {t("customize_time_range")}
+                        {t("common.customize_time_range")}
                       </button>
                     </>
                   </CustomSelect>

--- a/web/core/components/automation/auto-close-automation.tsx
+++ b/web/core/components/automation/auto-close-automation.tsx
@@ -124,7 +124,7 @@ export const AutoCloseAutomation: React.FC<Props> = observer((props) => {
                       <>
                         {PROJECT_AUTOMATION_MONTHS.map((month) => (
                           <CustomSelect.Option key={month.i18n_label} value={month.value}>
-                            {t(month.i18n_label, { month: month.value })}
+                            {t(month.i18n_label, { months: month.value })}
                           </CustomSelect.Option>
                         ))}
                         <button
@@ -132,7 +132,7 @@ export const AutoCloseAutomation: React.FC<Props> = observer((props) => {
                           className="flex w-full select-none items-center rounded px-1 py-1.5 text-custom-text-200 hover:bg-custom-background-80"
                           onClick={() => setmonthModal(true)}
                         >
-                          {t("customize_time_range")}
+                          {t("common.customize_time_range")}
                         </button>
                       </>
                     </CustomSelect>


### PR DESCRIPTION
### Description
This PR fixes the translation bug in the automation setting date range selector.

### Type of Change
- [x] Bug fix

### References
[[WEB-3580]](https://app.plane.so/plane/browse/WEB-3580/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated translation keys used in automation features to ensure accurate pluralization for month labels and clearer text for time range customization.
	- These improvements result in a more consistent and coherent user interface, enhancing the overall experience when managing project automation settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->