### PR TITLE
[WEB-3853] fix: untitled page name issue

### DIFF
--- a/web/app/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/pages/(detail)/header.tsx
+++ b/web/app/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/pages/(detail)/header.tsx
@@ -13,6 +13,7 @@ import { BreadcrumbLink, SwitcherLabel } from "@/components/common";
 import { PageEditInformationPopover } from "@/components/pages";
 // helpers
 // hooks
+import { getPageName } from "@/helpers/page.helper";
 import { useProject } from "@/hooks/store";
 // plane web components
 import { ProjectBreadcrumb } from "@/plane-web/components/breadcrumbs";
@@ -61,7 +62,7 @@ export const PageDetailsHeader = observer(() => {
         content: (
           <div className="flex gap-2 items-center justify-between">
             <Link href={pageLink} className="flex gap-2 items-center justify-between w-full">
-              <SwitcherLabel logo_props={_page.logo_props} name={_page.name} LabelIcon={FileText} />
+              <SwitcherLabel logo_props={_page.logo_props} name={getPageName(_page.name)} LabelIcon={FileText} />
             </Link>
             <PageAccessIcon {..._page} />
           </div>
@@ -110,7 +111,9 @@ export const PageDetailsHeader = observer(() => {
                 <CustomSearchSelect
                   value={pageId}
                   options={switcherOptions}
-                  label={<SwitcherLabel logo_props={page.logo_props} name={page.name} LabelIcon={FileText} />}
+                  label={
+                    <SwitcherLabel logo_props={page.logo_props} name={getPageName(page.name)} LabelIcon={FileText} />
+                  }
                   onChange={() => {}}
                 />
               }


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
This update fixes the page name at switcher when the page title is 'Untitled'

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
<!-- Link related issues if there are any -->
[WEB-3853](https://app.plane.so/plane/browse/WEB-3853/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the project details header with refined page name presentation for a more consistent and clear display. Users will now experience uniform labeling that improves readability and interface polish. This update provides a smoother and more reliable viewing experience on all project-related pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->