### PR TITLE
[WEB-3953] fix: issue description assets upload when project id is switched

### DIFF
--- a/apiserver/plane/app/views/asset/v2.py
+++ b/apiserver/plane/app/views/asset/v2.py
@@ -683,7 +683,7 @@ class ProjectBulkAssetEndpoint(BaseAPIView):
             # For some cases, the bulk api is called after the issue is deleted creating
             # an integrity error
             try:
-                assets.update(issue_id=entity_id)
+                assets.update(issue_id=entity_id, project_id=project_id)
             except IntegrityError:
                 pass
 

--- a/web/core/components/issues/issue-modal/base.tsx
+++ b/web/core/components/issues/issue-modal/base.tsx
@@ -132,10 +132,14 @@ export const CreateUpdateIssueModalBase: React.FC<IssuesModalProps> = observer((
   };
 
   const addIssueToModule = async (issue: TIssue, moduleIds: string[]) => {
-    if (!workspaceSlug || !activeProjectId) return;
+    if (!workspaceSlug || !issue.project_id) return;
 
-    await issues.changeModulesInIssue(workspaceSlug.toString(), activeProjectId, issue.id, moduleIds, []);
-    moduleIds.forEach((moduleId) => fetchModuleDetails(workspaceSlug.toString(), activeProjectId, moduleId));
+    await Promise.all([
+      issues.changeModulesInIssue(workspaceSlug.toString(), issue.project_id, issue.id, moduleIds, []),
+      ...moduleIds.map(
+        (moduleId) => issue.project_id && fetchModuleDetails(workspaceSlug.toString(), issue.project_id, moduleId)
+      ),
+    ]);
   };
 
   const handleCreateMoreToggleChange = (value: boolean) => {
@@ -182,7 +186,7 @@ export const CreateUpdateIssueModalBase: React.FC<IssuesModalProps> = observer((
       if (uploadedAssetIds.length > 0) {
         await fileService.updateBulkProjectAssetsUploadStatus(
           workspaceSlug?.toString() ?? "",
-          activeProjectId ?? "",
+          response?.project_id ?? "",
           response?.id ?? "",
           {
             asset_ids: uploadedAssetIds,


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
In this PR, I have fixed an issue where the uploaded images where not rendering when project Id was switched after uploading those images. 

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Media
* Before

https://github.com/user-attachments/assets/419dd7fd-551c-4d08-8f16-b2f558ef4ed6


* After

https://github.com/user-attachments/assets/4c29fffd-f14f-4465-bc17-83a9badd3254


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved accuracy when updating assets related to issues, ensuring the correct project is associated.
	- Fixed issue where project ID was not properly set during bulk asset status updates after creating an issue.
	- Enhanced issue-module linking logic to use the issue's actual project ID, improving reliability.

- **Performance**
	- Optimized module updates and details fetching by executing them concurrently, resulting in faster operations when managing issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->