### PR TITLE
[WEB-4160] fix: close the context menu after select

### DIFF
--- a/web/core/components/workspace/sidebar/projects-list-item.tsx
+++ b/web/core/components/workspace/sidebar/projects-list-item.tsx
@@ -311,6 +311,7 @@ export const SidebarProjectsListItem: React.FC<Props> = observer((props) => {
                   customButtonClassName="grid place-items-center"
                   placement="bottom-start"
                   useCaptureForOutsideClick
+                  closeOnSelect
                 >
                   {/* TODO: Removed is_favorite logic due to the optimization in projects API */}
                   {/* {isAuthorized && (


### PR DESCRIPTION
### Description
close context menu  after select
<img width="321" alt="Screenshot 2025-05-23 at 3 21 01 PM" src="https://github.com/user-attachments/assets/d87f078b-9c40-4800-8ce0-454e669b5604" />


### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Improvement (change that would cause existing functionality to not work as expected)
