### PR TITLE
[WEB-4115] fix: update issue count status query to handle null values

### DIFF
--- a/apiserver/plane/space/views/issue.py
+++ b/apiserver/plane/space/views/issue.py
@@ -179,7 +179,7 @@ class ProjectIssuesPublicEndpoint(BaseAPIView):
                             Q(issue_intake__status=1)
                             | Q(issue_intake__status=-1)
                             | Q(issue_intake__status=2)
-                            | Q(issue_intake__status=True),
+                            | Q(issue_intake__isnull=True),
                             archived_at__isnull=True,
                             is_draft=False,
                         ),
@@ -205,7 +205,7 @@ class ProjectIssuesPublicEndpoint(BaseAPIView):
                         Q(issue_intake__status=1)
                         | Q(issue_intake__status=-1)
                         | Q(issue_intake__status=2)
-                        | Q(issue_intake__status=True),
+                        | Q(issue_intake__isnull=True),
                         archived_at__isnull=True,
                         is_draft=False,
                     ),


### PR DESCRIPTION
### Description
Fixed wrong issue count on published page by updating the status query to handle null values


### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Screenshots and Media (if applicable)
before
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/47404896-5bc4-44cd-b5eb-0ccf1874fccb" />

after
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/e14c06d5-6def-4b4b-92d1-a7c5a9ff5dae" />


### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
<!-- Link related issues if there are any -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved issue filtering to include cases where the issue intake status is not specified.
- **New Features**
  - Enhanced analytics tables with customizable header text and dynamic search placeholders.
  - Updated project selection to reflect joined projects instead of workspace-specific projects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->