### PR TITLE
[feature]: Alert when creating a work item without properties #6872

### DIFF
--- a/web/core/components/issues/issue-modal/form.tsx
+++ b/web/core/components/issues/issue-modal/form.tsx
@@ -231,18 +231,6 @@ export const IssueFormRoot: FC<IssueFormProps> = observer((props) => {
         formData?.start_date,
       ];
       
-      console.log(formData?.archived_at)
-      console.log(formData?.label_ids?.length)
-      console.log(formData?.assignee_ids?.length)
-      console.log(formData?.start_date)
-      console.log(formData?.cycle_id)
-      console.log(formData?.target_date)
-      console.log(formData?.parent_id)
-      console.log(formData?.label_ids?.length)
-      console.log(formData?.state_id)
-
-
-
       const hasAnyProp = propsToCheck.some((value) => value !== null && value !== undefined && value !== "" && value !==0);
 
       console.log(hasAnyProp)

--- a/web/core/components/issues/issue-modal/form.tsx
+++ b/web/core/components/issues/issue-modal/form.tsx
@@ -218,6 +218,42 @@ export const IssueFormRoot: FC<IssueFormProps> = observer((props) => {
       })
     )
       return;
+    
+      const propsToCheck = [
+        formData?.archived_at,
+        formData?.label_ids?.length,
+        formData?.assignee_ids?.length,
+        formData?.cycle_id,
+        formData?.parent_id,
+        formData?.label_ids?.length,
+        formData?.state_id,
+        formData?.target_date,
+        formData?.start_date,
+      ];
+      
+      console.log(formData?.archived_at)
+      console.log(formData?.label_ids?.length)
+      console.log(formData?.assignee_ids?.length)
+      console.log(formData?.start_date)
+      console.log(formData?.cycle_id)
+      console.log(formData?.target_date)
+      console.log(formData?.parent_id)
+      console.log(formData?.label_ids?.length)
+      console.log(formData?.state_id)
+
+
+
+      const hasAnyProp = propsToCheck.some((value) => value !== null && value !== undefined && value !== "" && value !==0);
+
+      console.log(hasAnyProp)
+    
+    if (!hasAnyProp) {
+      setToast({
+        type: TOAST_TYPE.WARNING,
+        title: t("Missing properties"),
+        message: t("you are creating a work item without any properties"),
+      });
+    }
 
     const submitData = !data?.id
       ? formData


### PR DESCRIPTION
### Description
This update include adding a warning toast when creating a work item with no properties.

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
**Create a work item with no properties :**
![Capture d’écran 2025-04-14 174054](https://github.com/user-attachments/assets/3cf887ff-cc1a-4ac1-a625-f042cb323e55)

**Create a work item with at least one property:**
![Capture d’écran 2025-04-14 174140](https://github.com/user-attachments/assets/398be28c-a2f0-4f42-b26c-d041a1df0503)


### Test Scenarios 
-In the first image, i created a work item with no properties (Label / Assignees ...), the user is still able to create it however we get a warning toast that alerts the user of the missing properties.
-In the second image, i created a work item with at least one property and it only shows the success toast.

### References
https://github.com/makeplane/plane/issues/6872

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the issue creation form with additional validation. Users now receive a warning notification when attempting to submit a work item without any provided details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->