### PR TITLE
[WEB-3732 | WEB-3731] feat: Vietnamese and Portuguese language support

### DIFF
--- a/packages/i18n/src/constants/language.ts
+++ b/packages/i18n/src/constants/language.ts
@@ -17,6 +17,7 @@ export const SUPPORTED_LANGUAGES: ILanguageOption[] = [
   { label: "Українська", value: "ua" },
   { label: "Polski", value: "pl" },
   { label: "한국어", value: "ko" },
+  { label: "Português Brasil", value: "pt-BR" },
   { label: "Indonesian", value: "id" },
   { label: "Română", value: "ro" },
 ];

--- a/packages/i18n/src/constants/language.ts
+++ b/packages/i18n/src/constants/language.ts
@@ -20,6 +20,7 @@ export const SUPPORTED_LANGUAGES: ILanguageOption[] = [
   { label: "Português Brasil", value: "pt-BR" },
   { label: "Indonesian", value: "id" },
   { label: "Română", value: "ro" },
+  { label: "Tiếng việt", value: "vi" },
 ];
 
 export const LANGUAGE_STORAGE_KEY = "userLanguage";

--- a/packages/i18n/src/constants/language.ts
+++ b/packages/i18n/src/constants/language.ts
@@ -20,7 +20,7 @@ export const SUPPORTED_LANGUAGES: ILanguageOption[] = [
   { label: "Português Brasil", value: "pt-BR" },
   { label: "Indonesian", value: "id" },
   { label: "Română", value: "ro" },
-  { label: "Tiếng việt", value: "vi" },
+  { label: "Tiếng việt", value: "vi-VN" },
 ];
 
 export const LANGUAGE_STORAGE_KEY = "userLanguage";

