### PR TITLE
chore: Add workspace slug to should render setting link method

### DIFF
--- a/web/app/[workspaceSlug]/(projects)/settings/(with-sidebar)/mobile-header-tabs.tsx
+++ b/web/app/[workspaceSlug]/(projects)/settings/(with-sidebar)/mobile-header-tabs.tsx
@@ -20,7 +20,7 @@ export const MobileWorkspaceSettingsTabs = observer(() => {
     <div className="flex-shrink-0 md:hidden sticky inset-0 flex overflow-x-auto bg-custom-background-100 z-10">
       {WORKSPACE_SETTINGS_LINKS.map(
         (item, index) =>
-          shouldRenderSettingLink(item.key) &&
+          shouldRenderSettingLink(workspaceSlug.toString(), item.key) &&
           allowPermissions(item.access, EUserPermissionsLevel.WORKSPACE, workspaceSlug.toString()) && (
             <div
               className={`${

--- a/web/app/[workspaceSlug]/(projects)/settings/(with-sidebar)/sidebar.tsx
+++ b/web/app/[workspaceSlug]/(projects)/settings/(with-sidebar)/sidebar.tsx
@@ -28,7 +28,7 @@ export const WorkspaceSettingsSidebar = observer(() => {
         <div className="flex w-full flex-col gap-1">
           {WORKSPACE_SETTINGS_LINKS.map(
             (link) =>
-              shouldRenderSettingLink(link.key) &&
+              shouldRenderSettingLink(workspaceSlug.toString(), link.key) &&
               allowPermissions(link.access, EUserPermissionsLevel.WORKSPACE, workspaceSlug.toString()) && (
                 <Link key={link.key} href={`/${workspaceSlug}${link.href}`}>
                   <SidebarNavItem

--- a/web/ce/helpers/workspace.helper.ts
+++ b/web/ce/helpers/workspace.helper.ts
@@ -1,2 +1,2 @@
 export type TRenderSettingsLink = (workspaceSlug: string, settingKey: string) => boolean;
-export const shouldRenderSettingLink: TRenderSettingsLink = () => true;
+export const shouldRenderSettingLink: TRenderSettingsLink = (workspaceSlug, settingKey) => true;

--- a/web/ce/helpers/workspace.helper.ts
+++ b/web/ce/helpers/workspace.helper.ts
@@ -1,2 +1,2 @@
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export const shouldRenderSettingLink = (settingKey: string) => true;
+export type TRenderSettingsLink = (workspaceSlug: string, settingKey: string) => boolean;
+export const shouldRenderSettingLink: TRenderSettingsLink = () => true;

--- a/web/core/components/command-palette/actions/workspace-settings-actions.tsx
+++ b/web/core/components/command-palette/actions/workspace-settings-actions.tsx
@@ -40,7 +40,7 @@ export const CommandPaletteWorkspaceSettingsActions: React.FC<Props> = (props) =
       {WORKSPACE_SETTINGS_LINKS.map(
         (setting) =>
           allowPermissions(setting.access, EUserPermissionsLevel.WORKSPACE, workspaceSlug.toString()) &&
-          shouldRenderSettingLink(setting.key) && (
+          shouldRenderSettingLink(workspaceSlug.toString(), setting.key) && (
             <Command.Item
               key={setting.key}
               onSelect={() => redirect(`/${workspaceSlug}${setting.href}`)}


### PR DESCRIPTION
### Description
Add workspace slug to should render setting link method

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
<!-- Link related issues if there are any -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Workspace settings now display tailored options based on your active workspace, enhancing the accuracy of visible settings across mobile, sidebar, and command palette views.
  - These updates ensure you access the most relevant settings for your workspace, providing a more context-aware and streamlined navigation experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->