### PR TITLE
Fix Redirect URL Generation for Google Auth by Enabling X-Forwarded-Host

### DIFF
--- a/apiserver/plane/settings/common.py
+++ b/apiserver/plane/settings/common.py
@@ -439,3 +439,6 @@ ATTACHMENT_MIME_TYPES = [
 
 # Seed directory path
 SEED_DIR = os.path.join(BASE_DIR, "seeds")
+
+# Use X-Forwarded-Host for get_host calls when behind proxy
+USE_X_FORWARDED_HOST = int(os.environ.get("USE_X_FORWARDED_HOST", 0)) == 1


### PR DESCRIPTION
### Description
This PR addresses an issue with the generation of the redirect_url during the Google OAuth flow. Previously, the backend was generating URLs using the internal host (api.domain.internal), which resulted in misconfigured redirect URIs and subsequent OAuth errors. 

According to [docs](https://docs.djangoproject.com/en/5.2/ref/settings/#std-setting-USE_X_FORWARDED_HOST) this setting should help.

This change makes sure that when the backend receives a /auth/google request, it includes the X-Forwarded-Host header containing the proper web host (e.g., mydomain.com). As a result, the generated redirect_url now aligns with the expected domain provided by GodMod, avoiding any discrepancies and OAuth errors.

I have also attached screenshots of the OAuth error screens for reference, which illustrate the issues encountered due to the mismatched redirect URIs.

Mismatched google oauth url looks like this:
`https://accounts.google.com/o/oauth2/v2/auth?client_id=<client_id>&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fuserinfo.email+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fuserinfo.profile&redirect_uri=https%3A%2F%2Fapi.domain.internal%3A8000%2Fauth%2Fgoogle%2Fcallback%2F&response_type=code&access_type=offline&prompt=consent&state=<some_state>`

─────────────────────────────  
### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

─────────────────────────────  
### Screenshots and Media (if applicable)
![Screenshot 2025-05-15 at 22 26 50](https://github.com/user-attachments/assets/3097cbbf-dd4c-4ad1-9ec2-472ad1bb6522)

─────────────────────────────  
### Test Scenarios
1. Trigger the /auth/google request from the frontend and inspect the HTTP headers to confirm that X-Forwarded-Host correctly reflects the web host.
2. Validate that the generated redirect_uri in the Google OAuth URL now uses the proper domain (e.g., https://mydomain.com/auth/google/callback), ensuring compliance with Google OAuth policies.
3. Check the OAuth flow end-to-end for both development and production to ensure no internal host remains in the URL.

─────────────────────────────  
### References
