### PR TITLE
[WEB-3494] chore: platform ux copy changes

### DIFF
--- a/packages/i18n/src/locales/cs/translations.json
+++ b/packages/i18n/src/locales/cs/translations.json
@@ -348,7 +348,7 @@
   "couldnt_remove_the_project_from_favorites": "Nepodařilo se odstranit projekt z oblíbených. Zkuste to prosím znovu.",
   "add_to_favorites": "Přidat do oblíbených",
   "remove_from_favorites": "Odebrat z oblíbených",
-  "publish_settings": "Nastavení publikování",
+  "publish_project": "Publikovat projekt",
   "publish": "Publikovat",
   "copy_link": "Kopírovat odkaz",
   "leave_project": "Opustit projekt",

--- a/packages/i18n/src/locales/de/translations.json
+++ b/packages/i18n/src/locales/de/translations.json
@@ -348,7 +348,7 @@
   "couldnt_remove_the_project_from_favorites": "Projekt konnte nicht aus den Favoriten entfernt werden. Bitte versuchen Sie es erneut.",
   "add_to_favorites": "Zu Favoriten hinzufügen",
   "remove_from_favorites": "Aus Favoriten entfernen",
-  "publish_settings": "Veröffentlichungseinstellungen",
+  "publish_project": "Projekt veröffentlichen",
   "publish": "Veröffentlichen",
   "copy_link": "Link kopieren",
   "leave_project": "Projekt verlassen",

--- a/packages/i18n/src/locales/en/translations.json
+++ b/packages/i18n/src/locales/en/translations.json
@@ -180,7 +180,7 @@
   "couldnt_remove_the_project_from_favorites": "Couldn't remove the project from favorites. Please try again.",
   "add_to_favorites": "Add to favorites",
   "remove_from_favorites": "Remove from favorites",
-  "publish_settings": "Publish settings",
+  "publish_project": "Publish project",
   "publish": "Publish",
   "copy_link": "Copy link",
   "leave_project": "Leave project",

--- a/packages/i18n/src/locales/es/translations.json
+++ b/packages/i18n/src/locales/es/translations.json
@@ -352,7 +352,7 @@
   "couldnt_remove_the_project_from_favorites": "No se pudo eliminar el proyecto de favoritos. Por favor, inténtalo de nuevo.",
   "add_to_favorites": "Agregar a favoritos",
   "remove_from_favorites": "Eliminar de favoritos",
-  "publish_settings": "Configuración de publicación",
+  "publish_project": "Publicar proyecto",
   "publish": "Publicar",
   "copy_link": "Copiar enlace",
   "leave_project": "Abandonar proyecto",

--- a/packages/i18n/src/locales/fr/translations.json
+++ b/packages/i18n/src/locales/fr/translations.json
@@ -350,7 +350,7 @@
   "couldnt_remove_the_project_from_favorites": "Impossible de supprimer le projet des favoris. Veuillez réessayer.",
   "add_to_favorites": "Ajouter aux favoris",
   "remove_from_favorites": "Supprimer des favoris",
-  "publish_settings": "Paramètres de publication",
+  "publish_project": "Publier le projet",
   "publish": "Publier",
   "copy_link": "Copier le lien",
   "leave_project": "Quitter le projet",

--- a/packages/i18n/src/locales/id/translations.json
+++ b/packages/i18n/src/locales/id/translations.json
@@ -350,7 +350,7 @@
   "couldnt_remove_the_project_from_favorites": "Tidak dapat menghapus proyek dari favorit. Silakan coba lagi.",
   "add_to_favorites": "Tambah ke favorit",
   "remove_from_favorites": "Hapus dari favorit",
-  "publish_settings": "Pengaturan publikasi",
+  "publish_project": "Publikasikan proyek",
   "publish": "Publikasikan",
   "copy_link": "Salin tautan",
   "leave_project": "Tinggalkan proyek",

--- a/packages/i18n/src/locales/it/translations.json
+++ b/packages/i18n/src/locales/it/translations.json
@@ -349,7 +349,7 @@
   "couldnt_remove_the_project_from_favorites": "Impossibile rimuovere il progetto dai preferiti. Per favore, riprova.",
   "add_to_favorites": "Aggiungi ai preferiti",
   "remove_from_favorites": "Rimuovi dai preferiti",
