### PR TITLE
[WIKI-181] chore: editor extension storage utility code split

### DIFF
--- a/packages/editor/src/ce/types/storage.ts
+++ b/packages/editor/src/ce/types/storage.ts
@@ -1,0 +1,13 @@
+import { HeadingExtensionStorage } from "@/extensions";
+import { CustomImageExtensionStorage } from "@/extensions/custom-image";
+import { CustomLinkStorage } from "@/extensions/custom-link";
+import { MentionExtensionStorage } from "@/extensions/mentions";
+import { ImageExtensionStorage } from "@/plugins/image";
+
+export type ExtensionStorageMap = {
+  imageComponent: CustomImageExtensionStorage;
+  image: ImageExtensionStorage;
+  link: CustomLinkStorage;
+  headingList: HeadingExtensionStorage;
+  mention: MentionExtensionStorage;
+};

--- a/packages/editor/src/core/extensions/custom-image/custom-image.ts
+++ b/packages/editor/src/core/extensions/custom-image/custom-image.ts
@@ -33,9 +33,9 @@ declare module "@tiptap/core" {
 }
 
 export const getImageComponentImageFileMap = (editor: Editor) =>
-  (editor.storage.imageComponent as UploadImageExtensionStorage | undefined)?.fileMap;
+  (editor.storage.imageComponent as CustomImageExtensionStorage | undefined)?.fileMap;
 
-export interface UploadImageExtensionStorage {
+export interface CustomImageExtensionStorage {
   assetsUploadStatus: TFileHandler["assetsUploadStatus"];
   fileMap: Map<string, UploadEntity>;
   deletedImageSet: Map<string, boolean>;
@@ -55,7 +55,7 @@ export const CustomImageExtension = (props: TFileHandler) => {
     validation: { maxFileSize },
   } = props;
 
-  return Image.extend<Record<string, unknown>, UploadImageExtensionStorage>({
+  return Image.extend<Record<string, unknown>, CustomImageExtensionStorage>({
     name: "imageComponent",
     selectable: true,
     group: "block",

--- a/packages/editor/src/core/extensions/custom-image/custom-image.ts
+++ b/packages/editor/src/core/extensions/custom-image/custom-image.ts
@@ -8,6 +8,7 @@ import { ACCEPTED_IMAGE_MIME_TYPES } from "@/constants/config";
 import { CustomImageNode } from "@/extensions/custom-image";
 // helpers
 import { isFileValid } from "@/helpers/file";
+import { getExtensionStorage } from "@/helpers/get-extension-storage";
 import { insertEmptyParagraphAtNodeBoundaries } from "@/helpers/insert-empty-paragraph-at-node-boundary";
 // plugins
 import { TrackImageDeletionPlugin, TrackImageRestorationPlugin } from "@/plugins/image";
@@ -32,8 +33,7 @@ declare module "@tiptap/core" {
   }
 }
 
-export const getImageComponentImageFileMap = (editor: Editor) =>
-  (editor.storage.imageComponent as CustomImageExtensionStorage | undefined)?.fileMap;
+export const getImageComponentImageFileMap = (editor: Editor) => getExtensionStorage(editor, "imageComponent")?.fileMap;
 
 export interface CustomImageExtensionStorage {
   assetsUploadStatus: TFileHandler["assetsUploadStatus"];

--- a/packages/editor/src/core/extensions/custom-image/read-only-custom-image.ts
+++ b/packages/editor/src/core/extensions/custom-image/read-only-custom-image.ts
@@ -2,14 +2,14 @@ import { mergeAttributes } from "@tiptap/core";
 import { Image } from "@tiptap/extension-image";
 import { ReactNodeViewRenderer } from "@tiptap/react";
 // components
-import { CustomImageNode, UploadImageExtensionStorage } from "@/extensions/custom-image";
+import { CustomImageNode, CustomImageExtensionStorage } from "@/extensions/custom-image";
 // types
 import { TReadOnlyFileHandler } from "@/types";
 
 export const CustomReadOnlyImageExtension = (props: TReadOnlyFileHandler) => {
   const { getAssetSrc, restore: restoreImageFn } = props;
 
-  return Image.extend<Record<string, unknown>, UploadImageExtensionStorage>({
+  return Image.extend<Record<string, unknown>, CustomImageExtensionStorage>({
     name: "imageComponent",
     selectable: false,
     group: "block",

--- a/packages/editor/src/core/helpers/get-extension-storage.ts
+++ b/packages/editor/src/core/helpers/get-extension-storage.ts
@@ -1,23 +1,8 @@
 import { Editor } from "@tiptap/core";
-import {
-  CustomLinkStorage,
-  HeadingExtensionStorage,
-  MentionExtensionStorage,
-  UploadImageExtensionStorage,
-} from "@/extensions";
-import { ImageExtensionStorage } from "@/plugins/image";
+// plane editor types
+import { ExtensionStorageMap } from "@/plane-editor/types/storage";
 
-type ExtensionNames = "imageComponent" | "image" | "link" | "headingList" | "mention";
-
-interface ExtensionStorageMap {
-  imageComponent: UploadImageExtensionStorage;
-  image: ImageExtensionStorage;
-  link: CustomLinkStorage;
-  headingList: HeadingExtensionStorage;
-  mention: MentionExtensionStorage;
-}
-
-export const getExtensionStorage = <K extends ExtensionNames>(
+export const getExtensionStorage = <K extends keyof ExtensionStorageMap>(
   editor: Editor,
   extensionName: K
 ): ExtensionStorageMap[K] => editor.storage[extensionName];


### PR DESCRIPTION
### Description

This PR refactors the utility function to get any extension storage.

### Type of Change

- [x] Code refactoring

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Centralized and updated type definitions for editor extension storage, improving consistency across the editor.
  - Renamed storage interface for custom image extensions to align with naming conventions.
  - Updated internal references to use the new centralized storage map type.

No changes to user-facing functionality or behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->