### PR TITLE
[WEB-3273]fix: editor bubble menu z-index

### DIFF
--- a/packages/editor/src/core/components/menus/bubble-menu/root.tsx
+++ b/packages/editor/src/core/components/menus/bubble-menu/root.tsx
@@ -103,6 +103,7 @@ export const EditorBubbleMenu: FC<EditorBubbleMenuProps> = (props: { editor: Edi
     tippyOptions: {
       moveTransition: "transform 0.15s ease-out",
       duration: [300, 0],
+      zIndex: 9,
       onShow: () => {
         props.editor.storage.link.isBubbleMenuOpen = true;
       },


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
Updated z-index for the editor bubble menu, this fixes the z-index issue between popover menu and editor menu.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
<!-- Link related issues if there are any -->
[WEB-3273](https://app.plane.so/plane/browse/WEB-3273/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Enhanced the visual stacking order for bubble menu tooltips, ensuring they reliably overlay other page elements for a smoother interaction experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->