-  "publish_settings": "Impostazioni di pubblicazione",
+  "publish_project": "Pubblica progetto",
   "publish": "Pubblica",
   "copy_link": "Copia link",
   "leave_project": "Lascia progetto",

--- a/packages/i18n/src/locales/ja/translations.json
+++ b/packages/i18n/src/locales/ja/translations.json
@@ -350,7 +350,7 @@
   "couldnt_remove_the_project_from_favorites": "プロジェクトをお気に入りから削除できませんでした。もう一度お試しください。",
   "add_to_favorites": "お気に入りに追加",
   "remove_from_favorites": "お気に入りから削除",
-  "publish_settings": "公開設定",
+  "publish_project": "プロジェクトを公開",
   "publish": "公開",
   "copy_link": "リンクをコピー",
   "leave_project": "プロジェクトを退出",

--- a/packages/i18n/src/locales/ko/translations.json
+++ b/packages/i18n/src/locales/ko/translations.json
@@ -350,7 +350,7 @@
   "couldnt_remove_the_project_from_favorites": "프로젝트를 즐겨찾기에서 제거하지 못했습니다. 다시 시도해주세요.",
   "add_to_favorites": "즐겨찾기에 추가",
   "remove_from_favorites": "즐겨찾기에서 제거",
-  "publish_settings": "설정 게시",
+  "publish_project": "프로젝트 게시",
   "publish": "게시",
   "copy_link": "링크 복사",
   "leave_project": "프로젝트 떠나기",

--- a/packages/i18n/src/locales/pl/translations.json
+++ b/packages/i18n/src/locales/pl/translations.json
@@ -348,7 +348,7 @@
   "couldnt_remove_the_project_from_favorites": "Nie udało się usunąć projektu z ulubionych. Spróbuj ponownie.",
   "add_to_favorites": "Dodaj do ulubionych",
   "remove_from_favorites": "Usuń z ulubionych",
-  "publish_settings": "Ustawienia publikowania",
+  "publish_project": "Opublikuj projekt",
   "publish": "Opublikuj",
   "copy_link": "Kopiuj link",
   "leave_project": "Opuść projekt",

--- a/packages/i18n/src/locales/pt-BR/translations.json
+++ b/packages/i18n/src/locales/pt-BR/translations.json
@@ -350,7 +350,7 @@
   "couldnt_remove_the_project_from_favorites": "Não foi possível remover o projeto dos favoritos. Por favor, tente novamente.",
   "add_to_favorites": "Adicionar aos favoritos",
   "remove_from_favorites": "Remover dos favoritos",
-  "publish_settings": "Configurações de publicação",
+  "publish_project": "Publicar projeto",
   "publish": "Publicar",
   "copy_link": "Copiar link",
   "leave_project": "Sair do projeto",

--- a/packages/i18n/src/locales/ro/translations.json
+++ b/packages/i18n/src/locales/ro/translations.json
@@ -350,7 +350,7 @@
   "couldnt_remove_the_project_from_favorites": "Nu s-a putut elimina proiectul din favorite. Încearcă din nou.",
   "add_to_favorites": "Adaugă la favorite",
   "remove_from_favorites": "Elimină din favorite",
-  "publish_settings": "Setări de publicare",
+  "publish_project": "Publică proiectul",
   "publish": "Publică",
   "copy_link": "Copiază link-ul",
   "leave_project": "Părăsește proiectul",

--- a/packages/i18n/src/locales/ru/translations.json
+++ b/packages/i18n/src/locales/ru/translations.json
@@ -348,7 +348,7 @@
   "couldnt_remove_the_project_from_favorites": "Не удалось удалить проект из избранного. Попробуйте снова.",
   "add_to_favorites": "Добавить в избранное",
   "remove_from_favorites": "Удалить из избранного",
-  "publish_settings": "Настройки публикации",
+  "publish_project": "Опубликовать проект",
   "publish": "Опубликовать",
   "copy_link": "Копировать ссылку",
   "leave_project": "Покинуть проект",

