### PR TITLE
[WEB-3286] fix: allow admins to delete other admins views

### DIFF
--- a/apiserver/plane/app/views/view/base.py
+++ b/apiserver/plane/app/views/view/base.py
@@ -116,7 +116,9 @@ class WorkspaceViewViewSet(BaseViewSet):
         )
         return Response(serializer.data, status=status.HTTP_200_OK)
 
-    @allow_permission(allowed_roles=[ROLE.ADMIN, ROLE.MEMBER], level="WORKSPACE")
+    @allow_permission(
+        allowed_roles=[ROLE.ADMIN], level="WORKSPACE", creator=True, model=IssueView
+    )
     def destroy(self, request, slug, pk):
         workspace_view = IssueView.objects.get(pk=pk, workspace__slug=slug)
 

--- a/apiserver/plane/app/views/view/base.py
+++ b/apiserver/plane/app/views/view/base.py
@@ -116,9 +116,7 @@ class WorkspaceViewViewSet(BaseViewSet):
         )
         return Response(serializer.data, status=status.HTTP_200_OK)
 
-    @allow_permission(
-        allowed_roles=[], level="WORKSPACE", creator=True, model=IssueView
-    )
+    @allow_permission(allowed_roles=[ROLE.ADMIN, ROLE.MEMBER], level="WORKSPACE")
     def destroy(self, request, slug, pk):
         workspace_view = IssueView.objects.get(pk=pk, workspace__slug=slug)
 


### PR DESCRIPTION
### Description
This PR will allow admins to delete a view created by other admins

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Adjusted deletion permissions to restrict this action to administrators only, enhancing overall security and ensuring that only authorized users can perform deletions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->