### PR TITLE
[WEB-4002] fix: sidebar tab highlight

### DIFF
--- a/web/core/components/workspace/sidebar/project-navigation.tsx
+++ b/web/core/components/workspace/sidebar/project-navigation.tsx
@@ -24,6 +24,7 @@ export type TNavigationItem = {
   shouldRender: boolean;
   sortOrder: number;
   i18n_key: string;
+  key: string;
 };
 
 type TProjectItemsProps = {
@@ -66,6 +67,7 @@ export const ProjectNavigation: FC<TProjectItemsProps> = observer((props) => {
     (workspaceSlug: string, projectId: string): TNavigationItem[] => [
       {
         i18n_key: "sidebar.work_items",
+        key: "work_items",
         name: "Work items",
         href: `/${workspaceSlug}/projects/${projectId}/issues`,
         icon: LayersIcon,
@@ -75,6 +77,7 @@ export const ProjectNavigation: FC<TProjectItemsProps> = observer((props) => {
       },
       {
         i18n_key: "sidebar.cycles",
+        key: "cycles",
         name: "Cycles",
         href: `/${workspaceSlug}/projects/${projectId}/cycles`,
         icon: ContrastIcon,
@@ -84,6 +87,7 @@ export const ProjectNavigation: FC<TProjectItemsProps> = observer((props) => {
       },
       {
         i18n_key: "sidebar.modules",
+        key: "modules",
         name: "Modules",
         href: `/${workspaceSlug}/projects/${projectId}/modules`,
         icon: DiceIcon,
@@ -93,6 +97,7 @@ export const ProjectNavigation: FC<TProjectItemsProps> = observer((props) => {
       },
       {
         i18n_key: "sidebar.views",
+        key: "views",
         name: "Views",
         href: `/${workspaceSlug}/projects/${projectId}/views`,
         icon: Layers,
@@ -102,6 +107,7 @@ export const ProjectNavigation: FC<TProjectItemsProps> = observer((props) => {
       },
       {
         i18n_key: "sidebar.pages",
+        key: "pages",
         name: "Pages",
         href: `/${workspaceSlug}/projects/${projectId}/pages`,
         icon: FileText,
@@ -111,6 +117,7 @@ export const ProjectNavigation: FC<TProjectItemsProps> = observer((props) => {
       },
       {
         i18n_key: "sidebar.intake",
+        key: "intake",
         name: "Intake",
         href: `/${workspaceSlug}/projects/${projectId}/inbox`,
         icon: Intake,
@@ -149,8 +156,8 @@ export const ProjectNavigation: FC<TProjectItemsProps> = observer((props) => {
       // epic condition
       const epicCondition = workItemId && workItem && workItem?.is_epic && workItem?.project_id === projectId;
       // is active
-      const isWorkItemActive = item.i18n_key === "sidebar.work_items" && workItemCondition;
-      const isEpicActive = item.i18n_key === "sidebar.epics" && epicCondition;
+      const isWorkItemActive = item.key === "work_items" && workItemCondition;
+      const isEpicActive = item.key === "epics" && epicCondition;
       // pathname condition
       const isPathnameActive = pathname.includes(item.href);
       // return

--- a/web/core/components/workspace/sidebar/project-navigation.tsx
+++ b/web/core/components/workspace/sidebar/project-navigation.tsx
@@ -35,7 +35,7 @@ type TProjectItemsProps = {
 
 export const ProjectNavigation: FC<TProjectItemsProps> = observer((props) => {
   const { workspaceSlug, projectId, additionalNavigationItems, isSidebarCollapsed } = props;
-  const { workItem: workItemIdFromRoute } = useParams();
+  const { workItem: workItemIdentifierFromRoute } = useParams();
   // store hooks
   const { t } = useTranslation();
   const { toggleSidebar } = useAppTheme();
@@ -48,7 +48,9 @@ export const ProjectNavigation: FC<TProjectItemsProps> = observer((props) => {
   // pathname
   const pathname = usePathname();
   // derived values
-  const workItemId = workItemIdFromRoute ? getIssueIdByIdentifier(workItemIdFromRoute?.toString()) : undefined;
+  const workItemId = workItemIdentifierFromRoute
+    ? getIssueIdByIdentifier(workItemIdentifierFromRoute?.toString())
+    : undefined;
   const workItem = workItemId ? getIssueById(workItemId) : undefined;
   const project = getPartialProjectById(projectId);
   // handlers

--- a/web/core/store/issue/issue-details/issue.store.ts
+++ b/web/core/store/issue/issue-details/issue.store.ts
@@ -306,7 +306,6 @@ export class IssueStore implements IIssueStore {
       : this.rootIssueDetailStore.rootIssueStore.issueDetail;
 
     if (!issue || !projectId || !issueId) throw new Error("Issue not found");
-    this.rootIssueDetailStore.rootIssueStore.issues.addIssueIdentifier(issueIdentifier, issueId);
 
     const issuePayload = this.addIssueToStore(issue);
     this.rootIssueDetailStore.rootIssueStore.issues.addIssue([issuePayload]);

--- a/web/core/store/issue/issue-details/issue.store.ts
+++ b/web/core/store/issue/issue-details/issue.store.ts
@@ -306,6 +306,7 @@ export class IssueStore implements IIssueStore {
       : this.rootIssueDetailStore.rootIssueStore.issueDetail;
 
     if (!issue || !projectId || !issueId) throw new Error("Issue not found");
+    this.rootIssueDetailStore.rootIssueStore.issues.addIssueIdentifier(issueIdentifier, issueId);
 
     const issuePayload = this.addIssueToStore(issue);
     this.rootIssueDetailStore.rootIssueStore.issues.addIssue([issuePayload]);

--- a/web/core/store/issue/issue.store.ts
+++ b/web/core/store/issue/issue.store.ts
@@ -7,6 +7,7 @@ import { computedFn } from "mobx-utils";
 import { TIssue } from "@plane/types";
 // helpers
 import { getCurrentDateTimeInISO } from "@/helpers/date-time.helper";
+import { rootStore } from "@/lib/store-context";
 // services
 import { deleteIssueFromLocal } from "@/local-db/utils/load-issues";
 import { updatePersistentLayer } from "@/local-db/utils/utils";
@@ -59,6 +60,12 @@ export class IssueStore implements IIssueStore {
     if (issues && issues.length <= 0) return;
     runInAction(() => {
       issues.forEach((issue) => {
+        // add issue identifier to the issuesIdentifierMap
+        const projectIdentifier = rootStore.projectRoot.project.getProjectIdentifierById(issue?.project_id);
+        const workItemSequenceId = issue?.sequence_id;
+        const issueIdentifier = `${projectIdentifier}-${workItemSequenceId}`;
+        set(this.issuesIdentifierMap, issueIdentifier, issue.id);
+
         if (!this.issuesMap[issue.id]) set(this.issuesMap, issue.id, issue);
         else update(this.issuesMap, issue.id, (prevIssue) => ({ ...prevIssue, ...issue }));
       });


### PR DESCRIPTION
### Description
This PR resolves an issue where the Work Item tab was not correctly highlighted in the sidebar when viewing the detail page.

### Type of Change
- [x] Bug fix

### Media
| Before | After |
|--------|--------|
| ![WEB-4002-Before](https://github.com/user-attachments/assets/63af8e6b-0238-4acd-8534-fd686b0606b3) | ![WEB-4002-After](https://github.com/user-attachments/assets/789b214c-136f-43b2-9f38-07df759697ad) |

### References
[[WEB-4002]](https://app.plane.so/plane/browse/WEB-4002/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved the logic for determining the active sidebar navigation item, making it more accurate by considering issue type and project membership.
  - Streamlined the sidebar code by introducing a dedicated function for active state checks.

- **New Features**
  - Sidebar navigation items now have unique identifiers for better management and tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->