--- a/packages/i18n/src/locales/sk/translations.json
+++ b/packages/i18n/src/locales/sk/translations.json
@@ -348,7 +348,7 @@
   "couldnt_remove_the_project_from_favorites": "Nepodarilo sa odstrániť projekt z obľúbených. Skúste to prosím znova.",
   "add_to_favorites": "Pridať do obľúbených",
   "remove_from_favorites": "Odstrániť z obľúbených",
-  "publish_settings": "Nastavenia publikovania",
+  "publish_project": "Publikovať projekt",
   "publish": "Publikovať",
   "copy_link": "Kopírovať odkaz",
   "leave_project": "Opustiť projekt",

--- a/packages/i18n/src/locales/tr-TR/translations.json
+++ b/packages/i18n/src/locales/tr-TR/translations.json
@@ -350,7 +350,7 @@
   "couldnt_remove_the_project_from_favorites": "Proje favorilerden kaldırılamadı. Lütfen tekrar deneyin.",
   "add_to_favorites": "Favorilere ekle",
   "remove_from_favorites": "Favorilerden kaldır",
-  "publish_settings": "Yayınlama ayarları",
+  "publish_project": "Projeyi yayımla",
   "publish": "Yayınla",
   "copy_link": "Bağlantıyı kopyala",
   "leave_project": "Projeden ayrıl",

--- a/packages/i18n/src/locales/ua/translations.json
+++ b/packages/i18n/src/locales/ua/translations.json
@@ -348,7 +348,7 @@
   "couldnt_remove_the_project_from_favorites": "Не вдалося вилучити проєкт із вибраного. Спробуйте ще раз.",
   "add_to_favorites": "Додати у вибране",
   "remove_from_favorites": "Вилучити з вибраного",
-  "publish_settings": "Налаштування публікації",
+  "publish_project": "Опублікувати проєкт",
   "publish": "Опублікувати",
   "copy_link": "Скопіювати посилання",
   "leave_project": "Вийти з проєкту",

--- a/packages/i18n/src/locales/vi-VN/translations.json
+++ b/packages/i18n/src/locales/vi-VN/translations.json
@@ -348,7 +348,7 @@
   "couldnt_remove_the_project_from_favorites": "Không thể xóa dự án khỏi mục yêu thích. Vui lòng thử lại.",
   "add_to_favorites": "Thêm vào mục yêu thích",
   "remove_from_favorites": "Xóa khỏi mục yêu thích",
-  "publish_settings": "Cài đặt xuất bản",
+  "publish_project": "Xuất bản dự án",
   "publish": "Xuất bản",
   "copy_link": "Sao chép liên kết",
   "leave_project": "Rời dự án",

--- a/packages/i18n/src/locales/zh-CN/translations.json
+++ b/packages/i18n/src/locales/zh-CN/translations.json
@@ -350,7 +350,7 @@
   "couldnt_remove_the_project_from_favorites": "无法从收藏中移除项目。请重试。",
   "add_to_favorites": "添加到收藏",
   "remove_from_favorites": "从收藏中移除",
-  "publish_settings": "发布设置",
+  "publish_project": "发布项目",
   "publish": "发布",
   "copy_link": "复制链接",
   "leave_project": "离开项目",

--- a/packages/i18n/src/locales/zh-TW/translations.json
+++ b/packages/i18n/src/locales/zh-TW/translations.json
@@ -350,7 +350,7 @@
   "couldnt_remove_the_project_from_favorites": "無法從我的最愛移除專案。請再試一次。",
   "add_to_favorites": "加入我的最愛",
   "remove_from_favorites": "從我的最愛移除",
-  "publish_settings": "發布設定",
+  "publish_project": "發佈專案",
   "publish": "發布",
   "copy_link": "複製連結",
   "leave_project": "離開專案",

--- a/web/core/components/onboarding/tour/root.tsx
+++ b/web/core/components/onboarding/tour/root.tsx
@@ -26,7 +26,7 @@ type Props = {
   onComplete: () => void;
 };
 
