### PR TITLE
[WEB-2057]fix: fixed page title reset 

### DIFF
--- a/packages/ui/src/hooks/use-page-title.tsx
+++ b/packages/ui/src/hooks/use-page-title.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+import { SITE_TITLE } from "@plane/constants";
 
 interface IUseHeadParams {
   title?: string;
@@ -7,7 +8,9 @@ interface IUseHeadParams {
 export const useHead = ({ title }: IUseHeadParams) => {
   useEffect(() => {
     if (title) {
-      document.title = title ?? "Plane | Simple, extensible, open-source project management tool.";
+      document.title = title;
+    } else {
+      document.title = SITE_TITLE;
     }
   }, [title]);
 };

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -8,13 +8,13 @@ import "@/styles/react-day-picker.css";
 // meta data info
 
 import { SITE_DESCRIPTION, SITE_NAME } from "@plane/constants";
+import { PageHead } from "@/components/core";
 // helpers
 import { API_BASE_URL, cn } from "@/helpers/common.helper";
 // local
 import { AppProvider } from "./provider";
 
 export const metadata: Metadata = {
-  title: "Plane | Simple, extensible, open-source project management tool.",
   description: SITE_DESCRIPTION,
   openGraph: {
     title: "Plane | Simple, extensible, open-source project management tool.",
@@ -74,6 +74,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       </head>
       <body>
         <div id="context-menu-portal" />
+        <PageHead />
         <AppProvider>
           <div
             className={cn(

--- a/web/core/components/core/page-title.tsx
+++ b/web/core/components/core/page-title.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useHead } from "@plane/ui";
 
 type PageHeadTitleProps = {


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
Fixed page title reset while navigation.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
<!-- Link related issues if there are any -->
[WEB-2057](https://app.plane.so/plane/browse/WEB-2057/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved dynamic page title behavior: custom titles are now prioritized, while a centralized default is applied when absent.
  - Upgraded layout integration with a dedicated header for managing metadata to enhance page consistency.

- **Chores**
  - Optimized title management components for client-side rendering to ensure smoother performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->