### PR TITLE
[WEB-3906] fix: page table of content overlap with the page content

### DIFF
--- a/packages/editor/src/styles/variables.css
+++ b/packages/editor/src/styles/variables.css
@@ -233,7 +233,9 @@
     padding-left: var(--normal-content-margin);
     padding-right: var(--normal-content-margin);
   }
+}
 
+@container page-content-container (max-width: 930px) {
   .page-summary-container {
     display: none;
   }


### PR DESCRIPTION
### Description

This PR fixes the bug where the page content and table of content overlap by increasing the threshold to hide the TOC to 930px from 712px.

This is a temporary fix which will later be taken care of by the new pages sidebar.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected a CSS issue to ensure responsive styles are properly applied at specific container widths.

- **New Features**
  - Added a new responsive style that hides the summary container on narrower screens for improved layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->