### PR TITLE
[WEB-4008] fix: handle when settings are None

### DIFF
--- a/apiserver/plane/authentication/utils/host.py
+++ b/apiserver/plane/authentication/utils/host.py
@@ -21,7 +21,9 @@ def base_host(
 
     # Admin redirection
     if is_admin:
-        admin_base_path = getattr(settings, "ADMIN_BASE_PATH", "/god-mode/")
+        admin_base_path = getattr(settings, "ADMIN_BASE_PATH", None)
+        if not isinstance(admin_base_path, str):
+            admin_base_path = "/god-mode/"
         if not admin_base_path.startswith("/"):
             admin_base_path = "/" + admin_base_path
         if not admin_base_path.endswith("/"):
@@ -34,7 +36,9 @@ def base_host(
 
     # Space redirection
     if is_space:
-        space_base_path = getattr(settings, "SPACE_BASE_PATH", "/spaces/")
+        space_base_path = getattr(settings, "SPACE_BASE_PATH", None)
+        if not isinstance(space_base_path, str):
+            space_base_path = "/spaces/"
         if not space_base_path.startswith("/"):
             space_base_path = "/" + space_base_path
         if not space_base_path.endswith("/"):

--- a/apiserver/plane/utils/host.py
+++ b/apiserver/plane/utils/host.py
@@ -25,7 +25,9 @@ def base_host(
 
     # Admin redirection
     if is_admin:
-        admin_base_path = getattr(settings, "ADMIN_BASE_PATH", "/god-mode/")
+        admin_base_path = getattr(settings, "ADMIN_BASE_PATH", None)
+        if not isinstance(admin_base_path, str):
+            admin_base_path = "/god-mode/"
         if not admin_base_path.startswith("/"):
             admin_base_path = "/" + admin_base_path
         if not admin_base_path.endswith("/"):
@@ -38,7 +40,9 @@ def base_host(
 
     # Space redirection
     if is_space:
-        space_base_path = getattr(settings, "SPACE_BASE_PATH", "/spaces/")
+        space_base_path = getattr(settings, "SPACE_BASE_PATH", None)
+        if not isinstance(space_base_path, str):
+            space_base_path = "/spaces/"
         if not space_base_path.startswith("/"):
             space_base_path = "/" + space_base_path
         if not space_base_path.endswith("/"):


### PR DESCRIPTION
### Description

`space_base_path = getattr(settings, "SPACE_BASE_PATH", "/spaces/")` could still return `None` when configuration sets it to `None`. This caused an error to be thrown on the following line `if not space_base_path.startswith("/")`.
 

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
https://app.plane.so/plane/browse/WEB-4008/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation of admin and space base path settings to ensure correct handling and normalization, preventing potential errors from invalid configuration types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->