### PR TITLE
[WEB-3923] fix: applied filters list

### DIFF
--- a/web/core/components/issues/issue-layouts/filters/applied-filters/roots/project-root.tsx
+++ b/web/core/components/issues/issue-layouts/filters/applied-filters/roots/project-root.tsx
@@ -81,6 +81,7 @@ export const ProjectAppliedFiltersRoot: React.FC<TProjectAppliedFiltersRootProps
           handleRemoveFilter={handleRemoveFilter}
           labels={projectLabels ?? []}
           states={projectStates}
+          alwaysAllowEditing
         />
       </Header.LeftItem>
       <Header.RightItem>


### PR DESCRIPTION
### Description
This PR fixes a bug in the applied filters list on the Project Work Items page. Previously, users with the Guest role were unable to clear applied filters from the filter section. This update ensures that all users, including guests, can now remove filters as expected.

### Type of Change
- [x] Bug fix 

### References
[[WEB-3923]](https://app.plane.so/plane/browse/WEB-3923/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Editing of applied filters is now always allowed within project filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->