### PR TITLE
[WEB-3839] fix: peek overview description version history

### DIFF
--- a/apiserver/plane/app/serializers/issue.py
+++ b/apiserver/plane/app/serializers/issue.py
@@ -352,8 +352,19 @@ class IssueRelationSerializer(BaseSerializer):
             "state_id",
             "priority",
             "assignee_ids",
+            "created_by",
+            "created_at",
+            "updated_at",
+            "updated_by",
         ]
-        read_only_fields = ["workspace", "project"]
+        read_only_fields = [
+            "workspace",
+            "project",
+            "created_by",
+            "created_at",
+            "updated_by",
+            "updated_at",
+        ]
 
 
 class RelatedIssueSerializer(BaseSerializer):
@@ -383,8 +394,18 @@ class RelatedIssueSerializer(BaseSerializer):
             "state_id",
             "priority",
             "assignee_ids",
+            "created_by",
+            "created_at",
+            "updated_by",
+            "updated_at",
         ]
-        read_only_fields = ["workspace", "project"]
+        read_only_fields = [
+            "workspace",
+            "projectcreated_by",
+            "created_at",
+            "updated_by",
+            "updated_at",
+        ]
 
 
 class IssueAssigneeSerializer(BaseSerializer):

--- a/apiserver/plane/app/serializers/issue.py
+++ b/apiserver/plane/app/serializers/issue.py
@@ -401,7 +401,8 @@ class RelatedIssueSerializer(BaseSerializer):
         ]
         read_only_fields = [
             "workspace",
-            "projectcreated_by",
+            "project",
+            "created_by",
             "created_at",
             "updated_by",
             "updated_at",

--- a/web/core/components/inbox/content/issue-root.tsx
+++ b/web/core/components/inbox/content/issue-root.tsx
@@ -232,7 +232,7 @@ export const InboxIssueMainContent: React.FC<Props> = observer((props) => {
             <DescriptionVersionsRoot
               className="flex-shrink-0"
               entityInformation={{
-                createdAt: new Date(issue.created_at ?? ""),
+                createdAt: issue.created_at ? new Date(issue.created_at) : new Date(),
                 createdByDisplayName:
                   inboxIssue.source === EInboxIssueSource.FORMS
                     ? "Intake Form user"

--- a/web/core/components/issues/issue-detail/main-content.tsx
+++ b/web/core/components/issues/issue-detail/main-content.tsx
@@ -155,7 +155,7 @@ export const IssueMainContent: React.FC<Props> = observer((props) => {
             <DescriptionVersionsRoot
               className="flex-shrink-0"
               entityInformation={{
-                createdAt: new Date(issue.created_at),
+                createdAt: new Date(issue.created_at ?? ""),
                 createdByDisplayName: getUserDetails(issue.created_by ?? "")?.display_name ?? "",
                 id: issueId,
                 isRestoreDisabled: !isEditable || isArchived,

--- a/web/core/components/issues/issue-detail/main-content.tsx
+++ b/web/core/components/issues/issue-detail/main-content.tsx
@@ -155,7 +155,7 @@ export const IssueMainContent: React.FC<Props> = observer((props) => {
             <DescriptionVersionsRoot
               className="flex-shrink-0"
               entityInformation={{
-                createdAt: new Date(issue.created_at ?? ""),
+                createdAt: issue.created_at ? new Date(issue.created_at) : new Date(),
                 createdByDisplayName: getUserDetails(issue.created_by ?? "")?.display_name ?? "",
                 id: issueId,
                 isRestoreDisabled: !isEditable || isArchived,

--- a/web/core/components/issues/peek-overview/issue-detail.tsx
+++ b/web/core/components/issues/peek-overview/issue-detail.tsx
@@ -147,7 +147,7 @@ export const PeekOverviewIssueDetails: FC<IPeekOverviewIssueDetails> = observer(
           <DescriptionVersionsRoot
             className="flex-shrink-0"
             entityInformation={{
-              createdAt: new Date(issue.created_at),
+              createdAt: new Date(issue.created_at ?? ""),
               createdByDisplayName: getUserDetails(issue.created_by ?? "")?.display_name ?? "",
               id: issueId,
               isRestoreDisabled: disabled || isArchived,

--- a/web/core/components/issues/peek-overview/issue-detail.tsx
+++ b/web/core/components/issues/peek-overview/issue-detail.tsx
@@ -147,7 +147,7 @@ export const PeekOverviewIssueDetails: FC<IPeekOverviewIssueDetails> = observer(
           <DescriptionVersionsRoot
             className="flex-shrink-0"
             entityInformation={{
-              createdAt: new Date(issue.created_at ?? ""),
+              createdAt: issue.created_at ? new Date(issue.created_at) : new Date(),
               createdByDisplayName: getUserDetails(issue.created_by ?? "")?.display_name ?? "",
               id: issueId,
               isRestoreDisabled: disabled || isArchived,


### PR DESCRIPTION
### Description

This PR fixes the bug where redirecting to any relation immediately after creating it was crashing the app, by-

1. Handling undefined `created_at` values for description version history.
2. Passing `created_at` in the response of relation `POST` request.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Issue displays now include additional metadata—creator, creation time, last updater, and update time—to provide more comprehensive details.
  
- **Bug Fixes**
  - Improved date handling in issue views to prevent errors when date information is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->