### PR TITLE
[RANTS-57] chore: replace target date with due date in work item filters dropdown

### DIFF
--- a/web/core/components/issues/issue-layouts/filters/header/filters/due-date.tsx
+++ b/web/core/components/issues/issue-layouts/filters/header/filters/due-date.tsx
@@ -12,7 +12,7 @@ type Props = {
   searchQuery: string;
 };
 
-export const FilterTargetDate: React.FC<Props> = observer((props) => {
+export const FilterDueDate: React.FC<Props> = observer((props) => {
   const { appliedFilters, handleUpdate, searchQuery } = props;
 
   const [previewEnabled, setPreviewEnabled] = useState(true);
@@ -46,7 +46,7 @@ export const FilterTargetDate: React.FC<Props> = observer((props) => {
         />
       )}
       <FilterHeader
-        title={`Target date${appliedFiltersCount > 0 ? ` (${appliedFiltersCount})` : ""}`}
+        title={`Due date${appliedFiltersCount > 0 ? ` (${appliedFiltersCount})` : ""}`}
         isPreviewEnabled={previewEnabled}
         handleIsPreviewEnabled={() => setPreviewEnabled(!previewEnabled)}
       />

--- a/web/core/components/issues/issue-layouts/filters/header/filters/filters-selection.tsx
+++ b/web/core/components/issues/issue-layouts/filters/header/filters/filters-selection.tsx
@@ -18,13 +18,13 @@ import {
   FilterAssignees,
   FilterMentions,
   FilterCreatedBy,
+  FilterDueDate,
   FilterLabels,
   FilterPriority,
   FilterProjects,
   FilterStartDate,
   FilterState,
   FilterStateGroup,
-  FilterTargetDate,
   FilterCycle,
   FilterModule,
   FilterIssueGrouping,
@@ -276,7 +276,7 @@ export const FilterSelection: React.FC<Props> = observer((props) => {
         {/* target_date */}
         {isFilterEnabled("target_date") && (
           <div className="py-2">
-            <FilterTargetDate
+            <FilterDueDate
               appliedFilters={filters.target_date ?? null}
               handleUpdate={(val) => handleFiltersUpdate("target_date", val)}
               searchQuery={filtersSearchQuery}

--- a/web/core/components/issues/issue-layouts/filters/header/filters/index.ts
+++ b/web/core/components/issues/issue-layouts/filters/header/filters/index.ts
@@ -1,6 +1,7 @@
 export * from "./assignee";
 export * from "./mentions";
 export * from "./created-by";
+export * from "./due-date";
 export * from "./filters-selection";
 export * from "./labels";
 export * from "./priority";
@@ -10,4 +11,3 @@ export * from "./state-group";
 export * from "./state";
 export * from "./cycle";
 export * from "./module";
-export * from "./target-date";


### PR DESCRIPTION
### Description

This PR fixes the incorrect terminology used in the work item filters dropdown where `Due date` was incorrectly termed `Target date`.

### Type of Change

- [x] Improvement (change that would cause existing functionality to not work as expected)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the issue filter header to display “Due Date” instead of “Target Date,” providing clearer labeling for filtering by dates while maintaining the existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->