### PR TITLE
[WEB-3992] chore: support for x-zip-compressed type

### DIFF
--- a/apiserver/plane/settings/common.py
+++ b/apiserver/plane/settings/common.py
@@ -377,6 +377,7 @@ ATTACHMENT_MIME_TYPES = [
     # Archives
     "application/zip",
     "application/x-rar-compressed",
+    "application/x-zip-compressed",
     "application/x-tar",
     "application/gzip",
     # 3D Models


### PR DESCRIPTION
### Description
This PR will provide support to attach type `x-zip-compressed` files.

### References
https://github.com/makeplane/plane/issues/6999