### PR TITLE
[WEB-3747] regression: readonly mode with fragments

### DIFF
--- a/packages/editor/src/core/components/editors/document/page-renderer.tsx
+++ b/packages/editor/src/core/components/editors/document/page-renderer.tsx
@@ -28,11 +28,11 @@ export const PageRenderer = (props: IPageRenderer) => {
       >
         <EditorContentWrapper editor={editor} id={id} tabIndex={tabIndex} />
         {editor.isEditable && (
-          <>
+          <div>
             {bubbleMenuEnabled && <EditorBubbleMenu editor={editor} />}
             <BlockMenu editor={editor} />
             <AIFeaturesMenu menu={aiHandler?.menu} />
-          </>
+          </div>
         )}
       </EditorContainer>
     </div>

--- a/packages/editor/src/core/components/links/link-edit-view.tsx
+++ b/packages/editor/src/core/components/links/link-edit-view.tsx
@@ -128,10 +128,9 @@ export const LinkEditView = ({ viewProps }: LinkEditViewProps) => {
   return (
     <div
       onKeyDown={handleKeyDown}
-      className="shadow-md rounded p-2 flex flex-col gap-3 bg-custom-background-90 border-custom-border-100 border-2 animate-in fade-in translate-y-1 duration-200 origin-center"
+      className="shadow-md rounded p-2 flex flex-col gap-3 bg-custom-background-90 border-custom-border-100 border-2 animate-in fade-in translate-y-1"
       style={{
-        animationTimingFunction: "cubic-bezier(.55, .085, .68, .53)",
-        transformOrigin: "center",
+        transition: "all 0.1s cubic-bezier(.55, .085, .68, .53)",
       }}
       tabIndex={0}
     >

--- a/packages/editor/src/core/components/links/link-preview.tsx
+++ b/packages/editor/src/core/components/links/link-preview.tsx
@@ -23,10 +23,9 @@ export const LinkPreview = ({
 
   return (
     <div
-      className="absolute left-0 top-0 max-w-max animate-in fade-in translate-y-1 duration-300 origin-center"
+      className="absolute left-0 top-0 max-w-max animate-in fade-in translate-y-1"
       style={{
-        animationTimingFunction: "cubic-bezier(.55, .085, .68, .53)",
-        transformOrigin: "center",
+        transition: "all 0.2s cubic-bezier(.55, .085, .68, .53)",
       }}
     >
       <div className="shadow-md items-center rounded p-2 flex gap-3 bg-custom-background-90 border-custom-border-100 border-2 text-custom-text-300 text-xs">

--- a/web/core/components/pages/editor/title.tsx
+++ b/web/core/components/pages/editor/title.tsx
@@ -42,7 +42,7 @@ export const PageEditorTitle: React.FC<Props> = observer((props) => {
             {
               "text-custom-text-400": !title,
             },
-            "break-words pb-1.5"
+            "break-words"
           )}
         >
           {getPageName(title)}


### PR DESCRIPTION
### Description

Fixes a couple of css bugs while toggling read only mode of the page and along with that also fixes error due to fragments while unmounting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the layout structure in the editor to ensure a more consistent element grouping without impacting functionality.

- **Style**
  - Enhanced transition effects in the link editing and preview areas for smoother and more responsive interactions.
  - Adjusted title spacing for a refined and improved visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->