### PR TITLE
[WEB-3819] fix: images now restore in read only mode as well

### DIFF
--- a/packages/editor/src/core/extensions/custom-image/read-only-custom-image.ts
+++ b/packages/editor/src/core/extensions/custom-image/read-only-custom-image.ts
@@ -7,7 +7,7 @@ import { CustomImageNode, UploadImageExtensionStorage } from "@/extensions/custo
 import { TReadOnlyFileHandler } from "@/types";
 
 export const CustomReadOnlyImageExtension = (props: TReadOnlyFileHandler) => {
-  const { getAssetSrc } = props;
+  const { getAssetSrc, restore: restoreImageFn } = props;
 
   return Image.extend<Record<string, unknown>, UploadImageExtensionStorage>({
     name: "imageComponent",
@@ -66,6 +66,9 @@ export const CustomReadOnlyImageExtension = (props: TReadOnlyFileHandler) => {
     addCommands() {
       return {
         getImageSource: (path: string) => async () => await getAssetSrc(path),
+        restoreImage: (src) => async () => {
+          await restoreImageFn(src);
+        },
       };
     },
 


### PR DESCRIPTION
### Description
Images now restore in read only mode as well for all editors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an image restoration command that enables users to recover images seamlessly within the editor.
  - Enhanced image management while preserving the original functionality.

This update improves the overall user experience by offering an additional option for handling images effortlessly during typical editing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->