### PR TITLE
[WIKI-306] fix: handle editor click behavior on the last node

### DIFF
--- a/packages/editor/src/core/components/editors/editor-container.tsx
+++ b/packages/editor/src/core/components/editors/editor-container.tsx
@@ -47,15 +47,23 @@ export const EditorContainer: FC<EditorContainerProps> = (props) => {
         return;
       }
 
-      // Insert a new paragraph at the end of the document
-      const endPosition = editor?.state.doc.content.size;
-      editor?.chain().insertContentAt(endPosition, { type: "paragraph" }).run();
+      // Get the last node in the document
+      const docSize = editor.state.doc.content.size;
+      const lastNodePos = editor.state.doc.resolve(Math.max(0, docSize - 2));
+      const lastNode = lastNodePos.node();
 
-      // Focus the newly added paragraph for immediate editing
-      editor
-        .chain()
-        .setTextSelection(endPosition + 1)
-        .run();
+      // Check if the last node is a  not paragraph
+      if (lastNode && lastNode.type.name !== "paragraph") {
+        // If last node is not a paragraph, insert a new paragraph at the end
+        const endPosition = editor?.state.doc.content.size;
+        editor?.chain().insertContentAt(endPosition, { type: "paragraph" }).run();
+
+        // Focus the newly added paragraph for immediate editing
+        editor
+          .chain()
+          .setTextSelection(endPosition + 1)
+          .run();
+      }
     } catch (error) {
       console.error("An error occurred while handling container click to insert new empty node at bottom:", error);
     }


### PR DESCRIPTION
### Description
If the last node is a paragraph, we focus on it. Otherwise, we insert a new paragraph.

### issue
#6876 

### Screenshots and Media (if applicable)

https://github.com/user-attachments/assets/3b54831d-2ed3-4d95-8a94-075a50d2b0bd



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Refined the editor behavior so that clicking the container inserts a new paragraph only when the document's last element isn't already a paragraph, resulting in a smoother editing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->