### PR TITLE
[WEB-4104] fix: project loading state

### DIFF
--- a/web/core/store/project/project.store.ts
+++ b/web/core/store/project/project.store.ts
@@ -293,7 +293,7 @@ export class ProjectStore implements IProjectStore {
           update(this.projectMap, [project.id], (p) => ({ ...p, ...project }));
         });
         this.loader = "loaded";
-        this.fetchStatus = "partial";
+        if (!this.fetchStatus) this.fetchStatus = "partial";
       });
       return projectsResponse;
     } catch (error) {


### PR DESCRIPTION
### Description
In case the project lite api gets stale, its refetched resulting in /projects route getting stuck in loading state forever

### References
[[WEB-4104]](https://app.plane.so/plane/browse/WEB-4104/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of project loading status to prevent unintended overwriting of existing status indicators when fetching partial projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->