### PR TITLE
chore: revamped the analytics for cycle and module in peek view.

### DIFF
--- a/apiserver/plane/app/urls/analytic.py
+++ b/apiserver/plane/app/urls/analytic.py
@@ -11,7 +11,6 @@ from plane.app.views import (
     AdvanceAnalyticsChartEndpoint,
     DefaultAnalyticsEndpoint,
     ProjectStatsEndpoint,
-    AdvanceAnalyticsExportEndpoint,
 )
 
 
@@ -67,10 +66,5 @@ urlpatterns = [
         "workspaces/<str:slug>/advance-analytics-charts/",
         AdvanceAnalyticsChartEndpoint.as_view(),
         name="advance-analytics-chart",
-    ),
-    path(
-        "workspaces/<str:slug>/advance-analytics-export/",
-        AdvanceAnalyticsExportEndpoint.as_view(),
-        name="advance-analytics-export",
     ),
 ]

--- a/apiserver/plane/app/views/__init__.py
+++ b/apiserver/plane/app/views/__init__.py
@@ -203,7 +203,6 @@ from .analytic.advance import (
     AdvanceAnalyticsEndpoint,
     AdvanceAnalyticsStatsEndpoint,
     AdvanceAnalyticsChartEndpoint,
-    AdvanceAnalyticsExportEndpoint,
 )
 
 from .notification.base import (

--- a/apiserver/plane/app/views/analytic/advance.py
+++ b/apiserver/plane/app/views/analytic/advance.py
@@ -370,7 +370,7 @@ class AdvanceAnalyticsChartEndpoint(AdvanceAnalyticsBaseView):
                 **self.filters["base_filters"], cycle_id=cycle_id
             ).values_list("issue_id", flat=True)
             cycle = Cycle.objects.filter(id=cycle_id).first()
-            if cycle.start_date:
+            if cycle and cycle.start_date:
                 start_date = cycle.start_date.date()
                 end_date = cycle.end_date.date()
             else:
@@ -381,7 +381,7 @@ class AdvanceAnalyticsChartEndpoint(AdvanceAnalyticsBaseView):
                 **self.filters["base_filters"], module_id=module_id
             ).values_list("issue_id", flat=True)
             module = Module.objects.filter(id=module_id).first()
-            if module.start_date:
+            if module and module.start_date:
                 start_date = module.start_date
                 end_date = module.target_date
             else:

--- a/apiserver/plane/utils/date_utils.py
+++ b/apiserver/plane/utils/date_utils.py
@@ -174,8 +174,8 @@ def get_analytics_filters(
         "workspace__slug": slug,
         "project_projectmember__member": user,
         "project_projectmember__is_active": True,
-        "project__deleted_at__isnull": True,
-        "project__archived_at__isnull": True,
+        "deleted_at__isnull": True,
+        "archived_at__isnull": True,
     }
 
     # Add project IDs to filters if provided

--- a/packages/types/src/analytics-v2.d.ts
+++ b/packages/types/src/analytics-v2.d.ts
@@ -41,6 +41,7 @@ export interface WorkItemInsightColumns {
   // because of the peek view, we will display the name of the project instead of project__name
   display_name?: string;
   avatar_url?: string;
+  assignee_id?: string;
 }
 
 export type AnalyticsTableDataMap = {

--- a/packages/types/src/analytics-v2.d.ts
+++ b/packages/types/src/analytics-v2.d.ts
@@ -1,52 +1,54 @@
 import { ChartXAxisProperty, ChartYAxisMetric } from "@plane/constants";
 import { TChartData } from "./charts";
 
-export type TAnalyticsTabsV2Base = "overview" | "work-items"
-export type TAnalyticsGraphsV2Base = "projects" | "work-items" | "custom-work-items"
-
+export type TAnalyticsTabsV2Base = "overview" | "work-items";
+export type TAnalyticsGraphsV2Base = "projects" | "work-items" | "custom-work-items";
 
 // service types
 
 export interface IAnalyticsResponseV2 {
-    [key: string]: any;
+  [key: string]: any;
 }
 
 export interface IAnalyticsResponseFieldsV2 {
-    count: number;
-    filter_count: number;
+  count: number;
+  filter_count: number;
 }
 
 export interface IAnalyticsRadarEntityV2 {
-    key: string,
-    name: string,
-    count: number
+  key: string;
+  name: string;
+  count: number;
 }
 
 // chart types
 
 export interface IChartResponseV2 {
-    schema: Record<string, string>;
-    data: TChartData<string, string>[];
+  schema: Record<string, string>;
+  data: TChartData<string, string>[];
 }
 
 // table types
 
 export interface WorkItemInsightColumns {
-    project_id: string;
-    project__name: string;
-    cancelled_work_items: number;
-    completed_work_items: number;
-    backlog_work_items: number;
-    un_started_work_items: number;
-    started_work_items: number;
+  project_id?: string;
+  project__name?: string;
+  cancelled_work_items: number;
+  completed_work_items: number;
+  backlog_work_items: number;
+  un_started_work_items: number;
+  started_work_items: number;
+  // because of the peek view, we will display the name of the project instead of project__name
+  display_name?: string;
+  avatar_url?: string;
 }
 
 export type AnalyticsTableDataMap = {
-    "work-items": WorkItemInsightColumns,
-}
+  "work-items": WorkItemInsightColumns;
+};
 
 export interface IAnalyticsV2Params {
-    x_axis: ChartXAxisProperty;
-    y_axis: ChartYAxisMetric;
-    group_by?: ChartXAxisProperty;
+  x_axis: ChartXAxisProperty;
+  y_axis: ChartYAxisMetric;
+  group_by?: ChartXAxisProperty;
 }

