### PR TITLE
[RANTS-29] fix: enter key does not work in the workspace member invite modal

### DIFF
--- a/web/core/components/workspace/invite-modal/form.tsx
+++ b/web/core/components/workspace/invite-modal/form.tsx
@@ -16,13 +16,7 @@ export const InvitationForm = observer((props: TInvitationFormProps) => {
   const { title, description, children, actions, onSubmit, className } = props;
 
   return (
-    <form
-      onSubmit={onSubmit}
-      onKeyDown={(e) => {
-        if (e.code === "Enter") e.preventDefault();
-      }}
-      className={className}
-    >
+    <form onSubmit={onSubmit} className={className}>
       <div className="space-y-4">
         <Dialog.Title as="h3" className="text-lg font-medium leading-6 text-custom-text-100">
           {title}


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [x] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
<!-- Link related issues if there are any -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the invitation form so that pressing the Enter key now triggers the expected submission behavior, streamlining the user interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->