### PR TITLE
[WEB-2508] fix: page favorite item title mutation

### DIFF
--- a/web/core/hooks/use-favorite-item-details.tsx
+++ b/web/core/hooks/use-favorite-item-details.tsx
@@ -47,7 +47,7 @@ export const useFavoriteItemDetails = (workspaceSlug: string, favorite: IFavorit
       itemIcon = getFavoriteItemIcon("project", currentProjectDetails?.logo_props || favoriteItemLogoProps);
       break;
     case "page":
-      itemTitle = getPageName(pageDetail?.name || favoriteItemName);
+      itemTitle = getPageName(pageDetail?.name);
       itemIcon = getFavoriteItemIcon("page", pageDetail?.logo_props || favoriteItemLogoProps);
       break;
     case "view":

--- a/web/core/hooks/use-favorite-item-details.tsx
+++ b/web/core/hooks/use-favorite-item-details.tsx
@@ -43,23 +43,23 @@ export const useFavoriteItemDetails = (workspaceSlug: string, favorite: IFavorit
 
   switch (favoriteItemEntityType) {
     case "project":
-      itemTitle = currentProjectDetails?.name || favoriteItemName;
+      itemTitle = currentProjectDetails?.name ?? favoriteItemName;
       itemIcon = getFavoriteItemIcon("project", currentProjectDetails?.logo_props || favoriteItemLogoProps);
       break;
     case "page":
-      itemTitle = getPageName(pageDetail?.name);
-      itemIcon = getFavoriteItemIcon("page", pageDetail?.logo_props || favoriteItemLogoProps);
+      itemTitle = getPageName(pageDetail?.name ?? favoriteItemName);
+      itemIcon = getFavoriteItemIcon("page", pageDetail?.logo_props ?? favoriteItemLogoProps);
       break;
     case "view":
-      itemTitle = viewDetails?.name || favoriteItemName;
+      itemTitle = viewDetails?.name ?? favoriteItemName;
       itemIcon = getFavoriteItemIcon("view", viewDetails?.logo_props || favoriteItemLogoProps);
       break;
     case "cycle":
-      itemTitle = cycleDetail?.name || favoriteItemName;
+      itemTitle = cycleDetail?.name ?? favoriteItemName;
       itemIcon = getFavoriteItemIcon("cycle");
       break;
     case "module":
-      itemTitle = moduleDetail?.name || favoriteItemName;
+      itemTitle = moduleDetail?.name ?? favoriteItemName;
       itemIcon = getFavoriteItemIcon("module");
       break;
     default: {


### PR DESCRIPTION
### Description

This PR fixes the mutation of page title in the favorites list when the title of the page changes from some text to untitled.

**Cause of the bug-** When the page title becomes untitled(empty string), the title is being rendered using the fallback from the initial API response which is always stale because of the use of logical operator(`||`).

**Fix-** Updated the fallback logic to use nullish coalescing operator(`??`).

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the display of page names in favorite item details to ensure more accurate titles are shown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->