### PR TITLE
[WEB-3831] chore: add validation for project_id in cycle serializer

### DIFF
--- a/apiserver/plane/api/serializers/cycle.py
+++ b/apiserver/plane/api/serializers/cycle.py
@@ -39,7 +39,15 @@ class CycleSerializer(BaseSerializer):
             data.get("start_date", None) is not None
             and data.get("end_date", None) is not None
         ):
-            project_id = self.initial_data.get("project_id") or self.instance.project_id
+            project_id = self.initial_data.get("project_id") or (
+                self.instance.project_id
+                if self.instance and hasattr(self.instance, "project_id")
+                else None
+            )
+
+            if not project_id:
+                raise serializers.ValidationError("Project ID is required")
+
             is_start_date_end_date_equal = (
                 True
                 if str(data.get("start_date")) == str(data.get("end_date"))


### PR DESCRIPTION
### Description
Adds validation for project_id in cycle serializer. We need project to resolve timezone for datetime fields.

### Type of Change
- [X] Improvement (change that would cause existing functionality to not work as expected)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved validation to ensure that when both start and end dates are provided, a valid project identifier must also be included. This update results in clearer error messages and smoother operation when required data is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->