### PR TITLE
[WEB-3494] fix: size of created at value

### DIFF
--- a/web/core/components/issues/peek-overview/properties.tsx
+++ b/web/core/components/issues/peek-overview/properties.tsx
@@ -135,7 +135,7 @@ export const PeekOverviewProperties: FC<IPeekOverviewProperties> = observer((pro
                 showTooltip
                 userIds={createdByDetails?.display_name.includes("-intake") ? null : createdByDetails?.id}
               />
-              <span className="flex-grow truncate text-xs leading-5">
+              <span className="flex-grow truncate  leading-5">
                 {createdByDetails?.display_name.includes("-intake") ? "Plane" : createdByDetails?.display_name}
               </span>
             </div>


### PR DESCRIPTION
### Description
Fixed the size of created at value

Before
<img width="397" alt="image" src="https://github.com/user-attachments/assets/a6b7a4c4-c9e2-4576-a562-5afd1b6b662c" />


After
<img width="321" alt="Screenshot 2025-05-23 at 3 21 01 PM" src="https://github.com/user-attachments/assets/35d72db0-e9ef-415d-8ab9-1e07e39278cb" />


### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [x] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

