### PR TITLE
[WEB-] chore: extend custom font family in tailwind config

### DIFF
--- a/packages/tailwind-config/tailwind.config.js
+++ b/packages/tailwind-config/tailwind.config.js
@@ -462,9 +462,6 @@ module.exports = {
         "onboarding-gradient-300": "var( --gradient-onboarding-300)",
       },
     },
-    fontFamily: {
-      custom: ["Inter", "sans-serif"],
-    },
   },
   plugins: [
     require("tailwindcss-animate"),

--- a/packages/tailwind-config/tailwind.config.js
+++ b/packages/tailwind-config/tailwind.config.js
@@ -461,6 +461,9 @@ module.exports = {
         "onboarding-gradient-200": "var( --gradient-onboarding-200)",
         "onboarding-gradient-300": "var( --gradient-onboarding-300)",
       },
+      fontFamily: {
+        custom: ["Inter", "sans-serif"],
+      },
     },
   },
   plugins: [


### PR DESCRIPTION
### Description

This PR fixes the tailwind config by moving the custom font families to the extend object to prevent overwriting the default ones.

### Type of Change

- [x] Improvement (change that would cause existing functionality to not work as expected)