### PR TITLE
[WEB-3920]fix: estimate activity

### DIFF
--- a/web/core/components/issues/issue-detail/issue-activity/activity/activity-list.tsx
+++ b/web/core/components/issues/issue-detail/issue-activity/activity/activity-list.tsx
@@ -39,7 +39,7 @@ export const IssueActivityItem: FC<TIssueActivityItem> = observer((props) => {
   // hooks
   const {
     activity: { getActivityById },
-    comment: { },
+    comment: {},
   } = useIssueDetail();
   const ISSUE_RELATION_OPTIONS = useTimeLineRelationOptions();
   const activityRelations = getValidKeysFromObject(ISSUE_RELATION_OPTIONS);
@@ -62,6 +62,7 @@ export const IssueActivityItem: FC<TIssueActivityItem> = observer((props) => {
       return <IssuePriorityActivity {...componentDefaultProps} showIssue={false} />;
     case "estimate_points":
     case "estimate_categories":
+    case "estimate_point" /* This case is to handle all the older recorded activities for estimates. Field changed from  "estimate_point" -> `estimate_${estimate_type}`*/:
       return <IssueEstimateActivity {...componentDefaultProps} showIssue={false} />;
     case "parent":
       return <IssueParentActivity {...componentDefaultProps} showIssue={false} />;


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
This update fixes the display of older activities for estimate in work items.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
<!-- Link related issues if there are any -->
[WEB-3920](https://app.plane.so/plane/browse/WEB-3920/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for displaying legacy estimate activity records in issue activity history.

- **Bug Fixes**
  - Improved compatibility with older activity data for issue estimates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->