### PR TITLE
fix: prevent prematurely triggered Japanese label creation

### DIFF
--- a/packages/ui/src/hooks/use-dropdown-key-down.tsx
+++ b/packages/ui/src/hooks/use-dropdown-key-down.tsx
@@ -12,7 +12,7 @@ type TUseDropdownKeyDown = {
 export const useDropdownKeyDown: TUseDropdownKeyDown = (onOpen, onClose, isOpen, selectActiveItem?) => {
   const handleKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLElement>) => {
-      if (event.key === "Enter") {
+      if (event.key === "Enter" && !event.nativeEvent.isComposing) {
         if (!isOpen) {
           event.stopPropagation();
           onOpen();

--- a/web/core/components/issues/issue-detail/label/select/label-select.tsx
+++ b/web/core/components/issues/issue-detail/label/select/label-select.tsx
@@ -99,7 +99,7 @@ export const IssueLabelSelect: React.FC<IIssueLabelSelect> = observer((props) =>
       setQuery("");
     }
 
-    if (query !== "" && e.key === "Enter" && canCreateLabel) {
+    if (query !== "" && e.key === "Enter" && !e.nativeEvent.isComposing && canCreateLabel) {
       e.stopPropagation();
       e.preventDefault();
       await handleAddLabel(query);

--- a/web/core/components/issues/issue-layouts/properties/label-dropdown.tsx
+++ b/web/core/components/issues/issue-layouts/properties/label-dropdown.tsx
@@ -158,7 +158,7 @@ export const LabelDropdown = (props: ILabelDropdownProps) => {
       setQuery("");
     }
 
-    if (query !== "" && e.key === "Enter" && canCreateLabel) {
+    if (query !== "" && e.key === "Enter" && !e.nativeEvent.isComposing && canCreateLabel) {
       e.preventDefault();
       await handleAddLabel(query);
     }

--- a/web/core/hooks/use-dropdown-key-down.tsx
+++ b/web/core/hooks/use-dropdown-key-down.tsx
@@ -21,7 +21,7 @@ export const useDropdownKeyDown: TUseDropdownKeyDown = (onEnterKeyDown, onEscKey
 
   const handleKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLElement>) => {
-      if (event.key === "Enter") {
+      if (event.key === "Enter" && !event.nativeEvent.isComposing) {
         stopEventPropagation(event);
         onEnterKeyDown();
       } else if (event.key === "Escape") {


### PR DESCRIPTION
### Description
The changes ensure that the Enter key press during Japanese IME composition will not prematurely trigger label creation.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
Before the change, the Enter key prematurely created a label, "安全なう上の". With the change in place, an intended label, "安全なう上の監査", was successfully created. 

<img width="401" alt="image" src="https://github.com/user-attachments/assets/d4a4c4ab-433d-4549-8e87-9735430b931a" />


### Test Scenarios 
Confirmed intended Japanese labels are successfully generated with the change. Also, verified the change does not affect the existing workflow for English label creation.

### References
#7022 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of the Enter key in dropdowns and label creation fields to prevent unintended actions while using Input Method Editors (IME) for complex character input. This ensures that actions like opening dropdowns or creating labels are not triggered prematurely during text composition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->