### PR TITLE
[WEB-4182] fix: toast in small screens

### DIFF
--- a/packages/ui/src/toast/index.tsx
+++ b/packages/ui/src/toast/index.tsx
@@ -108,7 +108,7 @@ export const setToast = (props: SetToastProps) => {
         )}
       >
         <X
-          className="fixed top-2 right-2.5 text-toast-text-secondary hover:text-toast-text-tertiary cursor-pointer"
+          className="absolute top-2 right-2.5 text-toast-text-secondary hover:text-toast-text-tertiary cursor-pointer"
           strokeWidth={1.5}
           width={14}
           height={14}


### PR DESCRIPTION
### Description
fixed the position of X in the toast for small screens

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Improvement (change that would cause existing functionality to not work as expected)

Before
<img width="465" alt="Screenshot 2025-05-26 at 6 45 08 PM" src="https://github.com/user-attachments/assets/86c0ead9-cdca-4e0a-8803-5b595b83f47a" />

After
<img width="486" alt="Screenshot 2025-05-26 at 6 47 32 PM" src="https://github.com/user-attachments/assets/8fcdebb1-2baf-49e6-a628-4b70eb98658d" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the positioning of the close (X) icon in toast notifications for improved alignment within the toast component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->