### PR TITLE
[WEB-3849] chore: added intake source in the list

### DIFF
--- a/web/ce/components/inbox/source-pill.tsx
+++ b/web/ce/components/inbox/source-pill.tsx
@@ -1,6 +1,7 @@
 import { EInboxIssueSource } from "@plane/constants";
 
-type TInboxSourcePill = {
+export type TInboxSourcePill = {
   source: EInboxIssueSource;
 };
+
 export const InboxSourcePill = (props: TInboxSourcePill) => <></>;

--- a/web/ce/components/inbox/source-pill.tsx
+++ b/web/ce/components/inbox/source-pill.tsx
@@ -1,0 +1,6 @@
+import { EInboxIssueSource } from "@plane/constants";
+
+type TInboxSourcePill = {
+  source: EInboxIssueSource;
+};
+export const InboxSourcePill = (props: TInboxSourcePill) => <></>;

--- a/web/core/components/inbox/sidebar/inbox-list-item.tsx
+++ b/web/core/components/inbox/sidebar/inbox-list-item.tsx
@@ -15,6 +15,7 @@ import { renderFormattedDate } from "@/helpers/date-time.helper";
 import { getFileURL } from "@/helpers/file.helper";
 import { useLabel, useMember, useProjectInbox } from "@/hooks/store";
 import { usePlatformOS } from "@/hooks/use-platform-os";
+import { InboxSourcePill } from "@/plane-web/components/inbox/source-pill";
 
 type InboxIssueListItemProps = {
   workspaceSlug: string;
@@ -65,7 +66,10 @@ export const InboxIssueListItem: FC<InboxIssueListItemProps> = observer((props) 
               <div className="flex-shrink-0 text-xs font-medium text-custom-text-300">
                 {projectIdentifier}-{issue.sequence_id}
               </div>
-              {inboxIssue.status !== -2 && <InboxIssueStatus inboxIssue={inboxIssue} iconSize={12} />}
+              <div className="flex items-center gap-2">
+                {inboxIssue.source && <InboxSourcePill source={inboxIssue.source} />}
+                {inboxIssue.status !== -2 && <InboxIssueStatus inboxIssue={inboxIssue} iconSize={12} />}
+              </div>
             </div>
             <h3 className="truncate w-full text-sm">{issue.name}</h3>
           </div>

--- a/web/core/components/issues/issue-detail/issue-activity/activity/actions/default.tsx
+++ b/web/core/components/issues/issue-detail/issue-activity/activity/actions/default.tsx
@@ -6,6 +6,7 @@ import { observer } from "mobx-react";
 import { EInboxIssueSource } from "@plane/constants";
 import { LayersIcon } from "@plane/ui";
 // hooks
+import { capitalizeFirstLetter } from "@plane/utils";
 import { useIssueDetail } from "@/hooks/store";
 // local imports
 import { IssueActivityBlockComponent } from "./";
@@ -34,7 +35,8 @@ export const IssueDefaultActivity: FC<TIssueDefaultActivity> = observer((props) 
         {activity.verb === "created" ? (
           source && source !== EInboxIssueSource.IN_APP ? (
             <span>
-              created the work item via <span className="font-medium">{source.toLowerCase()}</span>.
+              created the work item via{" "}
+              <span className="font-medium">{capitalizeFirstLetter(source.toLowerCase() || "")}</span>.
             </span>
           ) : (
             <span> created the work item.</span>

--- a/web/ee/components/inbox/source-pill.tsx
+++ b/web/ee/components/inbox/source-pill.tsx
@@ -1,0 +1,1 @@
+export * from "ce/components/inbox/source-pill";


### PR DESCRIPTION
### Description
- Css changes for intake source display in the activity section
- InboxSourcePill component to show the source in the list 

### References
[[WEB-3849]](https://app.plane.so/plane/browse/WEB-3849/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new component, `InboxSourcePill`, to enhance the inbox interface with additional context.
  
- **Enhancements**
  - Improved the inbox list layout to ensure proper alignment of the new indicator with existing status elements.
  - Updated activity displays to capitalize the first letter of the source text for better readability.
  
- **Chores**
  - Established a single entry point for the `source-pill` module, streamlining component accessibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->