### PR TITLE
[WEB-4074]fix: removed sub-work item filters at nested levels

### DIFF
--- a/web/core/components/issues/issue-detail-widgets/sub-issues/issues-list/list-group.tsx
+++ b/web/core/components/issues/issue-detail-widgets/sub-issues/issues-list/list-group.tsx
@@ -15,6 +15,7 @@ interface TSubIssuesListGroupProps {
   serviceType: TIssueServiceType;
   disabled: boolean;
   parentIssueId: string;
+  rootIssueId: string;
   handleIssueCrudState: (
     key: "create" | "existing" | "update" | "delete",
     issueId: string,
@@ -31,6 +32,7 @@ export const SubIssuesListGroup: FC<TSubIssuesListGroupProps> = observer((props)
     serviceType,
     disabled,
     parentIssueId,
+    rootIssueId,
     projectId,
     workspaceSlug,
     handleIssueCrudState,
@@ -79,7 +81,7 @@ export const SubIssuesListGroup: FC<TSubIssuesListGroupProps> = observer((props)
               workspaceSlug={workspaceSlug}
               projectId={projectId}
               parentIssueId={parentIssueId}
-              rootIssueId={parentIssueId}
+              rootIssueId={rootIssueId}
               issueId={workItemId}
               disabled={disabled}
               handleIssueCrudState={handleIssueCrudState}

--- a/web/core/components/issues/issue-detail-widgets/sub-issues/issues-list/root.tsx
+++ b/web/core/components/issues/issue-detail-widgets/sub-issues/issues-list/root.tsx
@@ -50,7 +50,7 @@ export const SubIssuesListRoot: React.FC<Props> = observer((props) => {
   } = useIssueDetail(issueServiceType);
 
   // derived values
-  const filters = getSubIssueFilters(parentIssueId);
+  const filters = getSubIssueFilters(rootIssueId);
   const isRootLevel = useMemo(() => rootIssueId === parentIssueId, [rootIssueId, parentIssueId]);
   const group_by = isRootLevel ? (filters?.displayFilters?.group_by ?? null) : null;
   const filteredSubWorkItemsCount = (getFilteredSubWorkItems(rootIssueId, filters.filters ?? {}) ?? []).length;
@@ -66,37 +66,20 @@ export const SubIssuesListRoot: React.FC<Props> = observer((props) => {
   const getWorkItemIds = useCallback(
     (groupId: string) => {
       if (isRootLevel) {
-        const groupedSubIssues = getGroupedSubWorkItems(parentIssueId);
+        const groupedSubIssues = getGroupedSubWorkItems(rootIssueId);
         return groupedSubIssues?.[groupId] ?? [];
       }
       const subIssueIds = subIssuesByIssueId(parentIssueId);
       return subIssueIds ?? [];
     },
-    [isRootLevel, subIssuesByIssueId, parentIssueId, getGroupedSubWorkItems]
+    [isRootLevel, subIssuesByIssueId, rootIssueId, getGroupedSubWorkItems, parentIssueId]
   );
 
   const isSubWorkItems = issueServiceType === EIssueServiceType.ISSUES;
 
   return (
     <div className="relative">
-      {filteredSubWorkItemsCount > 0 ? (
-        groups?.map((group) => (
-          <SubIssuesListGroup
-            key={group.id}
-            workItemIds={getWorkItemIds(group.id)}
-            projectId={projectId}
-            workspaceSlug={workspaceSlug}
-            group={group}
-            serviceType={issueServiceType}
-            disabled={disabled}
-            parentIssueId={parentIssueId}
-            handleIssueCrudState={handleIssueCrudState}
-            subIssueOperations={subIssueOperations}
-            storeType={storeType}
-            spacingLeft={spacingLeft}
-          />
-        ))
-      ) : (
+      {isRootLevel && filteredSubWorkItemsCount === 0 ? (
         <SectionEmptyState
           title={
             !isSubWorkItems
@@ -116,6 +99,24 @@ export const SubIssuesListRoot: React.FC<Props> = observer((props) => {
             </Button>
           }
         />
+      ) : (
+        groups?.map((group) => (
+          <SubIssuesListGroup
+            key={group.id}
+            workItemIds={getWorkItemIds(group.id)}
+            projectId={projectId}
+            workspaceSlug={workspaceSlug}
+            group={group}
+            serviceType={issueServiceType}
+            disabled={disabled}
+            parentIssueId={parentIssueId}
+            rootIssueId={rootIssueId}
+            handleIssueCrudState={handleIssueCrudState}
+            subIssueOperations={subIssueOperations}
+            storeType={storeType}
+            spacingLeft={spacingLeft}
+          />
+        ))
       )}
     </div>
   );


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
This updated fixes the filtering of sub work items at levels other than the root level.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
<!-- Link related issues if there are any -->
[WEB-4074](https://app.plane.so/plane/browse/WEB-4074/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved filtering and grouping of sub-issues to consistently use the root issue context.
  - Refined display logic so that the empty state is only shown at the root level when no sub-issues are present.

- **New Features**
  - Enhanced sub-issues list groups to utilize the root issue identifier for more accurate grouping and filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->