### PR TITLE
[WEB-3614] fix: cmd-k items

### DIFF
--- a/web/styles/command-pallette.css
+++ b/web/styles/command-pallette.css
@@ -30,7 +30,7 @@
   background-color: rgba(var(--color-background-100));
 }
 
-[cmdk-item]:hover {
+[cmdk-item]:focus {
   background-color: rgba(var(--color-background-80));
 }
 
@@ -45,7 +45,7 @@
   background-color: transparent;
 }
 
-[cmdk-item][aria-disabled="true"]:hover,
-[cmdk-item][data-disabled="true"]:hover {
+[cmdk-item][aria-disabled="true"]:focus,
+[cmdk-item][data-disabled="true"]:focus {
   background-color: rgba(var(--color-background-80), 0.7);
 }


### PR DESCRIPTION
### Description
This PR fixes an issue in the Command + K menu where hovering over an item and using the up/down arrow keys simultaneously caused two selections to appear.

### Type of Change
- [x] Bug fix 

### Media
| Before | After |
|--------|--------|
| ![before](https://github.com/user-attachments/assets/47f9cbe2-87a2-4725-9526-7614482f4621) | ![after](https://github.com/user-attachments/assets/70076fbe-3ad9-4e9d-b81f-87d577c92243) |

### References
[[WEB-3614]](https://app.plane.so/plane/browse/WEB-3614/)