### PR TITLE
[WEB-2403] fix: alignment of project states in collapsed view

### DIFF
--- a/web/core/components/issues/issue-layouts/kanban/default.tsx
+++ b/web/core/components/issues/issue-layouts/kanban/default.tsx
@@ -162,7 +162,7 @@ export const KanBan: React.FC<IKanBan> = observer((props) => {
               } `}
             >
               {sub_group_by === null && (
-                <div className="sticky top-0 z-[2] w-full flex-shrink-0 bg-custom-background-90 py-1 mb-1">
+                <div className="sticky top-0 z-[2] w-full flex-shrink-0 bg-custom-background-90 py-1">
                   <HeaderGroupByCard
                     sub_group_by={sub_group_by}
                     group_by={group_by}

--- a/web/core/components/issues/issue-layouts/kanban/headers/group-by-card.tsx
+++ b/web/core/components/issues/issue-layouts/kanban/headers/group-by-card.tsx
@@ -117,7 +117,7 @@ export const HeaderGroupByCard: FC<IHeaderGroupByCard> = observer((props) => {
           verticalAlignPosition ? `w-[44px] flex-col items-center` : `w-full flex-row items-center`
         }`}
       >
-        <div className="flex h-[20px] flex-shrink-0 items-center justify-center overflow-hidden rounded-sm">
+        <div className="flex h-[25px] w-[20px] flex-shrink-0 items-center justify-center overflow-hidden rounded-sm">
           {icon ? icon : <Circle width={14} strokeWidth={2} />}
         </div>
 


### PR DESCRIPTION
### Description
Alignment of project states in collapsed view

Before
![Screenshot 2025-05-23 at 5 26 37 PM](https://github.com/user-attachments/assets/62d01862-eefc-41ad-91d1-a92819e36e8c)

After
![Screenshot 2025-05-23 at 5 27 27 PM](https://github.com/user-attachments/assets/8fa9990c-7c1d-493f-80f0-70606718cb1d)


### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Improvement (change that would cause existing functionality to not work as expected)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved layout by removing extra bottom margin from the sticky header in the Kanban view.
  - Adjusted icon container size in header cards for better alignment and visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->