### PR TITLE
[WEB-4080]fix: set sub work items groups to expand by default

### DIFF
--- a/web/core/components/issues/issue-detail-widgets/sub-issues/issues-list/list-group.tsx
+++ b/web/core/components/issues/issue-detail-widgets/sub-issues/issues-list/list-group.tsx
@@ -45,7 +45,7 @@ export const SubIssuesListGroup: FC<TSubIssuesListGroupProps> = observer((props)
   const isAllIssues = group.id === ALL_ISSUES;
 
   // states
-  const [isCollapsibleOpen, setIsCollapsibleOpen] = useState(isAllIssues);
+  const [isCollapsibleOpen, setIsCollapsibleOpen] = useState(true);
 
   if (!workItemIds.length) return null;
 

--- a/web/core/components/issues/issue-detail-widgets/sub-issues/issues-list/root.tsx
+++ b/web/core/components/issues/issue-detail-widgets/sub-issues/issues-list/root.tsx
@@ -5,7 +5,7 @@ import { ListFilter } from "lucide-react";
 import { EIssueServiceType, EIssuesStoreType } from "@plane/constants";
 import { GroupByColumnTypes, TIssue, TIssueServiceType, TSubIssueOperations } from "@plane/types";
 // hooks
-import { Button } from "@plane/ui";
+import { Button, Loader } from "@plane/ui";
 import { SectionEmptyState } from "@/components/empty-state";
 import { getGroupByColumns, isWorkspaceLevel } from "@/components/issues/issue-layouts/utils";
 import { useIssueDetail } from "@/hooks/store";
@@ -44,7 +44,7 @@ export const SubIssuesListRoot: React.FC<Props> = observer((props) => {
   // store hooks
   const {
     subIssues: {
-      subIssuesByIssueId,
+      subIssuesByIssueId, loader,
       filters: { getSubIssueFilters, getGroupedSubWorkItems, getFilteredSubWorkItems, resetFilters },
     },
   } = useIssueDetail(issueServiceType);
@@ -76,6 +76,16 @@ export const SubIssuesListRoot: React.FC<Props> = observer((props) => {
   );
 
   const isSubWorkItems = issueServiceType === EIssueServiceType.ISSUES;
+
+    if (loader === "init-loader") {
+      return (
+        <Loader className="space-y-2">
+          {Array.from({ length: 5 }).map((_, index) => (
+            <Loader.Item key={index} height="35px" width="100%" />
+          ))}
+        </Loader>
+      );
+    }
 
   return (
     <div className="relative">


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
This update sets the groups in sub-work items to expand by default.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
<!-- Link related issues if there are any -->
[WEB-4080](https://app.plane.so/plane/browse/WEB-4080/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a loading indicator with placeholders when sub-issues are initializing.

- **Refactor**
  - Sub-issue groups now always start expanded by default, regardless of group type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->