### PR TITLE
[WEB-3155]fix: email notification comments overflow

### DIFF
--- a/apiserver/templates/emails/notifications/issue-updates.html
+++ b/apiserver/templates/emails/notifications/issue-updates.html
@@ -209,7 +209,7 @@
                     {% for actor_comment in comment.actor_comments.new_value %} 
                     <tr>
                       <td>
-                        <div style=" padding: 6px 10px; margin-left: 10px; background-color: white; font-size: 0.8rem; color: #525252; margin-top: 5px; border-radius: 4px; display: flex; align-items: center; " >
+                        <div style=" padding: 6px 10px; margin-left: 10px; background-color: white; font-size: 0.8rem; color: #525252; margin-top: 5px; border-radius: 4px; overflow-x: scroll; max-width: 430px;" >
                           <p> {{ actor_comment|safe }} </p>
                         </div>
                       </td>


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
This update fixes the overflow issue for long comments in email notifications.


### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
<!-- Link related issues if there are any -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the display of comments in notification emails to use horizontal scrolling within a fixed-width container, improving the handling of long comment content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->