### PR TITLE
chore: removed the deprecated intake urls

### DIFF
--- a/apiserver/plane/api/serializers/project.py
+++ b/apiserver/plane/api/serializers/project.py
@@ -16,7 +16,6 @@ class ProjectSerializer(BaseSerializer):
     member_role = serializers.IntegerField(read_only=True)
     is_deployed = serializers.BooleanField(read_only=True)
     cover_image_url = serializers.CharField(read_only=True)
-    inbox_view = serializers.BooleanField(read_only=True, source="intake_view")
 
     class Meta:
         model = Project

--- a/apiserver/plane/api/urls/intake.py
+++ b/apiserver/plane/api/urls/intake.py
@@ -5,16 +5,6 @@ from plane.api.views import IntakeIssueAPIEndpoint
 
 urlpatterns = [
     path(
-        "workspaces/<str:slug>/projects/<uuid:project_id>/inbox-issues/",
-        IntakeIssueAPIEndpoint.as_view(),
-        name="inbox-issue",
-    ),
-    path(
-        "workspaces/<str:slug>/projects/<uuid:project_id>/inbox-issues/<uuid:issue_id>/",
-        IntakeIssueAPIEndpoint.as_view(),
-        name="inbox-issue",
-    ),
-    path(
         "workspaces/<str:slug>/projects/<uuid:project_id>/intake-issues/",
         IntakeIssueAPIEndpoint.as_view(),
         name="intake-issue",

--- a/apiserver/plane/api/views/project.py
+++ b/apiserver/plane/api/views/project.py
@@ -258,9 +258,7 @@ class ProjectAPIEndpoint(BaseAPIView):
                 ProjectSerializer(project).data, cls=DjangoJSONEncoder
             )
 
-            intake_view = request.data.get(
-                "inbox_view", request.data.get("intake_view", project.intake_view)
-            )
+            intake_view = request.data.get("intake_view", project.intake_view)
 
             if project.archived_at:
                 return Response(


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
this pull request removes the deprecated intake endpoints.
### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Code refactoring

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->
- External Intake Api's


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed an unused project field from responses.
  - Updated API endpoints to consolidate issue handling under a unified naming convention.
  - Streamlined update logic by eliminating redundant field handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->