### PR TITLE
chore: add disable_auto_set_user flag on base model save method

### DIFF
--- a/apiserver/plane/db/models/base.py
+++ b/apiserver/plane/db/models/base.py
@@ -18,22 +18,28 @@ class BaseModel(AuditModel):
     class Meta:
         abstract = True
 
-    def save(self, *args, **kwargs):
-        user = get_current_user()
+    def save(self, *args, created_by_id=None, disable_auto_set_user=False, **kwargs):
+        if not disable_auto_set_user:
+            # Check if created_by_id is provided
+            if created_by_id:
+                self.created_by_id = created_by_id
+            else:
+                user = get_current_user()
 
-        if user is None or user.is_anonymous:
-            self.created_by = None
-            self.updated_by = None
-            super(BaseModel, self).save(*args, **kwargs)
-        else:
-            # Check if the model is being created or updated
-            if self._state.adding:
-                # If created only set created_by value: set updated_by to None
-                self.created_by = user
-                self.updated_by = None
-            # If updated only set updated_by value don't touch created_by
-            self.updated_by = user
-            super(BaseModel, self).save(*args, **kwargs)
+                if user is None or user.is_anonymous:
+                    self.created_by = None
+                    self.updated_by = None
+                else:
+                    # Check if the model is being created or updated
+                    if self._state.adding:
+                        # If creating, set created_by and leave updated_by as None
+                        self.created_by = user
+                        self.updated_by = None
+                    else:
+                        # If updating, set updated_by only
+                        self.updated_by = user
+
+        super(BaseModel, self).save(*args, **kwargs)
 
     def __str__(self):
         return str(self.id)


### PR DESCRIPTION
### Description
- when disable_auto_set_user flag is set, user fields like created_by are derived from payload instead of crum

<!-- Provide a detailed description of the changes in this PR -->

### Type of Change
- [X] Feature (non-breaking change which adds functionality)
- [X] Improvement (change that would cause existing functionality to not work as expected)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved user tracking for record creation and updates, allowing more flexible assignment of user information.
- **Bug Fixes**
  - Ensured consistent saving behavior regardless of user assignment conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->