### PR TITLE
[WEB-3701] fix: use `getCycleById` to ensure null handling for cycle access

### DIFF
--- a/web/core/store/cycle.store.ts
+++ b/web/core/store/cycle.store.ts
@@ -241,10 +241,10 @@ export class CycleStore implements ICycleStore {
   }
 
   getIsPointsDataAvailable = computedFn((cycleId: string) => {
-    const cycle = this.cycleMap[cycleId];
+    const cycle = this.getCycleById(cycleId);
     if (!cycle) return false;
-    if (this.cycleMap[cycleId].version === 2) return cycle.progress.some((p) => p.total_estimate_points > 0);
-    else if (this.cycleMap[cycleId].version === 1) {
+    if (cycle.version === 2) return cycle.progress?.some((p) => p.total_estimate_points > 0);
+    else if (cycle.version === 1) {
       const completionChart = cycle.estimate_distribution?.completion_chart || {};
       return !isEmpty(completionChart) && Object.keys(completionChart).some((p) => completionChart[p]! > 0);
     } else return false;
@@ -560,8 +560,7 @@ export class CycleStore implements ICycleStore {
    * @returns
    */
   updateCycleDistribution = (distributionUpdates: DistributionUpdates, cycleId: string) => {
-    const cycle = this.cycleMap[cycleId];
-
+    const cycle = this.getCycleById(cycleId);
     if (!cycle) return;
 
     runInAction(() => {
@@ -644,7 +643,7 @@ export class CycleStore implements ICycleStore {
         entity_type: "cycle",
         entity_identifier: cycleId,
         project_id: projectId,
-        entity_data: { name: this.cycleMap[cycleId].name || "" },
+        entity_data: { name: currentCycle?.name || "" },
       });
       return response;
     } catch (error) {

--- a/web/core/store/issue/cycle/issue.store.ts
+++ b/web/core/store/issue/cycle/issue.store.ts
@@ -21,6 +21,7 @@ import {
 // helpers
 import { getDistributionPathsPostUpdate } from "@/helpers/distribution-update.helper";
 //local
+import { storage } from "@/lib/local-storage";
 import { persistence } from "@/local-db/storage.sqlite";
 import { BaseIssuesStore, IBaseIssuesStore } from "../helpers/base-issues.store";
 //
@@ -142,8 +143,12 @@ export class CycleIssues extends BaseIssuesStore implements ICycleIssues {
 
     projectId && cycleId && this.rootIssueStore.rootStore.cycle.fetchCycleDetails(workspaceSlug, projectId, cycleId);
     // fetch cycle progress
+    const isSidebarCollapsed = storage.get("cycle_sidebar_collapsed");
     projectId &&
       cycleId &&
+      this.rootIssueStore.rootStore.cycle.getCycleById(cycleId)?.version === 2 &&
+      isSidebarCollapsed &&
+      JSON.parse(isSidebarCollapsed) === "false" &&
       this.rootIssueStore.rootStore.cycle.fetchActiveCycleProgressPro(workspaceSlug, projectId, cycleId);
   };
 


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
Previously, `this.rootIssueStore.rootStore.cycle.cycleMap` was accessed directly, which could lead to errors when the cycle was undefined. This has been updated to use `getCycleById`, which safely returns either the cycle details or null. This ensures that all usages of cycle data now explicitly handle the null case, improving type safety and preventing potential runtime errors.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update