### PR TITLE
[WEB-3794]chore: set project states to expand by default

### DIFF
--- a/web/core/components/project-states/group-list.tsx
+++ b/web/core/components/project-states/group-list.tsx
@@ -15,7 +15,13 @@ type TGroupList = {
 export const GroupList: FC<TGroupList> = observer((props) => {
   const { workspaceSlug, projectId, groupedStates } = props;
   // states
-  const [groupsExpanded, setGroupsExpanded] = useState<Partial<TStateGroups>[]>([]);
+  const [groupsExpanded, setGroupsExpanded] = useState<Partial<TStateGroups>[]>([
+    "backlog",
+    "unstarted",
+    "started",
+    "completed",
+    "cancelled",
+  ]);
 
   const handleGroupCollapse = (groupKey: TStateGroups) => {
     setGroupsExpanded((prev) => {


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
This update sets project states in settings to update by default.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [x] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
<!-- Link related issues if there are any -->
[WEB-3794](https://app.plane.so/plane/browse/WEB-3794/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the default view so that key project groups (backlog, unstarted, started, completed, cancelled) are expanded on first load for enhanced visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->