### PR TITLE
[WEB-4137] chore: restrict SVG file selection

### DIFF
--- a/packages/constants/src/file.ts
+++ b/packages/constants/src/file.ts
@@ -1,1 +1,14 @@
 export const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+
+export const ACCEPTED_AVATAR_IMAGE_MIME_TYPES_FOR_REACT_DROPZONE = {
+  "image/jpeg": [],
+  "image/jpg": [],
+  "image/png": [],
+  "image/webp": [],
+};
+export const ACCEPTED_COVER_IMAGE_MIME_TYPES_FOR_REACT_DROPZONE = {
+  "image/jpeg": [],
+  "image/jpg": [],
+  "image/png": [],
+  "image/webp": [],
+};

--- a/web/core/components/core/image-picker-popover.tsx
+++ b/web/core/components/core/image-picker-popover.tsx
@@ -9,7 +9,7 @@ import { Control, Controller } from "react-hook-form";
 import useSWR from "swr";
 import { Tab, Popover } from "@headlessui/react";
 // plane imports
-import { MAX_FILE_SIZE } from "@plane/constants";
+import { ACCEPTED_COVER_IMAGE_MIME_TYPES_FOR_REACT_DROPZONE, MAX_FILE_SIZE } from "@plane/constants";
 import { useOutsideClickDetector } from "@plane/hooks";
 // plane types
 import { EFileAssetType } from "@plane/types/src/enums";
@@ -88,9 +88,7 @@ export const ImagePickerPopover: React.FC<Props> = observer((props) => {
 
   const { getRootProps, getInputProps, isDragActive, fileRejections } = useDropzone({
     onDrop,
-    accept: {
-      "image/*": [".png", ".jpg", ".jpeg", ".webp"],
-    },
+    accept: ACCEPTED_COVER_IMAGE_MIME_TYPES_FOR_REACT_DROPZONE,
     maxSize: MAX_FILE_SIZE,
   });
 

--- a/web/core/components/core/modals/user-image-upload-modal.tsx
+++ b/web/core/components/core/modals/user-image-upload-modal.tsx
@@ -6,7 +6,7 @@ import { useDropzone } from "react-dropzone";
 import { UserCircle2 } from "lucide-react";
 import { Transition, Dialog } from "@headlessui/react";
 // plane imports
-import { MAX_FILE_SIZE } from "@plane/constants";
+import { ACCEPTED_AVATAR_IMAGE_MIME_TYPES_FOR_REACT_DROPZONE, MAX_FILE_SIZE } from "@plane/constants";
 import { EFileAssetType } from "@plane/types/src/enums";
 import { Button, TOAST_TYPE, setToast } from "@plane/ui";
 // helpers
@@ -35,9 +35,7 @@ export const UserImageUploadModal: React.FC<Props> = observer((props) => {
 
   const { getRootProps, getInputProps, isDragActive, fileRejections } = useDropzone({
     onDrop,
-    accept: {
-      "image/*": [".png", ".jpg", ".jpeg", ".webp"],
-    },
+    accept: ACCEPTED_AVATAR_IMAGE_MIME_TYPES_FOR_REACT_DROPZONE,
     maxSize: MAX_FILE_SIZE,
     multiple: false,
   });

--- a/web/core/components/core/modals/workspace-image-upload-modal.tsx
+++ b/web/core/components/core/modals/workspace-image-upload-modal.tsx
@@ -6,7 +6,7 @@ import { useDropzone } from "react-dropzone";
 import { UserCircle2 } from "lucide-react";
 import { Transition, Dialog } from "@headlessui/react";
 // plane imports
-import { MAX_FILE_SIZE } from "@plane/constants";
+import { ACCEPTED_AVATAR_IMAGE_MIME_TYPES_FOR_REACT_DROPZONE, MAX_FILE_SIZE } from "@plane/constants";
 import { EFileAssetType } from "@plane/types/src/enums";
 import { Button } from "@plane/ui";
 // helpers
@@ -43,9 +43,7 @@ export const WorkspaceImageUploadModal: React.FC<Props> = observer((props) => {
 
   const { getRootProps, getInputProps, isDragActive, fileRejections } = useDropzone({
     onDrop,
-    accept: {
-      "image/*": [".png", ".jpg", ".jpeg", ".webp"],
-    },
+    accept: ACCEPTED_AVATAR_IMAGE_MIME_TYPES_FOR_REACT_DROPZONE,
     maxSize: MAX_FILE_SIZE,
     multiple: false,
   });


### PR DESCRIPTION
### Description

This PR restricts SVG file selection when trying to upload user avatar, workspace logo or any other cover image.

**Cause of bug-** Currently, the mime type provided to the dropzone library is `image/*` which allows all files to be selected.

**Fix-** Now, only selected mime types are provided for better filtering.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)