--- a/packages/i18n/src/locales/pt-BR/translations.json
+++ b/packages/i18n/src/locales/pt-BR/translations.json
@@ -1,4 +1,174 @@
 {
+  "sidebar": {
+    "projects": "Projetos",
+    "pages": "Páginas",
+    "new_work_item": "Novo item",
+    "home": "Home",
+    "your_work": "Seu trabalho",
+    "inbox": "Inbox",
+    "workspace": "Workspace",
+    "views": "Visualizações",
+    "analytics": "Analytics",
+    "work_items": "Itens",
+    "cycles": "Ciclos",
+    "modules": "Módulos",
+    "intake": "Intake",
+    "drafts": "Rascunhos",
+    "favorites": "Favoritos",
+    "pro": "Pro",
+    "upgrade": "Upgrade"
+  },
+
+  "auth": {
+    "common": {
+      "email": {
+        "label": "Email",
+        "placeholder": "nome@empresa.com",
+        "errors": {
+          "required": "Email é obrigatório",
+          "invalid": "Email inválido"
+        }
+      },
+      "password": {
+        "label": "Senha",
+        "set_password": "Definir senha",
+        "placeholder": "Digite a senha",
+        "confirm_password": {
+          "label": "Confirmar senha",
+          "placeholder": "Confirmar senha"
+        },
+        "current_password": {
+          "label": "Senha atual"
+        },
+        "new_password": {
+          "label": "Nova senha",
+          "placeholder": "Digite a nova senha"
+        },
+        "change_password": {
+          "label": {
+            "default": "Alterar senha",
+            "submitting": "Alterando senha"
+          }
+        },
+        "errors": {
+          "match": "As senhas não coincidem",
+          "empty": "Por favor digite sua senha",
+          "length": "A senha deve ter mais de 8 caracteres",
+          "strength": {
+            "weak": "Senha fraca",
+            "strong": "Senha forte"
+          }
+        },
+        "submit": "Definir senha",
+        "toast": {
+          "change_password": {
+            "success": {
+              "title": "Sucesso!",
+              "message": "Senha alterada com sucesso."
+            },
+            "error": {
+              "title": "Erro!",
+              "message": "Algo deu errado. Por favor, tente novamente."
+            }
+          }
+        }
+      },
+      "unique_code": {
+        "label": "Código único",
+        "placeholder": "gets-sets-flys",
+        "paste_code": "Cole o código enviado para seu email",
+        "requesting_new_code": "Solicitando novo código",
+        "sending_code": "Enviando código"
+      },
+      "already_have_an_account": "Já tem uma conta?",
+      "login": "Login",
+      "create_account": "Criar conta",
+      "new_to_plane": "Novo no Plane?",
+      "back_to_sign_in": "Voltar ao login",
+      "resend_in": "Reenviar em {seconds} segundos",
+      "sign_in_with_unique_code": "Login com código único",
+      "forgot_password": "Esqueceu sua senha?"
+    },
+    "sign_up": {
+      "header": {
+        "label": "Crie uma conta para começar a gerenciar trabalho com sua equipe.",
+        "step": {
+          "email": {
+            "header": "Cadastro",
+            "sub_header": ""
+          },
+          "password": {
+            "header": "Cadastro",
+            "sub_header": "Cadastre-se usando email e senha."
+          },
+          "unique_code": {
+            "header": "Cadastro",
+            "sub_header": "Cadastre-se usando um código único enviado para o email acima."
+          }
+        }
+      },
+      "errors": {
+        "password": {
+          "strength": "Tente definir uma senha forte para continuar"
+        }
+      }
+    },
+    "sign_in": {
+      "header": {
+        "label": "Faça login para começar a gerenciar trabalho com sua equipe.",
+        "step": {
+          "email": {
+            "header": "Login ou cadastro",
+            "sub_header": ""
+          },
+          "password": {
+            "header": "Login ou cadastro",
+            "sub_header": "Use seu email e senha para fazer login."
+          },
+          "unique_code": {
+            "header": "Login ou cadastro",
+            "sub_header": "Faça login usando um código único enviado para o email acima."
+          }
+        }
+      }
+    },
+    "forgot_password": {
+      "title": "Redefinir sua senha",
+      "description": "Digite o email verificado da sua conta e enviaremos um link para redefinir sua senha.",
+      "email_sent": "Enviamos o link de redefinição para seu email",
+      "send_reset_link": "Enviar link de redefinição",
+      "errors": {
+        "smtp_not_enabled": "Vemos que seu administrador não habilitou SMTP, não poderemos enviar um link de redefinição de senha"
+      },
+      "toast": {
+        "success": {
+          "title": "Email enviado",
+          "message": "Verifique sua caixa de entrada para um link de redefinição de senha. Se não aparecer em alguns minutos, verifique sua pasta de spam."
+        },
+        "error": {
+          "title": "Erro!",
+          "message": "Algo deu errado. Por favor, tente novamente."
+        }
+      }
+    },
+    "reset_password": {
+      "title": "Definir nova senha",
+      "description": "Proteja sua conta com uma senha forte"
+    },
+    "set_password": {
+      "title": "Proteja sua conta",
+      "description": "Definir uma senha ajuda você a fazer login com segurança"
+    },
+    "sign_out": {
+      "toast": {
+        "error": {
+          "title": "Erro!",
+          "message": "Falha ao sair. Por favor, tente novamente."
+        }
+      }
+    }
+  },
+
   "submit": "Enviar",
   "cancel": "Cancelar",
   "loading": "Carregando",
@@ -331,6 +501,9 @@
   "re_generate_key": "Regerar chave",
   "export": "Exportar",
   "member": "{count, plural, one{# membro} other{# membros}}",
+  "new_password_must_be_different_from_old_password": "Nova senha deve ser diferente da senha antiga",
+  "edited": "editado",
+  "bot": "robô",
 
   "project_view": {
     "sort_by": {

--- a/packages/i18n/src/locales/pt-BR/translations.json
+++ b/packages/i18n/src/locales/pt-BR/translations.json
@@ -1,0 +1,2200 @@
+{
+  "submit": "Enviar",
+  "cancel": "Cancelar",
+  "loading": "Carregando",
+  "error": "Erro",
+  "success": "Sucesso",
+  "warning": "Aviso",
+  "info": "Informação",
+  "close": "Fechar",
+  "yes": "Sim",
+  "no": "Não",
+  "ok": "OK",
+  "name": "Nome",
+  "description": "Descrição",
+  "search": "Pesquisar",
+  "add_member": "Adicionar membro",
+  "adding_members": "Adicionando membros",
+  "remove_member": "Remover membro",
+  "add_members": "Adicionar membros",
+  "adding_member": "Adicionando membro",
+  "remove_members": "Remover membros",
+  "add": "Adicionar",
+  "adding": "Adicionando",
+  "remove": "Remover",
+  "add_new": "Adicionar novo",
+  "remove_selected": "Remover selecionado",
+  "first_name": "Primeiro nome",
+  "last_name": "Sobrenome",
+  "email": "E-mail",
+  "display_name": "Nome de exibição",
+  "role": "Cargo",
+  "timezone": "Fuso horário",
+  "avatar": "Avatar",
+  "cover_image": "Imagem de capa",
+  "password": "Senha",
+  "change_cover": "Alterar capa",
+  "language": "Idioma",
+  "saving": "Salvando",
+  "save_changes": "Salvar alterações",
+  "deactivate_account": "Desativar conta",
+  "deactivate_account_description": "Ao desativar uma conta, todos os dados e recursos dessa conta serão removidos permanentemente e não poderão ser recuperados.",
+  "profile_settings": "Configurações de perfil",
+  "your_account": "Sua conta",
+  "security": "Segurança",
+  "activity": "Atividade",
+  "appearance": "Aparência",
+  "notifications": "Notificações",
+  "workspaces": "Espaços de trabalho",
+  "create_workspace": "Criar espaço de trabalho",
+  "invitations": "Convites",
+  "summary": "Resumo",
+  "assigned": "Atribuído",
+  "created": "Criado",
+  "subscribed": "Inscrito",
+  "you_do_not_have_the_permission_to_access_this_page": "Você não tem permissão para acessar esta página.",
+  "something_went_wrong_please_try_again": "Algo deu errado. Por favor, tente novamente.",
+  "load_more": "Carregar mais",
+  "select_or_customize_your_interface_color_scheme": "Selecione ou personalize o esquema de cores da sua interface.",
+  "theme": "Tema",
+  "system_preference": "Preferência do sistema",
+  "light": "Claro",
+  "dark": "Escuro",
+  "light_contrast": "Alto contraste claro",
+  "dark_contrast": "Alto contraste escuro",
+  "custom": "Personalizado",
+  "select_your_theme": "Selecione seu tema",
+  "customize_your_theme": "Personalize seu tema",
+  "background_color": "Cor de fundo",
+  "text_color": "Cor do texto",
+  "primary_color": "Cor primária (Tema)",
+  "sidebar_background_color": "Cor de fundo da barra lateral",
+  "sidebar_text_color": "Cor do texto da barra lateral",
+  "set_theme": "Definir tema",
+  "enter_a_valid_hex_code_of_6_characters": "Insira um código hexadecimal válido de 6 caracteres",
+  "background_color_is_required": "A cor de fundo é obrigatória",
+  "text_color_is_required": "A cor do texto é obrigatória",
+  "primary_color_is_required": "A cor primária é obrigatória",
+  "sidebar_background_color_is_required": "A cor de fundo da barra lateral é obrigatória",
+  "sidebar_text_color_is_required": "A cor do texto da barra lateral é obrigatória",
+  "updating_theme": "Atualizando tema",
+  "theme_updated_successfully": "Tema atualizado com sucesso",
+  "failed_to_update_the_theme": "Falha ao atualizar o tema",
+  "email_notifications": "Notificações por e-mail",
+  "stay_in_the_loop_on_issues_you_are_subscribed_to_enable_this_to_get_notified": "Mantenha-se informado sobre os itens de trabalho aos quais você está inscrito. Ative isso para ser notificado.",
+  "email_notification_setting_updated_successfully": "Configuração de notificação por e-mail atualizada com sucesso",
+  "failed_to_update_email_notification_setting": "Falha ao atualizar a configuração de notificação por e-mail",
+  "notify_me_when": "Notifique-me quando",
+  "property_changes": "Alterações de propriedade",
+  "property_changes_description": "Notifique-me quando as propriedades dos itens de trabalho, como responsáveis, prioridade, estimativas ou qualquer outra coisa, mudarem.",
+  "state_change": "Mudança de estado",
+  "state_change_description": "Notifique-me quando os itens de trabalho mudarem para um estado diferente",
+  "issue_completed": "Item de trabalho concluído",
+  "issue_completed_description": "Notifique-me apenas quando um item de trabalho for concluído",
+  "comments": "Comentários",
+  "comments_description": "Notifique-me quando alguém deixar um comentário no item de trabalho",
+  "mentions": "Menções",
+  "mentions_description": "Notifique-me apenas quando alguém me mencionar nos comentários ou na descrição",
+  "old_password": "Senha antiga",
+  "general_settings": "Configurações gerais",
+  "sign_out": "Sair",
+  "signing_out": "Saindo",
+  "active_cycles": "Ciclos ativos",
+  "active_cycles_description": "Monitore os ciclos entre os projetos, rastreie os itens de trabalho de alta prioridade e amplie os ciclos que precisam de atenção.",
+  "on_demand_snapshots_of_all_your_cycles": "Snapshots sob demanda de todos os seus ciclos",
+  "upgrade": "Upgrade",
+  "10000_feet_view": "Visão geral de todos os ciclos ativos.",
+  "10000_feet_view_description": "Reduza o zoom para ver os ciclos em execução em todos os seus projetos de uma só vez, em vez de ir de ciclo para ciclo em cada projeto.",
+  "get_snapshot_of_each_active_cycle": "Obtenha um snapshot de cada ciclo ativo.",
+  "get_snapshot_of_each_active_cycle_description": "Rastreie as métricas de alto nível para todos os ciclos ativos, veja seu estado de progresso e tenha uma noção do escopo em relação aos prazos.",
+  "compare_burndowns": "Compare burndowns.",
+  "compare_burndowns_description": "Monitore o desempenho de cada uma de suas equipes com uma olhada no relatório de burndown de cada ciclo.",
+  "quickly_see_make_or_break_issues": "Veja rapidamente os itens de trabalho decisivos.",
+  "quickly_see_make_or_break_issues_description": "Visualize os itens de trabalho de alta prioridade para cada ciclo em relação aos prazos. Veja todos eles por ciclo com um clique.",
+  "zoom_into_cycles_that_need_attention": "Amplie os ciclos que precisam de atenção.",
+  "zoom_into_cycles_that_need_attention_description": "Investigue o estado de qualquer ciclo que não esteja em conformidade com as expectativas com um clique.",
+  "stay_ahead_of_blockers": "Fique à frente dos bloqueios.",
+  "stay_ahead_of_blockers_description": "Identifique desafios de um projeto para outro e veja as dependências entre ciclos que não são óbvias em nenhuma outra visualização.",
+  "analytics": "Análises",
+  "workspace_invites": "Convites para o espaço de trabalho",
+  "enter_god_mode": "Entrar no God Mode",
+  "workspace_logo": "Logo do espaço de trabalho",
+  "new_issue": "Novo item de trabalho",
+  "your_work": "Seu trabalho",
+  "drafts": "Rascunhos",
+  "projects": "Projetos",
+  "views": "Visualizações",
+  "workspace": "Espaço de trabalho",
+  "archives": "Arquivos",
+  "settings": "Configurações",
+  "failed_to_move_favorite": "Falha ao mover o favorito",
+  "favorites": "Favoritos",
+  "no_favorites_yet": "Nenhum favorito ainda",
+  "create_folder": "Criar pasta",
+  "new_folder": "Nova pasta",
+  "favorite_updated_successfully": "Favorito atualizado com sucesso",
+  "favorite_created_successfully": "Favorito criado com sucesso",
+  "folder_already_exists": "A pasta já existe",
+  "folder_name_cannot_be_empty": "O nome da pasta não pode estar vazio",
+  "something_went_wrong": "Algo deu errado",
+  "failed_to_reorder_favorite": "Falha ao reordenar o favorito",
+  "favorite_removed_successfully": "Favorito removido com sucesso",
+  "failed_to_create_favorite": "Falha ao criar favorito",
+  "failed_to_rename_favorite": "Falha ao renomear favorito",
+  "project_link_copied_to_clipboard": "Link do projeto copiado para a área de transferência",
+  "link_copied": "Link copiado",
+  "add_project": "Adicionar projeto",
+  "create_project": "Criar projeto",
+  "failed_to_remove_project_from_favorites": "Não foi possível remover o projeto dos favoritos. Por favor, tente novamente.",
+  "project_created_successfully": "Projeto criado com sucesso",
+  "project_created_successfully_description": "Projeto criado com sucesso. Agora você pode começar a adicionar itens de trabalho a ele.",
+  "project_cover_image_alt": "Imagem de capa do projeto",
+  "name_is_required": "Nome é obrigatório",
+  "title_should_be_less_than_255_characters": "O título deve ter menos de 255 caracteres",
+  "project_name": "Nome do projeto",
+  "project_id_must_be_at_least_1_character": "O ID do projeto deve ter pelo menos 1 caractere",
+  "project_id_must_be_at_most_5_characters": "O ID do projeto deve ter no máximo 5 caracteres",
+  "project_id": "ID do projeto",
+  "project_id_tooltip_content": "Ajuda você a identificar itens de trabalho no projeto de forma exclusiva. Máximo de 5 caracteres.",
+  "description_placeholder": "Descrição",
+  "only_alphanumeric_non_latin_characters_allowed": "Apenas caracteres alfanuméricos e não latinos são permitidos.",
+  "project_id_is_required": "O ID do projeto é obrigatório",
+  "project_id_allowed_char": "Apenas caracteres alfanuméricos e não latinos são permitidos.",
+  "project_id_min_char": "O ID do projeto deve ter pelo menos 1 caractere",
+  "project_id_max_char": "O ID do projeto deve ter no máximo 5 caracteres",
+  "project_description_placeholder": "Insira a descrição do projeto",
+  "select_network": "Selecione a rede",
+  "lead": "Líder",
+  "date_range": "Intervalo de datas",
+  "private": "Privado",
+  "public": "Público",
+  "accessible_only_by_invite": "Acessível apenas por convite",
+  "anyone_in_the_workspace_except_guests_can_join": "Qualquer pessoa no espaço de trabalho, exceto convidados, pode participar",
+  "creating": "Criando",
+  "creating_project": "Criando projeto",
+  "adding_project_to_favorites": "Adicionando projeto aos favoritos",
+  "project_added_to_favorites": "Projeto adicionado aos favoritos",
+  "couldnt_add_the_project_to_favorites": "Não foi possível adicionar o projeto aos favoritos. Por favor, tente novamente.",
+  "removing_project_from_favorites": "Removendo projeto dos favoritos",
+  "project_removed_from_favorites": "Projeto removido dos favoritos",
+  "couldnt_remove_the_project_from_favorites": "Não foi possível remover o projeto dos favoritos. Por favor, tente novamente.",
+  "add_to_favorites": "Adicionar aos favoritos",
+  "remove_from_favorites": "Remover dos favoritos",
+  "publish_settings": "Configurações de publicação",
+  "publish": "Publicar",
+  "copy_link": "Copiar link",
+  "leave_project": "Sair do projeto",
+  "join_the_project_to_rearrange": "Participe do projeto para reorganizar",
+  "drag_to_rearrange": "Arraste para reorganizar",
+  "congrats": "Parabéns!",
+  "open_project": "Abrir projeto",
+  "issues": "Itens de trabalho",
+  "cycles": "Ciclos",
+  "modules": "Módulos",
+  "pages": "Páginas",
+  "intake": "Admissão",
+  "time_tracking": "Rastreamento de tempo",
+  "work_management": "Gerenciamento de trabalho",
+  "projects_and_issues": "Projetos e itens de trabalho",
+  "projects_and_issues_description": "Ative ou desative estes neste projeto.",
+  "cycles_description": "Defina o tempo de trabalho como achar melhor por projeto e altere a frequência de um período para o próximo.",
+  "modules_description": "Agrupe o trabalho em configurações semelhantes a subprojetos com seus próprios líderes e responsáveis.",
+  "views_description": "Salve classificações, filtros e opções de exibição para mais tarde ou compartilhe-os.",
+  "pages_description": "Escreva qualquer coisa como você escreveria normalmente.",
+  "intake_description": "Mantenha-se informado sobre os itens de trabalho aos quais você está inscrito. Ative isso para ser notificado.",
+  "time_tracking_description": "Rastreie o tempo gasto em itens de trabalho e projetos.",
+  "work_management_description": "Gerencie seu trabalho e projetos com facilidade.",
+  "documentation": "Documentação",
+  "message_support": "Suporte por mensagem",
+  "contact_sales": "Contatar vendas",
+  "hyper_mode": "Modo Hyper",
+  "keyboard_shortcuts": "Atalhos do teclado",
+  "whats_new": "O que há de novo?",
+  "version": "Versão",
+  "we_are_having_trouble_fetching_the_updates": "Estamos tendo problemas para buscar as atualizações.",
+  "our_changelogs": "nossos changelogs",
+  "for_the_latest_updates": "para as últimas atualizações.",
+  "please_visit": "Por favor, visite",
+  "docs": "Documentos",
+  "full_changelog": "Changelog completo",
+  "support": "Suporte",
+  "discord": "Discord",
+  "powered_by_plane_pages": "Desenvolvido por Plane Pages",
+  "please_select_at_least_one_invitation": "Selecione pelo menos um convite.",
+  "please_select_at_least_one_invitation_description": "Selecione pelo menos um convite para entrar no espaço de trabalho.",
+  "we_see_that_someone_has_invited_you_to_join_a_workspace": "Vemos que alguém convidou você para entrar em um espaço de trabalho",
+  "join_a_workspace": "Entrar em um espaço de trabalho",
+  "we_see_that_someone_has_invited_you_to_join_a_workspace_description": "Vemos que alguém convidou você para entrar em um espaço de trabalho",
+  "join_a_workspace_description": "Entrar em um espaço de trabalho",
+  "accept_and_join": "Aceitar e entrar",
+  "go_home": "Ir para a página inicial",
+  "no_pending_invites": "Nenhum convite pendente",
+  "you_can_see_here_if_someone_invites_you_to_a_workspace": "Você pode ver aqui se alguém convida você para um espaço de trabalho",
+  "back_to_home": "Voltar para a página inicial",
+  "workspace_name": "nome-do-espaço-de-trabalho",
+  "deactivate_your_account": "Desativar sua conta",
+  "deactivate_your_account_description": "Uma vez desativada, você não poderá ser atribuído a itens de trabalho e ser cobrado pelo seu espaço de trabalho. Para reativar sua conta, você precisará de um convite para um espaço de trabalho neste endereço de e-mail.",
+  "deactivating": "Desativando",
+  "confirm": "Confirmar",
+  "confirming": "Confirmando",
+  "draft_created": "Rascunho criado",
+  "issue_created_successfully": "Item de trabalho criado com sucesso",
+  "draft_creation_failed": "Falha na criação do rascunho",
+  "issue_creation_failed": "Falha na criação do item de trabalho",
+  "draft_issue": "Rascunhar item de trabalho",
+  "issue_updated_successfully": "Item de trabalho atualizado com sucesso",
+  "issue_could_not_be_updated": "Não foi possível atualizar o item de trabalho",
+  "create_a_draft": "Criar um rascunho",
+  "save_to_drafts": "Salvar em rascunhos",
+  "save": "Salvar",
+  "update": "Atualizar",
+  "updating": "Atualizando",
+  "create_new_issue": "Criar novo item de trabalho",
+  "editor_is_not_ready_to_discard_changes": "O editor não está pronto para descartar as alterações",
+  "failed_to_move_issue_to_project": "Falha ao mover o item de trabalho para o projeto",
+  "create_more": "Criar mais",
+  "add_to_project": "Adicionar ao projeto",
+  "discard": "Descartar",
+  "duplicate_issue_found": "Item de trabalho duplicado encontrado",
+  "duplicate_issues_found": "Itens de trabalho duplicados encontrados",
+  "no_matching_results": "Nenhum resultado correspondente",
+  "title_is_required": "O título é obrigatório",
+  "title": "Título",
+  "state": "Estado",
+  "priority": "Prioridade",
+  "none": "Nenhum",
+  "urgent": "Urgente",
+  "high": "Alta",
+  "medium": "Média",
+  "low": "Baixa",
+  "members": "Membros",
+  "assignee": "Responsável",
+  "assignees": "Responsáveis",
+  "you": "Você",
+  "labels": "Etiquetas",
+  "create_new_label": "Criar nova etiqueta",
+  "start_date": "Data de início",
+  "end_date": "Data de término",
+  "due_date": "Data de vencimento",
+  "estimate": "Estimativa",
+  "change_parent_issue": "Alterar item de trabalho pai",
+  "remove_parent_issue": "Remover item de trabalho pai",
+  "add_parent": "Adicionar pai",
+  "loading_members": "Carregando membros",
+  "view_link_copied_to_clipboard": "Link de visualização copiado para a área de transferência.",
+  "required": "Obrigatório",
+  "optional": "Opcional",
+  "Cancel": "Cancelar",
+  "edit": "Editar",
+  "archive": "Arquivar",
+  "restore": "Restaurar",
+  "open_in_new_tab": "Abrir em nova aba",
+  "delete": "Excluir",
+  "deleting": "Excluindo",
+  "make_a_copy": "Fazer uma cópia",
+  "move_to_project": "Mover para o projeto",
+  "good": "Bom",
+  "morning": "manhã",
+  "afternoon": "tarde",
+  "evening": "noite",
+  "show_all": "Mostrar tudo",
+  "show_less": "Mostrar menos",
+  "no_data_yet": "Nenhum dado ainda",
+  "syncing": "Sincronizando",
+  "add_work_item": "Adicionar item de trabalho",
+  "advanced_description_placeholder": "Pressione '/' para comandos",
+  "create_work_item": "Criar item de trabalho",
+  "attachments": "Anexos",
+  "declining": "Recusando",
+  "declined": "Recusado",
+  "decline": "Recusar",
+  "unassigned": "Não atribuído",
+  "work_items": "Itens de trabalho",
+  "add_link": "Adicionar link",
+  "points": "Pontos",
+  "no_assignee": "Sem responsável",
+  "no_assignees_yet": "Nenhum responsável ainda",
+  "no_labels_yet": "Nenhuma etiqueta ainda",
+  "ideal": "Ideal",
+  "current": "Atual",
+  "no_matching_members": "Nenhum membro correspondente",
+  "leaving": "Saindo",
+  "removing": "Removendo",
+  "leave": "Sair",
+  "refresh": "Atualizar",
+  "refreshing": "Atualizando",
+  "refresh_status": "Status da atualização",
+  "prev": "Anterior",
+  "next": "Próximo",
+  "re_generating": "Regerando",
+  "re_generate": "Regerar",
+  "re_generate_key": "Regerar chave",
+  "export": "Exportar",
+  "member": "{count, plural, one{# membro} other{# membros}}",
+
+  "project_view": {
+    "sort_by": {
+      "created_at": "Criado em",
+      "updated_at": "Atualizado em",
+      "name": "Nome"
+    }
+  },
+
+  "toast": {
+    "success": "Sucesso!",
+    "error": "Erro!"
+  },
+
+  "links": {
+    "toasts": {
+      "created": {
+        "title": "Link criado",
+        "message": "O link foi criado com sucesso"
+      },
+      "not_created": {
+        "title": "Link não criado",
+        "message": "O link não pôde ser criado"
+      },
+      "updated": {
+        "title": "Link atualizado",
+        "message": "O link foi atualizado com sucesso"
+      },
+      "not_updated": {
+        "title": "Link não atualizado",
+        "message": "O link não pôde ser atualizado"
+      },
+      "removed": {
+        "title": "Link removido",
+        "message": "O link foi removido com sucesso"
+      },
+      "not_removed": {
+        "title": "Link não removido",
+        "message": "O link não pôde ser removido"
+      }
+    }
+  },
+
+  "home": {
+    "empty": {
+      "quickstart_guide": "Seu guia de início rápido",
+      "not_right_now": "Agora não",
+      "create_project": {
+        "title": "Criar um projeto",
+        "description": "A maioria das coisas começa com um projeto no Plane.",
+        "cta": "Começar"
+      },
+      "invite_team": {
+        "title": "Convide sua equipe",
+        "description": "Construa, entregue e gerencie com colegas de trabalho.",
+        "cta": "Convidar"
+      },
+      "configure_workspace": {
+        "title": "Configure seu espaço de trabalho.",
+        "description": "Ative ou desative recursos ou vá além disso.",
+        "cta": "Configurar este espaço de trabalho"
+      },
+      "personalize_account": {
+        "title": "Personalize o Plane.",
+        "description": "Escolha sua foto, cores e muito mais.",
+        "cta": "Personalizar agora"
+      },
+      "widgets": {
+        "title": "Está quieto sem widgets, ative-os",
+        "description": "Parece que todos os seus widgets estão desativados. Ative-os\nagora para melhorar sua experiência!",
+        "primary_button": {
+          "text": "Gerenciar widgets"
+        }
+      }
+    },
+    "quick_links": {
+      "empty": "Salve links para os itens de trabalho que você gostaria de ter à mão.",
+      "add": "Adicionar link rápido",
+      "title": "Link rápido",
+      "title_plural": "Links rápidos"
+    },
+    "recents": {
+      "title": "Recentes",
+      "empty": {
+      "project": "Seus projetos recentes aparecerão aqui quando você visitar um.",
+      "page": "Suas páginas recentes aparecerão aqui quando você visitar uma.",
+      "issue": "Seus itens de trabalho recentes aparecerão aqui quando você visitar um.",
+      "default": "Você não tem nenhum item recente ainda."
+      },
+      "filters": {
+      "all": "Todos os itens",
+      "projects": "Projetos",
+      "pages": "Páginas",
+      "issues": "Itens de trabalho"
+      }
+    },
+    "new_at_plane": {
+      "title": "Novidades no Plane"
+    },
+    "quick_tutorial": {
+      "title": "Tutorial rápido"
+    },
+    "widget": {
+      "reordered_successfully": "Widget reordenado com sucesso.",
+      "reordering_failed": "Ocorreu um erro ao reordenar o widget."
+    },
+    "manage_widgets": "Gerenciar widgets",
+    "title": "Página inicial",
+    "star_us_on_github": "Nos dê uma estrela no GitHub"
+    },
+
+    "link": {
+    "modal": {
+      "url": {
+      "text": "URL",
+      "required": "URL inválido",
+      "placeholder": "Digite ou cole um URL"
+      },
+      "title": {
+      "text": "Título de exibição",
+      "placeholder": "Como você gostaria de ver este link"
+      }
+    }
+    },
+
+  "common": {
+    "all": "Todos",
+    "states": "Estados",
+    "state": "Estado",
+    "state_groups": "Grupos de estado",
+    "state_group": "Grupo de estado",
+    "priorities": "Prioridades",
+    "priority": "Prioridade",
+    "team_project": "Projeto de equipe",
+    "project": "Projeto",
+    "cycle": "Ciclo",
+    "cycles": "Ciclos",
+    "module": "Módulo",
+    "modules": "Módulos",
+    "labels": "Etiquetas",
+    "label": "Etiqueta",
+    "assignees": "Responsáveis",
+    "assignee": "Responsável",
+    "created_by": "Criado por",
+    "none": "Nenhum",
+    "link": "Link",
+    "estimates": "Estimativas",
+    "estimate": "Estimativa",
+    "created_at": "Criado em",
+    "completed_at": "Concluído em",
+    "layout": "Layout",
+    "filters": "Filtros",
+    "display": "Exibir",
+    "load_more": "Carregar mais",
+    "activity": "Atividade",
+    "analytics": "Análises",
+    "dates": "Datas",
+    "success": "Sucesso!",
+    "something_went_wrong": "Algo deu errado",
+    "error": {
+      "label": "Erro!",
+      "message": "Ocorreu algum erro. Por favor, tente novamente."
+    },
+    "group_by": "Agrupar por",
+    "epic": "Épico",
+    "epics": "Épicos",
+    "work_item": "Item de trabalho",
+    "work_items": "Itens de trabalho",
+    "sub_work_item": "Sub-item de trabalho",
+    "add": "Adicionar",
+    "warning": "Aviso",
+    "updating": "Atualizando",
+    "adding": "Adicionando",
+    "update": "Atualizar",
+    "creating": "Criando",
+    "create": "Criar",
+    "cancel": "Cancelar",
+    "description": "Descrição",
+    "title": "Título",
+    "attachment": "Anexo",
+    "general": "Geral",
+    "features": "Funcionalidades",
+    "automation": "Automação",
+    "project_name": "Nome do projeto",
+    "project_id": "ID do projeto",
+    "project_timezone": "Fuso horário do projeto",
+    "created_on": "Criado em",
+    "update_project": "Atualizar projeto",
+    "identifier_already_exists": "O identificador já existe",
+    "add_more": "Adicionar mais",
+    "defaults": "Padrões",
+    "add_label": "Adicionar etiqueta",
+    "customize_time_range": "Personalizar intervalo de tempo",
+    "loading": "Carregando",
+    "attachments": "Anexos",
+    "property": "Propriedade",
+    "properties": "Propriedades",
+    "parent": "Pai",
+    "page": "Página",
+    "remove": "Remover",
+    "archiving": "Arquivando",
+    "archive": "Arquivar",
+    "access": {
+      "public": "Público",
+      "private": "Privado"
+    },
+    "done": "Concluído",
+    "sub_work_items": "Sub-itens de trabalho",
+    "comment": "Comentário",
+    "workspace_level": "Nível do espaço de trabalho",
+    "order_by": {
+      "label": "Ordenar por",
+      "manual": "Manual",
+      "last_created": "Último criado",
+      "last_updated": "Último atualizado",
+      "start_date": "Data de início",
+      "due_date": "Data de vencimento",
+      "asc": "Ascendente",
+      "desc": "Descendente",
+      "updated_on": "Atualizado em"
+    },
+    "sort": {
+      "asc": "Ascendente",
+      "desc": "Descendente",
+      "created_on": "Criado em",
+      "updated_on": "Atualizado em"
+    },
+    "comments": "Comentários",
+    "updates": "Atualizações",
+    "clear_all": "Limpar tudo",
+    "copied": "Copiado!",
+    "link_copied": "Link copiado!",
+    "link_copied_to_clipboard": "Link copiado para a área de transferência",
+    "copied_to_clipboard": "Link do item de trabalho copiado para a área de transferência",
+    "is_copied_to_clipboard": "O link do item de trabalho foi copiado para a área de transferência",
+    "no_links_added_yet": "Nenhum link adicionado ainda",
+    "add_link": "Adicionar link",
+    "links": "Links",
+    "go_to_workspace": "Ir para o espaço de trabalho",
+    "progress": "Progresso",
+    "optional": "Opcional",
+    "join": "Participar",
+    "go_back": "Voltar",
+    "continue": "Continuar",
+    "resend": "Reenviar",
+    "relations": "Relações",
+    "errors": {
+      "default": {
+      "title": "Erro!",
+      "message": "Algo deu errado. Por favor, tente novamente."
+      },
+      "required": "Este campo é obrigatório",
+      "entity_required": "{entity} é obrigatório"
+    },
+    "update_link": "Atualizar link",
+    "attach": "Anexar",
+    "create_new": "Criar novo",
+    "add_existing": "Adicionar existente",
+    "type_or_paste_a_url": "Digite ou cole uma URL",
+    "url_is_invalid": "URL inválida",
+    "display_title": "Título de exibição",
+    "link_title_placeholder": "Como você gostaria de ver este link",
+    "url": "URL",
+    "side_peek": "Visualização lateral",
+    "modal": "Modal",
+    "full_screen": "Tela cheia",
+    "close_peek_view": "Fechar a visualização",
+    "toggle_peek_view_layout": "Alternar layout de visualização rápida",
+    "options": "Opções",
+    "duration": "Duração",
+    "today": "Hoje",
+    "week": "Semana",
+    "month": "Mês",
+    "quarter": "Trimestre",
+    "press_for_commands": "Pressione '/' para comandos",
+    "click_to_add_description": "Clique para adicionar descrição",
+    "search": {
+      "label": "Buscar",
+      "placeholder": "Digite para buscar",
+      "no_matches_found": "Nenhum resultado encontrado",
+      "no_matching_results": "Nenhum resultado correspondente"
+    },
+    "actions": {
+      "edit": "Editar",
+      "make_a_copy": "Fazer uma cópia",
+      "open_in_new_tab": "Abrir em nova aba",
+      "copy_link": "Copiar link",
+      "archive": "Arquivar",
+      "restore": "Restaurar",
+      "delete": "Excluir",
+      "remove_relation": "Remover relação",
+      "subscribe": "Inscrever-se",
+      "unsubscribe": "Cancelar inscrição",
+      "clear_sorting": "Limpar ordenação",
+      "show_weekends": "Mostrar fins de semana",
+      "enable": "Habilitar",
+      "disable": "Desabilitar"
+    },
+    "name": "Nome",
+    "discard": "Descartar",
+    "confirm": "Confirmar",
+    "confirming": "Confirmando",
+    "read_the_docs": "Ler a documentação",
+    "default": "Padrão",
+    "active": "Ativo",
+    "enabled": "Habilitado",
+    "disabled": "Desabilitado",
+    "mandate": "Mandato",
+    "mandatory": "Obrigatório",
+    "yes": "Sim",
+    "no": "Não",
+    "please_wait": "Por favor, aguarde",
+    "enabling": "Habilitando",
+    "disabling": "Desabilitando",
+    "beta": "Beta",
+    "or": "ou",
+    "next": "Próximo",
+    "back": "Voltar",
+    "cancelling": "Cancelando",
+    "configuring": "Configurando",
+    "clear": "Limpar",
+    "import": "Importar",
+    "connect": "Conectar",
+    "authorizing": "Autorizando",
+    "processing": "Processando",
+    "no_data_available": "Nenhum dado disponível",
+    "from": "de {name}",
+    "authenticated": "Autenticado",
+    "select": "Selecionar",
+    "upgrade": "Upgrade",
+    "add_seats": "Adicionar lugares",
+    "projects": "Projetos",
+    "workspace": "Espaço de trabalho",
+    "workspaces": "Espaços de trabalho",
+    "team": "Equipe",
+    "teams": "Equipes",
+    "entity": "Entidade",
+    "entities": "Entidades",
+    "task": "Tarefa",
+    "tasks": "Tarefas",
+    "section": "Seção",
+    "sections": "Seções",
+    "edit": "Editar",
+    "connecting": "Conectando",
+    "connected": "Conectado",
+    "disconnect": "Desconectar",
+    "disconnecting": "Desconectando",
+    "installing": "Instalando",
+    "install": "Instalar",
+    "reset": "Redefinir",
+    "live": "Ao vivo",
+    "change_history": "Histórico de alterações",
+    "coming_soon": "Em breve",
+    "members": "Membros",
+    "you": "Você",
+    "upgrade_cta": {
+      "higher_subscription": "Faça upgrade para uma assinatura superior",
+      "talk_to_sales": "Fale com o departamento de vendas"
+    },
+    "category": "Categoria",
+    "categories": "Categorias",
+    "saving": "Salvando",
+    "save_changes": "Salvar alterações",
+    "delete": "Excluir",
+    "deleting": "Excluindo",
+    "pending": "Pendente",
+    "invite": "Convidar",
+    "view": "Visualizar"
+  },
+
+  "chart": {
+    "x_axis": "Eixo X",
+    "y_axis": "Eixo Y",
+    "metric": "Métrica"
+  },
+
+  "form": {
+    "title": {
+      "required": "Título é obrigatório",
+      "max_length": "O título deve ter menos de {length} caracteres"
+    }
+  },
+
+  "entity": {
+    "grouping_title": "Agrupamento de {entity}",
+    "priority": "Prioridade de {entity}",
+    "all": "Todos os {entity}",
+    "drop_here_to_move": "Solte aqui para mover o {entity}",
+    "delete": {
+      "label": "Excluir {entity}",
+      "success": "{entity} excluído com sucesso",
+      "failed": "Falha ao excluir {entity}"
+    },
+    "update": {
+      "failed": "Falha ao atualizar {entity}",
+      "success": "{entity} atualizado com sucesso"
+    },
+    "link_copied_to_clipboard": "Link de {entity} copiado para a área de transferência",
+    "fetch": {
+      "failed": "Erro ao buscar {entity}"
+    },
+    "add": {
+      "success": "{entity} adicionado com sucesso",
+      "failed": "Erro ao adicionar {entity}"
+    }
+  },
+
+  "epic": {
+    "all": "Todos os Épicos",
+    "label": "{count, plural, one {Épico} other {Épicos}}",
+    "new": "Novo Épico",
+    "adding": "Adicionando épico",
+    "create": {
+      "success": "Épico criado com sucesso"
+    },
+    "add": {
+      "press_enter": "Pressione 'Enter' para adicionar outro épico",
+      "label": "Adicionar Épico"
+    },
+    "title": {
+      "label": "Título do Épico",
+      "required": "O título do épico é obrigatório."
+    }
+  },
+
+  "issue": {
+    "label": "{count, plural, one {Item de trabalho} other {Itens de trabalho}}",
+    "all": "Todos os Itens de trabalho",
+    "edit": "Editar item de trabalho",
+    "title": {
+      "label": "Título do item de trabalho",
+      "required": "O título do item de trabalho é obrigatório."
+    },
+    "add": {
+      "press_enter": "Pressione 'Enter' para adicionar outro item de trabalho",
+      "label": "Adicionar item de trabalho",
+      "cycle": {
+        "failed": "Não foi possível adicionar o item de trabalho ao ciclo. Por favor, tente novamente.",
+        "success": "{count, plural, one {Item de trabalho} other {Itens de trabalho}} adicionado(s) ao ciclo com sucesso.",
+        "loading": "Adicionando {count, plural, one {item de trabalho} other {itens de trabalho}} ao ciclo"
+      },
+      "assignee": "Adicionar responsáveis",
+      "start_date": "Adicionar data de início",
+      "due_date": "Adicionar data de vencimento",
+      "parent": "Adicionar item de trabalho pai",
+      "sub_issue": "Adicionar sub-item de trabalho",
+      "relation": "Adicionar relação",
+      "link": "Adicionar link",
+      "existing": "Adicionar item de trabalho existente"
+    },
+    "remove": {
+      "label": "Remover item de trabalho",
+      "cycle": {
+        "loading": "Removendo item de trabalho do ciclo",
+        "success": "Item de trabalho removido do ciclo com sucesso.",
+        "failed": "Não foi possível remover o item de trabalho do ciclo. Por favor, tente novamente."
+      },
+      "module": {
+        "loading": "Removendo item de trabalho do módulo",
+        "success": "Item de trabalho removido do módulo com sucesso.",
+        "failed": "Não foi possível remover o item de trabalho do módulo. Por favor, tente novamente."
+      },
+      "parent": {
+        "label": "Remover item de trabalho pai"
+      }
+    },
+    "new": "Novo Item de trabalho",
+    "adding": "Adicionando item de trabalho",
+    "create": {
+      "success": "Item de trabalho criado com sucesso"
+    },
+    "priority": {
+      "urgent": "Urgente",
+      "high": "Alta",
+      "medium": "Média",
+      "low": "Baixa"
+    },
+    "display": {
+      "properties": {
+        "label": "Exibir Propriedades",
+        "id": "ID",
+        "issue_type": "Tipo de Item de Trabalho",
+        "sub_issue_count": "Contagem de sub-itens de trabalho",
+        "attachment_count": "Contagem de anexos",
+        "created_on": "Criado em",
+        "sub_issue": "Sub-item de trabalho",
+        "work_item_count": "Contagem de itens de trabalho"
+      },
+      "extra": {
+        "show_sub_issues": "Mostrar sub-itens de trabalho",
+        "show_empty_groups": "Mostrar grupos vazios"
+      }
+    },
+    "layouts": {
+      "ordered_by_label": "Este layout é ordenado por",
+      "list": "Lista",
+      "kanban": "Quadro",
+      "calendar": "Calendário",
+      "spreadsheet": "Tabela",
+      "gantt": "Cronograma",
+      "title": {
+        "list": "Layout de Lista",
+        "kanban": "Layout de Quadro",
+        "calendar": "Layout de Calendário",
+        "spreadsheet": "Layout de Tabela",
+        "gantt": "Layout de Cronograma"
+      }
+    },
+    "states": {
+      "active": "Ativo",
+      "backlog": "Backlog"
+    },
+    "comments": {
+      "placeholder": "Adicionar comentário",
+      "switch": {
+        "private": "Alternar para comentário privado",
+        "public": "Alternar para comentário público"
+      },
+      "create": {
+        "success": "Comentário criado com sucesso",
+        "error": "Falha ao criar o comentário. Por favor, tente novamente mais tarde."
+      },
+      "update": {
+        "success": "Comentário atualizado com sucesso",
+        "error": "Falha ao atualizar o comentário. Por favor, tente novamente mais tarde."
+      },
+      "remove": {
+        "success": "Comentário removido com sucesso",
+        "error": "Falha ao remover o comentário. Por favor, tente novamente mais tarde."
+      },
+      "upload": {
+        "error": "Falha ao carregar o recurso. Por favor, tente novamente mais tarde."
+      }
+    },
+    "empty_state": {
+      "issue_detail": {
+        "title": "O item de trabalho não existe",
+        "description": "O item de trabalho que você está procurando não existe, foi arquivado ou foi excluído.",
+        "primary_button": {
+          "text": "Visualizar outros itens de trabalho"
+        }
+      }
+    },
+    "sibling": {
+      "label": "Itens de trabalho irmãos"
+    },
+    "archive": {
+      "description": "Apenas itens de trabalho concluídos ou cancelados\npodem ser arquivados",
+      "label": "Arquivar Item de Trabalho",
+      "confirm_message": "Tem certeza de que deseja arquivar o item de trabalho? Todos os seus itens de trabalho arquivados podem ser restaurados posteriormente.",
+      "success": {
+        "label": "Sucesso ao arquivar",
+        "message": "Seus arquivos podem ser encontrados nos arquivos do projeto."
+      },
+      "failed": {
+        "message": "Não foi possível arquivar o item de trabalho. Por favor, tente novamente."
+      }
+    },
+    "restore": {
+      "success": {
+        "title": "Sucesso ao restaurar",
+        "message": "Seu item de trabalho pode ser encontrado nos itens de trabalho do projeto."
+      },
+      "failed": {
+        "message": "Não foi possível restaurar o item de trabalho. Por favor, tente novamente."
+      }
+    },
+    "relation": {
+      "relates_to": "Relacionado a",
+      "duplicate": "Duplicado de",
+      "blocked_by": "Bloqueado por",
+      "blocking": "Bloqueando"
+    },
+    "copy_link": "Copiar link do item de trabalho",
+    "delete": {
+      "label": "Excluir item de trabalho",
+      "error": "Erro ao excluir item de trabalho"
+    },
+    "subscription": {
+      "actions": {
+        "subscribed": "Item de trabalho inscrito com sucesso",
+        "unsubscribed": "Item de trabalho não inscrito com sucesso"
+      }
+    },
+    "select": {
+      "error": "Selecione pelo menos um item de trabalho",
+      "empty": "Nenhum item de trabalho selecionado",
+      "add_selected": "Adicionar itens de trabalho selecionados"
+    },
+    "open_in_full_screen": "Abrir item de trabalho em tela cheia"
+  },
+
+  "attachment": {
+    "error": "Não foi possível anexar o arquivo. Tente enviar novamente.",
+    "only_one_file_allowed": "Apenas um arquivo pode ser enviado por vez.",
+    "file_size_limit": "O arquivo deve ter {size}MB ou menos.",
+    "drag_and_drop": "Arraste e solte em qualquer lugar para enviar",
+    "delete": "Excluir anexo"
+  },
+
+  "label": {
+    "select": "Selecionar etiqueta",
+    "create": {
+      "success": "Etiqueta criada com sucesso",
+      "failed": "Falha ao criar etiqueta",
+      "already_exists": "Etiqueta já existe",
+      "type": "Digite para adicionar uma nova etiqueta"
+    }
+  },
+
+  "sub_work_item": {
+    "update": {
+      "success": "Sub-item de trabalho atualizado com sucesso",
+      "error": "Erro ao atualizar sub-item de trabalho"
+    },
+    "remove": {
+      "success": "Sub-item de trabalho removido com sucesso",
+      "error": "Erro ao remover sub-item de trabalho"
+    }
+  },
+
+  "view": {
+    "label": "{count, plural, one {Visualização} other {Visualizações}}",
+    "create": {
+      "label": "Criar Visualização"
+    },
+    "update": {
+      "label": "Atualizar Visualização"
+    }
+  },
+
+  "inbox_issue": {
+    "status": {
+      "pending": {
+        "title": "Pendente",
+        "description": "Pendente"
+      },
+      "declined": {
+        "title": "Recusado",
+        "description": "Recusado"
+      },
+      "snoozed": {
+        "title": "Adiado",
+        "description": "{days, plural, one{Falta # dia} other{Faltam # dias}}"
+      },
+      "accepted": {
+        "title": "Aceito",
+        "description": "Aceito"
+      },
+      "duplicate": {
+        "title": "Duplicado",
+        "description": "Duplicado"
+      }
+    },
+    "modals": {
+      "decline": {
+        "title": "Recusar item de trabalho",
+        "content": "Tem certeza de que deseja recusar o item de trabalho {value}?"
+      },
+      "delete": {
+        "title": "Excluir item de trabalho",
+        "content": "Tem certeza de que deseja excluir o item de trabalho {value}?",
+        "success": "Item de trabalho excluído com sucesso"
+      }
+    },
+    "errors": {
+      "snooze_permission": "Apenas administradores do projeto podem adiar/reativar itens de trabalho",
+      "accept_permission": "Apenas administradores do projeto podem aceitar itens de trabalho",
+      "decline_permission": "Apenas administradores do projeto podem recusar itens de trabalho"
+    },
+    "actions": {
+      "accept": "Aceitar",
+      "decline": "Recusar",
+      "snooze": "Adiar",
+      "unsnooze": "Reativar",
+      "copy": "Copiar link do item de trabalho",
+      "delete": "Excluir",
+      "open": "Abrir item de trabalho",
+      "mark_as_duplicate": "Marcar como duplicado",
+      "move": "Mover {value} para os itens de trabalho do projeto"
+    },
+    "source": {
+      "in-app": "no aplicativo"
+    },
+    "order_by": {
+      "created_at": "Criado em",
+      "updated_at": "Atualizado em",
+      "id": "ID"
+    },
+    "label": "Admissão",
+    "page_label": "{workspace} - Admissão",
+    "modal": {
+      "title": "Criar item de trabalho de admissão"
+    },
+    "tabs": {
+      "open": "Aberto",
+      "closed": "Fechado"
+    },
+    "empty_state": {
+      "sidebar_open_tab": {
+        "title": "Nenhum item de trabalho aberto",
+        "description": "Encontre itens de trabalho abertos aqui. Crie um novo item de trabalho."
+      },
+      "sidebar_closed_tab": {
+        "title": "Nenhum item de trabalho fechado",
+        "description": "Todos os itens de trabalho, sejam aceitos ou recusados, podem ser encontrados aqui."
+      },
+      "sidebar_filter": {
+        "title": "Nenhum item de trabalho correspondente",
+        "description": "Nenhum item de trabalho corresponde ao filtro aplicado na admissão. Crie um novo item de trabalho."
+      },
+      "detail": {
+        "title": "Selecione um item de trabalho para visualizar seus detalhes."
+      }
+    }
+  },
+
+  "workspace_creation": {
+    "heading": "Crie seu espaço de trabalho",
+    "subheading": "Para começar a usar o Plane, você precisa criar ou entrar em um espaço de trabalho.",
+    "form": {
+      "name": {
+        "label": "Nomeie seu espaço de trabalho",
+        "placeholder": "Algo familiar e reconhecível é sempre melhor."
+      },
+      "url": {
+        "label": "Defina o URL do seu espaço de trabalho",
+        "placeholder": "Digite ou cole um URL",
+        "edit_slug": "Você só pode editar o slug do URL"
+      },
+      "organization_size": {
+        "label": "Quantas pessoas usarão este espaço de trabalho?",
+        "placeholder": "Selecione um intervalo"
+      }
+    },
+    "errors": {
+      "creation_disabled": {
+        "title": "Apenas o administrador da sua instância pode criar espaços de trabalho",
+        "description": "Se você souber o endereço de e-mail do administrador da sua instância, clique no botão abaixo para entrar em contato com ele.",
+        "request_button": "Solicitar administrador da instância"
+      },
+      "validation": {
+        "name_alphanumeric": "Os nomes dos espaços de trabalho podem conter apenas (' '), ('-'), ('_') e caracteres alfanuméricos.",
+        "name_length": "Limite seu nome a 80 caracteres.",
+        "url_alphanumeric": "Os URLs podem conter apenas ('-') e caracteres alfanuméricos.",
+        "url_length": "Limite seu URL a 48 caracteres.",
+        "url_already_taken": "O URL do espaço de trabalho já está em uso!"
+      }
+    },
+    "request_email": {
+      "subject": "Solicitando um novo espaço de trabalho",
+      "body": "Olá, administrador(es) da instância,\n\nPor favor, crie um novo espaço de trabalho com o URL [/nome-do-espaço-de-trabalho] para [finalidade de criar o espaço de trabalho].\n\nObrigado,\n{firstName} {lastName}\n{email}"
+    },
+    "button": {
+      "default": "Criar espaço de trabalho",
+      "loading": "Criando espaço de trabalho"
+    },
+    "toast": {
+      "success": {
+        "title": "Sucesso",
+        "message": "Espaço de trabalho criado com sucesso"
+      },
+      "error": {
+        "title": "Erro",
+        "message": "Não foi possível criar o espaço de trabalho. Por favor, tente novamente."
+      }
+    }
+  },
+
+  "workspace_dashboard": {
+    "empty_state": {
+      "general": {
+        "title": "Visão geral dos seus projetos, atividades e métricas",
+        "description": "Bem-vindo ao Plane, estamos animados por tê-lo aqui. Crie seu primeiro projeto e rastreie seus itens de trabalho, e esta página se transformará em um espaço que ajuda você a progredir. Os administradores também verão itens que ajudam sua equipe a progredir.",
+        "primary_button": {
+          "text": "Construa seu primeiro projeto",
+          "comic": {
+            "title": "Tudo começa com um projeto no Plane",
+            "description": "Um projeto pode ser o planejamento de um produto, uma campanha de marketing ou o lançamento de um novo carro."
+          }
+        }
+      }
+    }
+  },
+
+  "workspace_analytics": {
+    "label": "Análises",
+    "page_label": "{workspace} - Análises",
+    "open_tasks": "Total de tarefas abertas",
+    "error": "Ocorreu algum erro ao buscar os dados.",
+    "work_items_closed_in": "Itens de trabalho fechados em",
+    "selected_projects": "Projetos selecionados",
+    "total_members": "Total de membros",
+    "total_cycles": "Total de ciclos",
+    "total_modules": "Total de módulos",
+    "pending_work_items": {
+      "title": "Itens de trabalho pendentes",
+      "empty_state": "A análise de itens de trabalho pendentes por colegas de trabalho aparece aqui."
+    },
+    "work_items_closed_in_a_year": {
+      "title": "Itens de trabalho fechados em um ano",
+      "empty_state": "Feche os itens de trabalho para visualizar a análise dos mesmos na forma de um gráfico."
+    },
+    "most_work_items_created": {
+      "title": "Itens de trabalho mais criados",
+      "empty_state": "Colegas de trabalho e o número de itens de trabalho criados por eles aparecem aqui."
+    },
+    "most_work_items_closed": {
+      "title": "Itens de trabalho mais fechados",
+      "empty_state": "Colegas de trabalho e o número de itens de trabalho fechados por eles aparecem aqui."
+    },
+    "tabs": {
+      "scope_and_demand": "Escopo e Demanda",
+      "custom": "Análises Personalizadas"
+    },
+    "empty_state": {
+      "general": {
+        "title": "Acompanhe o progresso, as cargas de trabalho e as alocações. Identifique tendências, remova bloqueadores e mova o trabalho mais rapidamente",
+        "description": "Veja o escopo versus a demanda, as estimativas e o aumento do escopo. Obtenha o desempenho por membros da equipe e equipes, e certifique-se de que seu projeto seja executado no prazo.",
+        "primary_button": {
+          "text": "Comece seu primeiro projeto",
+          "comic": {
+            "title": "A análise funciona melhor com Ciclos + Módulos",
+            "description": "Primeiro, coloque seus itens de trabalho em Ciclos e, se puder, agrupe os itens de trabalho que abrangem mais de um ciclo em Módulos. Confira ambos na navegação à esquerda."
+          }
+        }
+      }
+    }
+  },
+
+  "workspace_projects": {
+    "label": "{count, plural, one {Projeto} other {Projetos}}",
+    "create": {
+      "label": "Adicionar Projeto"
+    },
+    "network": {
+      "label": "Rede",
+      "private": {
+        "title": "Privado",
+        "description": "Acessível apenas por convite"
+      },
+      "public": {
+        "title": "Público",
+        "description": "Qualquer pessoa no espaço de trabalho, exceto convidados, pode participar"
+      }
+    },
+    "error": {
+      "permission": "Você não tem permissão para realizar esta ação.",
+      "cycle_delete": "Falha ao excluir o ciclo",
+      "module_delete": "Falha ao excluir o módulo",
+      "issue_delete": "Falha ao excluir o item de trabalho"
+    },
+    "state": {
+      "backlog": "Backlog",
+      "unstarted": "Não iniciado",
+      "started": "Iniciado",
+      "completed": "Concluído",
+      "cancelled": "Cancelado"
+    },
+    "sort": {
+      "manual": "Manual",
+      "name": "Nome",
+      "created_at": "Data de criação",
+      "members_length": "Número de membros"
+    },
+    "scope": {
+      "my_projects": "Meus projetos",
+      "archived_projects": "Arquivados"
+    },
+    "common": {
+      "months_count": "{months, plural, one{# mês} other{# meses}}"
+    },
+    "empty_state": {
+      "general": {
+        "title": "Nenhum projeto ativo",
+        "description": "Pense em cada projeto como o pai do trabalho orientado a objetivos. Os projetos são onde os Trabalhos, Ciclos e Módulos vivem e, junto com seus colegas, ajudam você a atingir esse objetivo. Crie um novo projeto ou filtre os projetos arquivados.",
+        "primary_button": {
+          "text": "Comece seu primeiro projeto",
+          "comic": {
+            "title": "Tudo começa com um projeto no Plane",
+            "description": "Um projeto pode ser o roteiro de um produto, uma campanha de marketing ou o lançamento de um novo carro."
+          }
+        }
+      },
+      "no_projects": {
+        "title": "Nenhum projeto",
+        "description": "Para criar itens de trabalho ou gerenciar seu trabalho, você precisa criar um projeto ou fazer parte de um.",
+        "primary_button": {
+          "text": "Comece seu primeiro projeto",
+          "comic": {
+            "title": "Tudo começa com um projeto no Plane",
+            "description": "Um projeto pode ser o roteiro de um produto, uma campanha de marketing ou o lançamento de um novo carro."
+          }
+        }
+      },
+      "filter": {
+        "title": "Nenhum projeto correspondente",
+        "description": "Nenhum projeto detectado com os critérios correspondentes. \n Crie um novo projeto em vez disso."
+      },
+      "search": {
+        "description": "Nenhum projeto detectado com os critérios correspondentes.\nCrie um novo projeto em vez disso"
+      }
+    }
+  },
+
+  "workspace_views": {
+    "add_view": "Adicionar visualização",
+    "empty_state": {
+      "all-issues": {
+        "title": "Nenhum item de trabalho no projeto",
+        "description": "Primeiro projeto concluído! Agora, divida seu trabalho em partes rastreáveis com itens de trabalho. Vamos lá!",
+        "primary_button": {
+          "text": "Criar novo item de trabalho"
+        }
+      },
+      "assigned": {
+        "title": "Nenhum item de trabalho ainda",
+        "description": "Os itens de trabalho atribuídos a você podem ser rastreados aqui.",
+        "primary_button": {
+          "text": "Criar novo item de trabalho"
+        }
+      },
+      "created": {
+        "title": "Nenhum item de trabalho ainda",
+        "description": "Todos os itens de trabalho criados por você vêm aqui, rastreie-os aqui diretamente.",
+        "primary_button": {
+          "text": "Criar novo item de trabalho"
+        }
+      },
+      "subscribed": {
+        "title": "Nenhum item de trabalho ainda",
+        "description": "Inscreva-se nos itens de trabalho nos quais você está interessado, rastreie todos eles aqui."
+      },
+      "custom-view": {
+        "title": "Nenhum item de trabalho ainda",
+        "description": "Itens de trabalho que se aplicam aos filtros, rastreie todos eles aqui."
+      }
+    }
+  },
+
+  "workspace_settings": {
+    "label": "Configurações do espaço de trabalho",
+    "page_label": "{workspace} - Configurações gerais",
+    "key_created": "Chave criada",
+    "copy_key": "Copie e salve esta chave secreta no Páginas do Plane. Você não pode ver esta chave depois de clicar em Fechar. Um arquivo CSV contendo a chave foi baixado.",
+    "token_copied": "Token copiado para a área de transferência.",
+    "settings": {
+      "general": {
+        "title": "Geral",
+        "upload_logo": "Carregar logo",
+        "edit_logo": "Editar logo",
+        "name": "Nome do espaço de trabalho",
+        "company_size": "Tamanho da empresa",
+        "url": "URL do espaço de trabalho",
+        "update_workspace": "Atualizar espaço de trabalho",
+        "delete_workspace": "Excluir este espaço de trabalho",
+        "delete_workspace_description": "Ao excluir um espaço de trabalho, todos os dados e recursos dentro desse espaço de trabalho serão permanentemente removidos e não poderão ser recuperados.",
+        "delete_btn": "Excluir este espaço de trabalho",
+        "delete_modal": {
+          "title": "Tem certeza de que deseja excluir este espaço de trabalho?",
+          "description": "Você tem uma avaliação ativa para um de nossos planos pagos. Cancele-o primeiro para prosseguir.",
+          "dismiss": "Dispensar",
+          "cancel": "Cancelar avaliação",
+          "success_title": "Espaço de trabalho excluído.",
+          "success_message": "Em breve, você irá para a página do seu perfil.",
+          "error_title": "Isso não funcionou.",
+          "error_message": "Tente novamente, por favor."
+        },
+        "errors": {
+          "name": {
+            "required": "O nome é obrigatório",
+            "max_length": "O nome do espaço de trabalho não deve exceder 80 caracteres"
+          },
+          "company_size": {
+            "required": "O tamanho da empresa é obrigatório",
+            "select_a_range": "Selecione o tamanho da organização"
+          }
+        }
+      },
+      "members": {
+        "title": "Membros",
+        "add_member": "Adicionar membro",
+        "pending_invites": "Convites pendentes",
+        "invitations_sent_successfully": "Convites enviados com sucesso",
+        "leave_confirmation": "Tem certeza de que deseja sair do espaço de trabalho? Você não terá mais acesso a este espaço de trabalho. Esta ação não pode ser desfeita.",
+        "details": {
+          "full_name": "Nome completo",
+          "display_name": "Nome de exibição",
+          "email_address": "Endereço de e-mail",
+          "account_type": "Tipo de conta",
+          "authentication": "Autenticação",
+          "joining_date": "Data de adesão"
+        },
+        "modal": {
+          "title": "Convidar pessoas para colaborar",
+          "description": "Convide pessoas para colaborar em seu espaço de trabalho.",
+          "button": "Enviar convites",
+          "button_loading": "Enviando convites",
+          "placeholder": "nome@empresa.com",
+          "errors": {
+            "required": "Precisamos de um endereço de e-mail para convidá-los.",
+            "invalid": "E-mail inválido"
+          }
+        }
+      },
+      "billing_and_plans": {
+        "title": "Faturamento e planos",
+        "current_plan": "Plano atual",
+        "free_plan": "Você está usando o plano gratuito atualmente",
+        "view_plans": "Ver planos"
+      },
+      "exports": {
+        "title": "Exportações",
+        "exporting": "Exportando",
+        "previous_exports": "Exportações anteriores",
+        "export_separate_files": "Exporte os dados em arquivos separados",
+        "modal": {
+          "title": "Exportar para",
+          "toasts": {
+            "success": {
+              "title": "Exportação bem-sucedida",
+              "message": "Você poderá baixar o(a) {entity} exportado(a) na exportação anterior."
+            },
+            "error": {
+              "title": "Falha na exportação",
+              "message": "A exportação não foi bem-sucedida. Tente novamente."
+            }
+          }
+        }
+      },
+      "webhooks": {
+        "title": "Webhooks",
+        "add_webhook": "Adicionar webhook",
+        "modal": {
+          "title": "Criar webhook",
+          "details": "Detalhes do webhook",
+          "payload": "URL do payload",
+          "question": "Quais eventos você gostaria de acionar este webhook?",
+          "error": "URL é obrigatório"
+        },
+        "secret_key": {
+          "title": "Chave secreta",
+          "message": "Gere um token para fazer login no payload do webhook"
+        },
+        "options": {
+          "all": "Envie-me tudo",
+          "individual": "Selecionar eventos individuais"
+        },
+        "toasts": {
+          "created": {
+            "title": "Webhook criado",
+            "message": "O webhook foi criado com sucesso"
+          },
+          "not_created": {
+            "title": "Webhook não criado",
+            "message": "O webhook não pôde ser criado"
+          },
+          "updated": {
+            "title": "Webhook atualizado",
+            "message": "O webhook foi atualizado com sucesso"
+          },
+          "not_updated": {
+            "title": "Webhook não atualizado",
+            "message": "O webhook não pôde ser atualizado"
+          },
+          "removed": {
+            "title": "Webhook removido",
+            "message": "O webhook foi removido com sucesso"
+          },
+          "not_removed": {
+            "title": "Webhook não removido",
+            "message": "O webhook não pôde ser removido"
+          },
+          "secret_key_copied": {
+            "message": "Chave secreta copiada para a área de transferência."
+          },
+          "secret_key_not_copied": {
+            "message": "Ocorreu um erro ao copiar a chave secreta."
+          }
+        }
+      },
+      "api_tokens": {
+        "title": "Tokens de API",
+        "add_token": "Adicionar token de API",
+        "create_token": "Criar token",
+        "never_expires": "Nunca expira",
+        "generate_token": "Gerar token",
+        "generating": "Gerando",
+        "delete": {
+          "title": "Excluir token de API",
+          "description": "Qualquer aplicativo que use este token não terá mais acesso aos dados do Plane. Esta ação não pode ser desfeita.",
+          "success": {
+            "title": "Sucesso!",
+            "message": "O token de API foi excluído com sucesso"
+          },
+          "error": {
+            "title": "Erro!",
+            "message": "O token de API não pôde ser excluído"
+          }
+        }
+      }
+    },
+    "empty_state": {
+      "api_tokens": {
+        "title": "Nenhum token de API criado",
+        "description": "As APIs do Plane podem ser usadas para integrar seus dados no Plane com qualquer sistema externo. Crie um token para começar."
+      },
+      "webhooks": {
+        "title": "Nenhum webhook adicionado",
+        "description": "Crie webhooks para receber atualizações em tempo real e automatizar ações."
+      },
+      "exports": {
+        "title": "Nenhuma exportação ainda",
+        "description": "Sempre que você exportar, você também terá uma cópia aqui para referência."
+      },
+      "imports": {
+        "title": "Nenhuma importação ainda",
+        "description": "Encontre todas as suas importações anteriores aqui e baixe-as."
+      }
+    }
+  },
+
+  "profile": {
+    "label": "Perfil",
+    "page_label": "Seu trabalho",
+    "work": "Trabalho",
+    "details": {
+      "joined_on": "Entrou em",
+      "time_zone": "Fuso horário"
+    },
+    "stats": {
+      "workload": "Carga de trabalho",
+      "overview": "Visão geral",
+      "created": "Itens de trabalho criados",
+      "assigned": "Itens de trabalho atribuídos",
+      "subscribed": "Itens de trabalho inscritos",
+      "state_distribution": {
+        "title": "Itens de trabalho por estado",
+        "empty": "Crie itens de trabalho para visualizá-los por estado no gráfico para uma melhor análise."
+      },
+      "priority_distribution": {
+        "title": "Itens de trabalho por prioridade",
+        "empty": "Crie itens de trabalho para visualizá-los por prioridade no gráfico para uma melhor análise."
+      },
+      "recent_activity": {
+        "title": "Atividade recente",
+        "empty": "Não foi possível encontrar dados. Por favor, verifique suas entradas",
+        "button": "Baixar atividade de hoje",
+        "button_loading": "Baixando"
+      }
+    },
+    "actions": {
+      "profile": "Perfil",
+      "security": "Segurança",
+      "activity": "Atividade",
+      "appearance": "Aparência",
+      "notifications": "Notificações"
+    },
+    "tabs": {
+      "summary": "Resumo",
+      "assigned": "Atribuído",
+      "created": "Criado",
+      "subscribed": "Inscrito",
+      "activity": "Atividade"
+    },
+    "empty_state": {
+      "activity": {
+        "title": "Nenhuma atividade ainda",
+        "description": "Comece criando um novo item de trabalho! Adicione detalhes e propriedades a ele. Explore mais no Plane para ver sua atividade."
+      },
+      "assigned": {
+        "title": "Nenhum item de trabalho atribuído a você",
+        "description": "Os itens de trabalho atribuídos a você podem ser rastreados aqui."
+      },
+      "created": {
+        "title": "Nenhum item de trabalho ainda",
+        "description": "Todos os itens de trabalho criados por você vêm aqui, rastreie-os aqui diretamente."
+      },
+      "subscribed": {
+        "title": "Nenhum item de trabalho ainda",
+        "description": "Inscreva-se nos itens de trabalho nos quais você está interessado, rastreie todos eles aqui."
+      }
+    }
+  },
+
+  "project_settings": {
+    "general": {
+      "enter_project_id": "Inserir ID do projeto",
+      "please_select_a_timezone": "Por favor, selecione um fuso horário",
+      "archive_project": {
+        "title": "Arquivar projeto",
+        "description": "Arquivar um projeto removerá seu projeto da navegação lateral, embora você ainda possa acessá-lo na página de projetos. Você pode restaurar o projeto ou excluí-lo quando quiser.",
+        "button": "Arquivar projeto"
+      },
+      "delete_project": {
+        "title": "Excluir projeto",
+        "description": "Ao excluir um projeto, todos os dados e recursos dentro desse projeto serão removidos permanentemente e não poderão ser recuperados.",
+        "button": "Excluir meu projeto"
+      },
+      "toast": {
+        "success": "Projeto atualizado com sucesso",
+        "error": "Não foi possível atualizar o projeto. Por favor, tente novamente."
+      }
+    },
+    "members": {
+      "label": "Membros",
+      "project_lead": "Líder do projeto",
+      "default_assignee": "Responsável padrão",
+      "guest_super_permissions": {
+        "title": "Conceder acesso de visualização a todos os itens de trabalho para usuários convidados:",
+        "sub_heading": "Isso permitirá que os convidados tenham acesso de visualização a todos os itens de trabalho do projeto."
+      },
+      "invite_members": {
+        "title": "Convidar membros",
+        "sub_heading": "Convide membros para trabalhar em seu projeto.",
+        "select_co_worker": "Selecionar colega de trabalho"
+      }
+    },
+    "states": {
+      "describe_this_state_for_your_members": "Descreva este estado para seus membros.",
+      "empty_state": {
+        "title": "Nenhum estado disponível para o grupo {groupKey}",
+        "description": "Por favor, crie um novo estado"
+      }
+    },
+    "labels": {
+      "label_title": "Título da etiqueta",
+      "label_title_is_required": "O título da etiqueta é obrigatório",
+      "label_max_char": "O nome da etiqueta não deve exceder 255 caracteres",
+      "toast": {
+        "error": "Erro ao atualizar a etiqueta"
+      }
+    },
+    "estimates": {
+      "title": "Habilitar estimativas para meu projeto",
+      "description": "Elas ajudam você a comunicar a complexidade e a carga de trabalho da equipe."
+    },
+    "automations": {
+      "label": "Automações",
+      "auto-archive": {
+        "title": "Arquivar automaticamente itens de trabalho fechados",
+        "description": "O Plane arquivará automaticamente os itens de trabalho que foram concluídos ou cancelados.",
+        "duration": "Arquivar automaticamente itens de trabalho que estão fechados por"
+      },
+      "auto-close": {
+        "title": "Fechar automaticamente itens de trabalho",
+        "description": "O Plane fechará automaticamente os itens de trabalho que não foram concluídos ou cancelados.",
+        "duration": "Fechar automaticamente itens de trabalho que estão inativos por",
+        "auto_close_status": "Status de fechamento automático"
+      }
+    },
+
+    "empty_state": {
+      "labels": {
+        "title": "Nenhuma etiqueta ainda",
+        "description": "Crie etiquetas para ajudar a organizar e filtrar itens de trabalho em seu projeto."
+      },
+      "estimates": {
+        "title": "Nenhum sistema de estimativa ainda",
+        "description": "Crie um conjunto de estimativas para comunicar a quantidade de trabalho por item de trabalho.",
+        "primary_button": "Adicionar sistema de estimativa"
+      }
+    }
+  },
+
+  "project_cycles": {
+    "add_cycle": "Adicionar ciclo",
+    "more_details": "Mais detalhes",
+    "cycle": "Ciclo",
+    "update_cycle": "Atualizar ciclo",
+    "create_cycle": "Criar ciclo",
+    "no_matching_cycles": "Nenhum ciclo correspondente",
+    "remove_filters_to_see_all_cycles": "Remova os filtros para ver todos os ciclos",
+    "remove_search_criteria_to_see_all_cycles": "Remova os critérios de pesquisa para ver todos os ciclos",
+    "only_completed_cycles_can_be_archived": "Apenas ciclos concluídos podem ser arquivados",
+    "active_cycle": {
+      "label": "Ciclo ativo",
+      "progress": "Progresso",
+      "chart": "Gráfico de burndown",
+      "priority_issue": "Itens de trabalho prioritários",
+      "assignees": "Responsáveis",
+      "issue_burndown": "Burndown de itens de trabalho",
+      "ideal": "Ideal",
+      "current": "Atual",
+      "labels": "Etiquetas"
+    },
+    "upcoming_cycle": {
+      "label": "Próximo ciclo"
+    },
+    "completed_cycle": {
+      "label": "Ciclo concluído"
+    },
+    "status": {
+      "days_left": "Dias restantes",
+      "completed": "Concluído",
+      "yet_to_start": "Ainda não começou",
+      "in_progress": "Em progresso",
+      "draft": "Rascunho"
+    },
+    "action": {
+      "restore": {
+        "title": "Restaurar ciclo",
+        "success": {
+          "title": "Ciclo restaurado",
+          "description": "O ciclo foi restaurado."
+        },
+        "failed": {
+          "title": "Falha ao restaurar o ciclo",
+          "description": "Não foi possível restaurar o ciclo. Por favor, tente novamente."
+        }
+      },
+      "favorite": {
+        "loading": "Adicionando ciclo aos favoritos",
+        "success": {
+          "description": "Ciclo adicionado aos favoritos.",
+          "title": "Sucesso!"
+        },
+        "failed": {
+          "description": "Não foi possível adicionar o ciclo aos favoritos. Por favor, tente novamente.",
+          "title": "Erro!"
+        }
+      },
+      "unfavorite": {
+        "loading": "Removendo ciclo dos favoritos",
+        "success": {
+          "description": "Ciclo removido dos favoritos.",
+          "title": "Sucesso!"
+        },
+        "failed": {
+          "description": "Não foi possível remover o ciclo dos favoritos. Por favor, tente novamente.",
+          "title": "Erro!"
+        }
+      },
+      "update": {
+        "loading": "Atualizando ciclo",
+        "success": {
+          "description": "Ciclo atualizado com sucesso.",
+          "title": "Sucesso!"
+        },
+        "failed": {
+          "description": "Erro ao atualizar o ciclo. Por favor, tente novamente.",
+          "title": "Erro!"
+        },
+        "error": {
+          "already_exists": "Você já tem um ciclo nas datas fornecidas, se você quiser criar um ciclo de rascunho, você pode fazer isso removendo ambas as datas."
+        }
+      }
+    },
+    "empty_state": {
+      "general": {
+        "title": "Agrupe e defina prazos para seu trabalho em Ciclos.",
+        "description": "Divida o trabalho em partes com prazos definidos, trabalhe de trás para frente a partir do prazo do seu projeto para definir datas e faça um progresso tangível como equipe.",
+        "primary_button": {
+          "text": "Defina seu primeiro ciclo",
+          "comic": {
+            "title": "Ciclos são caixas de tempo repetitivas.",
+            "description": "Uma sprint, uma iteração ou qualquer outro termo que você use para rastreamento semanal ou quinzenal do trabalho é um ciclo."
+          }
+        }
+      },
+      "no_issues": {
+        "title": "Nenhum item de trabalho adicionado ao ciclo",
+        "description": "Adicione ou crie itens de trabalho que você deseja definir prazos e entregar dentro deste ciclo",
+        "primary_button": {
+          "text": "Criar novo item de trabalho"
+        },
+        "secondary_button": {
+          "text": "Adicionar item de trabalho existente"
+        }
+      },
+      "completed_no_issues": {
+        "title": "Nenhum item de trabalho no ciclo",
+        "description": "Nenhum item de trabalho no ciclo. Os itens de trabalho são transferidos ou ocultos. Para ver os itens de trabalho ocultos, se houver, atualize suas propriedades de exibição de acordo."
+      },
+      "active": {
+        "title": "Nenhum ciclo ativo",
+        "description": "Um ciclo ativo inclui qualquer período que abranja a data de hoje dentro de seu intervalo. Encontre o progresso e os detalhes do ciclo ativo aqui."
+      },
+      "archived": {
+        "title": "Nenhum ciclo arquivado ainda",
+        "description": "Para organizar seu projeto, arquive os ciclos concluídos. Encontre-os aqui quando forem arquivados."
+      }
+    }
+  },
+
+  "project_issues": {
+    "empty_state": {
+      "no_issues": {
+        "title": "Crie um item de trabalho e atribua-o a alguém, mesmo a você mesmo",
+        "description": "Pense nos itens de trabalho como tarefas, trabalhos ou JTBD. O que nós gostamos. Um item de trabalho e seus subitens de trabalho são geralmente acionáveis ​​baseados no tempo atribuídos aos membros de sua equipe. Sua equipe cria, atribui e conclui itens de trabalho para mover seu projeto em direção à sua meta.",
+        "primary_button": {
+          "text": "Crie seu primeiro item de trabalho",
+          "comic": {
+            "title": "Os itens de trabalho são blocos de construção no Plane.",
+            "description": "Redesenhar a interface do usuário do Plane, reformular a marca da empresa ou lançar o novo sistema de injeção de combustível são exemplos de itens de trabalho que provavelmente têm subitens de trabalho."
+          }
+        }
+      },
+      "no_archived_issues": {
+        "title": "Nenhum item de trabalho arquivado ainda",
+        "description": "Manualmente ou por meio de automação, você pode arquivar itens de trabalho que foram concluídos ou cancelados. Encontre-os aqui quando forem arquivados.",
+        "primary_button": {
+          "text": "Definir automação"
+        }
+      },
+      "issues_empty_filter": {
+        "title": "Nenhum item de trabalho encontrado correspondendo aos filtros aplicados",
+        "secondary_button": {
+          "text": "Limpar todos os filtros"
+        }
+      }
+    }
+  },
+
+  "project_module": {
+    "add_module": "Adicionar Módulo",
+    "update_module": "Atualizar Módulo",
+    "create_module": "Criar Módulo",
+    "archive_module": "Arquivar Módulo",
+    "restore_module": "Restaurar Módulo",
+    "delete_module": "Excluir módulo",
+    "empty_state": {
+      "general": {
+        "title": "Mapeie os marcos do seu projeto para Módulos e rastreie o trabalho agregado facilmente.",
+        "description": "Um grupo de itens de trabalho que pertencem a um pai lógico e hierárquico forma um módulo. Pense neles como uma forma de rastrear o trabalho por marcos do projeto. Eles têm seus próprios períodos e prazos, bem como análises para ajudá-lo a ver o quão perto ou longe você está de um marco.",
+        "primary_button": {
+          "text": "Construa seu primeiro módulo",
+          "comic": {
+            "title": "Os módulos ajudam a agrupar o trabalho por hierarquia.",
+            "description": "Um módulo de carrinho, um módulo de chassi e um módulo de armazém são todos bons exemplos desse agrupamento."
+          }
+        }
+      },
+      "no_issues": {
+        "title": "Nenhum item de trabalho no módulo",
+        "description": "Crie ou adicione itens de trabalho que você deseja realizar como parte deste módulo",
+        "primary_button": {
+          "text": "Criar novos itens de trabalho"
+        },
+        "secondary_button": {
+          "text": "Adicionar um item de trabalho existente"
+        }
+      },
+      "archived": {
+        "title": "Nenhum Módulo arquivado ainda",
+        "description": "Para organizar seu projeto, arquive os módulos concluídos ou cancelados. Encontre-os aqui quando forem arquivados."
+      },
+      "sidebar": {
+        "in_active": "Este módulo ainda não está ativo.",
+        "invalid_date": "Data inválida. Por favor, insira uma data válida."
+      }
+    },
+    "quick_actions": {
+      "archive_module": "Arquivar módulo",
+      "archive_module_description": "Apenas módulos concluídos ou cancelados\npodem ser arquivados.",
+      "delete_module": "Excluir módulo"
+    },
+    "toast": {
+      "copy": {
+        "success": "Link do módulo copiado para a área de transferência"
+      },
+      "delete": {
+        "success": "Módulo excluído com sucesso",
+        "error": "Falha ao excluir o módulo"
+      }
+    }
+  },
+
+  "project_views": {
+    "empty_state": {
+      "general": {
+        "title": "Salve visualizações filtradas para o seu projeto. Crie quantas precisar",
+        "description": "As visualizações são um conjunto de filtros salvos que você usa com frequência ou deseja acesso fácil. Todos os seus colegas em um projeto podem ver as visualizações de todos e escolher o que melhor se adapta às suas necessidades.",
+        "primary_button": {
+          "text": "Crie sua primeira visualização",
+          "comic": {
+            "title": "As visualizações funcionam sobre as propriedades do item de trabalho.",
+            "description": "Você pode criar uma visualização a partir daqui com quantas propriedades como filtros que você achar adequado."
+          }
+        }
+      },
+      "filter": {
+        "title": "Nenhuma visualização correspondente",
+        "description": "Nenhuma visualização corresponde aos critérios de pesquisa.\nCrie uma nova visualização em vez disso."
+      }
+    }
+  },
+
+  "project_page": {
+    "empty_state": {
+      "general": {
+        "title": "Escreva uma nota, um documento ou uma base de conhecimento completa. Peça a Galileo, o assistente de IA do Plane, para ajudá-lo a começar",
+        "description": "As páginas são espaço para registrar pensamentos no Plane. Anote notas de reunião, formate-as facilmente, incorpore itens de trabalho, organize-os usando uma biblioteca de componentes e mantenha-os todos no contexto do seu projeto. Para facilitar qualquer documento, invoque Galileo, a IA do Plane, com um atalho ou o clique de um botão.",
+        "primary_button": {
+          "text": "Crie sua primeira página"
+        }
+      },
+      "private": {
+        "title": "Nenhuma página privada ainda",
+        "description": "Mantenha seus pensamentos privados aqui. Quando estiver pronto para compartilhar, a equipe está a apenas um clique de distância.",
+        "primary_button": {
+          "text": "Crie sua primeira página"
+        }
+      },
+      "public": {
+        "title": "Nenhuma página pública ainda",
+        "description": "Veja as páginas compartilhadas com todos em seu projeto aqui mesmo.",
+        "primary_button": {
+          "text": "Crie sua primeira página"
+        }
+      },
+      "archived": {
+        "title": "Nenhuma página arquivada ainda",
+        "description": "Arquive as páginas que não estão no seu radar. Acesse-as aqui quando necessário."
+      }
+    }
+  },
+
+  "command_k": {
+    "empty_state": {
+      "search": {
+        "title": "Nenhum resultado encontrado"
+      }
+    }
+  },
+
+  "issue_relation": {
+    "empty_state": {
+      "search": {
+        "title": "Nenhum item de trabalho correspondente encontrado"
+      },
+      "no_issues": {
+        "title": "Nenhum item de trabalho encontrado"
+      }
+    }
+  },
+
+  "issue_comment": {
+    "empty_state": {
+      "general": {
+        "title": "Nenhum comentário ainda",
+        "description": "Os comentários podem ser usados como um espaço de discussão e acompanhamento para os itens de trabalho"
+      }
+    }
+  },
+
+  "notification": {
+    "label": "Caixa de entrada",
+    "page_label": "{workspace} - Caixa de entrada",
+    "options": {
+      "mark_all_as_read": "Marcar tudo como lido",
+      "mark_read": "Marcar como lido",
+      "mark_unread": "Marcar como não lido",
+      "refresh": "Atualizar",
+      "filters": "Filtros da caixa de entrada",
+      "show_unread": "Mostrar não lidos",
+      "show_snoozed": "Mostrar adiados",
+      "show_archived": "Mostrar arquivados",
+      "mark_archive": "Arquivar",
+      "mark_unarchive": "Desarquivar",
+      "mark_snooze": "Adiar",
+      "mark_unsnooze": "Reativar"
+    },
+    "toasts": {
+      "read": "Notificação marcada como lida",
+      "unread": "Notificação marcada como não lida",
+      "archived": "Notificação marcada como arquivada",
+      "unarchived": "Notificação marcada como não arquivada",
+      "snoozed": "Notificação adiada",
+      "unsnoozed": "Notificação reativada"
+    },
+    "empty_state": {
+      "detail": {
+        "title": "Selecione para ver os detalhes."
+      },
+      "all": {
+        "title": "Nenhum item de trabalho atribuído",
+        "description": "As atualizações para itens de trabalho atribuídos a você podem ser\nvistas aqui"
+      },
+      "mentions": {
+        "title": "Nenhum item de trabalho atribuído",
+        "description": "As atualizações para itens de trabalho atribuídos a você podem ser\nvistas aqui"
+      }
+    },
+    "tabs": {
+      "all": "Todos",
+      "mentions": "Menções"
+    },
+    "filter": {
+      "assigned": "Atribuído a mim",
+      "created": "Criado por mim",
+      "subscribed": "Inscrito por mim"
+    },
+    "snooze": {
+      "1_day": "1 dia",
+      "3_days": "3 dias",
+      "5_days": "5 dias",
+      "1_week": "1 semana",
+      "2_weeks": "2 semanas",
+      "custom": "Personalizado"
+    }
+  },
+
+  "active_cycle": {
+    "empty_state": {
+      "progress": {
+        "title": "Adicione itens de trabalho ao ciclo para visualizar seu progresso"
+      },
+      "chart": {
+        "title": "Adicione itens de trabalho ao ciclo para visualizar o gráfico de burndown."
+      },
+      "priority_issue": {
+        "title": "Observe os itens de trabalho de alta prioridade abordados no ciclo rapidamente."
+      },
+      "assignee": {
+        "title": "Adicione responsáveis aos itens de trabalho para ver uma divisão do trabalho por responsáveis."
+      },
+      "label": {
+        "title": "Adicione etiquetas aos itens de trabalho para ver a divisão do trabalho por etiquetas."
+      }
+    }
+  },
+  "disabled_project": {
+    "empty_state": {
+      "inbox": {
+        "title": "A Admissão não está habilitado para o projeto.",
+        "description": "A Admissão ajuda você a gerenciar as solicitações recebidas para o seu projeto e adicioná-las como itens de trabalho em seu fluxo de trabalho. Habilite a admissão nas configurações do projeto para gerenciar as solicitações.",
+        "primary_button": {
+          "text": "Gerenciar funcionalidades"
+        }
+      },
+      "cycle": {
+        "title": "Os ciclos não estão habilitados para este projeto.",
+        "description": "Divida o trabalho em partes com prazos definidos, trabalhe de trás para frente a partir do prazo do seu projeto para definir datas e faça um progresso tangível como equipe. Habilite o recurso de ciclos para o seu projeto para começar a usá-los.",
+        "primary_button": {
+          "text": "Gerenciar funcionalidades"
+        }
+      },
+      "module": {
+        "title": "Os módulos não estão habilitados para o projeto.",
+        "description": "Os módulos são os blocos de construção do seu projeto. Habilite os módulos nas configurações do projeto para começar a usá-los.",
+        "primary_button": {
+          "text": "Gerenciar funcionalidades"
+        }
+      },
+      "page": {
+        "title": "As páginas não estão habilitadas para o projeto.",
+        "description": "As páginas são os blocos de construção do seu projeto. Habilite as páginas nas configurações do projeto para começar a usá-las.",
+        "primary_button": {
+          "text": "Gerenciar funcionalidades"
+        }
+      },
+      "view": {
+        "title": "As visualizações não estão habilitadas para o projeto.",
+        "description": "As visualizações são os blocos de construção do seu projeto. Habilite as visualizações nas configurações do projeto para começar a usá-las.",
+        "primary_button": {
+          "text": "Gerenciar funcionalidades"
+        }
+      }
+    }
+  },
+  "workspace_draft_issues": {
+    "draft_an_issue": "Rascunhar um item de trabalho",
+    "empty_state": {
+      "title": "Itens de trabalho semi-escritos e, em breve, os comentários aparecerão aqui.",
+      "description": "Para experimentar, comece a adicionar um item de trabalho e deixe-o no meio do caminho ou crie seu primeiro rascunho abaixo. 😉",
+      "primary_button": {
+        "text": "Criar seu primeiro rascunho"
+      }
+    },
+    "delete_modal": {
+      "title": "Excluir rascunho",
+      "description": "Tem certeza de que deseja excluir este rascunho? Isso não pode ser desfeito."
+    },
+    "toasts": {
+      "created": {
+        "success": "Rascunho criado",
+        "error": "Não foi possível criar o item de trabalho. Por favor, tente novamente."
+      },
+      "deleted": {
+        "success": "Rascunho excluído"
+      }
+    }
+  },
+
+  "stickies": {
+    "title": "Suas anotações",
+    "placeholder": "clique para digitar aqui",
+    "all": "Todas as anotações",
+    "no-data": "Anote uma ideia, capture um insight ou registre uma onda cerebral. Adicione uma anotação para começar.",
+    "add": "Adicionar anotação",
+    "search_placeholder": "Pesquisar por título",
+    "delete": "Excluir anotação",
+    "delete_confirmation": "Tem certeza de que deseja excluir esta anotação?",
+    "empty_state": {
+      "simple": "Anote uma ideia, capture um insight ou registre uma onda cerebral. Adicione uma anotação para começar.",
+      "general": {
+        "title": "As anotações são notas rápidas e tarefas que você anota rapidamente.",
+        "description": "Capture seus pensamentos e ideias sem esforço, criando anotações que você pode acessar a qualquer momento e de qualquer lugar.",
+        "primary_button": {
+          "text": "Adicionar anotação"
+        }
+      },
+      "search": {
+        "title": "Isso não corresponde a nenhuma de suas anotações.",
+        "description": "Tente um termo diferente ou nos informe\nse você tem certeza de que sua pesquisa está correta.",
+        "primary_button": {
+          "text": "Adicionar anotação"
+        }
+      }
+    },
+    "toasts": {
+      "errors": {
+        "wrong_name": "O nome da anotação não pode ter mais de 100 caracteres.",
+        "already_exists": "Já existe uma anotação sem descrição"
+      },
+      "created": {
+        "title": "Anotação criada",
+        "message": "A anotação foi criada com sucesso"
+      },
+      "not_created": {
+        "title": "Anotação não criada",
+        "message": "A anotação não pôde ser criada"
+      },
+      "updated": {
+        "title": "Anotação atualizada",
+        "message": "A anotação foi atualizada com sucesso"
+      },
+      "not_updated": {
+        "title": "Anotação não atualizada",
+        "message": "A anotação não pôde ser atualizada"
+      },
+      "removed": {
+        "title": "Anotação removida",
+        "message": "A anotação foi removida com sucesso"
+      },
+      "not_removed": {
+        "title": "Anotação não removida",
+        "message": "A anotação não pôde ser removida"
+      }
+    }
+  },
+
+  "role_details": {
+    "guest": {
+      "title": "Convidado",
+      "description": "Membros externos de organizações podem ser convidados como convidados."
+    },
+    "member": {
+      "title": "Membro",
+      "description": "Capacidade de ler, escrever, editar e excluir entidades dentro de projetos, ciclos e módulos"
+    },
+    "admin": {
+      "title": "Administrador",
+      "description": "Todas as permissões definidas como verdadeiras dentro do espaço de trabalho."
+    }
+  },
+
+  "user_roles": {
+    "product_or_project_manager": "Gerente de Produto / Projeto",
+    "development_or_engineering": "Desenvolvimento / Engenharia",
+    "founder_or_executive": "Fundador / Executivo",
+    "freelancer_or_consultant": "Freelancer / Consultor",
+    "marketing_or_growth": "Marketing / Crescimento",
+    "sales_or_business_development": "Vendas / Desenvolvimento de Negócios",
+    "support_or_operations": "Suporte / Operações",
+    "student_or_professor": "Estudante / Professor",
+    "human_resources": "Recursos Humanos",
+    "other": "Outro"
+  },
+
+  "importer": {
+    "github": {
+      "title": "Github",
+      "description": "Importe itens de trabalho de repositórios do GitHub e sincronize-os."
+    },
+    "jira": {
+      "title": "Jira",
+      "description": "Importe itens de trabalho e épicos de projetos e épicos do Jira."
+    }
+  },
+
+  "exporter": {
+    "csv": {
+      "title": "CSV",
+      "description": "Exporte itens de trabalho para um arquivo CSV.",
+      "short_description": "Exportar como CSV"
+    },
+    "excel": {
+      "title": "Excel",
+      "description": "Exporte itens de trabalho para um arquivo Excel.",
+      "short_description": "Exportar como Excel"
+    },
+    "xlsx": {
+      "title": "Excel",
+      "description": "Exporte itens de trabalho para um arquivo Excel.",
+      "short_description": "Exportar como Excel"
+    },
+    "json": {
+      "title": "JSON",
+      "description": "Exporte itens de trabalho para um arquivo JSON.",
+      "short_description": "Exportar como JSON"
+    }
+  },
+  "default_global_view": {
+    "all_issues": "Todos os itens de trabalho",
+    "assigned": "Atribuído",
+    "created": "Criado",
+    "subscribed": "Inscrito"
+  },
+
+  "themes": {
+    "theme_options": {
+      "system_preference": {
+        "label": "Preferência do sistema"
+      },
+      "light": {
+        "label": "Claro"
+      },
+      "dark": {
+        "label": "Escuro"
+      },
+      "light_contrast": {
+        "label": "Alto contraste claro"
+      },
+      "dark_contrast": {
+        "label": "Alto contraste escuro"
+      },
+      "custom": {
+        "label": "Tema personalizado"
+      }
+    }
+  },
+  "project_modules": {
+    "status": {
+      "backlog": "Backlog",
+      "planned": "Planejado",
+      "in_progress": "Em Andamento",
+      "paused": "Pausado",
+      "completed": "Concluído",
+      "cancelled": "Cancelado"
+    },
+    "layout": {
+      "list": "Layout de lista",
+      "board": "Layout de galeria",
+      "timeline": "Layout de linha do tempo"
+    },
+    "order_by": {
+      "name": "Nome",
+      "progress": "Progresso",
+      "issues": "Número de itens de trabalho",
+      "due_date": "Data de vencimento",
+      "created_at": "Data de criação",
+      "manual": "Manual"
+    }
+  },
+
+  "cycle": {
+    "label": "{count, plural, one {Ciclo} other {Ciclos}}",
+    "no_cycle": "Nenhum ciclo"
+  },
+
+  "module": {
+    "label": "{count, plural, one {Módulo} other {Módulos}}",
+    "no_module": "Nenhum módulo"
+  }
+}

--- a/packages/i18n/src/locales/pt-BR/translations.json
+++ b/packages/i18n/src/locales/pt-BR/translations.json
@@ -415,16 +415,16 @@
     "recents": {
       "title": "Recentes",
       "empty": {
-      "project": "Seus projetos recentes aparecerão aqui quando você visitar um.",
-      "page": "Suas páginas recentes aparecerão aqui quando você visitar uma.",
-      "issue": "Seus itens de trabalho recentes aparecerão aqui quando você visitar um.",
-      "default": "Você não tem nenhum item recente ainda."
+        "project": "Seus projetos recentes aparecerão aqui quando você visitar um.",
+        "page": "Suas páginas recentes aparecerão aqui quando você visitar uma.",
+        "issue": "Seus itens de trabalho recentes aparecerão aqui quando você visitar um.",
+        "default": "Você não tem nenhum item recente ainda."
       },
       "filters": {
-      "all": "Todos os itens",
-      "projects": "Projetos",
-      "pages": "Páginas",
-      "issues": "Itens de trabalho"
+        "all": "Todos os itens",
+        "projects": "Projetos",
+        "pages": "Páginas",
+        "issues": "Itens de trabalho"
       }
     },
     "new_at_plane": {
@@ -440,21 +440,21 @@
     "manage_widgets": "Gerenciar widgets",
     "title": "Página inicial",
     "star_us_on_github": "Nos dê uma estrela no GitHub"
-    },
+  },
 
-    "link": {
+  "link": {
     "modal": {
       "url": {
-      "text": "URL",
-      "required": "URL inválido",
-      "placeholder": "Digite ou cole um URL"
+        "text": "URL",
+        "required": "URL inválido",
+        "placeholder": "Digite ou cole um URL"
       },
       "title": {
-      "text": "Título de exibição",
-      "placeholder": "Como você gostaria de ver este link"
+        "text": "Título de exibição",
+        "placeholder": "Como você gostaria de ver este link"
       }
     }
-    },
+  },
 
   "common": {
     "all": "Todos",
@@ -579,8 +579,8 @@
     "relations": "Relações",
     "errors": {
       "default": {
-      "title": "Erro!",
-      "message": "Algo deu errado. Por favor, tente novamente."
+        "title": "Erro!",
+        "message": "Algo deu errado. Por favor, tente novamente."
       },
       "required": "Este campo é obrigatório",
       "entity_required": "{entity} é obrigatório"

--- a/packages/i18n/src/locales/vi-VN/translations.json
+++ b/packages/i18n/src/locales/vi-VN/translations.json
@@ -499,6 +499,10 @@
   "re_generate_key": "Tạo lại khóa",
   "export": "Xuất",
   "member": "{count, plural, other{# thành viên}}",
+  "new_password_must_be_different_from_old_password": "Mật khẩu mới phải khác mật khẩu cũ",
+  "edited": "đã chỉnh sửa",
+  "bot": "bot",
+
   "project_view": {
     "sort_by": {
       "created_at": "Thời gian tạo",

--- a/packages/i18n/src/locales/vi/translations.json
+++ b/packages/i18n/src/locales/vi/translations.json
@@ -1,0 +1,2329 @@
+{
+  "sidebar": {
+    "projects": "Dự án",
+    "pages": "Trang",
+    "new_work_item": "Mục công việc mới",
+    "home": "Trang chủ",
+    "your_work": "Công việc của tôi",
+    "inbox": "Hộp thư đến",
+    "workspace": "Không gian làm việc",
+    "views": "Chế độ xem",
+    "analytics": "Phân tích",
+    "work_items": "Mục công việc",
+    "cycles": "Chu kỳ",
+    "modules": "Mô-đun",
+    "intake": "Thu thập",
+    "drafts": "Bản nháp",
+    "favorites": "Yêu thích",
+    "pro": "Phiên bản Pro",
+    "upgrade": "Nâng cấp"
+  },
+  "auth": {
+    "common": {
+      "email": {
+        "label": "Email",
+        "placeholder": "name@company.com",
+        "errors": {
+          "required": "Email là bắt buộc",
+          "invalid": "Email không hợp lệ"
+        }
+      },
+      "password": {
+        "label": "Mật khẩu",
+        "set_password": "Đặt mật khẩu",
+        "placeholder": "Nhập mật khẩu",
+        "confirm_password": {
+          "label": "Xác nhận mật khẩu",
+          "placeholder": "Xác nhận mật khẩu"
+        },
+        "current_password": {
+          "label": "Mật khẩu hiện tại"
+        },
+        "new_password": {
+          "label": "Mật khẩu mới",
+          "placeholder": "Nhập mật khẩu mới"
+        },
+        "change_password": {
+          "label": {
+            "default": "Thay đổi mật khẩu",
+            "submitting": "Đang thay đổi mật khẩu"
+          }
+        },
+        "errors": {
+          "match": "Mật khẩu không khớp",
+          "empty": "Vui lòng nhập mật khẩu",
+          "length": "Mật khẩu phải dài hơn 8 ký tự",
+          "strength": {
+            "weak": "Mật khẩu yếu",
+            "strong": "Mật khẩu mạnh"
+          }
+        },
+        "submit": "Đặt mật khẩu",
+        "toast": {
+          "change_password": {
+            "success": {
+              "title": "Thành công!",
+              "message": "Mật khẩu đã được thay đổi thành công."
+            },
+            "error": {
+              "title": "Lỗi!",
+              "message": "Đã xảy ra lỗi. Vui lòng thử lại."
+            }
+          }
+        }
+      },
+      "unique_code": {
+        "label": "Mã duy nhất",
+        "placeholder": "gets-sets-flys",
+        "paste_code": "Dán mã xác minh đã gửi đến email của bạn",
+        "requesting_new_code": "Đang yêu cầu mã mới",
+        "sending_code": "Đang gửi mã"
+      },
+      "already_have_an_account": "Đã có tài khoản?",
+      "login": "Đăng nhập",
+      "create_account": "Tạo tài khoản",
+      "new_to_plane": "Lần đầu sử dụng Plane?",
+      "back_to_sign_in": "Quay lại đăng nhập",
+      "resend_in": "Gửi lại sau {seconds} giây",
+      "sign_in_with_unique_code": "Đăng nhập bằng mã duy nhất",
+      "forgot_password": "Quên mật khẩu?"
+    },
+    "sign_up": {
+      "header": {
+        "label": "Tạo tài khoản để bắt đầu quản lý công việc cùng nhóm của bạn.",
+        "step": {
+          "email": {
+            "header": "Đăng ký",
+            "sub_header": ""
+          },
+          "password": {
+            "header": "Đăng ký",
+            "sub_header": "Đăng ký bằng cách kết hợp email-mật khẩu."
+          },
+          "unique_code": {
+            "header": "Đăng ký",
+            "sub_header": "Đăng ký bằng mã duy nhất được gửi đến email trên."
+          }
+        }
+      },
+      "errors": {
+        "password": {
+          "strength": "Vui lòng đặt mật khẩu mạnh để tiếp tục"
+        }
+      }
+    },
+    "sign_in": {
+      "header": {
+        "label": "Đăng nhập để bắt đầu quản lý công việc cùng nhóm của bạn.",
+        "step": {
+          "email": {
+            "header": "Đăng nhập hoặc đăng ký",
+            "sub_header": ""
+          },
+          "password": {
+            "header": "Đăng nhập hoặc đăng ký",
+            "sub_header": "Đăng nhập bằng cách kết hợp email-mật khẩu của bạn."
+          },
+          "unique_code": {
+            "header": "Đăng nhập hoặc đăng ký",
+            "sub_header": "Đăng nhập bằng mã duy nhất được gửi đến email trên."
+          }
+        }
+      }
+    },
+    "forgot_password": {
+      "title": "Đặt lại mật khẩu",
+      "description": "Nhập địa chỉ email đã xác minh cho tài khoản người dùng của bạn và chúng tôi sẽ gửi cho bạn liên kết đặt lại mật khẩu.",
+      "email_sent": "Chúng tôi đã gửi liên kết đặt lại đến email của bạn",
+      "send_reset_link": "Gửi liên kết đặt lại",
+      "errors": {
+        "smtp_not_enabled": "Chúng tôi nhận thấy quản trị viên của bạn chưa bật SMTP, chúng tôi sẽ không thể gửi liên kết đặt lại mật khẩu"
+      },
+      "toast": {
+        "success": {
+          "title": "Email đã được gửi",
+          "message": "Hãy kiểm tra hộp thư đến của bạn để lấy liên kết đặt lại mật khẩu. Nếu bạn không nhận được trong vòng vài phút, vui lòng kiểm tra thư mục spam."
+        },
+        "error": {
+          "title": "Lỗi!",
+          "message": "Đã xảy ra lỗi. Vui lòng thử lại."
+        }
+      }
+    },
+    "reset_password": {
+      "title": "Đặt mật khẩu mới",
+      "description": "Bảo vệ tài khoản của bạn bằng mật khẩu mạnh"
+    },
+    "set_password": {
+      "title": "Bảo vệ tài khoản của bạn",
+      "description": "Đặt mật khẩu giúp bạn đăng nhập an toàn"
+    },
+    "sign_out": {
+      "toast": {
+        "error": {
+          "title": "Lỗi!",
+          "message": "Không thể đăng xuất. Vui lòng thử lại."
+        }
+      }
+    }
+  },
+  "submit": "Gửi",
+  "cancel": "Hủy",
+  "loading": "Đang tải",
+  "error": "Lỗi",
+  "success": "Thành công",
+  "warning": "Cảnh báo",
+  "info": "Thông tin",
+  "close": "Đóng",
+  "yes": "Có",
+  "no": "Không",
+  "ok": "OK",
+  "name": "Tên",
+  "description": "Mô tả",
+  "search": "Tìm kiếm",
+  "add_member": "Thêm thành viên",
+  "adding_members": "Đang thêm thành viên",
+  "remove_member": "Xóa thành viên",
+  "add_members": "Thêm thành viên",
+  "adding_member": "Đang thêm thành viên",
+  "remove_members": "Xóa thành viên",
+  "add": "Thêm",
+  "adding": "Đang thêm",
+  "remove": "Xóa",
+  "add_new": "Thêm mới",
+  "remove_selected": "Xóa đã chọn",
+  "first_name": "Tên",
+  "last_name": "Họ",
+  "email": "Email",
+  "display_name": "Tên hiển thị",
+  "role": "Vai trò",
+  "timezone": "Múi giờ",
+  "avatar": "Ảnh đại diện",
+  "cover_image": "Ảnh bìa",
+  "password": "Mật khẩu",
+  "change_cover": "Thay đổi ảnh bìa",
+  "language": "Ngôn ngữ",
+  "saving": "Đang lưu",
+  "save_changes": "Lưu thay đổi",
+  "deactivate_account": "Vô hiệu hóa tài khoản",
+  "deactivate_account_description": "Khi tài khoản bị vô hiệu hóa, tất cả dữ liệu và tài nguyên trong tài khoản đó sẽ bị xóa vĩnh viễn và không thể khôi phục.",
+  "profile_settings": "Cài đặt hồ sơ",
+  "your_account": "Tài khoản của bạn",
+  "security": "Bảo mật",
+  "activity": "Hoạt động",
+  "appearance": "Giao diện",
+  "notifications": "Thông báo",
+  "workspaces": "Không gian làm việc",
+  "create_workspace": "Tạo không gian làm việc",
+  "invitations": "Lời mời",
+  "summary": "Tóm tắt",
+  "assigned": "Đã phân công",
+  "created": "Đã tạo",
+  "subscribed": "Đã đăng ký",
+  "you_do_not_have_the_permission_to_access_this_page": "Bạn không có quyền truy cập trang này.",
+  "something_went_wrong_please_try_again": "Đã xảy ra lỗi. Vui lòng thử lại.",
+  "load_more": "Tải thêm",
+  "select_or_customize_your_interface_color_scheme": "Chọn hoặc tùy chỉnh sơ đồ màu giao diện của bạn.",
+  "theme": "Chủ đề",
+  "system_preference": "Tùy chọn hệ thống",
+  "light": "Sáng",
+  "dark": "Tối",
+  "light_contrast": "Sáng tương phản cao",
+  "dark_contrast": "Tối tương phản cao",
+  "custom": "Tùy chỉnh",
+  "select_your_theme": "Chọn chủ đề của bạn",
+  "customize_your_theme": "Tùy chỉnh chủ đề của bạn",
+  "background_color": "Màu nền",
+  "text_color": "Màu chữ",
+  "primary_color": "Màu chính (chủ đề)",
+  "sidebar_background_color": "Màu nền thanh bên",
+  "sidebar_text_color": "Màu chữ thanh bên",
+  "set_theme": "Đặt chủ đề",
+  "enter_a_valid_hex_code_of_6_characters": "Nhập mã hex hợp lệ gồm 6 ký tự",
+  "background_color_is_required": "Màu nền là bắt buộc",
+  "text_color_is_required": "Màu chữ là bắt buộc",
+  "primary_color_is_required": "Màu chính là bắt buộc",
+  "sidebar_background_color_is_required": "Màu nền thanh bên là bắt buộc",
+  "sidebar_text_color_is_required": "Màu chữ thanh bên là bắt buộc",
+  "updating_theme": "Đang cập nhật chủ đề",
+  "theme_updated_successfully": "Chủ đề đã được cập nhật thành công",
+  "failed_to_update_the_theme": "Không thể cập nhật chủ đề",
+  "email_notifications": "Thông báo qua email",
+  "stay_in_the_loop_on_issues_you_are_subscribed_to_enable_this_to_get_notified": "Cập nhật những mục công việc bạn đã đăng ký. Bật tính năng này để nhận thông báo.",
+  "email_notification_setting_updated_successfully": "Cài đặt thông báo email đã được cập nhật thành công",
+  "failed_to_update_email_notification_setting": "Không thể cập nhật cài đặt thông báo email",
+  "notify_me_when": "Thông báo cho tôi khi",
+  "property_changes": "Thay đổi thuộc tính",
+  "property_changes_description": "Thông báo cho tôi khi thuộc tính của mục công việc (như người phụ trách, mức độ ưu tiên, ước tính, v.v.) thay đổi.",
+  "state_change": "Thay đổi trạng thái",
+  "state_change_description": "Thông báo cho tôi khi mục công việc được chuyển sang trạng thái khác",
+  "issue_completed": "Mục công việc hoàn thành",
+  "issue_completed_description": "Chỉ thông báo cho tôi khi mục công việc hoàn thành",
+  "comments": "Bình luận",
+  "comments_description": "Thông báo cho tôi khi ai đó bình luận về mục công việc",
+  "mentions": "Đề cập",
+  "mentions_description": "Chỉ thông báo cho tôi khi ai đó đề cập đến tôi trong bình luận hoặc mô tả",
+  "old_password": "Mật khẩu cũ",
+  "general_settings": "Cài đặt chung",
+  "sign_out": "Đăng xuất",
+  "signing_out": "Đang đăng xuất",
+  "active_cycles": "Chu kỳ hoạt động",
+  "active_cycles_description": "Theo dõi chu kỳ trên các dự án, theo dõi mục công việc ưu tiên cao và chú ý đến các chu kỳ cần quan tâm.",
+  "on_demand_snapshots_of_all_your_cycles": "Ảnh chụp nhanh theo yêu cầu của tất cả chu kỳ của bạn",
+  "upgrade": "Nâng cấp",
+  "10000_feet_view": "Góc nhìn tổng quan về tất cả chu kỳ hoạt động.",
+  "10000_feet_view_description": "Phóng to tầm nhìn để xem tất cả chu kỳ đang diễn ra trong tất cả dự án cùng một lúc, thay vì xem từng chu kỳ trong mỗi dự án.",
+  "get_snapshot_of_each_active_cycle": "Nhận ảnh chụp nhanh của mỗi chu kỳ hoạt động.",
+  "get_snapshot_of_each_active_cycle_description": "Theo dõi số liệu tổng hợp cho tất cả chu kỳ hoạt động, xem trạng thái tiến độ và hiểu phạm vi liên quan đến thời hạn.",
+  "compare_burndowns": "So sánh biểu đồ burndown.",
+  "compare_burndowns_description": "Giám sát hiệu suất của từng nhóm bằng cách xem báo cáo burndown cho mỗi chu kỳ.",
+  "quickly_see_make_or_break_issues": "Nhanh chóng xem các vấn đề quan trọng.",
+  "quickly_see_make_or_break_issues_description": "Xem trước các mục công việc ưu tiên cao liên quan đến thời hạn trong mỗi chu kỳ. Xem tất cả mục công việc trong mỗi chu kỳ chỉ bằng một cú nhấp chuột.",
+  "zoom_into_cycles_that_need_attention": "Phóng to vào chu kỳ cần chú ý.",
+  "zoom_into_cycles_that_need_attention_description": "Điều tra bất kỳ trạng thái chu kỳ nào không đáp ứng mong đợi chỉ bằng một cú nhấp chuột.",
+  "stay_ahead_of_blockers": "Đi trước các yếu tố chặn.",
+  "stay_ahead_of_blockers_description": "Phát hiện thách thức từ dự án này sang dự án khác và xem các phụ thuộc giữa các chu kỳ không dễ thấy từ các chế độ xem khác.",
+  "analytics": "Phân tích",
+  "workspace_invites": "Lời mời không gian làm việc",
+  "enter_god_mode": "Vào chế độ quản trị viên",
+  "workspace_logo": "Logo không gian làm việc",
+  "new_issue": "Mục công việc mới",
+  "your_work": "Công việc của tôi",
+  "drafts": "Bản nháp",
+  "projects": "Dự án",
+  "views": "Chế độ xem",
+  "workspace": "Không gian làm việc",
+  "archives": "Lưu trữ",
+  "settings": "Cài đặt",
+  "failed_to_move_favorite": "Không thể di chuyển mục yêu thích",
+  "favorites": "Yêu thích",
+  "no_favorites_yet": "Chưa có mục yêu thích",
+  "create_folder": "Tạo thư mục",
+  "new_folder": "Thư mục mới",
+  "favorite_updated_successfully": "Đã cập nhật mục yêu thích thành công",
+  "favorite_created_successfully": "Đã tạo mục yêu thích thành công",
+  "folder_already_exists": "Thư mục đã tồn tại",
+  "folder_name_cannot_be_empty": "Tên thư mục không thể trống",
+  "something_went_wrong": "Đã xảy ra lỗi",
+  "failed_to_reorder_favorite": "Không thể sắp xếp lại mục yêu thích",
+  "favorite_removed_successfully": "Đã xóa mục yêu thích thành công",
+  "failed_to_create_favorite": "Không thể tạo mục yêu thích",
+  "failed_to_rename_favorite": "Không thể đổi tên mục yêu thích",
+  "project_link_copied_to_clipboard": "Đã sao chép liên kết dự án vào bảng tạm",
+  "link_copied": "Đã sao chép liên kết",
+  "add_project": "Thêm dự án",
+  "create_project": "Tạo dự án",
+  "failed_to_remove_project_from_favorites": "Không thể xóa dự án khỏi mục yêu thích. Vui lòng thử lại.",
+  "project_created_successfully": "Dự án đã được tạo thành công",
+  "project_created_successfully_description": "Dự án đã được tạo thành công. Bây giờ bạn có thể bắt đầu thêm mục công việc.",
+  "project_cover_image_alt": "Ảnh bìa dự án",
+  "name_is_required": "Tên là bắt buộc",
+  "title_should_be_less_than_255_characters": "Tiêu đề phải ít hơn 255 ký tự",
+  "project_name": "Tên dự án",
+  "project_id_must_be_at_least_1_character": "ID dự án phải có ít nhất 1 ký tự",
+  "project_id_must_be_at_most_5_characters": "ID dự án chỉ được tối đa 5 ký tự",
+  "project_id": "ID dự án",
+  "project_id_tooltip_content": "Giúp xác định duy nhất mục công việc trong dự án của bạn. Tối đa 5 ký tự.",
+  "description_placeholder": "Mô tả",
+  "only_alphanumeric_non_latin_characters_allowed": "Chỉ cho phép các ký tự chữ số và không phải Latin.",
+  "project_id_is_required": "ID dự án là bắt buộc",
+  "project_id_allowed_char": "Chỉ cho phép các ký tự chữ số và không phải Latin.",
+  "project_id_min_char": "ID dự án phải có ít nhất 1 ký tự",
+  "project_id_max_char": "ID dự án chỉ được tối đa 5 ký tự",
+  "project_description_placeholder": "Nhập mô tả dự án",
+  "select_network": "Chọn mạng",
+  "lead": "Người phụ trách",
+  "date_range": "Khoảng thời gian",
+  "private": "Riêng tư",
+  "public": "Công khai",
+  "accessible_only_by_invite": "Chỉ truy cập được bằng lời mời",
+  "anyone_in_the_workspace_except_guests_can_join": "Bất kỳ ai trong không gian làm việc ngoại trừ khách đều có thể tham gia",
+  "creating": "Đang tạo",
+  "creating_project": "Đang tạo dự án",
+  "adding_project_to_favorites": "Đang thêm dự án vào mục yêu thích",
+  "project_added_to_favorites": "Đã thêm dự án vào mục yêu thích",
+  "couldnt_add_the_project_to_favorites": "Không thể thêm dự án vào mục yêu thích. Vui lòng thử lại.",
+  "removing_project_from_favorites": "Đang xóa dự án khỏi mục yêu thích",
+  "project_removed_from_favorites": "Đã xóa dự án khỏi mục yêu thích",
+  "couldnt_remove_the_project_from_favorites": "Không thể xóa dự án khỏi mục yêu thích. Vui lòng thử lại.",
+  "add_to_favorites": "Thêm vào mục yêu thích",
+  "remove_from_favorites": "Xóa khỏi mục yêu thích",
+  "publish_settings": "Cài đặt xuất bản",
+  "publish": "Xuất bản",
+  "copy_link": "Sao chép liên kết",
+  "leave_project": "Rời dự án",
+  "join_the_project_to_rearrange": "Tham gia dự án để sắp xếp lại",
+  "drag_to_rearrange": "Kéo để sắp xếp lại",
+  "congrats": "Chúc mừng!",
+  "open_project": "Mở dự án",
+  "issues": "Mục công việc",
+  "cycles": "Chu kỳ",
+  "modules": "Mô-đun",
+  "pages": "Trang",
+  "intake": "Thu thập",
+  "time_tracking": "Theo dõi thời gian",
+  "work_management": "Quản lý công việc",
+  "projects_and_issues": "Dự án và mục công việc",
+  "projects_and_issues_description": "Bật hoặc tắt các tính năng này trong dự án này. Có thể thay đổi theo thời gian phù hợp với nhu cầu.",
+  "cycles_description": "Thiết lập khung thời gian cho dự án theo nhu cầu, có thể thay đổi tần suất theo các khoảng thời gian khác nhau.",
+  "modules_description": "Nhóm công việc thành cấu trúc giống như các dự án con, với người phụ trách và người được phân công riêng.",
+  "views_description": "Lưu các tùy chọn sắp xếp, lọc và hiển thị để sử dụng hoặc chia sẻ sau này.",
+  "pages_description": "Viết bất cứ thứ gì giống như viết bất cứ thứ gì.",
+  "intake_description": "Cập nhật những mục công việc bạn đã đăng ký. Bật tính năng này để nhận thông báo.",
+  "time_tracking_description": "Theo dõi thời gian dành cho mục công việc và dự án.",
+  "work_management_description": "Quản lý công việc và dự án của bạn một cách dễ dàng.",
+  "documentation": "Tài liệu",
+  "message_support": "Liên hệ hỗ trợ",
+  "contact_sales": "Liên hệ bộ phận bán hàng",
+  "hyper_mode": "Chế độ siêu tốc",
+  "keyboard_shortcuts": "Phím tắt",
+  "whats_new": "Có gì mới",
+  "version": "Phiên bản",
+  "we_are_having_trouble_fetching_the_updates": "Chúng tôi đang gặp sự cố khi lấy bản cập nhật.",
+  "our_changelogs": "Nhật ký thay đổi của chúng tôi",
+  "for_the_latest_updates": "Để cập nhật mới nhất.",
+  "please_visit": "Vui lòng truy cập",
+  "docs": "Tài liệu",
+  "full_changelog": "Nhật ký thay đổi đầy đủ",
+  "support": "Hỗ trợ",
+  "discord": "Discord",
+  "powered_by_plane_pages": "Được hỗ trợ bởi Plane Pages",
+  "please_select_at_least_one_invitation": "Vui lòng chọn ít nhất một lời mời.",
+  "please_select_at_least_one_invitation_description": "Vui lòng chọn ít nhất một lời mời để tham gia không gian làm việc.",
+  "we_see_that_someone_has_invited_you_to_join_a_workspace": "Chúng tôi thấy có người đã mời bạn tham gia không gian làm việc",
+  "join_a_workspace": "Tham gia không gian làm việc",
+  "we_see_that_someone_has_invited_you_to_join_a_workspace_description": "Chúng tôi thấy có người đã mời bạn tham gia không gian làm việc",
+  "join_a_workspace_description": "Tham gia không gian làm việc",
+  "accept_and_join": "Chấp nhận và tham gia",
+  "go_home": "Về trang chủ",
+  "no_pending_invites": "Không có lời mời đang chờ xử lý",
+  "you_can_see_here_if_someone_invites_you_to_a_workspace": "Bạn có thể xem ở đây nếu ai đó mời bạn vào không gian làm việc",
+  "back_to_home": "Quay lại trang chủ",
+  "workspace_name": "Tên không gian làm việc",
+  "deactivate_your_account": "Vô hiệu hóa tài khoản của bạn",
+  "deactivate_your_account_description": "Khi đã vô hiệu hóa, bạn sẽ không được phân công công việc và sẽ không được tính vào hóa đơn của không gian làm việc. Để kích hoạt lại tài khoản, bạn cần nhận được lời mời không gian làm việc gửi đến địa chỉ email này.",
+  "deactivating": "Đang vô hiệu hóa",
+  "confirm": "Xác nhận",
+  "confirming": "Đang xác nhận",
+  "draft_created": "Đã tạo bản nháp",
+  "issue_created_successfully": "Đã tạo mục công việc thành công",
+  "draft_creation_failed": "Tạo bản nháp thất bại",
+  "issue_creation_failed": "Tạo mục công việc thất bại",
+  "draft_issue": "Mục công việc nháp",
+  "issue_updated_successfully": "Đã cập nhật mục công việc thành công",
+  "issue_could_not_be_updated": "Không thể cập nhật mục công việc",
+  "create_a_draft": "Tạo bản nháp",
+  "save_to_drafts": "Lưu vào bản nháp",
+  "save": "Lưu",
+  "update": "Cập nhật",
+  "updating": "Đang cập nhật",
+  "create_new_issue": "Tạo mục công việc mới",
+  "editor_is_not_ready_to_discard_changes": "Trình soạn thảo chưa sẵn sàng để hủy bỏ thay đổi",
+  "failed_to_move_issue_to_project": "Không thể di chuyển mục công việc đến dự án",
+  "create_more": "Tạo thêm",
+  "add_to_project": "Thêm vào dự án",
+  "discard": "Hủy bỏ",
+  "duplicate_issue_found": "Đã tìm thấy mục công việc trùng lặp",
+  "duplicate_issues_found": "Đã tìm thấy các mục công việc trùng lặp",
+  "no_matching_results": "Không có kết quả phù hợp",
+  "title_is_required": "Tiêu đề là bắt buộc",
+  "title": "Tiêu đề",
+  "state": "Trạng thái",
+  "priority": "Ưu tiên",
+  "none": "Không có",
+  "urgent": "Khẩn cấp",
+  "high": "Cao",
+  "medium": "Trung bình",
+  "low": "Thấp",
+  "members": "Thành viên",
+  "assignee": "Người phụ trách",
+  "assignees": "Người phụ trách",
+  "you": "Bạn",
+  "labels": "Nhãn",
+  "create_new_label": "Tạo nhãn mới",
+  "start_date": "Ngày bắt đầu",
+  "end_date": "Ngày kết thúc",
+  "due_date": "Ngày hết hạn",
+  "estimate": "Ước tính",
+  "change_parent_issue": "Thay đổi mục công việc cha",
+  "remove_parent_issue": "Xóa mục công việc cha",
+  "add_parent": "Thêm mục cha",
+  "loading_members": "Đang tải thành viên",
+  "view_link_copied_to_clipboard": "Đã sao chép liên kết xem vào bảng tạm",
+  "required": "Bắt buộc",
+  "optional": "Tùy chọn",
+  "Cancel": "Hủy",
+  "edit": "Chỉnh sửa",
+  "archive": "Lưu trữ",
+  "restore": "Khôi phục",
+  "open_in_new_tab": "Mở trong tab mới",
+  "delete": "Xóa",
+  "deleting": "Đang xóa",
+  "make_a_copy": "Tạo bản sao",
+  "move_to_project": "Di chuyển đến dự án",
+  "good": "Chào buổi sáng",
+  "morning": "Buổi sáng",
+  "afternoon": "Buổi chiều",
+  "evening": "Buổi tối",
+  "show_all": "Hiển thị tất cả",
+  "show_less": "Hiển thị ít hơn",
+  "no_data_yet": "Chưa có dữ liệu",
+  "syncing": "Đang đồng bộ",
+  "add_work_item": "Thêm mục công việc",
+  "advanced_description_placeholder": "Nhấn '/' để sử dụng lệnh",
+  "create_work_item": "Tạo mục công việc",
+  "attachments": "Tệp đính kèm",
+  "declining": "Đang từ chối",
+  "declined": "Đã từ chối",
+  "decline": "Từ chối",
+  "unassigned": "Chưa phân công",
+  "work_items": "Mục công việc",
+  "add_link": "Thêm liên kết",
+  "points": "Điểm",
+  "no_assignee": "Không có người phụ trách",
+  "no_assignees_yet": "Chưa có người phụ trách",
+  "no_labels_yet": "Chưa có nhãn",
+  "ideal": "Lý tưởng",
+  "current": "Hiện tại",
+  "no_matching_members": "Không có thành viên phù hợp",
+  "leaving": "Đang rời",
+  "removing": "Đang xóa",
+  "leave": "Rời",
+  "refresh": "Làm mới",
+  "refreshing": "Đang làm mới",
+  "refresh_status": "Làm mới trạng thái",
+  "prev": "Trước",
+  "next": "Tiếp",
+  "re_generating": "Đang tạo lại",
+  "re_generate": "Tạo lại",
+  "re_generate_key": "Tạo lại khóa",
+  "export": "Xuất",
+  "member": "{count, plural, other{# thành viên}}",
+  "project_view": {
+    "sort_by": {
+      "created_at": "Thời gian tạo",
+      "updated_at": "Thời gian cập nhật",
+      "name": "Tên"
+    }
+  },
+  "toast": {
+    "success": "Thành công!",
+    "error": "Lỗi!"
+  },
+  "links": {
+    "toasts": {
+      "created": {
+        "title": "Đã tạo liên kết",
+        "message": "Liên kết đã được tạo thành công"
+      },
+      "not_created": {
+        "title": "Chưa tạo liên kết",
+        "message": "Không thể tạo liên kết"
+      },
+      "updated": {
+        "title": "Đã cập nhật liên kết",
+        "message": "Liên kết đã được cập nhật thành công"
+      },
+      "not_updated": {
+        "title": "Chưa cập nhật liên kết",
+        "message": "Không thể cập nhật liên kết"
+      },
+      "removed": {
+        "title": "Đã xóa liên kết",
+        "message": "Liên kết đã được xóa thành công"
+      },
+      "not_removed": {
+        "title": "Chưa xóa liên kết",
+        "message": "Không thể xóa liên kết"
+      }
+    }
+  },
+  "home": {
+    "empty": {
+      "quickstart_guide": "Hướng dẫn nhanh",
+      "not_right_now": "Không phải bây giờ",
+      "create_project": {
+        "title": "Tạo dự án",
+        "description": "Trong Plane, hầu hết mọi thứ đều bắt đầu từ dự án.",
+        "cta": "Bắt đầu"
+      },
+      "invite_team": {
+        "title": "Mời nhóm của bạn",
+        "description": "Xây dựng, phát hành và quản lý cùng với đồng nghiệp.",
+        "cta": "Mời họ tham gia"
+      },
+      "configure_workspace": {
+        "title": "Thiết lập không gian làm việc của bạn",
+        "description": "Bật hoặc tắt tính năng, hoặc thiết lập thêm.",
+        "cta": "Cấu hình không gian làm việc này"
+      },
+      "personalize_account": {
+        "title": "Cá nhân hóa Plane cho bạn",
+        "description": "Chọn ảnh đại diện, màu sắc và nhiều hơn nữa.",
+        "cta": "Cá nhân hóa ngay"
+      },
+      "widgets": {
+        "title": "Không có tiện ích nào trông có vẻ yên tĩnh, hãy bật chúng lên",
+        "description": "Có vẻ như tất cả tiện ích của bạn đều đã bị tắt. Bật chúng ngay\nđể nâng cao trải nghiệm của bạn!",
+        "primary_button": {
+          "text": "Quản lý tiện ích"
+        }
+      }
+    },
+    "quick_links": {
+      "empty": "Lưu liên kết liên quan đến công việc mà bạn muốn truy cập thuận tiện.",
+      "add": "Thêm liên kết nhanh",
+      "title": "Liên kết nhanh",
+      "title_plural": "Liên kết nhanh"
+    },
+    "recents": {
+      "title": "Gần đây",
+      "empty": {
+        "project": "Sau khi truy cập dự án, các dự án gần đây của bạn sẽ xuất hiện ở đây.",
+        "page": "Sau khi truy cập trang, các trang gần đây của bạn sẽ xuất hiện ở đây.",
+        "issue": "Sau khi truy cập mục công việc, các mục công việc gần đây của bạn sẽ xuất hiện ở đây.",
+        "default": "Bạn chưa có dự án gần đây nào."
+      },
+      "filters": {
+        "all": "Tất cả dự án",
+        "projects": "Dự án",
+        "pages": "Trang",
+        "issues": "Mục công việc"
+      }
+    },
+    "new_at_plane": {
+      "title": "Tính năng mới của Plane"
+    },
+    "quick_tutorial": {
+      "title": "Hướng dẫn nhanh"
+    },
+    "widget": {
+      "reordered_successfully": "Đã sắp xếp lại tiện ích thành công.",
+      "reordering_failed": "Đã xảy ra lỗi khi sắp xếp lại tiện ích."
+    },
+    "manage_widgets": "Quản lý tiện ích",
+    "title": "Trang chủ",
+    "star_us_on_github": "Gắn sao cho chúng tôi trên GitHub"
+  },
+  "link": {
+    "modal": {
+      "url": {
+        "text": "URL",
+        "required": "URL không hợp lệ",
+        "placeholder": "Nhập hoặc dán URL"
+      },
+      "title": {
+        "text": "Tiêu đề hiển thị",
+        "placeholder": "Bạn muốn hiển thị liên kết này như thế nào"
+      }
+    }
+  },
+  "common": {
+    "all": "Tất cả",
+    "states": "Trạng thái",
+    "state": "Trạng thái",
+    "state_groups": "Nhóm trạng thái",
+    "state_group": "Nhóm trạng thái",
+    "priorities": "Ưu tiên",
+    "priority": "Ưu tiên",
+    "team_project": "Dự án nhóm",
+    "project": "Dự án",
+    "cycle": "Chu kỳ",
+    "cycles": "Chu kỳ",
+    "module": "Mô-đun",
+    "modules": "Mô-đun",
+    "labels": "Nhãn",
+    "label": "Nhãn",
+    "assignees": "Người phụ trách",
+    "assignee": "Người phụ trách",
+    "created_by": "Người tạo",
+    "none": "Không có",
+    "link": "Liên kết",
+    "estimates": "Ước tính",
+    "estimate": "Ước tính",
+    "created_at": "Được tạo vào",
+    "completed_at": "Hoàn thành vào",
+    "layout": "Bố cục",
+    "filters": "Bộ lọc",
+    "display": "Hiển thị",
+    "load_more": "Tải thêm",
+    "activity": "Hoạt động",
+    "analytics": "Phân tích",
+    "dates": "Ngày tháng",
+    "success": "Thành công!",
+    "something_went_wrong": "Đã xảy ra lỗi",
+    "error": {
+      "label": "Lỗi!",
+      "message": "Đã xảy ra lỗi. Vui lòng thử lại."
+    },
+    "group_by": "Nhóm theo",
+    "epic": "Sử thi",
+    "epics": "Sử thi",
+    "work_item": "Mục công việc",
+    "work_items": "Mục công việc",
+    "sub_work_item": "Mục công việc con",
+    "add": "Thêm",
+    "warning": "Cảnh báo",
+    "updating": "Đang cập nhật",
+    "adding": "Đang thêm",
+    "update": "Cập nhật",
+    "creating": "Đang tạo",
+    "create": "Tạo",
+    "cancel": "Hủy",
+    "description": "Mô tả",
+    "title": "Tiêu đề",
+    "attachment": "Tệp đính kèm",
+    "general": "Chung",
+    "features": "Tính năng",
+    "automation": "Tự động hóa",
+    "project_name": "Tên dự án",
+    "project_id": "ID dự án",
+    "project_timezone": "Múi giờ dự án",
+    "created_on": "Được tạo vào",
+    "update_project": "Cập nhật dự án",
+    "identifier_already_exists": "Định danh đã tồn tại",
+    "add_more": "Thêm nữa",
+    "defaults": "Mặc định",
+    "add_label": "Thêm nhãn",
+    "customize_time_range": "Tùy chỉnh khoảng thời gian",
+    "loading": "Đang tải",
+    "attachments": "Tệp đính kèm",
+    "property": "Thuộc tính",
+    "properties": "Thuộc tính",
+    "parent": "Mục cha",
+    "page": "Trang",
+    "remove": "Xóa",
+    "archiving": "Đang lưu trữ",
+    "archive": "Lưu trữ",
+    "access": {
+      "public": "Công khai",
+      "private": "Riêng tư"
+    },
+    "done": "Hoàn thành",
+    "sub_work_items": "Mục công việc con",
+    "comment": "Bình luận",
+    "workspace_level": "Cấp không gian làm việc",
+    "order_by": {
+      "label": "Sắp xếp theo",
+      "manual": "Thủ công",
+      "last_created": "Mới tạo nhất",
+      "last_updated": "Mới cập nhật nhất",
+      "start_date": "Ngày bắt đầu",
+      "due_date": "Ngày hết hạn",
+      "asc": "Tăng dần",
+      "desc": "Giảm dần",
+      "updated_on": "Cập nhật vào"
+    },
+    "sort": {
+      "asc": "Tăng dần",
+      "desc": "Giảm dần",
+      "created_on": "Thời gian tạo",
+      "updated_on": "Thời gian cập nhật"
+    },
+    "comments": "Bình luận",
+    "updates": "Cập nhật",
+    "clear_all": "Xóa tất cả",
+    "copied": "Đã sao chép!",
+    "link_copied": "Đã sao chép liên kết!",
+    "link_copied_to_clipboard": "Đã sao chép liên kết vào bảng tạm",
+    "copied_to_clipboard": "Đã sao chép liên kết mục công việc vào bảng tạm",
+    "is_copied_to_clipboard": "Mục công việc đã được sao chép vào bảng tạm",
+    "no_links_added_yet": "Chưa có liên kết nào được thêm",
+    "add_link": "Thêm liên kết",
+    "links": "Liên kết",
+    "go_to_workspace": "Đi đến không gian làm việc",
+    "progress": "Tiến độ",
+    "optional": "Tùy chọn",
+    "join": "Tham gia",
+    "go_back": "Quay lại",
+    "continue": "Tiếp tục",
+    "resend": "Gửi lại",
+    "relations": "Mối quan hệ",
+    "errors": {
+      "default": {
+        "title": "Lỗi!",
+        "message": "Đã xảy ra lỗi. Vui lòng thử lại."
+      },
+      "required": "Trường này là bắt buộc",
+      "entity_required": "{entity} là bắt buộc"
+    },
+    "update_link": "Cập nhật liên kết",
+    "attach": "Đính kèm",
+    "create_new": "Tạo mới",
+    "add_existing": "Thêm mục hiện có",
+    "type_or_paste_a_url": "Nhập hoặc dán URL",
+    "url_is_invalid": "URL không hợp lệ",
+    "display_title": "Tiêu đề hiển thị",
+    "link_title_placeholder": "Bạn muốn hiển thị liên kết này như thế nào",
+    "url": "URL",
+    "side_peek": "Xem lướt bên cạnh",
+    "modal": "Cửa sổ",
+    "full_screen": "Toàn màn hình",
+    "close_peek_view": "Đóng chế độ xem lướt",
+    "toggle_peek_view_layout": "Chuyển đổi bố cục xem lướt",
+    "options": "Tùy chọn",
+    "duration": "Thời lượng",
+    "today": "Hôm nay",
+    "week": "Tuần",
+    "month": "Tháng",
+    "quarter": "Quý",
+    "press_for_commands": "Nhấn '/' để sử dụng lệnh",
+    "click_to_add_description": "Nhấp để thêm mô tả",
+    "search": {
+      "label": "Tìm kiếm",
+      "placeholder": "Nhập nội dung tìm kiếm",
+      "no_matches_found": "Không tìm thấy kết quả phù hợp",
+      "no_matching_results": "Không có kết quả phù hợp"
+    },
+    "actions": {
+      "edit": "Chỉnh sửa",
+      "make_a_copy": "Tạo bản sao",
+      "open_in_new_tab": "Mở trong tab mới",
+      "copy_link": "Sao chép liên kết",
+      "archive": "Lưu trữ",
+      "delete": "Xóa",
+      "remove_relation": "Xóa mối quan hệ",
+      "subscribe": "Đăng ký",
+      "unsubscribe": "Hủy đăng ký",
+      "clear_sorting": "Xóa sắp xếp",
+      "show_weekends": "Hiển thị cuối tuần",
+      "enable": "Bật",
+      "disable": "Tắt"
+    },
+    "name": "Tên",
+    "discard": "Hủy bỏ",
+    "confirm": "Xác nhận",
+    "confirming": "Đang xác nhận",
+    "read_the_docs": "Đọc tài liệu",
+    "default": "Mặc định",
+    "active": "Hoạt động",
+    "enabled": "Đã bật",
+    "disabled": "Đã tắt",
+    "mandate": "Ủy quyền",
+    "mandatory": "Bắt buộc",
+    "yes": "Có",
+    "no": "Không",
+    "please_wait": "Vui lòng đợi",
+    "enabling": "Đang bật",
+    "disabling": "Đang tắt",
+    "beta": "Phiên bản beta",
+    "or": "Hoặc",
+    "next": "Tiếp theo",
+    "back": "Quay lại",
+    "cancelling": "Đang hủy",
+    "configuring": "Đang cấu hình",
+    "clear": "Xóa",
+    "import": "Nhập",
+    "connect": "Kết nối",
+    "authorizing": "Đang xác thực",
+    "processing": "Đang xử lý",
+    "no_data_available": "Không có dữ liệu",
+    "from": "Từ {name}",
+    "authenticated": "Đã xác thực",
+    "select": "Chọn",
+    "upgrade": "Nâng cấp",
+    "add_seats": "Thêm vị trí",
+    "projects": "Dự án",
+    "workspace": "Không gian làm việc",
+    "workspaces": "Không gian làm việc",
+    "team": "Nhóm",
+    "teams": "Nhóm",
+    "entity": "Thực thể",
+    "entities": "Thực thể",
+    "task": "Nhiệm vụ",
+    "tasks": "Nhiệm vụ",
+    "section": "Phần",
+    "sections": "Phần",
+    "edit": "Chỉnh sửa",
+    "connecting": "Đang kết nối",
+    "connected": "Đã kết nối",
+    "disconnect": "Ngắt kết nối",
+    "disconnecting": "Đang ngắt kết nối",
+    "installing": "Đang cài đặt",
+    "install": "Cài đặt",
+    "reset": "Đặt lại",
+    "live": "Trực tiếp",
+    "change_history": "Lịch sử thay đổi",
+    "coming_soon": "Sắp ra mắt",
+    "members": "Thành viên",
+    "you": "Bạn",
+    "upgrade_cta": {
+      "higher_subscription": "Nâng cấp lên gói cao hơn",
+      "talk_to_sales": "Liên hệ bộ phận bán hàng"
+    },
+    "category": "Danh mục",
+    "categories": "Danh mục",
+    "saving": "Đang lưu",
+    "save_changes": "Lưu thay đổi",
+    "delete": "Xóa",
+    "deleting": "Đang xóa",
+    "pending": "Đang chờ xử lý",
+    "invite": "Mời",
+    "view": "Xem"
+  },
+  "chart": {
+    "x_axis": "Trục X",
+    "y_axis": "Trục Y",
+    "metric": "Chỉ số"
+  },
+  "form": {
+    "title": {
+      "required": "Tiêu đề là bắt buộc",
+      "max_length": "Tiêu đề phải ít hơn {length} ký tự"
+    }
+  },
+  "entity": {
+    "grouping_title": "Nhóm {entity}",
+    "priority": "Ưu tiên {entity}",
+    "all": "Tất cả {entity}",
+    "drop_here_to_move": "Kéo thả vào đây để di chuyển {entity}",
+    "delete": {
+      "label": "Xóa {entity}",
+      "success": "Đã xóa {entity} thành công",
+      "failed": "Xóa {entity} thất bại"
+    },
+    "update": {
+      "failed": "Cập nhật {entity} thất bại",
+      "success": "Đã cập nhật {entity} thành công"
+    },
+    "link_copied_to_clipboard": "Đã sao chép liên kết {entity} vào bảng tạm",
+    "fetch": {
+      "failed": "Đã xảy ra lỗi khi tải {entity}"
+    },
+    "add": {
+      "success": "Đã thêm {entity} thành công",
+      "failed": "Đã xảy ra lỗi khi thêm {entity}"
+    }
+  },
+  "epic": {
+    "all": "Tất cả sử thi",
+    "label": "{count, plural, one {sử thi} other {sử thi}}",
+    "new": "Sử thi mới",
+    "adding": "Đang thêm sử thi",
+    "create": {
+      "success": "Đã tạo sử thi thành công"
+    },
+    "add": {
+      "press_enter": "Nhấn 'Enter' để thêm sử thi khác",
+      "label": "Thêm sử thi"
+    },
+    "title": {
+      "label": "Tiêu đề sử thi",
+      "required": "Tiêu đề sử thi là bắt buộc"
+    }
+  },
+  "issue": {
+    "label": "{count, plural, one {mục công việc} other {mục công việc}}",
+    "all": "Tất cả mục công việc",
+    "edit": "Chỉnh sửa mục công việc",
+    "title": {
+      "label": "Tiêu đề mục công việc",
+      "required": "Tiêu đề mục công việc là bắt buộc"
+    },
+    "add": {
+      "press_enter": "Nhấn 'Enter' để thêm mục công việc khác",
+      "label": "Thêm mục công việc",
+      "cycle": {
+        "failed": "Không thể thêm mục công việc vào chu kỳ. Vui lòng thử lại.",
+        "success": "{count, plural, one {Mục công việc} other {Mục công việc}} đã được thêm vào chu kỳ thành công.",
+        "loading": "Đang thêm {count, plural, one {mục công việc} other {mục công việc}} vào chu kỳ"
+      },
+      "assignee": "Thêm người phụ trách",
+      "start_date": "Thêm ngày bắt đầu",
+      "due_date": "Thêm ngày hết hạn",
+      "parent": "Thêm mục công việc cha",
+      "sub_issue": "Thêm mục công việc con",
+      "relation": "Thêm mối quan hệ",
+      "link": "Thêm liên kết",
+      "existing": "Thêm mục công việc hiện có"
+    },
+    "remove": {
+      "label": "Xóa mục công việc",
+      "cycle": {
+        "loading": "Đang xóa mục công việc khỏi chu kỳ",
+        "success": "Đã xóa mục công việc khỏi chu kỳ thành công.",
+        "failed": "Không thể xóa mục công việc khỏi chu kỳ. Vui lòng thử lại."
+      },
+      "module": {
+        "loading": "Đang xóa mục công việc khỏi mô-đun",
+        "success": "Đã xóa mục công việc khỏi mô-đun thành công.",
+        "failed": "Không thể xóa mục công việc khỏi mô-đun. Vui lòng thử lại."
+      },
+      "parent": {
+        "label": "Xóa mục công việc cha"
+      }
+    },
+    "new": "Mục công việc mới",
+    "adding": "Đang thêm mục công việc",
+    "create": {
+      "success": "Đã tạo mục công việc thành công"
+    },
+    "priority": {
+      "urgent": "Khẩn cấp",
+      "high": "Cao",
+      "medium": "Trung bình",
+      "low": "Thấp"
+    },
+    "display": {
+      "properties": {
+        "label": "Hiển thị thuộc tính",
+        "id": "ID",
+        "issue_type": "Loại mục công việc",
+        "sub_issue_count": "Số lượng mục công việc con",
+        "attachment_count": "Số lượng tệp đính kèm",
+        "created_on": "Được tạo vào",
+        "sub_issue": "Mục công việc con",
+        "work_item_count": "Số lượng mục công việc"
+      },
+      "extra": {
+        "show_sub_issues": "Hiển thị mục công việc con",
+        "show_empty_groups": "Hiển thị nhóm trống"
+      }
+    },
+    "layouts": {
+      "ordered_by_label": "Bố cục này được sắp xếp theo",
+      "list": "Danh sách",
+      "kanban": "Kanban",
+      "calendar": "Lịch",
+      "spreadsheet": "Bảng tính",
+      "gantt": "Dòng thời gian",
+      "title": {
+        "list": "Bố cục danh sách",
+        "kanban": "Bố cục kanban",
+        "calendar": "Bố cục lịch",
+        "spreadsheet": "Bố cục bảng tính",
+        "gantt": "Bố cục dòng thời gian"
+      }
+    },
+    "states": {
+      "active": "Hoạt động",
+      "backlog": "Tồn đọng"
+    },
+    "comments": {
+      "placeholder": "Thêm bình luận",
+      "switch": {
+        "private": "Chuyển sang bình luận riêng tư",
+        "public": "Chuyển sang bình luận công khai"
+      },
+      "create": {
+        "success": "Đã tạo bình luận thành công",
+        "error": "Không thể tạo bình luận. Vui lòng thử lại sau."
+      },
+      "update": {
+        "success": "Đã cập nhật bình luận thành công",
+        "error": "Không thể cập nhật bình luận. Vui lòng thử lại sau."
+      },
+      "remove": {
+        "success": "Đã xóa bình luận thành công",
+        "error": "Không thể xóa bình luận. Vui lòng thử lại sau."
+      },
+      "upload": {
+        "error": "Không thể tải lên tài nguyên. Vui lòng thử lại sau."
+      }
+    },
+    "empty_state": {
+      "issue_detail": {
+        "title": "Mục công việc không tồn tại",
+        "description": "Mục công việc bạn đang tìm kiếm không tồn tại, đã được lưu trữ hoặc đã bị xóa.",
+        "primary_button": {
+          "text": "Xem các mục công việc khác"
+        }
+      }
+    },
+    "sibling": {
+      "label": "Mục công việc cùng cấp"
+    },
+    "archive": {
+      "description": "Chỉ những mục công việc đã hoàn thành hoặc đã hủy\ncó thể được lưu trữ",
+      "label": "Lưu trữ mục công việc",
+      "confirm_message": "Bạn có chắc chắn muốn lưu trữ mục công việc này không? Tất cả mục công việc đã lưu trữ có thể được khôi phục sau.",
+      "success": {
+        "label": "Lưu trữ thành công",
+        "message": "Mục đã lưu trữ của bạn có thể được tìm thấy trong phần lưu trữ của dự án."
+      },
+      "failed": {
+        "message": "Không thể lưu trữ mục công việc. Vui lòng thử lại."
+      }
+    },
+    "restore": {
+      "success": {
+        "title": "Khôi phục thành công",
+        "message": "Mục công việc của bạn có thể được tìm thấy trong mục công việc của dự án."
+      },
+      "failed": {
+        "message": "Không thể khôi phục mục công việc. Vui lòng thử lại."
+      }
+    },
+    "relation": {
+      "relates_to": "Liên quan đến",
+      "duplicate": "Trùng lặp với",
+      "blocked_by": "Bị chặn bởi",
+      "blocking": "Đang chặn"
+    },
+    "copy_link": "Sao chép liên kết mục công việc",
+    "delete": {
+      "label": "Xóa mục công việc",
+      "error": "Đã xảy ra lỗi khi xóa mục công việc"
+    },
+    "subscription": {
+      "actions": {
+        "subscribed": "Đã đăng ký mục công việc thành công",
+        "unsubscribed": "Đã hủy đăng ký mục công việc thành công"
+      }
+    },
+    "select": {
+      "error": "Vui lòng chọn ít nhất một mục công việc",
+      "empty": "Chưa chọn mục công việc",
+      "add_selected": "Thêm mục công việc đã chọn"
+    },
+    "open_in_full_screen": "Mở mục công việc trong chế độ toàn màn hình"
+  },
+  "attachment": {
+    "error": "Không thể đính kèm tệp. Vui lòng tải lên lại.",
+    "only_one_file_allowed": "Chỉ có thể tải lên một tệp mỗi lần.",
+    "file_size_limit": "Kích thước tệp phải nhỏ hơn hoặc bằng {size}MB.",
+    "drag_and_drop": "Kéo và thả vào bất kỳ đâu để tải lên",
+    "delete": "Xóa tệp đính kèm"
+  },
+  "label": {
+    "select": "Chọn nhãn",
+    "create": {
+      "success": "Đã tạo nhãn thành công",
+      "failed": "Tạo nhãn thất bại",
+      "already_exists": "Nhãn đã tồn tại",
+      "type": "Nhập để thêm nhãn mới"
+    }
+  },
+  "sub_work_item": {
+    "update": {
+      "success": "Đã cập nhật mục công việc con thành công",
+      "error": "Đã xảy ra lỗi khi cập nhật mục công việc con"
+    },
+    "remove": {
+      "success": "Đã xóa mục công việc con thành công",
+      "error": "Đã xảy ra lỗi khi xóa mục công việc con"
+    }
+  },
+  "view": {
+    "label": "{count, plural, one {chế độ xem} other {chế độ xem}}",
+    "create": {
+      "label": "Tạo chế độ xem"
+    },
+    "update": {
+      "label": "Cập nhật chế độ xem"
+    }
+  },
+  "inbox_issue": {
+    "status": {
+      "pending": {
+        "title": "Đang chờ xử lý",
+        "description": "Đang chờ xử lý"
+      },
+      "declined": {
+        "title": "Đã từ chối",
+        "description": "Đã từ chối"
+      },
+      "snoozed": {
+        "title": "Đã tạm hoãn",
+        "description": "Còn lại {days, plural, one{# ngày} other{# ngày}}"
+      },
+      "accepted": {
+        "title": "Đã chấp nhận",
+        "description": "Đã chấp nhận"
+      },
+      "duplicate": {
+        "title": "Trùng lặp",
+        "description": "Trùng lặp"
+      }
+    },
+    "modals": {
+      "decline": {
+        "title": "Từ chối mục công việc",
+        "content": "Bạn có chắc chắn muốn từ chối mục công việc {value} không?"
+      },
+      "delete": {
+        "title": "Xóa mục công việc",
+        "content": "Bạn có chắc chắn muốn xóa mục công việc {value} không?",
+        "success": "Đã xóa mục công việc thành công"
+      }
+    },
+    "errors": {
+      "snooze_permission": "Chỉ quản trị viên dự án mới có thể tạm hoãn/hủy tạm hoãn mục công việc",
+      "accept_permission": "Chỉ quản trị viên dự án mới có thể chấp nhận mục công việc",
+      "decline_permission": "Chỉ quản trị viên dự án mới có thể từ chối mục công việc"
+    },
+    "actions": {
+      "accept": "Chấp nhận",
+      "decline": "Từ chối",
+      "snooze": "Tạm hoãn",
+      "unsnooze": "Hủy tạm hoãn",
+      "copy": "Sao chép liên kết mục công việc",
+      "delete": "Xóa",
+      "open": "Mở mục công việc",
+      "mark_as_duplicate": "Đánh dấu là trùng lặp",
+      "move": "Di chuyển {value} đến mục công việc dự án"
+    },
+    "source": {
+      "in-app": "Trong ứng dụng"
+    },
+    "order_by": {
+      "created_at": "Thời gian tạo",
+      "updated_at": "Thời gian cập nhật",
+      "id": "ID"
+    },
+    "label": "Thu thập",
+    "page_label": "{workspace} - Thu thập",
+    "modal": {
+      "title": "Tạo mục công việc thu thập"
+    },
+    "tabs": {
+      "open": "Chưa xử lý",
+      "closed": "Đã xử lý"
+    },
+    "empty_state": {
+      "sidebar_open_tab": {
+        "title": "Không có mục công việc chưa xử lý",
+        "description": "Tìm mục công việc chưa xử lý tại đây. Tạo mục công việc mới."
+      },
+      "sidebar_closed_tab": {
+        "title": "Không có mục công việc đã xử lý",
+        "description": "Tất cả mục công việc đã chấp nhận hoặc từ chối có thể được tìm thấy ở đây."
+      },
+      "sidebar_filter": {
+        "title": "Không có mục công việc phù hợp",
+        "description": "Không có mục công việc trong thu thập phù hợp với bộ lọc của bạn. Tạo mục công việc mới."
+      },
+      "detail": {
+        "title": "Chọn một mục công việc để xem chi tiết."
+      }
+    }
+  },
+  "workspace_creation": {
+    "heading": "Tạo không gian làm việc của bạn",
+    "subheading": "Để bắt đầu với Plane, bạn cần tạo hoặc tham gia một không gian làm việc.",
+    "form": {
+      "name": {
+        "label": "Đặt tên cho không gian làm việc của bạn",
+        "placeholder": "Một tên quen thuộc và dễ nhận diện luôn là tốt nhất."
+      },
+      "url": {
+        "label": "Thiết lập URL không gian làm việc của bạn",
+        "placeholder": "Nhập hoặc dán URL",
+        "edit_slug": "Bạn chỉ có thể chỉnh sửa phần định danh của URL"
+      },
+      "organization_size": {
+        "label": "Có bao nhiêu người sẽ sử dụng không gian làm việc này?",
+        "placeholder": "Chọn một phạm vi"
+      }
+    },
+    "errors": {
+      "creation_disabled": {
+        "title": "Chỉ quản trị viên hệ thống của bạn mới có thể tạo không gian làm việc",
+        "description": "Nếu bạn biết địa chỉ email của quản trị viên hệ thống, hãy nhấp vào nút bên dưới để liên hệ với họ.",
+        "request_button": "Yêu cầu quản trị viên hệ thống"
+      },
+      "validation": {
+        "name_alphanumeric": "Tên không gian làm việc chỉ có thể chứa (' '), ('-'), ('_') và các ký tự chữ số.",
+        "name_length": "Tên giới hạn trong 80 ký tự.",
+        "url_alphanumeric": "URL chỉ có thể chứa ('-') và các ký tự chữ số.",
+        "url_length": "URL giới hạn trong 48 ký tự.",
+        "url_already_taken": "URL không gian làm việc đã được sử dụng!"
+      }
+    },
+    "request_email": {
+      "subject": "Yêu cầu không gian làm việc mới",
+      "body": "Xin chào Quản trị viên hệ thống:\n\nVui lòng tạo một không gian làm việc mới có URL là [/workspace-name] cho [mục đích tạo không gian làm việc].\n\nCảm ơn,\n{firstName} {lastName}\n{email}"
+    },
+    "button": {
+      "default": "Tạo không gian làm việc",
+      "loading": "Đang tạo không gian làm việc"
+    },
+    "toast": {
+      "success": {
+        "title": "Thành công",
+        "message": "Đã tạo không gian làm việc thành công"
+      },
+      "error": {
+        "title": "Lỗi",
+        "message": "Tạo không gian làm việc thất bại. Vui lòng thử lại."
+      }
+    }
+  },
+  "workspace_dashboard": {
+    "empty_state": {
+      "general": {
+        "title": "Tổng quan về dự án, hoạt động và chỉ số",
+        "description": "Chào mừng đến với Plane, chúng tôi rất vui khi bạn ở đây. Tạo dự án đầu tiên của bạn và theo dõi mục công việc, trang này sẽ trở thành không gian giúp bạn tiến triển. Quản trị viên cũng sẽ thấy dự án giúp nhóm tiến triển.",
+        "primary_button": {
+          "text": "Xây dựng dự án đầu tiên của bạn",
+          "comic": {
+            "title": "Trong Plane, mọi thứ đều bắt đầu với dự án",
+            "description": "Dự án có thể là lộ trình sản phẩm, chiến dịch tiếp thị hoặc ra mắt xe mới."
+          }
+        }
+      }
+    }
+  },
+  "workspace_analytics": {
+    "label": "Phân tích",
+    "page_label": "{workspace} - Phân tích",
+    "open_tasks": "Tổng nhiệm vụ đang mở",
+    "error": "Đã xảy ra lỗi khi truy xuất dữ liệu.",
+    "work_items_closed_in": "Mục công việc đã đóng trong",
+    "selected_projects": "Dự án đã chọn",
+    "total_members": "Tổng số thành viên",
+    "total_cycles": "Tổng số chu kỳ",
+    "total_modules": "Tổng số mô-đun",
+    "pending_work_items": {
+      "title": "Mục công việc đang chờ xử lý",
+      "empty_state": "Phân tích mục công việc đang chờ xử lý của đồng nghiệp sẽ hiển thị ở đây."
+    },
+    "work_items_closed_in_a_year": {
+      "title": "Mục công việc đã đóng trong một năm",
+      "empty_state": "Đóng mục công việc để xem phân tích dưới dạng biểu đồ."
+    },
+    "most_work_items_created": {
+      "title": "Tạo nhiều mục công việc nhất",
+      "empty_state": "Đồng nghiệp và số lượng mục công việc họ đã tạo sẽ hiển thị ở đây."
+    },
+    "most_work_items_closed": {
+      "title": "Đóng nhiều mục công việc nhất",
+      "empty_state": "Đồng nghiệp và số lượng mục công việc họ đã đóng sẽ hiển thị ở đây."
+    },
+    "tabs": {
+      "scope_and_demand": "Phạm vi và nhu cầu",
+      "custom": "Phân tích tùy chỉnh"
+    },
+    "empty_state": {
+      "general": {
+        "title": "Theo dõi tiến độ, khối lượng công việc và phân công. Khám phá xu hướng, loại bỏ rào cản và đẩy nhanh công việc",
+        "description": "Xem phạm vi so với nhu cầu, ước tính và mở rộng phạm vi. Nhận hiệu suất của thành viên nhóm và nhóm, đảm bảo dự án của bạn đúng tiến độ.",
+        "primary_button": {
+          "text": "Bắt đầu dự án đầu tiên của bạn",
+          "comic": {
+            "title": "Phân tích hoạt động tốt nhất trong chu kỳ + mô-đun",
+            "description": "Đầu tiên, giới hạn mục công việc của bạn trong chu kỳ và nếu có thể, nhóm mục công việc kéo dài nhiều chu kỳ thành mô-đun. Xem cả hai trong thanh điều hướng bên trái."
+          }
+        }
+      }
+    }
+  },
+  "workspace_projects": {
+    "label": "{count, plural, one {dự án} other {dự án}}",
+    "create": {
+      "label": "Thêm dự án"
+    },
+    "network": {
+      "private": {
+        "title": "Riêng tư",
+        "description": "Chỉ truy cập bằng lời mời"
+      },
+      "public": {
+        "title": "Công khai",
+        "description": "Bất kỳ ai trong không gian làm việc ngoại trừ khách đều có thể tham gia"
+      }
+    },
+    "error": {
+      "permission": "Bạn không có quyền thực hiện thao tác này.",
+      "cycle_delete": "Xóa chu kỳ thất bại",
+      "module_delete": "Xóa mô-đun thất bại",
+      "issue_delete": "Xóa mục công việc thất bại"
+    },
+    "state": {
+      "backlog": "Tồn đọng",
+      "unstarted": "Chưa bắt đầu",
+      "started": "Đang tiến hành",
+      "completed": "Đã hoàn thành",
+      "cancelled": "Đã hủy"
+    },
+    "sort": {
+      "manual": "Thủ công",
+      "name": "Tên",
+      "created_at": "Ngày tạo",
+      "members_length": "Số lượng thành viên"
+    },
+    "scope": {
+      "my_projects": "Dự án của tôi",
+      "archived_projects": "Đã lưu trữ"
+    },
+    "common": {
+      "months_count": "{months, plural, one{# tháng} other{# tháng}}"
+    },
+    "empty_state": {
+      "general": {
+        "title": "Không có dự án hoạt động",
+        "description": "Coi mỗi dự án như là cấp cha của công việc định hướng mục tiêu. Dự án là nơi chứa mục công việc, chu kỳ và mô-đun, cùng với đồng nghiệp giúp bạn đạt được mục tiêu. Tạo dự án mới hoặc lọc dự án đã lưu trữ.",
+        "primary_button": {
+          "text": "Bắt đầu dự án đầu tiên của bạn",
+          "comic": {
+            "title": "Trong Plane, mọi thứ đều bắt đầu với dự án",
+            "description": "Dự án có thể là lộ trình sản phẩm, chiến dịch tiếp thị hoặc ra mắt xe mới."
+          }
+        }
+      },
+      "no_projects": {
+        "title": "Không có dự án",
+        "description": "Để tạo mục công việc hoặc quản lý công việc của bạn, bạn cần tạo dự án hoặc trở thành một phần của dự án.",
+        "primary_button": {
+          "text": "Bắt đầu dự án đầu tiên của bạn",
+          "comic": {
+            "title": "Trong Plane, mọi thứ đều bắt đầu với dự án",
+            "description": "Dự án có thể là lộ trình sản phẩm, chiến dịch tiếp thị hoặc ra mắt xe mới."
+          }
+        }
+      },
+      "filter": {
+        "title": "Không có dự án phù hợp",
+        "description": "Không phát hiện dự án nào phù hợp với điều kiện tìm kiếm.\nTạo dự án mới."
+      },
+      "search": {
+        "description": "Không phát hiện dự án nào phù hợp với điều kiện tìm kiếm.\nTạo dự án mới"
+      }
+    }
+  },
+  "workspace_views": {
+    "add_view": "Thêm chế độ xem",
+    "empty_state": {
+      "all-issues": {
+        "title": "Không có mục công việc trong dự án",
+        "description": "Dự án đầu tiên hoàn thành! Bây giờ, hãy chia nhỏ công việc của bạn thành các mục công việc có thể theo dõi. Hãy bắt đầu nào!",
+        "primary_button": {
+          "text": "Tạo mục công việc mới"
+        }
+      },
+      "assigned": {
+        "title": "Chưa có mục công việc",
+        "description": "Mục công việc được giao cho bạn có thể được theo dõi tại đây.",
+        "primary_button": {
+          "text": "Tạo mục công việc mới"
+        }
+      },
+      "created": {
+        "title": "Chưa có mục công việc",
+        "description": "Tất cả mục công việc bạn tạo sẽ xuất hiện ở đây, theo dõi chúng trực tiếp tại đây.",
+        "primary_button": {
+          "text": "Tạo mục công việc mới"
+        }
+      },
+      "subscribed": {
+        "title": "Chưa có mục công việc",
+        "description": "Đăng ký mục công việc bạn quan tâm, theo dõi tất cả chúng tại đây."
+      },
+      "custom-view": {
+        "title": "Chưa có mục công việc",
+        "description": "Mục công việc phù hợp với bộ lọc, theo dõi tất cả chúng tại đây."
+      }
+    }
+  },
+  "workspace_settings": {
+    "label": "Cài đặt không gian làm việc",
+    "page_label": "{workspace} - Cài đặt chung",
+    "key_created": "Đã tạo khóa",
+    "copy_key": "Sao chép và lưu khóa này trong Plane Pages. Bạn sẽ không thể thấy khóa này sau khi đóng. Tệp CSV chứa khóa đã được tải xuống.",
+    "token_copied": "Đã sao chép token vào bảng tạm.",
+    "settings": {
+      "general": {
+        "title": "Chung",
+        "upload_logo": "Tải lên logo",
+        "edit_logo": "Chỉnh sửa logo",
+        "name": "Tên không gian làm việc",
+        "company_size": "Quy mô công ty",
+        "url": "URL không gian làm việc",
+        "update_workspace": "Cập nhật không gian làm việc",
+        "delete_workspace": "Xóa không gian làm việc này",
+        "delete_workspace_description": "Khi xóa không gian làm việc, tất cả dữ liệu và tài nguyên trong không gian làm việc đó sẽ bị xóa vĩnh viễn và không thể khôi phục.",
+        "delete_btn": "Xóa không gian làm việc này",
+        "delete_modal": {
+          "title": "Bạn có chắc chắn muốn xóa không gian làm việc này không?",
+          "description": "Bạn hiện đang dùng thử gói trả phí của chúng tôi. Vui lòng hủy dùng thử trước khi tiếp tục.",
+          "dismiss": "Đóng",
+          "cancel": "Hủy dùng thử",
+          "success_title": "Đã xóa không gian làm việc.",
+          "success_message": "Sắp chuyển hướng đến trang hồ sơ của bạn.",
+          "error_title": "Thao tác thất bại.",
+          "error_message": "Vui lòng thử lại."
+        },
+        "errors": {
+          "name": {
+            "required": "Tên là bắt buộc",
+            "max_length": "Tên không gian làm việc không nên vượt quá 80 ký tự"
+          },
+          "company_size": {
+            "required": "Quy mô công ty là bắt buộc",
+            "select_a_range": "Chọn quy mô tổ chức"
+          }
+        }
+      },
+      "members": {
+        "title": "Thành viên",
+        "add_member": "Thêm thành viên",
+        "pending_invites": "Lời mời đang chờ xử lý",
+        "invitations_sent_successfully": "Đã gửi lời mời thành công",
+        "leave_confirmation": "Bạn có chắc chắn muốn rời khỏi không gian làm việc này không? Bạn sẽ không thể truy cập không gian làm việc này nữa. Hành động này không thể hoàn tác.",
+        "details": {
+          "full_name": "Tên đầy đủ",
+          "display_name": "Tên hiển thị",
+          "email_address": "Địa chỉ email",
+          "account_type": "Loại tài khoản",
+          "authentication": "Xác thực",
+          "joining_date": "Ngày tham gia"
+        },
+        "modal": {
+          "title": "Mời người cộng tác",
+          "description": "Mời người cộng tác trong không gian làm việc của bạn.",
+          "button": "Gửi lời mời",
+          "button_loading": "Đang gửi lời mời",
+          "placeholder": "name@company.com",
+          "errors": {
+            "required": "Chúng tôi cần một địa chỉ email để mời họ.",
+            "invalid": "Email không hợp lệ"
+          }
+        }
+      },
+      "billing_and_plans": {
+        "title": "Thanh toán và Kế hoạch",
+        "current_plan": "Kế hoạch hiện tại",
+        "free_plan": "Bạn đang sử dụng kế hoạch miễn phí",
+        "view_plans": "Xem kế hoạch"
+      },
+      "exports": {
+        "title": "Xuất",
+        "exporting": "Đang xuất",
+        "previous_exports": "Xuất trước đây",
+        "export_separate_files": "Xuất dữ liệu thành các tệp riêng biệt",
+        "modal": {
+          "title": "Xuất đến",
+          "toasts": {
+            "success": {
+              "title": "Xuất thành công",
+              "message": "Bạn có thể tải xuống {entity} đã xuất từ phần xuất trước đây"
+            },
+            "error": {
+              "title": "Xuất thất bại",
+              "message": "Xuất không thành công. Vui lòng thử lại."
+            }
+          }
+        }
+      },
+      "webhooks": {
+        "title": "Webhooks",
+        "add_webhook": "Thêm webhook",
+        "modal": {
+          "title": "Tạo webhook",
+          "details": "Chi tiết Webhook",
+          "payload": "URL tải",
+          "question": "Bạn muốn những sự kiện nào kích hoạt webhook này?",
+          "error": "URL là bắt buộc"
+        },
+        "secret_key": {
+          "title": "Khóa bí mật",
+          "message": "Tạo token để đăng nhập tải webhook"
+        },
+        "options": {
+          "all": "Gửi tất cả",
+          "individual": "Chọn từng sự kiện"
+        },
+        "toasts": {
+          "created": {
+            "title": "Đã tạo Webhook",
+            "message": "Webhook đã được tạo thành công"
+          },
+          "not_created": {
+            "title": "Chưa tạo Webhook",
+            "message": "Không thể tạo webhook"
+          },
+          "updated": {
+            "title": "Đã cập nhật Webhook",
+            "message": "Webhook đã được cập nhật thành công"
+          },
+          "not_updated": {
+            "title": "Chưa cập nhật Webhook",
+            "message": "Không thể cập nhật webhook"
+          },
+          "removed": {
+            "title": "Đã xóa Webhook",
+            "message": "Webhook đã được xóa thành công"
+          },
+          "not_removed": {
+            "title": "Chưa xóa Webhook",
+            "message": "Không thể xóa webhook"
+          },
+          "secret_key_copied": {
+            "message": "Đã sao chép khóa bí mật vào bảng tạm."
+          },
+          "secret_key_not_copied": {
+            "message": "Đã xảy ra lỗi khi sao chép khóa bí mật."
+          }
+        }
+      },
+      "api_tokens": {
+        "title": "Token API",
+        "add_token": "Thêm token API",
+        "create_token": "Tạo token",
+        "never_expires": "Không bao giờ hết hạn",
+        "generate_token": "Tạo token",
+        "generating": "Đang tạo",
+        "delete": {
+          "title": "Xóa token API",
+          "description": "Bất kỳ ứng dụng nào sử dụng token này sẽ không thể truy cập dữ liệu Plane nữa. Hành động này không thể hoàn tác.",
+          "success": {
+            "title": "Thành công!",
+            "message": "Đã xóa token API thành công"
+          },
+          "error": {
+            "title": "Lỗi!",
+            "message": "Không thể xóa token API"
+          }
+        }
+      }
+    },
+    "empty_state": {
+      "api_tokens": {
+        "title": "Chưa tạo token API",
+        "description": "API Plane có thể được sử dụng để tích hợp dữ liệu Plane của bạn với bất kỳ hệ thống bên ngoài nào. Tạo token để bắt đầu."
+      },
+      "webhooks": {
+        "title": "Chưa thêm webhook",
+        "description": "Tạo webhook để nhận cập nhật theo thời gian thực và tự động hóa hành động."
+      },
+      "exports": {
+        "title": "Chưa có xuất dữ liệu",
+        "description": "Mỗi khi xuất, bạn sẽ có một bản sao ở đây để tham khảo."
+      },
+      "imports": {
+        "title": "Chưa có nhập dữ liệu",
+        "description": "Tìm tất cả các lần nhập trước đây và tải xuống chúng tại đây."
+      }
+    }
+  },
+  "profile": {
+    "label": "Hồ sơ",
+    "page_label": "Công việc của bạn",
+    "work": "Công việc",
+    "details": {
+      "joined_on": "Tham gia vào",
+      "time_zone": "Múi giờ"
+    },
+    "stats": {
+      "workload": "Khối lượng công việc",
+      "overview": "Tổng quan",
+      "created": "Mục công việc đã tạo",
+      "assigned": "Mục công việc đã giao",
+      "subscribed": "Mục công việc đã đăng ký",
+      "state_distribution": {
+        "title": "Mục công việc theo trạng thái",
+        "empty": "Tạo mục công việc để xem phân loại theo trạng thái trong biểu đồ để phân tích tốt hơn."
+      },
+      "priority_distribution": {
+        "title": "Mục công việc theo mức độ ưu tiên",
+        "empty": "Tạo mục công việc để xem phân loại theo mức độ ưu tiên trong biểu đồ để phân tích tốt hơn."
+      },
+      "recent_activity": {
+        "title": "Hoạt động gần đây",
+        "empty": "Chúng tôi không tìm thấy dữ liệu. Vui lòng kiểm tra đầu vào của bạn",
+        "button": "Tải xuống hoạt động hôm nay",
+        "button_loading": "Đang tải xuống"
+      }
+    },
+    "actions": {
+      "profile": "Hồ sơ",
+      "security": "Bảo mật",
+      "activity": "Hoạt động",
+      "appearance": "Giao diện",
+      "notifications": "Thông báo"
+    },
+    "tabs": {
+      "summary": "Tóm tắt",
+      "assigned": "Đã giao",
+      "created": "Đã tạo",
+      "subscribed": "Đã đăng ký",
+      "activity": "Hoạt động"
+    },
+    "empty_state": {
+      "activity": {
+        "title": "Chưa có hoạt động",
+        "description": "Bắt đầu bằng cách tạo mục công việc mới! Thêm chi tiết và thuộc tính cho nó. Khám phá thêm trong Plane để xem hoạt động của bạn."
+      },
+      "assigned": {
+        "title": "Không có mục công việc nào được giao cho bạn",
+        "description": "Có thể theo dõi mục công việc được giao cho bạn từ đây."
+      },
+      "created": {
+        "title": "Chưa có mục công việc",
+        "description": "Tất cả mục công việc bạn tạo sẽ xuất hiện ở đây, theo dõi chúng trực tiếp tại đây."
+      },
+      "subscribed": {
+        "title": "Chưa có mục công việc",
+        "description": "Đăng ký mục công việc bạn quan tâm, theo dõi tất cả chúng tại đây."
+      }
+    }
+  },
+  "project_settings": {
+    "general": {
+      "enter_project_id": "Nhập ID dự án",
+      "please_select_a_timezone": "Vui lòng chọn múi giờ",
+      "archive_project": {
+        "title": "Lưu trữ dự án",
+        "description": "Lưu trữ dự án sẽ hủy liệt kê dự án của bạn khỏi thanh điều hướng bên, nhưng bạn vẫn có thể truy cập nó từ trang dự án. Bạn có thể khôi phục hoặc xóa dự án bất cứ lúc nào.",
+        "button": "Lưu trữ dự án"
+      },
+      "delete_project": {
+        "title": "Xóa dự án",
+        "description": "Khi xóa dự án, tất cả dữ liệu và tài nguyên trong dự án đó sẽ bị xóa vĩnh viễn và không thể khôi phục.",
+        "button": "Xóa dự án của tôi"
+      },
+      "toast": {
+        "success": "Dự án đã được cập nhật thành công",
+        "error": "Không thể cập nhật dự án. Vui lòng thử lại."
+      }
+    },
+    "members": {
+      "label": "Thành viên",
+      "project_lead": "Người phụ trách dự án",
+      "default_assignee": "Người nhận mặc định",
+      "guest_super_permissions": {
+        "title": "Cấp quyền cho người dùng khách xem tất cả mục công việc:",
+        "sub_heading": "Điều này sẽ cho phép khách xem tất cả mục công việc của dự án."
+      },
+      "invite_members": {
+        "title": "Mời thành viên",
+        "sub_heading": "Mời thành viên tham gia dự án của bạn.",
+        "select_co_worker": "Chọn đồng nghiệp"
+      }
+    },
+    "states": {
+      "describe_this_state_for_your_members": "Mô tả trạng thái này cho thành viên của bạn.",
+      "empty_state": {
+        "title": "Không có trạng thái trong nhóm {groupKey}",
+        "description": "Vui lòng tạo một trạng thái mới"
+      }
+    },
+    "labels": {
+      "label_title": "Tiêu đề nhãn",
+      "label_title_is_required": "Tiêu đề nhãn là bắt buộc",
+      "label_max_char": "Tên nhãn không nên vượt quá 255 ký tự",
+      "toast": {
+        "error": "Đã xảy ra lỗi khi cập nhật nhãn"
+      }
+    },
+    "estimates": {
+      "title": "Bật ước tính cho dự án của tôi",
+      "description": "Chúng giúp bạn truyền đạt độ phức tạp và khối lượng công việc của nhóm."
+    },
+    "automations": {
+      "label": "Tự động hóa",
+      "auto-archive": {
+        "title": "Tự động lưu trữ mục công việc đã đóng",
+        "description": "Plane sẽ tự động lưu trữ các mục công việc đã hoàn thành hoặc đã hủy.",
+        "duration": "Tự động lưu trữ đã đóng"
+      },
+      "auto-close": {
+        "title": "Tự động đóng mục công việc",
+        "description": "Plane sẽ tự động đóng các mục công việc chưa hoàn thành hoặc hủy.",
+        "duration": "Tự động đóng không hoạt động",
+        "auto_close_status": "Trạng thái tự động đóng"
+      }
+    },
+    "empty_state": {
+      "labels": {
+        "title": "Chưa có nhãn",
+        "description": "Tạo nhãn để giúp tổ chức và lọc mục công việc trong dự án của bạn."
+      },
+      "estimates": {
+        "title": "Chưa có hệ thống ước tính",
+        "description": "Tạo một tập hợp ước tính để truyền đạt khối lượng công việc cho mỗi mục công việc.",
+        "primary_button": "Thêm hệ thống ước tính"
+      }
+    }
+  },
+  "project_cycles": {
+    "add_cycle": "Thêm chu kỳ",
+    "more_details": "Thêm chi tiết",
+    "cycle": "Chu kỳ",
+    "update_cycle": "Cập nhật chu kỳ",
+    "create_cycle": "Tạo chu kỳ",
+    "no_matching_cycles": "Không có chu kỳ phù hợp",
+    "remove_filters_to_see_all_cycles": "Xóa bộ lọc để xem tất cả chu kỳ",
+    "remove_search_criteria_to_see_all_cycles": "Xóa tiêu chí tìm kiếm để xem tất cả chu kỳ",
+    "only_completed_cycles_can_be_archived": "Chỉ có thể lưu trữ chu kỳ đã hoàn thành",
+    "start_date": "Ngày bắt đầu",
+    "end_date": "Ngày kết thúc",
+    "in_your_timezone": "Trong múi giờ của bạn",
+    "transfer_work_items": "Chuyển {count} mục công việc",
+    "date_range": "Khoảng thời gian",
+    "add_date": "Thêm ngày",
+    "active_cycle": {
+      "label": "Chu kỳ hoạt động",
+      "progress": "Tiến độ",
+      "chart": "Biểu đồ burndown",
+      "priority_issue": "Mục công việc ưu tiên",
+      "assignees": "Người được giao",
+      "issue_burndown": "Burndown mục công việc",
+      "ideal": "Lý tưởng",
+      "current": "Hiện tại",
+      "labels": "Nhãn"
+    },
+    "upcoming_cycle": {
+      "label": "Chu kỳ sắp tới"
+    },
+    "completed_cycle": {
+      "label": "Chu kỳ đã hoàn thành"
+    },
+    "status": {
+      "days_left": "Số ngày còn lại",
+      "completed": "Đã hoàn thành",
+      "yet_to_start": "Chưa bắt đầu",
+      "in_progress": "Đang tiến hành",
+      "draft": "Bản nháp"
+    },
+    "action": {
+      "restore": {
+        "title": "Khôi phục chu kỳ",
+        "success": {
+          "title": "Đã khôi phục chu kỳ",
+          "description": "Chu kỳ đã được khôi phục."
+        },
+        "failed": {
+          "title": "Khôi phục chu kỳ thất bại",
+          "description": "Không thể khôi phục chu kỳ. Vui lòng thử lại."
+        }
+      },
+      "favorite": {
+        "loading": "Đang thêm chu kỳ vào mục yêu thích",
+        "success": {
+          "description": "Chu kỳ đã được thêm vào mục yêu thích.",
+          "title": "Thành công!"
+        },
+        "failed": {
+          "description": "Không thể thêm chu kỳ vào mục yêu thích. Vui lòng thử lại.",
+          "title": "Lỗi!"
+        }
+      },
+      "unfavorite": {
+        "loading": "Đang xóa chu kỳ khỏi mục yêu thích",
+        "success": {
+          "description": "Chu kỳ đã được xóa khỏi mục yêu thích.",
+          "title": "Thành công!"
+        },
+        "failed": {
+          "description": "Không thể xóa chu kỳ khỏi mục yêu thích. Vui lòng thử lại.",
+          "title": "Lỗi!"
+        }
+      },
+      "update": {
+        "loading": "Đang cập nhật chu kỳ",
+        "success": {
+          "description": "Chu kỳ đã được cập nhật thành công.",
+          "title": "Thành công!"
+        },
+        "failed": {
+          "description": "Đã xảy ra lỗi khi cập nhật chu kỳ. Vui lòng thử lại.",
+          "title": "Lỗi!"
+        },
+        "error": {
+          "already_exists": "Đã tồn tại chu kỳ trong khoảng thời gian đã cho, nếu bạn muốn tạo chu kỳ nháp, bạn có thể làm vậy bằng cách xóa cả hai ngày."
+        }
+      }
+    },
+    "empty_state": {
+      "general": {
+        "title": "Nhóm và đặt khung thời gian cho công việc của bạn trong chu kỳ.",
+        "description": "Chia nhỏ công việc theo khung thời gian, đặt ngày từ thời hạn dự án và đạt được tiến độ cụ thể với tư cách là một nhóm.",
+        "primary_button": {
+          "text": "Thiết lập chu kỳ đầu tiên của bạn",
+          "comic": {
+            "title": "Chu kỳ là khung thời gian lặp lại.",
+            "description": "Sprint, iteration hoặc bất kỳ thuật ngữ nào khác bạn sử dụng để theo dõi công việc hàng tuần hoặc hai tuần một lần đều là một chu kỳ."
+          }
+        }
+      },
+      "no_issues": {
+        "title": "Chưa thêm mục công việc vào chu kỳ",
+        "description": "Thêm hoặc tạo mục công việc bạn muốn đặt khung thời gian và giao trong chu kỳ này",
+        "primary_button": {
+          "text": "Tạo mục công việc mới"
+        },
+        "secondary_button": {
+          "text": "Thêm mục công việc hiện có"
+        }
+      },
+      "completed_no_issues": {
+        "title": "Không có mục công việc trong chu kỳ",
+        "description": "Không có mục công việc trong chu kỳ. Mục công việc đã được chuyển hoặc ẩn. Để xem mục công việc đã ẩn (nếu có), vui lòng cập nhật thuộc tính hiển thị của bạn tương ứng."
+      },
+      "active": {
+        "title": "Không có chu kỳ hoạt động",
+        "description": "Chu kỳ hoạt động bao gồm bất kỳ khoảng thời gian nào có ngày hôm nay trong phạm vi của nó. Tìm tiến độ và chi tiết về chu kỳ hoạt động ở đây."
+      },
+      "archived": {
+        "title": "Chưa có chu kỳ đã lưu trữ",
+        "description": "Để tổ chức dự án của bạn, hãy lưu trữ chu kỳ đã hoàn thành. Bạn có thể tìm thấy chúng ở đây sau khi lưu trữ."
+      }
+    }
+  },
+  "project_issues": {
+    "empty_state": {
+      "no_issues": {
+        "title": "Tạo mục công việc và giao nó cho ai đó, thậm chí là chính bạn",
+        "description": "Xem mục công việc như công việc, nhiệm vụ hoặc công việc cần hoàn thành. Mục công việc và các mục công việc con của chúng thường dựa trên thời gian, được giao cho thành viên nhóm để thực hiện. Nhóm của bạn thúc đẩy dự án đạt được mục tiêu bằng cách tạo, giao và hoàn thành mục công việc.",
+        "primary_button": {
+          "text": "Tạo mục công việc đầu tiên của bạn",
+          "comic": {
+            "title": "Mục công việc là khối xây dựng cơ bản trong Plane.",
+            "description": "Thiết kế lại giao diện Plane, định vị lại thương hiệu công ty hoặc ra mắt hệ thống phun nhiên liệu mới đều là ví dụ về mục công việc có thể chứa các mục công việc con."
+          }
+        }
+      },
+      "no_archived_issues": {
+        "title": "Chưa có mục công việc đã lưu trữ",
+        "description": "Thông qua phương thức thủ công hoặc tự động, bạn có thể lưu trữ mục công việc đã hoàn thành hoặc đã hủy. Bạn có thể tìm thấy chúng ở đây sau khi lưu trữ.",
+        "primary_button": {
+          "text": "Thiết lập tự động hóa"
+        }
+      },
+      "issues_empty_filter": {
+        "title": "Không tìm thấy mục công việc phù hợp với bộ lọc",
+        "secondary_button": {
+          "text": "Xóa tất cả bộ lọc"
+        }
+      }
+    }
+  },
+  "project_module": {
+    "add_module": "Thêm mô-đun",
+    "update_module": "Cập nhật mô-đun",
+    "create_module": "Tạo mô-đun",
+    "archive_module": "Lưu trữ mô-đun",
+    "restore_module": "Khôi phục mô-đun",
+    "delete_module": "Xóa mô-đun",
+    "empty_state": {
+      "general": {
+        "title": "Ánh xạ cột mốc dự án vào mô-đun, dễ dàng theo dõi công việc tổng hợp.",
+        "description": "Một nhóm mục công việc thuộc cấp cha trong cấu trúc logic tạo thành một mô-đun. Xem nó như một cách theo dõi công việc theo cột mốc dự án. Chúng có chu kỳ riêng và thời hạn cùng với các tính năng phân tích giúp bạn hiểu bạn đang ở đâu so với cột mốc.",
+        "primary_button": {
+          "text": "Xây dựng mô-đun đầu tiên của bạn",
+          "comic": {
+            "title": "Mô-đun giúp nhóm công việc theo cấu trúc phân cấp.",
+            "description": "Mô-đun giỏ hàng, mô-đun khung gầm và mô-đun kho đều là ví dụ tốt về nhóm như vậy."
+          }
+        }
+      },
+      "no_issues": {
+        "title": "Không có mục công việc trong mô-đun",
+        "description": "Tạo hoặc thêm mục công việc bạn muốn hoàn thành như một phần của mô-đun này",
+        "primary_button": {
+          "text": "Tạo mục công việc mới"
+        },
+        "secondary_button": {
+          "text": "Thêm mục công việc hiện có"
+        }
+      },
+      "archived": {
+        "title": "Chưa có mô-đun đã lưu trữ",
+        "description": "Để tổ chức dự án của bạn, hãy lưu trữ mô-đun đã hoàn thành hoặc đã hủy. Bạn có thể tìm thấy chúng ở đây sau khi lưu trữ."
+      },
+      "sidebar": {
+        "in_active": "Mô-đun này chưa được kích hoạt.",
+        "invalid_date": "Ngày không hợp lệ. Vui lòng nhập ngày hợp lệ."
+      }
+    },
+    "quick_actions": {
+      "archive_module": "Lưu trữ mô-đun",
+      "archive_module_description": "Chỉ mô-đun đã hoàn thành hoặc đã hủy\ncó thể được lưu trữ.",
+      "delete_module": "Xóa mô-đun"
+    },
+    "toast": {
+      "copy": {
+        "success": "Đã sao chép liên kết mô-đun vào bảng tạm"
+      },
+      "delete": {
+        "success": "Đã xóa mô-đun thành công",
+        "error": "Xóa mô-đun thất bại"
+      }
+    }
+  },
+  "project_views": {
+    "empty_state": {
+      "general": {
+        "title": "Lưu chế độ xem đã lọc cho dự án của bạn. Tạo bao nhiêu tùy ý",
+        "description": "Chế độ xem là bộ bộ lọc đã lưu mà bạn thường xuyên sử dụng hoặc muốn truy cập dễ dàng. Tất cả đồng nghiệp trong dự án có thể thấy chế độ xem của mọi người và chọn cái phù hợp nhất với nhu cầu của họ.",
+        "primary_button": {
+          "text": "Tạo chế độ xem đầu tiên của bạn",
+          "comic": {
+            "title": "Chế độ xem hoạt động dựa trên thuộc tính mục công việc.",
+            "description": "Bạn có thể tạo chế độ xem ở đây sử dụng bất kỳ số lượng thuộc tính nào làm bộ lọc theo nhu cầu của bạn."
+          }
+        }
+      },
+      "filter": {
+        "title": "Không có chế độ xem phù hợp",
+        "description": "Không có chế độ xem phù hợp với tiêu chí tìm kiếm.\nTạo chế độ xem mới."
+      }
+    }
+  },
+  "project_page": {
+    "empty_state": {
+      "general": {
+        "title": "Viết ghi chú, tài liệu hoặc cơ sở kiến thức đầy đủ. Để trợ lý AI Galileo của Plane giúp bạn bắt đầu",
+        "description": "Trang là không gian ghi lại suy nghĩ trong Plane. Ghi lại các ghi chú cuộc họp, định dạng dễ dàng, nhúng mục công việc, sử dụng thư viện thành phần để bố cục và lưu tất cả trong ngữ cảnh dự án. Để hoàn thành nhanh bất kỳ tài liệu nào, bạn có thể gọi AI Galileo của Plane thông qua phím tắt hoặc nhấp nút.",
+        "primary_button": {
+          "text": "Tạo trang đầu tiên của bạn"
+        }
+      },
+      "private": {
+        "title": "Chưa có trang riêng tư",
+        "description": "Lưu ý riêng tư của bạn ở đây. Khi sẵn sàng chia sẻ, nhóm của bạn chỉ cách một cú nhấp chuột.",
+        "primary_button": {
+          "text": "Tạo trang đầu tiên của bạn"
+        }
+      },
+      "public": {
+        "title": "Chưa có trang công khai",
+        "description": "Xem các trang được chia sẻ với mọi người trong dự án tại đây.",
+        "primary_button": {
+          "text": "Tạo trang đầu tiên của bạn"
+        }
+      },
+      "archived": {
+        "title": "Chưa có trang đã lưu trữ",
+        "description": "Lưu trữ các trang không còn trong tầm nhìn của bạn. Truy cập chúng ở đây khi cần."
+      }
+    }
+  },
+  "command_k": {
+    "empty_state": {
+      "search": {
+        "title": "Không tìm thấy kết quả"
+      }
+    }
+  },
+  "issue_relation": {
+    "empty_state": {
+      "search": {
+        "title": "Không tìm thấy mục công việc phù hợp"
+      },
+      "no_issues": {
+        "title": "Không tìm thấy mục công việc"
+      }
+    }
+  },
+  "issue_comment": {
+    "empty_state": {
+      "general": {
+        "title": "Chưa có bình luận",
+        "description": "Bình luận có thể được sử dụng như không gian thảo luận và theo dõi cho mục công việc"
+      }
+    }
+  },
+  "notification": {
+    "label": "Hộp thư đến",
+    "page_label": "{workspace} - Hộp thư đến",
+    "options": {
+      "mark_all_as_read": "Đánh dấu tất cả là đã đọc",
+      "mark_read": "Đánh dấu đã đọc",
+      "mark_unread": "Đánh dấu chưa đọc",
+      "refresh": "Làm mới",
+      "filters": "Bộ lọc hộp thư đến",
+      "show_unread": "Hiển thị chưa đọc",
+      "show_snoozed": "Hiển thị đã tạm hoãn",
+      "show_archived": "Hiển thị đã lưu trữ",
+      "mark_archive": "Lưu trữ",
+      "mark_unarchive": "Hủy lưu trữ",
+      "mark_snooze": "Tạm hoãn",
+      "mark_unsnooze": "Hủy tạm hoãn"
+    },
+    "toasts": {
+      "read": "Thông báo đã được đánh dấu là đã đọc",
+      "unread": "Thông báo đã được đánh dấu là chưa đọc",
+      "archived": "Thông báo đã được đánh dấu là đã lưu trữ",
+      "unarchived": "Thông báo đã được đánh dấu là đã hủy lưu trữ",
+      "snoozed": "Thông báo đã được tạm hoãn",
+      "unsnoozed": "Thông báo đã được hủy tạm hoãn"
+    },
+    "empty_state": {
+      "detail": {
+        "title": "Chọn để xem chi tiết."
+      },
+      "all": {
+        "title": "Không có mục công việc được giao",
+        "description": "Xem cập nhật về mục công việc được giao cho bạn tại đây"
+      },
+      "mentions": {
+        "title": "Không có mục công việc được giao",
+        "description": "Xem cập nhật về mục công việc được giao cho bạn tại đây"
+      }
+    },
+    "tabs": {
+      "all": "Tất cả",
+      "mentions": "Đề cập"
+    },
+    "filter": {
+      "assigned": "Được giao cho tôi",
+      "created": "Được tạo bởi tôi",
+      "subscribed": "Được đăng ký bởi tôi"
+    },
+    "snooze": {
+      "1_day": "1 ngày",
+      "3_days": "3 ngày",
+      "5_days": "5 ngày",
+      "1_week": "1 tuần",
+      "2_weeks": "2 tuần",
+      "custom": "Tùy chỉnh"
+    }
+  },
+  "active_cycle": {
+    "empty_state": {
+      "progress": {
+        "title": "Thêm mục công việc vào chu kỳ để xem tiến độ của nó"
+      },
+      "chart": {
+        "title": "Thêm mục công việc vào chu kỳ để xem biểu đồ burndown."
+      },
+      "priority_issue": {
+        "title": "Xem nhanh các mục công việc ưu tiên cao đang được xử lý trong chu kỳ."
+      },
+      "assignee": {
+        "title": "Thêm người phụ trách cho mục công việc để xem phân tích công việc theo người phụ trách."
+      },
+      "label": {
+        "title": "Thêm nhãn cho mục công việc để xem phân tích công việc theo nhãn."
+      }
+    }
+  },
+  "disabled_project": {
+    "empty_state": {
+      "inbox": {
+        "title": "Dự án chưa bật tính năng thu thập.",
+        "description": "Tính năng thu thập giúp bạn quản lý các yêu cầu đến của dự án và thêm chúng như mục công việc trong quy trình làm việc. Bật tính năng thu thập từ cài đặt dự án để quản lý yêu cầu.",
+        "primary_button": {
+          "text": "Quản lý tính năng"
+        }
+      },
+      "cycle": {
+        "title": "Dự án này chưa bật tính năng chu kỳ.",
+        "description": "Chia nhỏ công việc theo khung thời gian, đặt ngày từ thời hạn dự án, và đạt được tiến độ cụ thể với tư cách là một nhóm. Bật tính năng chu kỳ cho dự án của bạn để bắt đầu sử dụng.",
+        "primary_button": {
+          "text": "Quản lý tính năng"
+        }
+      },
+      "module": {
+        "title": "Dự án chưa bật tính năng mô-đun.",
+        "description": "Mô-đun là khối xây dựng cơ bản của dự án. Bật mô-đun từ cài đặt dự án để bắt đầu sử dụng chúng.",
+        "primary_button": {
+          "text": "Quản lý tính năng"
+        }
+      },
+      "page": {
+        "title": "Dự án chưa bật tính năng trang.",
+        "description": "Trang là khối xây dựng cơ bản của dự án. Bật trang từ cài đặt dự án để bắt đầu sử dụng chúng.",
+        "primary_button": {
+          "text": "Quản lý tính năng"
+        }
+      },
+      "view": {
+        "title": "Dự án chưa bật tính năng chế độ xem.",
+        "description": "Chế độ xem là khối xây dựng cơ bản của dự án. Bật chế độ xem từ cài đặt dự án để bắt đầu sử dụng chúng.",
+        "primary_button": {
+          "text": "Quản lý tính năng"
+        }
+      }
+    }
+  },
+  "workspace_draft_issues": {
+    "draft_an_issue": "Nháp một mục công việc",
+    "empty_state": {
+      "title": "Mục công việc viết dở và bình luận sắp ra mắt sẽ hiển thị ở đây.",
+      "description": "Để thử tính năng này, hãy bắt đầu thêm mục công việc và rời đi giữa chừng, hoặc tạo bản nháp đầu tiên của bạn bên dưới. 😉",
+      "primary_button": {
+        "text": "Tạo bản nháp đầu tiên của bạn"
+      }
+    },
+    "delete_modal": {
+      "title": "Xóa bản nháp",
+      "description": "Bạn có chắc chắn muốn xóa bản nháp này không? Hành động này không thể hoàn tác."
+    },
+    "toasts": {
+      "created": {
+        "success": "Đã tạo bản nháp",
+        "error": "Không thể tạo mục công việc. Vui lòng thử lại."
+      },
+      "deleted": {
+        "success": "Đã xóa bản nháp"
+      }
+    }
+  },
+  "stickies": {
+    "title": "Ghi chú của bạn",
+    "placeholder": "Nhấp vào đây để nhập",
+    "all": "Tất cả ghi chú",
+    "no-data": "Ghi lại một ý tưởng, nắm bắt một cảm hứng, hoặc ghi lại một suy nghĩ chợt nảy ra. Thêm ghi chú để bắt đầu.",
+    "add": "Thêm ghi chú",
+    "search_placeholder": "Tìm kiếm theo tiêu đề",
+    "delete": "Xóa ghi chú",
+    "delete_confirmation": "Bạn có chắc chắn muốn xóa ghi chú này không?",
+    "empty_state": {
+      "simple": "Ghi lại một ý tưởng, nắm bắt một cảm hứng, hoặc ghi lại một suy nghĩ chợt nảy ra. Thêm ghi chú để bắt đầu.",
+      "general": {
+        "title": "Ghi chú là ghi chú nhanh và việc cần làm mà bạn ghi lại ngay lập tức.",
+        "description": "Dễ dàng nắm bắt ý tưởng và sáng tạo của bạn bằng cách tạo ghi chú có thể truy cập từ mọi nơi, mọi lúc.",
+        "primary_button": {
+          "text": "Thêm ghi chú"
+        }
+      },
+      "search": {
+        "title": "Điều này không khớp với bất kỳ ghi chú nào của bạn.",
+        "description": "Thử sử dụng các thuật ngữ khác, hoặc nếu bạn chắc chắn\ntìm kiếm là chính xác, hãy cho chúng tôi biết.",
+        "primary_button": {
+          "text": "Thêm ghi chú"
+        }
+      }
+    },
+    "toasts": {
+      "errors": {
+        "wrong_name": "Tên ghi chú không thể vượt quá 100 ký tự.",
+        "already_exists": "Đã tồn tại một ghi chú không có mô tả"
+      },
+      "created": {
+        "title": "Đã tạo ghi chú",
+        "message": "Ghi chú đã được tạo thành công"
+      },
+      "not_created": {
+        "title": "Chưa tạo ghi chú",
+        "message": "Không thể tạo ghi chú"
+      },
+      "updated": {
+        "title": "Đã cập nhật ghi chú",
+        "message": "Ghi chú đã được cập nhật thành công"
+      },
+      "not_updated": {
+        "title": "Chưa cập nhật ghi chú",
+        "message": "Không thể cập nhật ghi chú"
+      },
+      "removed": {
+        "title": "Đã xóa ghi chú",
+        "message": "Ghi chú đã được xóa thành công"
+      },
+      "not_removed": {
+        "title": "Chưa xóa ghi chú",
+        "message": "Không thể xóa ghi chú"
+      }
+    }
+  },
+  "role_details": {
+    "guest": {
+      "title": "Khách",
+      "description": "Thành viên bên ngoài của tổ chức có thể được mời với tư cách khách."
+    },
+    "member": {
+      "title": "Thành viên",
+      "description": "Có thể đọc, viết, chỉnh sửa và xóa thực thể trong dự án, chu kỳ và mô-đun"
+    },
+    "admin": {
+      "title": "Quản trị viên",
+      "description": "Tất cả quyền trong không gian làm việc đều được đặt là cho phép."
+    }
+  },
+  "user_roles": {
+    "product_or_project_manager": "Quản lý sản phẩm/dự án",
+    "development_or_engineering": "Phát triển/Kỹ thuật",
+    "founder_or_executive": "Nhà sáng lập/Giám đốc điều hành",
+    "freelancer_or_consultant": "Freelancer/Tư vấn viên",
+    "marketing_or_growth": "Marketing/Tăng trưởng",
+    "sales_or_business_development": "Bán hàng/Phát triển kinh doanh",
+    "support_or_operations": "Hỗ trợ/Vận hành",
+    "student_or_professor": "Sinh viên/Giáo sư",
+    "human_resources": "Nhân sự",
+    "other": "Khác"
+  },
+  "importer": {
+    "github": {
+      "title": "GitHub",
+      "description": "Nhập và đồng bộ mục công việc từ kho lưu trữ GitHub."
+    },
+    "jira": {
+      "title": "Jira",
+      "description": "Nhập mục công việc và sử thi từ dự án và sử thi Jira."
+    }
+  },
+  "exporter": {
+    "csv": {
+      "title": "CSV",
+      "description": "Xuất mục công việc thành tệp CSV.",
+      "short_description": "Xuất sang CSV"
+    },
+    "excel": {
+      "title": "Excel",
+      "description": "Xuất mục công việc thành tệp Excel.",
+      "short_description": "Xuất sang Excel"
+    },
+    "xlsx": {
+      "title": "Excel",
+      "description": "Xuất mục công việc thành tệp Excel.",
+      "short_description": "Xuất sang Excel"
+    },
+    "json": {
+      "title": "JSON",
+      "description": "Xuất mục công việc thành tệp JSON.",
+      "short_description": "Xuất sang JSON"
+    }
+  },
+  "default_global_view": {
+    "all_issues": "Tất cả mục công việc",
+    "assigned": "Đã giao",
+    "created": "Đã tạo",
+    "subscribed": "Đã đăng ký"
+  },
+  "themes": {
+    "theme_options": {
+      "system_preference": {
+        "label": "Tùy chọn hệ thống"
+      },
+      "light": {
+        "label": "Sáng"
+      },
+      "dark": {
+        "label": "Tối"
+      },
+      "light_contrast": {
+        "label": "Sáng tương phản cao"
+      },
+      "dark_contrast": {
+        "label": "Tối tương phản cao"
+      },
+      "custom": {
+        "label": "Chủ đề tùy chỉnh"
+      }
+    }
+  },
+  "project_modules": {
+    "status": {
+      "backlog": "Tồn đọng",
+      "planned": "Đã lên kế hoạch",
+      "in_progress": "Đang tiến hành",
+      "paused": "Đã tạm dừng",
+      "completed": "Đã hoàn thành",
+      "cancelled": "Đã hủy"
+    },
+    "layout": {
+      "list": "Bố cục danh sách",
+      "board": "Bố cục bảng",
+      "timeline": "Bố cục dòng thời gian"
+    },
+    "order_by": {
+      "name": "Tên",
+      "progress": "Tiến độ",
+      "issues": "Số lượng mục công việc",
+      "due_date": "Ngày hết hạn",
+      "created_at": "Ngày tạo",
+      "manual": "Thủ công"
+    }
+  },
+  "cycle": {
+    "label": "{count, plural, one {chu kỳ} other {chu kỳ}}",
+    "no_cycle": "Không có chu kỳ"
+  },
+  "module": {
+    "label": "{count, plural, one {mô-đun} other {mô-đun}}",
+    "no_module": "Không có mô-đun"
+  }
+}

--- a/packages/i18n/src/store/index.ts
+++ b/packages/i18n/src/store/index.ts
@@ -171,6 +171,8 @@ export class TranslationStore {
         return import("../locales/id/translations.json");
       case "ro":
         return import("../locales/ro/translations.json");
+      case "vi":
+        return import("../locales/vi/translations.json");
       default:
         throw new Error(`Unsupported language: ${language}`);
     }

--- a/packages/i18n/src/store/index.ts
+++ b/packages/i18n/src/store/index.ts
@@ -171,8 +171,8 @@ export class TranslationStore {
         return import("../locales/id/translations.json");
       case "ro":
         return import("../locales/ro/translations.json");
-      case "vi":
-        return import("../locales/vi/translations.json");
+      case "vi-VN":
+        return import("../locales/vi-VN/translations.json");
       default:
         throw new Error(`Unsupported language: ${language}`);
     }

--- a/packages/i18n/src/store/index.ts
+++ b/packages/i18n/src/store/index.ts
@@ -165,6 +165,8 @@ export class TranslationStore {
         return import("../locales/pl/translations.json");
       case "ko":
         return import("../locales/ko/translations.json");
+      case "pt-BR":
+        return import("../locales/pt-BR/translations.json");
       case "id":
         return import("../locales/id/translations.json");
       case "ro":

--- a/packages/i18n/src/types/language.ts
+++ b/packages/i18n/src/types/language.ts
@@ -15,7 +15,8 @@ export type TLanguage =
   | "ko"
   | "pt-BR"
   | "id"
-  | "ro";
+  | "ro"
+  | "vi";
 
 export interface ILanguageOption {
   label: string;

--- a/packages/i18n/src/types/language.ts
+++ b/packages/i18n/src/types/language.ts
@@ -13,6 +13,7 @@ export type TLanguage =
   | "ua"
   | "pl"
   | "ko"
+  | "pt-BR"
   | "id"
   | "ro";
 

--- a/packages/i18n/src/types/language.ts
+++ b/packages/i18n/src/types/language.ts
@@ -16,7 +16,7 @@ export type TLanguage =
   | "pt-BR"
   | "id"
   | "ro"
-  | "vi";
+  | "vi-VN";
 
 export interface ILanguageOption {
   label: string;


### PR DESCRIPTION
### Description
This PR includes following language support:
- Vietnamese
- Portuguese

### Type of Change
- [x] Feature

### References
[[WEB-3732](https://app.plane.so/plane/browse/WEB-3732/) | [WEB-3731](https://app.plane.so/plane/browse/WEB-3731/)]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded supported languages with the addition of Portuguese (Brazil) and Vietnamese, enhancing localization.
  - Introduced comprehensive translation support for user interface elements, authentication flows, notifications, and workspace management.
  - Updated the language loader to include the new language options.
  - Enhanced language type definitions to recognize the new language codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->