--- a/web/app/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/cycles/(detail)/header.tsx
+++ b/web/app/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/cycles/(detail)/header.tsx
@@ -27,7 +27,7 @@ import {
 // ui
 import { Breadcrumbs, Button, ContrastIcon, Tooltip, Header, CustomSearchSelect } from "@plane/ui";
 // components
-import { ProjectAnalyticsModal } from "@/components/analytics";
+import { WorkItemsModal } from "@/components/analytics-v2/work-items/modal";
 import { BreadcrumbLink, SwitcherLabel } from "@/components/common";
 import { CycleQuickActions } from "@/components/cycles";
 import { DisplayFiltersSelection, FiltersDropdown, FilterSelection, LayoutSelection } from "@/components/issues";
@@ -161,7 +161,8 @@ export const CycleIssuesHeader: React.FC = observer(() => {
 
   return (
     <>
-      <ProjectAnalyticsModal
+      <WorkItemsModal
+        projectDetails={currentProjectDetails}
         isOpen={analyticsModal}
         onClose={() => setAnalyticsModal(false)}
         cycleDetails={cycleDetails ?? undefined}

--- a/web/app/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/cycles/(detail)/mobile-header.tsx
+++ b/web/app/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/cycles/(detail)/mobile-header.tsx
@@ -19,7 +19,7 @@ import { IIssueDisplayFilterOptions, IIssueDisplayProperties, IIssueFilterOption
 // ui
 import { CustomMenu } from "@plane/ui";
 // components
-import { ProjectAnalyticsModal } from "@/components/analytics";
+import { WorkItemsModal } from "@/components/analytics-v2/work-items/modal";
 import { DisplayFiltersSelection, FilterSelection, FiltersDropdown, IssueLayoutIcon } from "@/components/issues";
 // helpers
 import { isIssueFilterActive } from "@/helpers/filter.helper";
@@ -123,7 +123,8 @@ export const CycleIssuesMobileHeader = () => {
 
   return (
     <>
-      <ProjectAnalyticsModal
+      <WorkItemsModal
+        projectDetails={currentProjectDetails}
         isOpen={analyticsModal}
         onClose={() => setAnalyticsModal(false)}
         cycleDetails={cycleDetails ?? undefined}

--- a/web/app/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/modules/(detail)/header.tsx
+++ b/web/app/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/modules/(detail)/header.tsx
@@ -25,7 +25,7 @@ import {
 // ui
 import { Breadcrumbs, Button, DiceIcon, Tooltip, Header, CustomSearchSelect } from "@plane/ui";
 // components
-import { ProjectAnalyticsModal } from "@/components/analytics";
+import { WorkItemsModal } from "@/components/analytics-v2/work-items/modal";
 import { BreadcrumbLink, SwitcherLabel } from "@/components/common";
 import { DisplayFiltersSelection, FiltersDropdown, FilterSelection, LayoutSelection } from "@/components/issues";
 // helpers
@@ -155,10 +155,11 @@ export const ModuleIssuesHeader: React.FC = observer(() => {
 
   return (
     <>
-      <ProjectAnalyticsModal
+      <WorkItemsModal
         isOpen={analyticsModal}
         onClose={() => setAnalyticsModal(false)}
         moduleDetails={moduleDetails ?? undefined}
+        projectDetails={currentProjectDetails}
       />
       <Header>
         <Header.LeftItem>

--- a/web/app/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/modules/(detail)/mobile-header.tsx
+++ b/web/app/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/modules/(detail)/mobile-header.tsx
@@ -21,6 +21,7 @@ import { IIssueDisplayFilterOptions, IIssueDisplayProperties, IIssueFilterOption
 import { CustomMenu } from "@plane/ui";
 // components
 import { ProjectAnalyticsModal } from "@/components/analytics";
+import { WorkItemsModal } from "@/components/analytics-v2/work-items/modal";
 import {
   DisplayFiltersSelection,
   FilterSelection,
@@ -106,10 +107,11 @@ export const ModuleIssuesMobileHeader = observer(() => {
 
   return (
     <div className="block md:hidden">
-      <ProjectAnalyticsModal
+      <WorkItemsModal
         isOpen={analyticsModal}
         onClose={() => setAnalyticsModal(false)}
         moduleDetails={moduleDetails ?? undefined}
+        projectDetails={currentProjectDetails}
       />
       <div className="flex justify-evenly border-b border-custom-border-200 bg-custom-background-100 py-2">
         <CustomMenu

--- a/web/core/components/analytics-v2/insight-table/root.tsx
+++ b/web/core/components/analytics-v2/insight-table/root.tsx
@@ -35,7 +35,7 @@ export const InsightTable = <T extends Exclude<TAnalyticsTabsV2Base, "overview">
 
   const exportCSV = (rows: Row<AnalyticsTableDataMap[T]>[]) => {
     const rowData: any = rows.map((row) => {
-      const { project_id, ...exportableData } = row.original;
+      const { project_id, avatar_url, assignee_id, ...exportableData } = row.original;
       return Object.fromEntries(
         Object.entries(exportableData).map(([key, value]) => {
           if (columnsLabels?.[key]) {

--- a/web/core/components/analytics-v2/overview/project-insights.tsx
+++ b/web/core/components/analytics-v2/overview/project-insights.tsx
@@ -27,15 +27,17 @@ const ProjectInsights = observer(() => {
   const params = useParams();
   const { t } = useTranslation();
   const workspaceSlug = params.workspaceSlug as string;
-  const { selectedDuration, selectedDurationLabel, selectedProjects } = useAnalyticsV2();
+  const { selectedDuration, selectedDurationLabel, selectedProjects, selectedCycle, selectedModule } = useAnalyticsV2();
   const resolvedPath = useResolvedAssetPath({ basePath: "/empty-state/analytics-v2/empty-chart-radar" });
 
   const { data: projectInsightsData, isLoading: isLoadingProjectInsight } = useSWR(
-    `radar-chart-${workspaceSlug}-${selectedDuration}-${selectedProjects}`,
+    `radar-chart-${workspaceSlug}-${selectedDuration}-${selectedProjects}-${selectedCycle}-${selectedModule}`,
     () =>
       analyticsV2Service.getAdvanceAnalyticsCharts<TChartData<string, string>[]>(workspaceSlug, "projects", {
         // date_filter: selectedDuration,
         ...(selectedProjects?.length > 0 && { project_ids: selectedProjects?.join(",") }),
+        ...(selectedCycle ? { cycle_id: selectedCycle } : {}),
+        ...(selectedModule ? { module_id: selectedModule } : {}),
       })
   );
 

--- a/web/core/components/analytics-v2/overview/project-insights.tsx
+++ b/web/core/components/analytics-v2/overview/project-insights.tsx
@@ -27,17 +27,19 @@ const ProjectInsights = observer(() => {
   const params = useParams();
   const { t } = useTranslation();
   const workspaceSlug = params.workspaceSlug as string;
-  const { selectedDuration, selectedDurationLabel, selectedProjects, selectedCycle, selectedModule } = useAnalyticsV2();
+  const { selectedDuration, selectedDurationLabel, selectedProjects, selectedCycle, selectedModule, isPeekView } =
+    useAnalyticsV2();
   const resolvedPath = useResolvedAssetPath({ basePath: "/empty-state/analytics-v2/empty-chart-radar" });
 
   const { data: projectInsightsData, isLoading: isLoadingProjectInsight } = useSWR(
-    `radar-chart-${workspaceSlug}-${selectedDuration}-${selectedProjects}-${selectedCycle}-${selectedModule}`,
+    `radar-chart-${workspaceSlug}-${selectedDuration}-${selectedProjects}-${selectedCycle}-${selectedModule}-${isPeekView}`,
     () =>
       analyticsV2Service.getAdvanceAnalyticsCharts<TChartData<string, string>[]>(workspaceSlug, "projects", {
         // date_filter: selectedDuration,
         ...(selectedProjects?.length > 0 && { project_ids: selectedProjects?.join(",") }),
         ...(selectedCycle ? { cycle_id: selectedCycle } : {}),
         ...(selectedModule ? { module_id: selectedModule } : {}),
+        ...(isPeekView ? { peek_view: true } : {}),
       })
   );
 

--- a/web/core/components/analytics-v2/total-insights.tsx
+++ b/web/core/components/analytics-v2/total-insights.tsx
@@ -20,14 +20,17 @@ const TotalInsights: React.FC<{ analyticsType: TAnalyticsTabsV2Base; peekView?: 
     const params = useParams();
     const workspaceSlug = params.workspaceSlug as string;
     const { t } = useTranslation();
-    const { selectedDuration, selectedProjects, selectedDurationLabel } = useAnalyticsV2();
+    const { selectedDuration, selectedProjects, selectedDurationLabel, selectedCycle, selectedModule } =
+      useAnalyticsV2();
 
     const { data: totalInsightsData, isLoading } = useSWR(
-      `total-insights-${analyticsType}-${selectedDuration}-${selectedProjects}`,
+      `total-insights-${analyticsType}-${selectedDuration}-${selectedProjects}-${selectedCycle}-${selectedModule}`,
       () =>
         analyticsV2Service.getAdvanceAnalytics<IAnalyticsResponseV2>(workspaceSlug, analyticsType, {
           // date_filter: selectedDuration,
           ...(selectedProjects?.length > 0 ? { project_ids: selectedProjects.join(",") } : {}),
+          ...(selectedCycle ? { cycle_id: selectedCycle } : {}),
+          ...(selectedModule ? { module_id: selectedModule } : {}),
         })
     );
     return (

--- a/web/core/components/analytics-v2/total-insights.tsx
+++ b/web/core/components/analytics-v2/total-insights.tsx
@@ -20,17 +20,18 @@ const TotalInsights: React.FC<{ analyticsType: TAnalyticsTabsV2Base; peekView?: 
     const params = useParams();
     const workspaceSlug = params.workspaceSlug as string;
     const { t } = useTranslation();
-    const { selectedDuration, selectedProjects, selectedDurationLabel, selectedCycle, selectedModule } =
+    const { selectedDuration, selectedProjects, selectedDurationLabel, selectedCycle, selectedModule, isPeekView } =
       useAnalyticsV2();
 
     const { data: totalInsightsData, isLoading } = useSWR(
-      `total-insights-${analyticsType}-${selectedDuration}-${selectedProjects}-${selectedCycle}-${selectedModule}`,
+      `total-insights-${analyticsType}-${selectedDuration}-${selectedProjects}-${selectedCycle}-${selectedModule}-${isPeekView}`,
       () =>
         analyticsV2Service.getAdvanceAnalytics<IAnalyticsResponseV2>(workspaceSlug, analyticsType, {
           // date_filter: selectedDuration,
           ...(selectedProjects?.length > 0 ? { project_ids: selectedProjects.join(",") } : {}),
           ...(selectedCycle ? { cycle_id: selectedCycle } : {}),
           ...(selectedModule ? { module_id: selectedModule } : {}),
+          ...(isPeekView ? { peek_view: true } : {}),
         })
     );
     return (

--- a/web/core/components/analytics-v2/work-items/created-vs-resolved.tsx
+++ b/web/core/components/analytics-v2/work-items/created-vs-resolved.tsx
@@ -19,17 +19,19 @@ import { ChartLoader } from "../loaders";
 
 const analyticsV2Service = new AnalyticsV2Service();
 const CreatedVsResolved = observer(() => {
-  const { selectedDuration, selectedDurationLabel, selectedProjects } = useAnalyticsV2();
+  const { selectedDuration, selectedDurationLabel, selectedProjects, selectedCycle, selectedModule } = useAnalyticsV2();
   const params = useParams();
   const { t } = useTranslation();
   const workspaceSlug = params.workspaceSlug as string;
   const resolvedPath = useResolvedAssetPath({ basePath: "/empty-state/analytics-v2/empty-chart-area" });
   const { data: createdVsResolvedData, isLoading: isCreatedVsResolvedLoading } = useSWR(
-    `created-vs-resolved-${workspaceSlug}-${selectedDuration}-${selectedProjects}`,
+    `created-vs-resolved-${workspaceSlug}-${selectedDuration}-${selectedProjects}-${selectedCycle}-${selectedModule}`,
     () =>
       analyticsV2Service.getAdvanceAnalyticsCharts<IChartResponseV2>(workspaceSlug, "work-items", {
         // date_filter: selectedDuration,
         ...(selectedProjects?.length > 0 && { project_ids: selectedProjects?.join(",") }),
+        ...(selectedCycle ? { cycle_id: selectedCycle } : {}),
+        ...(selectedModule ? { module_id: selectedModule } : {}),
       })
   );
   const parsedData: TChartData<string, string>[] = useMemo(() => {

--- a/web/core/components/analytics-v2/work-items/created-vs-resolved.tsx
+++ b/web/core/components/analytics-v2/work-items/created-vs-resolved.tsx
@@ -19,19 +19,20 @@ import { ChartLoader } from "../loaders";
 
 const analyticsV2Service = new AnalyticsV2Service();
 const CreatedVsResolved = observer(() => {
-  const { selectedDuration, selectedDurationLabel, selectedProjects, selectedCycle, selectedModule } = useAnalyticsV2();
+  const { selectedDuration, selectedDurationLabel, selectedProjects, selectedCycle, selectedModule, isPeekView } = useAnalyticsV2();
   const params = useParams();
   const { t } = useTranslation();
   const workspaceSlug = params.workspaceSlug as string;
   const resolvedPath = useResolvedAssetPath({ basePath: "/empty-state/analytics-v2/empty-chart-area" });
   const { data: createdVsResolvedData, isLoading: isCreatedVsResolvedLoading } = useSWR(
-    `created-vs-resolved-${workspaceSlug}-${selectedDuration}-${selectedProjects}-${selectedCycle}-${selectedModule}`,
+    `created-vs-resolved-${workspaceSlug}-${selectedDuration}-${selectedProjects}-${selectedCycle}-${selectedModule}-${isPeekView}`,
     () =>
       analyticsV2Service.getAdvanceAnalyticsCharts<IChartResponseV2>(workspaceSlug, "work-items", {
         // date_filter: selectedDuration,
         ...(selectedProjects?.length > 0 && { project_ids: selectedProjects?.join(",") }),
         ...(selectedCycle ? { cycle_id: selectedCycle } : {}),
         ...(selectedModule ? { module_id: selectedModule } : {}),
+        ...(isPeekView ? { peek_view: true } : {}),
       })
   );
   const parsedData: TChartData<string, string>[] = useMemo(() => {

--- a/web/core/components/analytics-v2/work-items/modal/content.tsx
+++ b/web/core/components/analytics-v2/work-items/modal/content.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import { observer } from "mobx-react";
 import { Tab } from "@headlessui/react";
 // plane package imports
-import { IProject } from "@plane/types";
+import { ICycle, IModule, IProject } from "@plane/types";
 import { Spinner } from "@plane/ui";
 // hooks
 import { useAnalyticsV2 } from "@/hooks/store";
@@ -15,20 +15,48 @@ import WorkItemsInsightTable from "../workitems-insight-table";
 type Props = {
   fullScreen: boolean;
   projectDetails: IProject | undefined;
+  cycleDetails: ICycle | undefined;
+  moduleDetails: IModule | undefined;
 };
 
 export const WorkItemsModalMainContent: React.FC<Props> = observer((props) => {
-  const { projectDetails, fullScreen } = props;
-  const { updateSelectedProjects } = useAnalyticsV2();
-  const [isProjectConfigured, setIsProjectConfigured] = useState(false);
+  const { projectDetails, cycleDetails, moduleDetails, fullScreen } = props;
+  const { updateSelectedProjects, updateSelectedCycle, updateSelectedModule } = useAnalyticsV2();
+  const [isModalConfigured, setIsModalConfigured] = useState(false);
 
   useEffect(() => {
-    if (!projectDetails?.id) return;
-    updateSelectedProjects([projectDetails?.id ?? ""]);
-    setIsProjectConfigured(true);
-  }, [projectDetails?.id, updateSelectedProjects]);
+    // Handle project selection
+    if (projectDetails?.id) {
+      updateSelectedProjects([projectDetails.id]);
+    }
 
-  if (!isProjectConfigured)
+    // Handle cycle selection
+    if (cycleDetails?.id) {
+      updateSelectedCycle(cycleDetails.id);
+    }
+
+    // Handle module selection
+    if (moduleDetails?.id) {
+      updateSelectedModule(moduleDetails.id);
+    }
+    setIsModalConfigured(true);
+
+    // Cleanup fields
+    return () => {
+      updateSelectedProjects([]);
+      updateSelectedCycle("");
+      updateSelectedModule("");
+    };
+  }, [
+    projectDetails?.id,
+    cycleDetails?.id,
+    moduleDetails?.id,
+    updateSelectedProjects,
+    updateSelectedCycle,
+    updateSelectedModule,
+  ]);
+
+  if (!isModalConfigured)
     return (
       <div className="flex h-full items-center justify-center">
         <Spinner />

--- a/web/core/components/analytics-v2/work-items/modal/content.tsx
+++ b/web/core/components/analytics-v2/work-items/modal/content.tsx
@@ -21,10 +21,12 @@ type Props = {
 
 export const WorkItemsModalMainContent: React.FC<Props> = observer((props) => {
   const { projectDetails, cycleDetails, moduleDetails, fullScreen } = props;
-  const { updateSelectedProjects, updateSelectedCycle, updateSelectedModule } = useAnalyticsV2();
+  const { updateSelectedProjects, updateSelectedCycle, updateSelectedModule, updateIsPeekView } = useAnalyticsV2();
   const [isModalConfigured, setIsModalConfigured] = useState(false);
 
   useEffect(() => {
+    updateIsPeekView(true);
+
     // Handle project selection
     if (projectDetails?.id) {
       updateSelectedProjects([projectDetails.id]);
@@ -46,6 +48,7 @@ export const WorkItemsModalMainContent: React.FC<Props> = observer((props) => {
       updateSelectedProjects([]);
       updateSelectedCycle("");
       updateSelectedModule("");
+      updateIsPeekView(false);
     };
   }, [
     projectDetails?.id,
@@ -54,6 +57,7 @@ export const WorkItemsModalMainContent: React.FC<Props> = observer((props) => {
     updateSelectedProjects,
     updateSelectedCycle,
     updateSelectedModule,
+    updateIsPeekView,
   ]);
 
   if (!isModalConfigured)

--- a/web/core/components/analytics-v2/work-items/modal/header.tsx
+++ b/web/core/components/analytics-v2/work-items/modal/header.tsx
@@ -1,21 +1,26 @@
 import { observer } from "mobx-react";
-
-// icons
+// plane package imports
 import { Expand, Shrink, X } from "lucide-react";
+import { ICycle, IModule } from "@plane/types";
+// icons
 
 type Props = {
   fullScreen: boolean;
   handleClose: () => void;
   setFullScreen: React.Dispatch<React.SetStateAction<boolean>>;
   title: string;
+  cycle?: ICycle;
+  module?: IModule;
 };
 
 export const WorkItemsModalHeader: React.FC<Props> = observer((props) => {
-  const { fullScreen, handleClose, setFullScreen, title } = props;
+  const { fullScreen, handleClose, setFullScreen, title, cycle, module } = props;
 
   return (
     <div className="flex items-center justify-between gap-4 bg-custom-background-100 px-5 py-4 text-sm">
-      <h3 className="break-words">Analytics for {title}</h3>
+      <h3 className="break-words">
+        Analytics for {title} {cycle && `in ${cycle.name}`} {module && `in ${module.name}`}
+      </h3>
       <div className="flex items-center gap-2">
         <button
           type="button"

--- a/web/core/components/analytics-v2/work-items/modal/index.tsx
+++ b/web/core/components/analytics-v2/work-items/modal/index.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { observer } from "mobx-react";
 import { Dialog, Transition } from "@headlessui/react";
 // plane package imports
-import { IProject } from "@plane/types";
+import { ICycle, IModule, IProject } from "@plane/types";
 // plane web components
 import { WorkItemsModalMainContent } from "./content";
 import { WorkItemsModalHeader } from "./header";
@@ -11,10 +11,12 @@ type Props = {
   isOpen: boolean;
   onClose: () => void;
   projectDetails?: IProject | undefined;
+  cycleDetails?: ICycle | undefined;
+  moduleDetails?: IModule | undefined;
 };
 
 export const WorkItemsModal: React.FC<Props> = observer((props) => {
-  const { isOpen, onClose, projectDetails } = props;
+  const { isOpen, onClose, projectDetails, moduleDetails, cycleDetails } = props;
 
   const [fullScreen, setFullScreen] = useState(false);
 
@@ -51,8 +53,15 @@ export const WorkItemsModal: React.FC<Props> = observer((props) => {
                     handleClose={handleClose}
                     setFullScreen={setFullScreen}
                     title={projectDetails?.name ?? ""}
+                    cycle={cycleDetails}
+                    module={moduleDetails}
                   />
-                  <WorkItemsModalMainContent fullScreen={fullScreen} projectDetails={projectDetails} />
+                  <WorkItemsModalMainContent
+                    fullScreen={fullScreen}
+                    projectDetails={projectDetails}
+                    cycleDetails={cycleDetails}
+                    moduleDetails={moduleDetails}
+                  />
                 </div>
               </div>
             </Dialog.Panel>

--- a/web/core/components/analytics-v2/work-items/priority-chart.tsx
+++ b/web/core/components/analytics-v2/work-items/priority-chart.tsx
@@ -46,7 +46,7 @@ const PriorityChart = observer((props: Props) => {
   const { t } = useTranslation();
   const resolvedPath = useResolvedAssetPath({ basePath: "/empty-state/analytics-v2/empty-chart-bar" });
   // store hooks
-  const { selectedDuration, selectedProjects } = useAnalyticsV2();
+  const { selectedDuration, selectedProjects, selectedCycle, selectedModule } = useAnalyticsV2();
   const { workspaceStates } = useProjectState();
   const { resolvedTheme } = useTheme();
   // router
@@ -54,11 +54,13 @@ const PriorityChart = observer((props: Props) => {
   const workspaceSlug = params.workspaceSlug as string;
 
   const { data: priorityChartData, isLoading: priorityChartLoading } = useSWR(
-    `customized-insights-chart-${workspaceSlug}-${selectedDuration}-${selectedProjects}-${props.x_axis}-${props.y_axis}-${props.group_by}`,
+    `customized-insights-chart-${workspaceSlug}-${selectedDuration}-${selectedProjects}-${selectedCycle}-${selectedModule}-${props.x_axis}-${props.y_axis}-${props.group_by}`,
     () =>
       analyticsV2Service.getAdvanceAnalyticsCharts<TChart>(workspaceSlug, "custom-work-items", {
         // date_filter: selectedDuration,
         ...(selectedProjects?.length > 0 && { project_ids: selectedProjects?.join(",") }),
+        ...(selectedCycle ? { cycle_id: selectedCycle } : {}),
+        ...(selectedModule ? { module_id: selectedModule } : {}),
         ...props,
       })
   );

--- a/web/core/components/analytics-v2/work-items/priority-chart.tsx
+++ b/web/core/components/analytics-v2/work-items/priority-chart.tsx
@@ -162,10 +162,20 @@ const PriorityChart = observer((props: Props) => {
   });
 
   const exportCSV = (rows: Row<TChartDatum>[]) => {
-    const rowData = rows.map((row) => ({
-      name: row.original.name,
-      count: row.original.count,
-    }));
+    const rowData = rows.map((row) => {
+      const otherFields = Object.keys(row.original).filter((key) => key !== "name" && key !== "count" && key !== "key");
+      return {
+        name: row.original.name,
+        count: row.original.count,
+        ...otherFields.reduce(
+          (acc, key) => {
+            acc[parsedData?.schema[key] ?? key] = row.original[key];
+            return acc;
+          },
+          {} as Record<string, string | number>
+        ),
+      };
+    });
     const csv = generateCsv(csvConfig)(rowData);
     download(csvConfig)(csv);
   };

--- a/web/core/components/analytics-v2/work-items/priority-chart.tsx
+++ b/web/core/components/analytics-v2/work-items/priority-chart.tsx
@@ -46,7 +46,7 @@ const PriorityChart = observer((props: Props) => {
   const { t } = useTranslation();
   const resolvedPath = useResolvedAssetPath({ basePath: "/empty-state/analytics-v2/empty-chart-bar" });
   // store hooks
-  const { selectedDuration, selectedProjects, selectedCycle, selectedModule } = useAnalyticsV2();
+  const { selectedDuration, selectedProjects, selectedCycle, selectedModule, isPeekView } = useAnalyticsV2();
   const { workspaceStates } = useProjectState();
   const { resolvedTheme } = useTheme();
   // router
@@ -54,13 +54,15 @@ const PriorityChart = observer((props: Props) => {
   const workspaceSlug = params.workspaceSlug as string;
 
   const { data: priorityChartData, isLoading: priorityChartLoading } = useSWR(
-    `customized-insights-chart-${workspaceSlug}-${selectedDuration}-${selectedProjects}-${selectedCycle}-${selectedModule}-${props.x_axis}-${props.y_axis}-${props.group_by}`,
+    `customized-insights-chart-${workspaceSlug}-${selectedDuration}-
+    ${selectedProjects}-${selectedCycle}-${selectedModule}-${props.x_axis}-${props.y_axis}-${props.group_by}-${isPeekView}`,
     () =>
       analyticsV2Service.getAdvanceAnalyticsCharts<TChart>(workspaceSlug, "custom-work-items", {
         // date_filter: selectedDuration,
         ...(selectedProjects?.length > 0 && { project_ids: selectedProjects?.join(",") }),
         ...(selectedCycle ? { cycle_id: selectedCycle } : {}),
         ...(selectedModule ? { module_id: selectedModule } : {}),
+        ...(isPeekView ? { peek_view: true } : {}),
         ...props,
       })
   );

--- a/web/core/components/analytics-v2/work-items/priority-chart.tsx
+++ b/web/core/components/analytics-v2/work-items/priority-chart.tsx
@@ -163,7 +163,10 @@ const PriorityChart = observer((props: Props) => {
 
   const exportCSV = (rows: Row<TChartDatum>[]) => {
     const rowData = rows.map((row) => {
-      const otherFields = Object.keys(row.original).filter((key) => key !== "name" && key !== "count" && key !== "key");
+      const hiddenFields = ["key", "avatar_url", "assignee_id", "project_id"];
+      const otherFields = Object.keys(row.original).filter(
+        (key) => key !== "name" && key !== "count" && !hiddenFields.includes(key) && !key.includes("id")
+      );
       return {
         name: row.original.name,
         count: row.original.count,

--- a/web/core/components/analytics-v2/work-items/workitems-insight-table.tsx
+++ b/web/core/components/analytics-v2/work-items/workitems-insight-table.tsx
@@ -25,13 +25,15 @@ const WorkItemsInsightTable = observer(() => {
   const { t } = useTranslation();
   // store hooks
   const { getProjectById } = useProject();
-  const { selectedDuration, selectedProjects } = useAnalyticsV2();
+  const { selectedDuration, selectedProjects, selectedCycle, selectedModule } = useAnalyticsV2();
   const { data: workItemsData, isLoading } = useSWR(
-    `insights-table-work-items-${workspaceSlug}-${selectedDuration}-${selectedProjects}`,
+    `insights-table-work-items-${workspaceSlug}-${selectedDuration}-${selectedProjects}-${selectedCycle}-${selectedModule}`,
     () =>
       analyticsV2Service.getAdvanceAnalyticsStats<WorkItemInsightColumns[]>(workspaceSlug, "work-items", {
         // date_filter: selectedDuration,
         ...(selectedProjects?.length > 0 ? { project_ids: selectedProjects.join(",") } : {}),
+        ...(selectedCycle ? { cycle_id: selectedCycle } : {}),
+        ...(selectedModule ? { module_id: selectedModule } : {}),
       })
   );
   // derived values

--- a/web/core/components/analytics-v2/work-items/workitems-insight-table.tsx
+++ b/web/core/components/analytics-v2/work-items/workitems-insight-table.tsx
@@ -3,11 +3,13 @@ import { ColumnDef } from "@tanstack/react-table";
 import { observer } from "mobx-react";
 import { useParams } from "next/navigation";
 import useSWR from "swr";
-import { Briefcase } from "lucide-react";
+import { Briefcase, UserRound } from "lucide-react";
 // plane package imports
 import { useTranslation } from "@plane/i18n";
 import { WorkItemInsightColumns, AnalyticsTableDataMap } from "@plane/types";
 // plane web components
+import { Avatar } from "@plane/ui";
+import { getFileURL } from "@plane/utils";
 import { Logo } from "@/components/common/logo";
 // hooks
 import { useAnalyticsV2 } from "@/hooks/store/use-analytics-v2";
@@ -25,42 +27,81 @@ const WorkItemsInsightTable = observer(() => {
   const { t } = useTranslation();
   // store hooks
   const { getProjectById } = useProject();
-  const { selectedDuration, selectedProjects, selectedCycle, selectedModule } = useAnalyticsV2();
+  const { selectedDuration, selectedProjects, selectedCycle, selectedModule, isPeekView } = useAnalyticsV2();
   const { data: workItemsData, isLoading } = useSWR(
-    `insights-table-work-items-${workspaceSlug}-${selectedDuration}-${selectedProjects}-${selectedCycle}-${selectedModule}`,
+    `insights-table-work-items-${workspaceSlug}-${selectedDuration}-${selectedProjects}-${selectedCycle}-${selectedModule}-${isPeekView}`,
     () =>
       analyticsV2Service.getAdvanceAnalyticsStats<WorkItemInsightColumns[]>(workspaceSlug, "work-items", {
         // date_filter: selectedDuration,
         ...(selectedProjects?.length > 0 ? { project_ids: selectedProjects.join(",") } : {}),
         ...(selectedCycle ? { cycle_id: selectedCycle } : {}),
         ...(selectedModule ? { module_id: selectedModule } : {}),
+        ...(isPeekView ? { peek_view: true } : {}),
       })
   );
   // derived values
-  const columnsLabels: Record<string, string> = {
-    backlog_work_items: t("workspace_projects.state.backlog"),
-    started_work_items: t("workspace_projects.state.started"),
-    un_started_work_items: t("workspace_projects.state.unstarted"),
-    completed_work_items: t("workspace_projects.state.completed"),
-    cancelled_work_items: t("workspace_projects.state.cancelled"),
-    project__name: t("common.project"),
-  };
+  const columnsLabels = useMemo(
+    () => ({
+      backlog_work_items: t("workspace_projects.state.backlog"),
+      started_work_items: t("workspace_projects.state.started"),
+      un_started_work_items: t("workspace_projects.state.unstarted"),
+      completed_work_items: t("workspace_projects.state.completed"),
+      cancelled_work_items: t("workspace_projects.state.cancelled"),
+      project__name: t("common.project"),
+      display_name: t("common.assignee"),
+    }),
+    [t]
+  );
   const columns = useMemo(
     () =>
       [
-        {
-          accessorKey: "project__name",
-          header: () => <div className="text-left">{columnsLabels["project__name"]}</div>,
-          cell: ({ row }) => {
-            const project = getProjectById(row.original.project_id);
-            return (
-              <div className="flex items-center gap-2">
-                {project?.logo_props ? <Logo logo={project.logo_props} size={18} /> : <Briefcase className="h-4 w-4" />}
-                {project?.name}
-              </div>
-            );
-          },
-        },
+        !isPeekView
+          ? {
+              accessorKey: "project__name",
+              header: () => <div className="text-left">{columnsLabels["project__name"]}</div>,
+              cell: ({ row }) => {
+                const project = getProjectById(row.original.project_id);
+                return (
+                  <div className="flex items-center gap-2">
+                    {project?.logo_props ? (
+                      <Logo logo={project.logo_props} size={18} />
+                    ) : (
+                      <Briefcase className="h-4 w-4" />
+                    )}
+                    {project?.name}
+                  </div>
+                );
+              },
+            }
+          : {
+              accessorKey: "display_name",
+              header: () => <div className="text-left">{columnsLabels["display_name"]}</div>,
+              cell: ({ row }) => (
+                <div className="text-left">
+                  <div className="flex items-center gap-2">
+                    {row.original.avatar_url && row.original.avatar_url !== "" ? (
+                      <Avatar
+                        name={row.original.display_name}
+                        src={getFileURL(row.original.avatar_url)}
+                        size={24}
+                        shape="circle"
+                      />
+                    ) : (
+                      <div className="flex h-4 w-4 flex-shrink-0 items-center justify-center rounded-full bg-custom-background-80  capitalize overflow-hidden">
+                        {row.original.display_name ? (
+                          row.original.display_name?.[0]
+                        ) : (
+                          <UserRound className="text-custom-text-200 " size={12} />
+                        )}
+                      </div>
+                    )}
+                    <span className="break-words text-custom-text-200">
+                      {row.original.display_name ?? t(`Unassigned`)}
+                    </span>
+                  </div>
+                </div>
+              ),
+            },
         {
           accessorKey: "backlog_work_items",
           header: () => <div className="text-right">{columnsLabels["backlog_work_items"]}</div>,
@@ -87,7 +128,7 @@ const WorkItemsInsightTable = observer(() => {
           cell: ({ row }) => <div className="text-right">{row.original.cancelled_work_items}</div>,
         },
       ] as ColumnDef<AnalyticsTableDataMap["work-items"]>[],
-    [getProjectById]
+    [columnsLabels, getProjectById, isPeekView, t]
   );
 
   return (

--- a/web/core/components/analytics-v2/work-items/workitems-insight-table.tsx
+++ b/web/core/components/analytics-v2/work-items/workitems-insight-table.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { ColumnDef } from "@tanstack/react-table";
+import { ColumnDef, Row } from "@tanstack/react-table";
 import { observer } from "mobx-react";
 import { useParams } from "next/navigation";
 import useSWR from "swr";
@@ -39,6 +39,11 @@ const WorkItemsInsightTable = observer(() => {
         ...(isPeekView ? { peek_view: true } : {}),
       })
   );
+  const showDisplayName = useMemo(() => {
+    if (isPeekView && (selectedCycle || selectedModule)) return true;
+    return false;
+  }, [selectedCycle, selectedModule, isPeekView]);
+  console.log("showDisplayName", showDisplayName, selectedCycle, selectedModule, isPeekView);
   // derived values
   const columnsLabels = useMemo(
     () => ({
@@ -55,7 +60,7 @@ const WorkItemsInsightTable = observer(() => {
   const columns = useMemo(
     () =>
       [
-        !isPeekView
+        !showDisplayName
           ? {
               accessorKey: "project__name",
               header: () => <div className="text-left">{columnsLabels["project__name"]}</div>,
@@ -76,7 +81,7 @@ const WorkItemsInsightTable = observer(() => {
           : {
               accessorKey: "display_name",
               header: () => <div className="text-left">{columnsLabels["display_name"]}</div>,
-              cell: ({ row }) => (
+              cell: ({ row }: { row: Row<WorkItemInsightColumns> }) => (
                 <div className="text-left">
                   <div className="flex items-center gap-2">
                     {row.original.avatar_url && row.original.avatar_url !== "" ? (
@@ -128,7 +133,7 @@ const WorkItemsInsightTable = observer(() => {
           cell: ({ row }) => <div className="text-right">{row.original.cancelled_work_items}</div>,
         },
       ] as ColumnDef<AnalyticsTableDataMap["work-items"]>[],
-    [columnsLabels, getProjectById, isPeekView, t]
+    [columnsLabels, getProjectById, isPeekView, showDisplayName, t]
   );
 
   return (

--- a/web/core/components/analytics-v2/work-items/workitems-insight-table.tsx
+++ b/web/core/components/analytics-v2/work-items/workitems-insight-table.tsx
@@ -39,10 +39,6 @@ const WorkItemsInsightTable = observer(() => {
         ...(isPeekView ? { peek_view: true } : {}),
       })
   );
-  const showDisplayName = useMemo(() => {
-    if (isPeekView && (selectedCycle || selectedModule)) return true;
-    return false;
-  }, [selectedCycle, selectedModule, isPeekView]);
   // derived values
   const columnsLabels = useMemo(
     () => ({
@@ -59,7 +55,7 @@ const WorkItemsInsightTable = observer(() => {
   const columns = useMemo(
     () =>
       [
-        !showDisplayName
+        !isPeekView
           ? {
               accessorKey: "project__name",
               header: () => <div className="text-left">{columnsLabels["project__name"]}</div>,
@@ -132,7 +128,7 @@ const WorkItemsInsightTable = observer(() => {
           cell: ({ row }) => <div className="text-right">{row.original.cancelled_work_items}</div>,
         },
       ] as ColumnDef<AnalyticsTableDataMap["work-items"]>[],
-    [columnsLabels, getProjectById, isPeekView, showDisplayName, t]
+    [columnsLabels, getProjectById, isPeekView, t]
   );
 
   return (

--- a/web/core/components/analytics-v2/work-items/workitems-insight-table.tsx
+++ b/web/core/components/analytics-v2/work-items/workitems-insight-table.tsx
@@ -43,7 +43,6 @@ const WorkItemsInsightTable = observer(() => {
     if (isPeekView && (selectedCycle || selectedModule)) return true;
     return false;
   }, [selectedCycle, selectedModule, isPeekView]);
-  console.log("showDisplayName", showDisplayName, selectedCycle, selectedModule, isPeekView);
   // derived values
   const columnsLabels = useMemo(
     () => ({

--- a/web/core/components/analytics/old-page.tsx
+++ b/web/core/components/analytics/old-page.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import React, { Fragment } from "react";
+import { observer } from "mobx-react";
+import { useSearchParams } from "next/navigation";
+import { Tab } from "@headlessui/react";
+// plane package imports
+import { ANALYTICS_TABS, EUserPermissionsLevel, EUserPermissions } from "@plane/constants";
+import { useTranslation } from "@plane/i18n";
+import { Header, EHeaderVariant } from "@plane/ui";
+// components
+import { CustomAnalytics, ScopeAndDemand } from "@/components/analytics";
+import { PageHead } from "@/components/core";
+import { ComicBoxButton, DetailedEmptyState } from "@/components/empty-state";
+// hooks
+import { useCommandPalette, useEventTracker, useProject, useUserPermissions, useWorkspace } from "@/hooks/store";
+import { useResolvedAssetPath } from "@/hooks/use-resolved-asset-path";
+
+const OldAnalyticsPage = observer(() => {
+  const searchParams = useSearchParams();
+  const analytics_tab = searchParams.get("analytics_tab");
+  // plane imports
+  const { t } = useTranslation();
+  // store hooks
+  const { toggleCreateProjectModal } = useCommandPalette();
+  const { setTrackElement } = useEventTracker();
+  const { workspaceProjectIds, loader } = useProject();
+  const { currentWorkspace } = useWorkspace();
+  const { allowPermissions } = useUserPermissions();
+  // helper hooks
+  const resolvedPath = useResolvedAssetPath({ basePath: "/empty-state/onboarding/analytics" });
+  // derived values
+  const pageTitle = currentWorkspace?.name
+    ? t(`workspace_analytics.page_label`, { workspace: currentWorkspace?.name })
+    : undefined;
+
+  // permissions
+  const canPerformEmptyStateActions = allowPermissions(
+    [EUserPermissions.ADMIN, EUserPermissions.MEMBER],
+    EUserPermissionsLevel.WORKSPACE
+  );
+
+  // TODO: refactor loader implementation
+  return (
+    <>
+      <PageHead title={pageTitle} />
+      {workspaceProjectIds && (
+        <>
+          {workspaceProjectIds.length > 0 || loader === "init-loader" ? (
+            <div className="flex h-full flex-col overflow-hidden bg-custom-background-100">
+              <Tab.Group as={Fragment} defaultIndex={analytics_tab === "custom" ? 1 : 0}>
+                <Header variant={EHeaderVariant.SECONDARY}>
+                  <Tab.List as="div" className="flex space-x-2 h-full">
+                    {ANALYTICS_TABS.map((tab) => (
+                      <Tab key={tab.key} as={Fragment}>
+                        {({ selected }) => (
+                          <button
+                            className={`text-sm group relative flex items-center gap-1 h-full px-3 cursor-pointer transition-all font-medium outline-none  ${
+                              selected ? "text-custom-primary-100 " : "hover:text-custom-text-200"
+                            }`}
+                          >
+                            {t(tab.i18n_title)}
+                            <div
+                              className={`border absolute bottom-0 right-0 left-0 rounded-t-md ${selected ? "border-custom-primary-100" : "border-transparent group-hover:border-custom-border-200"}`}
+                            />
+                          </button>
+                        )}
+                      </Tab>
+                    ))}
+                  </Tab.List>
+                </Header>
+                <Tab.Panels as={Fragment}>
+                  <Tab.Panel as={Fragment}>
+                    <ScopeAndDemand fullScreen />
+                  </Tab.Panel>
+                  <Tab.Panel as={Fragment}>
+                    <CustomAnalytics fullScreen />
+                  </Tab.Panel>
+                </Tab.Panels>
+              </Tab.Group>
+            </div>
+          ) : (
+            <DetailedEmptyState
+              title={t("workspace_analytics.empty_state.general.title")}
+              description={t("workspace_analytics.empty_state.general.description")}
+              assetPath={resolvedPath}
+              customPrimaryButton={
+                <ComicBoxButton
+                  label={t("workspace_analytics.empty_state.general.primary_button.text")}
+                  title={t("workspace_analytics.empty_state.general.primary_button.comic.title")}
+                  description={t("workspace_analytics.empty_state.general.primary_button.comic.description")}
+                  onClick={() => {
+                    setTrackElement("Analytics empty state");
+                    toggleCreateProjectModal(true);
+                  }}
+                  disabled={!canPerformEmptyStateActions}
+                />
+              }
+            />
+          )}
+        </>
+      )}
+    </>
+  );
+});
+
+export default OldAnalyticsPage;

--- a/web/core/store/analytics-v2.store.ts
+++ b/web/core/store/analytics-v2.store.ts
@@ -10,6 +10,8 @@ export interface IAnalyticsStoreV2 {
   currentTab: TAnalyticsTabsV2Base;
   selectedProjects: string[];
   selectedDuration: DurationType;
+  selectedCycle: string;
+  selectedModule: string;
 
   //computed
   selectedDurationLabel: DurationType | null;
@@ -17,6 +19,8 @@ export interface IAnalyticsStoreV2 {
   //actions
   updateSelectedProjects: (projects: string[]) => void;
   updateSelectedDuration: (duration: DurationType) => void;
+  updateSelectedCycle: (cycle: string) => void;
+  updateSelectedModule: (module: string) => void;
 }
 
 export class AnalyticsStoreV2 implements IAnalyticsStoreV2 {
@@ -24,18 +28,24 @@ export class AnalyticsStoreV2 implements IAnalyticsStoreV2 {
   currentTab: TAnalyticsTabsV2Base = "overview";
   selectedProjects: DurationType[] = [];
   selectedDuration: DurationType = "last_30_days";
+  selectedCycle: string = "";
+  selectedModule: string = "";
 
-  constructor(_rootStore: CoreRootStore) {
+  constructor() {
     makeObservable(this, {
       // observables
       currentTab: observable.ref,
       selectedDuration: observable.ref,
       selectedProjects: observable.ref,
+      selectedCycle: observable.ref,
+      selectedModule: observable.ref,
       // computed
       selectedDurationLabel: computed,
       // actions
       updateSelectedProjects: action,
       updateSelectedDuration: action,
+      updateSelectedCycle: action,
+      updateSelectedModule: action,
     });
   }
 
@@ -44,7 +54,6 @@ export class AnalyticsStoreV2 implements IAnalyticsStoreV2 {
   }
 
   updateSelectedProjects = (projects: string[]) => {
-    const initialState = this.selectedProjects;
     try {
       runInAction(() => {
         this.selectedProjects = projects;
@@ -64,5 +73,17 @@ export class AnalyticsStoreV2 implements IAnalyticsStoreV2 {
       console.error("Failed to update selected duration");
       throw error;
     }
+  };
+
+  updateSelectedCycle = (cycle: string) => {
+    runInAction(() => {
+      this.selectedCycle = cycle;
+    });
+  };
+
+  updateSelectedModule = (module: string) => {
+    runInAction(() => {
+      this.selectedModule = module;
+    });
   };
 }

--- a/web/core/store/analytics-v2.store.ts
+++ b/web/core/store/analytics-v2.store.ts
@@ -12,6 +12,7 @@ export interface IAnalyticsStoreV2 {
   selectedDuration: DurationType;
   selectedCycle: string;
   selectedModule: string;
+  isPeekView?: boolean;
 
   //computed
   selectedDurationLabel: DurationType | null;
@@ -21,6 +22,7 @@ export interface IAnalyticsStoreV2 {
   updateSelectedDuration: (duration: DurationType) => void;
   updateSelectedCycle: (cycle: string) => void;
   updateSelectedModule: (module: string) => void;
+  updateIsPeekView: (isPeekView: boolean) => void;
 }
 
 export class AnalyticsStoreV2 implements IAnalyticsStoreV2 {
@@ -30,7 +32,7 @@ export class AnalyticsStoreV2 implements IAnalyticsStoreV2 {
   selectedDuration: DurationType = "last_30_days";
   selectedCycle: string = "";
   selectedModule: string = "";
-
+  isPeekView: boolean = false;
   constructor() {
     makeObservable(this, {
       // observables
@@ -46,6 +48,7 @@ export class AnalyticsStoreV2 implements IAnalyticsStoreV2 {
       updateSelectedDuration: action,
       updateSelectedCycle: action,
       updateSelectedModule: action,
+      updateIsPeekView: action,
     });
   }
 
@@ -84,6 +87,12 @@ export class AnalyticsStoreV2 implements IAnalyticsStoreV2 {
   updateSelectedModule = (module: string) => {
     runInAction(() => {
       this.selectedModule = module;
+    });
+  };
+
+  updateIsPeekView = (isPeekView: boolean) => {
+    runInAction(() => {
+      this.isPeekView = isPeekView;
     });
   };
 }

--- a/web/core/store/root.store.ts
+++ b/web/core/store/root.store.ts
@@ -96,7 +96,7 @@ export class CoreRootStore {
     this.transient = new TransientStore();
     this.stickyStore = new StickyStore();
     this.editorAssetStore = new EditorAssetStore();
-    this.analyticsV2 = new AnalyticsStoreV2(this);
+    this.analyticsV2 = new AnalyticsStoreV2();
   }
 
   resetOnSignOut() {


### PR DESCRIPTION
### Description
this pull request adds the analytics for the cycles and modules in the peek view.
### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Improvement (change that would cause existing functionality to not work as expected)

https://github.com/user-attachments/assets/887a8dcd-42fc-4d0a-8e84-83178dbb9167







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Analytics dashboards now support filtering by cycle and module, and offer a "peek view" to display assignee-level insights.
  - Analytics modal updated to allow context-specific insights for projects, cycles, and modules.

- **Enhancements**
  - Analytics tables and charts adapt dynamically based on selected cycle, module, and view mode.
  - CSV export functionality improved to exclude sensitive fields and include relevant data.

- **Bug Fixes**
  - Improved data fetching and caching to reflect changes in analytics filters and view modes.

- **Deprecations**
  - Removed the legacy analytics export endpoint and related UI.

- **Other**
  - Minor type and interface improvements for analytics data consistency.
  - Introduced a legacy analytics page with tabbed navigation and empty state handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->