### PR TITLE
[WEB-3944] fix: Error Toast message content update while uploading images

### DIFF
--- a/apiserver/plane/app/views/asset/v2.py
+++ b/apiserver/plane/app/views/asset/v2.py
@@ -137,7 +137,7 @@ class UserAssetsV2Endpoint(BaseAPIView):
         if type not in allowed_types:
             return Response(
                 {
-                    "error": "Invalid file type. Only JPEG and PNG files are allowed.",
+                    "error": "Invalid file type. Only JPEG, PNG, WebP, JPG and GIF files are allowed.",
                     "status": False,
                 },
                 status=status.HTTP_400_BAD_REQUEST,
@@ -351,7 +351,7 @@ class WorkspaceFileAssetEndpoint(BaseAPIView):
         if type not in allowed_types:
             return Response(
                 {
-                    "error": "Invalid file type. Only JPEG and PNG files are allowed.",
+                    "error": "Invalid file type. Only JPEG, PNG, WebP, JPG and GIF files are allowed.",
                     "status": False,
                 },
                 status=status.HTTP_400_BAD_REQUEST,
@@ -552,7 +552,7 @@ class ProjectAssetEndpoint(BaseAPIView):
         if type not in allowed_types:
             return Response(
                 {
-                    "error": "Invalid file type. Only JPEG and PNG files are allowed.",
+                    "error": "Invalid file type. Only JPEG, PNG, WebP, JPG and GIF files are allowed.",
                     "status": False,
                 },
                 status=status.HTTP_400_BAD_REQUEST,

--- a/apiserver/plane/space/views/asset.py
+++ b/apiserver/plane/space/views/asset.py
@@ -96,7 +96,7 @@ class EntityAssetEndpoint(BaseAPIView):
         if type not in allowed_types:
             return Response(
                 {
-                    "error": "Invalid file type. Only JPEG and PNG files are allowed.",
+                    "error": "Invalid file type. Only JPEG, PNG, WebP, JPG and GIF files are allowed.",
                     "status": False,
                 },
                 status=status.HTTP_400_BAD_REQUEST,

--- a/web/core/components/core/image-picker-popover.tsx
+++ b/web/core/components/core/image-picker-popover.tsx
@@ -14,7 +14,7 @@ import { useOutsideClickDetector } from "@plane/hooks";
 // plane types
 import { EFileAssetType } from "@plane/types/src/enums";
 // ui
-import { Button, Input, Loader } from "@plane/ui";
+import { Button, Input, Loader, TOAST_TYPE, setToast } from "@plane/ui";
 // helpers
 import { getFileURL } from "@/helpers/file.helper";
 // hooks
@@ -114,7 +114,16 @@ export const ImagePickerPopover: React.FC<Props> = observer((props) => {
           },
           image
         )
-        .then((res) => uploadCallback(res.asset_url));
+        .then((res) => uploadCallback(res.asset_url))
+        .catch((error) => {
+          console.error("Error uploading user cover image:", error);
+          setIsImageUploading(false);
+          setToast({
+            message: error?.error ?? "The image could not be uploaded",
+            type: TOAST_TYPE.ERROR,
+            title: "Image not uploaded",
+          });
+        });
     } else {
       if (!workspaceSlug) return;
       await fileService
@@ -126,7 +135,16 @@ export const ImagePickerPopover: React.FC<Props> = observer((props) => {
           },
           image
         )
-        .then((res) => uploadCallback(res.asset_url));
+        .then((res) => uploadCallback(res.asset_url))
+        .catch((error) => {
+          console.error("Error uploading project cover image:", error);
+          setIsImageUploading(false);
+          setToast({
+            message: error?.error ?? "The image could not be uploaded",
+            type: TOAST_TYPE.ERROR,
+            title: "Image not uploaded",
+          });
+        });
     }
   };
 


### PR DESCRIPTION
### Description
Handled SVG upload failures in cover images

### References
[[WEB=3944]](https://app.plane.so/plane/browse/WEB-3944/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for image uploads in the image picker popover. Users will now see an error notification if an image fails to upload, and the uploading state will reset appropriately.
	- Updated error messages for unsupported image uploads to accurately reflect all allowed file types, including JPEG, PNG, WebP, JPG, and GIF.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->