-export type TTourSteps = "welcome" | "issues" | "cycles" | "modules" | "views" | "pages";
+export type TTourSteps = "welcome" | "work-items" | "cycles" | "modules" | "views" | "pages";
 
 const TOUR_STEPS: {
   key: TTourSteps;
@@ -37,10 +37,10 @@ const TOUR_STEPS: {
   nextStep?: TTourSteps;
 }[] = [
   {
-    key: "issues",
+    key: "work-items",
     title: "Plan with work items",
     description:
-      "The work item is the building block of the Plane. Most concepts in Plane are either associated with issues and their properties.",
+      "The work item is the building block of the Plane. Most concepts in Plane are either associated with work items and their properties.",
     image: IssuesTour,
     nextStep: "cycles",
   },
@@ -50,7 +50,7 @@ const TOUR_STEPS: {
     description:
       "Cycles help you and your team to progress faster, similar to the sprints commonly used in agile development.",
     image: CyclesTour,
-    prevStep: "issues",
+    prevStep: "work-items",
     nextStep: "modules",
   },
   {
@@ -113,7 +113,7 @@ export const TourRoot: React.FC<Props> = observer((props) => {
                     variant="primary"
                     onClick={() => {
                       captureEvent(PRODUCT_TOUR_STARTED);
-                      setStep("issues");
+                      setStep("work-items");
                     }}
                   >
                     Take a Product Tour
@@ -162,7 +162,7 @@ export const TourRoot: React.FC<Props> = observer((props) => {
                     </Button>
                   )}
                   {currentStep?.nextStep && (
-                    <Button variant="primary" onClick={() => setStep(currentStep.nextStep ?? "issues")}>
+                    <Button variant="primary" onClick={() => setStep(currentStep.nextStep ?? "work-items")}>
                       Next
                     </Button>
                   )}

--- a/web/core/components/onboarding/tour/sidebar.tsx
+++ b/web/core/components/onboarding/tour/sidebar.tsx
@@ -8,26 +8,32 @@ import { TTourSteps } from "./root";
 
 const sidebarOptions: {
   key: TTourSteps;
+  label: string;
   Icon: any;
 }[] = [
   {
-    key: "issues",
+    key: "work-items",
+    label: "Work items",
     Icon: LayersIcon,
   },
   {
     key: "cycles",
+    label: "Cycles",
     Icon: ContrastIcon,
   },
   {
     key: "modules",
+    label: "Modules",
     Icon: DiceIcon,
   },
   {
     key: "views",
+    label: "Views",
     Icon: Layers,
   },
   {
     key: "pages",
+    label: "Pages",
     Icon: FileText,
   },
 ];
@@ -57,7 +63,7 @@ export const TourSidebar: React.FC<Props> = ({ step, setStep }) => (
           role="button"
         >
           <option.Icon className="h-4 w-4" aria-hidden="true" />
-          {option.key}
+          {option.label}
         </h5>
       ))}
     </div>

--- a/web/core/components/workspace/sidebar/projects-list-item.tsx
+++ b/web/core/components/workspace/sidebar/projects-list-item.tsx
@@ -332,7 +332,7 @@ export const SidebarProjectsListItem: React.FC<Props> = observer((props) => {
                         <div className="flex h-4 w-4 cursor-pointer items-center justify-center rounded text-custom-sidebar-text-200 transition-all duration-300 hover:bg-custom-sidebar-background-80">
                           <Share2 className="h-3.5 w-3.5 stroke-[1.5]" />
                         </div>
-                        <div>{t("publish_settings")}</div>
+                        <div>{t("publish_project")}</div>
                       </div>
                     </CustomMenu.MenuItem>
                   )}


### PR DESCRIPTION
### Description
This PR introduces the following UX copy updates:
- App Sidebar → Project Quick Action Menu: Changed "Publish settings" to "Publish project"
- Product Tour Modal: Replaced all instances of "issues" with "Work items"

### Type of Change
- [x] UX copy.

### References
[[WEB-3494]](https://app.plane.so/plane/browse/WEB-3949/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated onboarding tour and sidebar to consistently use "Work items" instead of "Issues", improving clarity in navigation and labels.

- **Bug Fixes**
  - Corrected the publish project menu item label to display the updated translation key across all supported languages, ensuring accurate localization.

- **Style**
  - Sidebar options now display user-friendly labels, enhancing readability in the onboarding tour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->