### PR TITLE
[WEB-3866] fix: work item attachment activity

### DIFF
--- a/web/core/components/core/activity.tsx
+++ b/web/core/components/core/activity.tsx
@@ -196,15 +196,7 @@ const activityDetails: {
       if (activity.verb === "created")
         return (
           <>
-            uploaded a new{" "}
-            <a
-              href={`${activity.new_value}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-1 font-medium text-custom-text-100 hover:underline"
-            >
-              attachment
-            </a>
+            uploaded a new attachment
             {showIssue && (
               <>
                 {" "}

--- a/web/core/components/issues/issue-detail/issue-activity/activity/actions/attachment.tsx
+++ b/web/core/components/issues/issue-detail/issue-activity/activity/actions/attachment.tsx
@@ -25,17 +25,7 @@ export const IssueAttachmentActivity: FC<TIssueAttachmentActivity> = observer((p
       ends={ends}
     >
       <>
-        {activity.verb === "created" ? `uploaded a new ` : `removed an attachment`}
-        {activity.verb === "created" && (
-          <a
-            href={`${activity.new_value}`}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center gap-1 font-medium text-custom-text-100 hover:underline"
-          >
-            attachment
-          </a>
-        )}
+        {activity.verb === "created" ? `uploaded a new attachment` : `removed an attachment`}
         {showIssue && (activity.verb === "created" ? ` to ` : ` from `)}
         {showIssue && <IssueLink activityId={activityId} />}.
       </>


### PR DESCRIPTION
### Description
This PR fixes work item attachment activity redirection issue.

### Type of Change
- [x] Bug fix 

### References
[[WEB-3866]](https://app.plane.so/plane/browse/WEB-3866/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated activity messages for attachment uploads to display as plain text instead of clickable links. The message now states "uploaded a new attachment" without linking to the attachment URL. No other visible changes to activity messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->