### PR TITLE
[RANTS-65] fix: `undefined` work item sequence in bulk delete work item  modal

### DIFF
--- a/web/core/components/core/modals/bulk-delete-issues-modal-item.tsx
+++ b/web/core/components/core/modals/bulk-delete-issues-modal-item.tsx
@@ -34,7 +34,13 @@ export const BulkDeleteIssuesModalItem: React.FC<Props> = observer((props: Props
             backgroundColor: color,
           }}
         />
-        <IssueIdentifier issueId={issue.id} projectId={issue.project_id} textContainerClassName="text-xs" />
+        <IssueIdentifier
+          projectId={issue.project_id}
+          issueTypeId={issue.type_id}
+          projectIdentifier={issue.project__identifier}
+          issueSequenceId={issue.sequence_id}
+          textContainerClassName="text-xs"
+        />
         <span>{issue.name}</span>
       </div>
     </Combobox.Option>


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
The Work Item sequence ID was appearing as `undefined` in the bulk delete Work Item modal because we were relying on the store to retrieve Work Item details. However, since this is a search endpoint, not all details are available in the store. Instead of relying on the store, we should directly display the sequence ID using the data already available, as we have all the necessary information to construct it.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->
![image](https://github.com/user-attachments/assets/f6161ac5-aa2b-43ba-8b1c-836e53540be4)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced the bulk deletion modal to display additional, more detailed issue identifiers. This update improves clarity during the deletion process, ensuring users have greater context when managing issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->