### PR TITLE
[RANTS-75] chore: update profile sidebar icons and copy for consistency

### DIFF
--- a/web/app/profile/sidebar.tsx
+++ b/web/app/profile/sidebar.tsx
@@ -9,13 +9,13 @@ import {
   ChevronLeft,
   LogOut,
   MoveLeft,
-  Plus,
-  UserPlus,
   Activity,
   Bell,
   CircleUser,
   KeyRound,
   Settings2,
+  CirclePlus,
+  Mails,
 } from "lucide-react";
 // plane imports
 import { PROFILE_ACTION_LINKS } from "@plane/constants";
@@ -35,14 +35,14 @@ import { usePlatformOS } from "@/hooks/use-platform-os";
 const WORKSPACE_ACTION_LINKS = [
   {
     key: "create_workspace",
-    Icon: Plus,
-    label: "Create workspace",
+    Icon: CirclePlus,
+    i18n_label: "create_workspace",
     href: "/create-workspace",
   },
   {
     key: "invitations",
-    Icon: UserPlus,
-    label: "Invitations",
+    Icon: Mails,
+    i18n_label: "workspace_invites",
     href: "/invitations",
   },
 ];
@@ -243,8 +243,8 @@ export const ProfileLayoutSidebar = observer(() => {
                       sidebarCollapsed ? "justify-center" : ""
                     }`}
                   >
-                    {<link.Icon className="h-4 w-4" />}
-                    {!sidebarCollapsed && t(link.key)}
+                    {<link.Icon className="flex-shrink-0 size-4" />}
+                    {!sidebarCollapsed && t(link.i18n_label)}
                   </div>
                 </Tooltip>
               </Link>


### PR DESCRIPTION
### Description

This PR updates the icons and UX copy of the extra items in the profile sidebar to match with the ones in the workspace switcher dropdown.

### Type of Change

- [x] Improvement (change that would cause existing functionality to not work as expected)

### Screenshots

| Workspace switcher | Profile sidebar(Before) | Profile sidebar(after) |
|--------|--------|--------|
| <img width="329" alt="image" src="https://github.com/user-attachments/assets/0b1fff0d-7e9f-4e34-9fc4-7b9feddc28ca" /> | <img width="269" alt="image" src="https://github.com/user-attachments/assets/7d777f08-f9d8-4581-862d-2f858716969b" /> |<img width="269" alt="image" src="https://github.com/user-attachments/assets/581303a2-aec8-4d1a-aa65-6dcef1315084" /> | 
