### PR TITLE
[WEB-4159] feat: add 'restricted_entity' translation key across multiple languages

### DIFF
--- a/packages/i18n/src/locales/cs/translations.json
+++ b/packages/i18n/src/locales/cs/translations.json
@@ -746,7 +746,8 @@
         "message": "Něco se pokazilo. Zkuste to prosím znovu."
       },
       "required": "Toto pole je povinné",
-      "entity_required": "{entity} je povinná"
+      "entity_required": "{entity} je povinná",
+      "restricted_entity": "{entity} je omezen"
     },
     "update_link": "Aktualizovat odkaz",
     "attach": "Připojit",

--- a/packages/i18n/src/locales/de/translations.json
+++ b/packages/i18n/src/locales/de/translations.json
@@ -746,7 +746,8 @@
         "message": "Etwas ist schiefgelaufen. Bitte versuchen Sie es erneut."
       },
       "required": "Dieses Feld ist erforderlich",
-      "entity_required": "{entity} ist erforderlich"
+      "entity_required": "{entity} ist erforderlich",
+      "restricted_entity": "{entity} ist eingeschränkt"
     },
     "update_link": "Link aktualisieren",
     "attach": "Anhängen",

--- a/packages/i18n/src/locales/en/translations.json
+++ b/packages/i18n/src/locales/en/translations.json
@@ -580,7 +580,8 @@
         "message": "Something went wrong. Please try again."
       },
       "required": "This field is required",
-      "entity_required": "{entity} is required"
+      "entity_required": "{entity} is required",
+      "restricted_entity": "{entity} is restricted"
     },
     "update_link": "Update link",
     "attach": "Attach",

--- a/packages/i18n/src/locales/es/translations.json
+++ b/packages/i18n/src/locales/es/translations.json
@@ -750,7 +750,8 @@
         "message": "Algo salió mal. Por favor, inténtalo de nuevo."
       },
       "required": "Este campo es obligatorio",
-      "entity_required": "{entity} es obligatorio"
+      "entity_required": "{entity} es obligatorio",
+      "restricted_entity": "{entity} está restringido"
     },
     "update_link": "Actualizar enlace",
     "attach": "Adjuntar",

--- a/packages/i18n/src/locales/fr/translations.json
+++ b/packages/i18n/src/locales/fr/translations.json
@@ -748,7 +748,8 @@
         "message": "Quelque chose s'est mal passé. Veuillez réessayer."
       },
       "required": "Ce champ est obligatoire",
-      "entity_required": "{entity} est requis"
+      "entity_required": "{entity} est requis",
+      "restricted_entity": "{entity} est restreint"
     },
     "update_link": "Mettre à jour le lien",
     "attach": "Joindre",

--- a/packages/i18n/src/locales/id/translations.json
+++ b/packages/i18n/src/locales/id/translations.json
@@ -746,7 +746,8 @@
         "message": "Sesuatu telah salah. Silakan coba lagi."
       },
       "required": "Bidang ini diperlukan",
-      "entity_required": "{entity} diperlukan"
+      "entity_required": "{entity} diperlukan",
+      "restricted_entity": "{entity} dibatasi"
     },
     "update_link": "Perbarui tautan",
     "attach": "Lampirkan",

--- a/packages/i18n/src/locales/it/translations.json
+++ b/packages/i18n/src/locales/it/translations.json
@@ -743,7 +743,8 @@
         "message": "Qualcosa è andato storto. Per favore, riprova."
       },
       "required": "Questo campo è obbligatorio",
-      "entity_required": "{entity} è obbligatorio"
+      "entity_required": "{entity} è obbligatorio",
+      "restricted_entity": "{entity} è limitato"
     },
     "update_link": "Aggiorna link",
     "attach": "Allega",

--- a/packages/i18n/src/locales/ja/translations.json
+++ b/packages/i18n/src/locales/ja/translations.json
@@ -748,7 +748,8 @@
         "message": "問題が発生しました。もう一度お試しください。"
       },
       "required": "この項目は必須です",
-      "entity_required": "{entity}は必須です"
+      "entity_required": "{entity}は必須です",
+      "restricted_entity": "{entity} は制限されています"
     },
     "update_link": "リンクを更新",
     "attach": "添付",

--- a/packages/i18n/src/locales/ko/translations.json
+++ b/packages/i18n/src/locales/ko/translations.json
@@ -748,7 +748,8 @@
         "message": "문제가 발생했습니다. 다시 시도해주세요."
       },
       "required": "이 필드는 필수입니다",
-      "entity_required": "{entity}가 필요합니다"
+      "entity_required": "{entity}가 필요합니다",
+      "restricted_entity": "{entity}은(는) 제한되어 있습니다"
     },
     "update_link": "링크 업데이트",
     "attach": "첨부",

--- a/packages/i18n/src/locales/pl/translations.json
+++ b/packages/i18n/src/locales/pl/translations.json
@@ -748,7 +748,8 @@
         "message": "Coś poszło nie tak. Spróbuj ponownie."
       },
       "required": "To pole jest wymagane",
-      "entity_required": "{entity} jest wymagane"
+      "entity_required": "{entity} jest wymagane",
+      "restricted_entity": "{entity} jest ograniczony"
     },
     "update_link": "Zaktualizuj link",
     "attach": "Dołącz",

