### PR TITLE
[WEB-4107] chore: redirect user to the newly created project view after creation

### DIFF
--- a/web/core/components/views/modal.tsx
+++ b/web/core/components/views/modal.tsx
@@ -10,6 +10,7 @@ import { EModalPosition, EModalWidth, ModalCore, TOAST_TYPE, setToast } from "@p
 import { ProjectViewForm } from "@/components/views";
 // hooks
 import { useProjectView } from "@/hooks/store";
+import { useAppRouter } from "@/hooks/use-app-router";
 import useKeypress from "@/hooks/use-keypress";
 
 type Props = {
@@ -23,6 +24,8 @@ type Props = {
 
 export const CreateUpdateProjectViewModal: FC<Props> = observer((props) => {
   const { data, isOpen, onClose, preLoadedData, workspaceSlug, projectId } = props;
+  // router
+  const router = useAppRouter();
   // store hooks
   const { createView, updateView } = useProjectView();
 
@@ -32,8 +35,9 @@ export const CreateUpdateProjectViewModal: FC<Props> = observer((props) => {
 
   const handleCreateView = async (payload: IProjectView) => {
     await createView(workspaceSlug, projectId, payload)
-      .then(() => {
+      .then((res) => {
         handleClose();
+        router.push(`/${workspaceSlug}/projects/${projectId}/views/${res.id}`);
         setToast({
           type: TOAST_TYPE.SUCCESS,
           title: "Success!",


### PR DESCRIPTION
### Description
This PR introduces a user experience improvement where, upon creating a new project view, the user is immediately redirected to that specific view. This ensures a smoother and more intuitive workflow, allowing users to begin interacting with the new view right after creation without needing to manually navigate to it.

### Type of Change
- [x] Improvement

### Media
| Before | After |
|--------|--------|
| ![before](https://github.com/user-attachments/assets/9fbd8852-190b-4db6-8b44-c4970f6d910b) | ![after](https://github.com/user-attachments/assets/7078dd33-88bc-4860-8c8f-7734b8b95422) |

### References
[[WEB-4107]](https://app.plane.so/plane/browse/WEB-4107/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - After creating a new project view, users are now automatically redirected to the newly created view.

- **Enhancements**
  - Improved workflow by seamlessly navigating to the new project view upon creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->