### PR TITLE
[WEB-4051] fix: comment editor font size

### DIFF
--- a/web/core/components/comments/comment-card.tsx
+++ b/web/core/components/comments/comment-card.tsx
@@ -161,9 +161,8 @@ export const CommentCard: FC<TCommentCard> = observer((props) => {
                 return asset_id;
               }}
               projectId={projectId?.toString() ?? ""}
-              editorClassName="[&>*]:!py-0 [&>*]:!text-sm"
               parentClassName="p-2"
-              />
+            />
           </div>
           <div className="flex gap-1 self-end">
             {!isEmpty && (
@@ -208,7 +207,6 @@ export const CommentCard: FC<TCommentCard> = observer((props) => {
             initialValue={comment.comment_html ?? ""}
             workspaceId={workspaceId}
             workspaceSlug={workspaceSlug}
-            editorClassName="[&>*]:!py-0 [&>*]:!text-sm"
             containerClassName="!py-1"
             projectId={(projectId as string) ?? ""}
           />

--- a/web/core/components/comments/comment-create.tsx
+++ b/web/core/components/comments/comment-create.tsx
@@ -125,7 +125,7 @@ export const CommentCreate: FC<TCommentCreate> = observer((props) => {
                 }}
                 ref={editorRef}
                 initialValue={value ?? "<p></p>"}
-                containerClassName="min-h-min [&_p]:!p-0 [&_p]:!text-sm"
+                containerClassName="min-h-min"
                 onChange={(comment_json, comment_html) => onChange(comment_html)}
                 accessSpecifier={accessValue ?? EIssueCommentAccessSpecifier.INTERNAL}
                 handleAccessChange={onAccessChange}


### PR DESCRIPTION
### Description

This PR fixes the different font sizes of paragraphs and list items in the comment editor.

**Cause of bug-** Hardcoded font sizes and padding from the web app.

**Fix-** Removed the hardcoded classes and moved them to the editor package.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated comment editor and display components to remove certain custom text size and padding styles, resulting in a more consistent appearance for comment text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->