--- a/packages/i18n/src/locales/pt-BR/translations.json
+++ b/packages/i18n/src/locales/pt-BR/translations.json
@@ -748,7 +748,8 @@
         "message": "Algo deu errado. Por favor, tente novamente."
       },
       "required": "Este campo é obrigatório",
-      "entity_required": "{entity} é obrigatório"
+      "entity_required": "{entity} é obrigatório",
+      "restricted_entity": "{entity} está restrito"
     },
     "update_link": "Atualizar link",
     "attach": "Anexar",

--- a/packages/i18n/src/locales/ro/translations.json
+++ b/packages/i18n/src/locales/ro/translations.json
@@ -746,7 +746,8 @@
         "message": "Ceva a funcționat greșit. Te rugăm să încerci din nou."
       },
       "required": "Acest câmp este obligatoriu",
-      "entity_required": "{entity} este obligatoriu"
+      "entity_required": "{entity} este obligatoriu",
+      "restricted_entity": "{entity} este restricționat"
     },
     "update_link": "Actualizează link-ul",
     "attach": "Atașează",

--- a/packages/i18n/src/locales/ru/translations.json
+++ b/packages/i18n/src/locales/ru/translations.json
@@ -748,7 +748,8 @@
         "message": "Что-то пошло не так. Попробуйте позже."
       },
       "required": "Это поле обязательно",
-      "entity_required": "{entity} обязательно"
+      "entity_required": "{entity} обязательно",
+      "restricted_entity": "{entity} ограничен"
     },
     "update_link": "обновить ссылку",
     "attach": "Прикрепить",

--- a/packages/i18n/src/locales/sk/translations.json
+++ b/packages/i18n/src/locales/sk/translations.json
@@ -748,7 +748,8 @@
         "message": "Niečo sa pokazilo. Skúste to prosím znova."
       },
       "required": "Toto pole je povinné",
-      "entity_required": "{entity} je povinná"
+      "entity_required": "{entity} je povinná",
+      "restricted_entity": "{entity} je obmedzený"
     },
     "update_link": "Aktualizovať odkaz",
     "attach": "Pripojiť",

--- a/packages/i18n/src/locales/tr-TR/translations.json
+++ b/packages/i18n/src/locales/tr-TR/translations.json
@@ -748,7 +748,8 @@
         "message": "Bir hata oluştu. Lütfen tekrar deneyin."
       },
       "required": "Bu alan gereklidir",
-      "entity_required": "{entity} gereklidir"
+      "entity_required": "{entity} gereklidir",
+      "restricted_entity": "{entity} kısıtlanmıştır"
     },
     "update_link": "Bağlantıyı güncelle",
     "attach": "Ekle",

--- a/packages/i18n/src/locales/ua/translations.json
+++ b/packages/i18n/src/locales/ua/translations.json
@@ -747,8 +747,9 @@
         "title": "Помилка!",
         "message": "Щось пішло не так. Будь ласка, спробуйте ще раз."
       },
-      "required": "Це поле є обов’язковим",
-      "entity_required": "{entity} є обов’язковим"
+      "required": "Це поле є обов'язковим",
+      "entity_required": "{entity} є обов'язковим",
+      "restricted_entity": "{entity} обмежено"
     },
     "update_link": "Оновити посилання",
     "attach": "Прикріпити",

--- a/packages/i18n/src/locales/vi-VN/translations.json
+++ b/packages/i18n/src/locales/vi-VN/translations.json
@@ -748,7 +748,8 @@
         "message": "Đã xảy ra lỗi. Vui lòng thử lại."
       },
       "required": "Trường này là bắt buộc",
-      "entity_required": "{entity} là bắt buộc"
+      "entity_required": "{entity} là bắt buộc",
+      "restricted_entity": "{entity} bị hạn chế"
     },
     "update_link": "Cập nhật liên kết",
     "attach": "Đính kèm",

--- a/packages/i18n/src/locales/zh-CN/translations.json
+++ b/packages/i18n/src/locales/zh-CN/translations.json
@@ -748,7 +748,8 @@
         "message": "发生错误。请重试。"
       },
       "required": "此字段为必填项",
-      "entity_required": "{entity}为必填项"
+      "entity_required": "{entity}为必填项",
+      "restricted_entity": "{entity}已被限制"
     },
     "update_link": "更新链接",
     "attach": "附加",

--- a/packages/i18n/src/locales/zh-TW/translations.json
+++ b/packages/i18n/src/locales/zh-TW/translations.json
@@ -748,7 +748,8 @@
         "message": "發生錯誤。請再試一次。"
       },
       "required": "此欄位為必填",
-      "entity_required": "{entity} 為必填"
+      "entity_required": "{entity} 為必填",
+      "restricted_entity": "{entity}已被限制"
     },
     "update_link": "更新連結",
     "attach": "附加",


### PR DESCRIPTION
### Description
Added translations for restricted entities

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Improvement (change that would cause existing functionality to not work as expected)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new "restricted entity" error message translation across all supported languages, improving clarity for restricted entity errors in multiple locales.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->