### PR TITLE
[WEB-4130] fix: cycle charts minor optimizations

### DIFF
--- a/web/core/components/cycles/analytics-sidebar/issue-progress.tsx
+++ b/web/core/components/cycles/analytics-sidebar/issue-progress.tsx
@@ -32,7 +32,7 @@ type Options = {
 
 export const cycleEstimateOptions: Options[] = [
   { value: "issues", label: "Work items" },
-  { value: "points", label: "Points" },
+  { value: "points", label: "Estimates" },
 ];
 export const cycleChartOptions: Options[] = [
   { value: "burndown", label: "Burn-down" },

--- a/web/core/components/cycles/dropdowns/estimate-type-dropdown.tsx
+++ b/web/core/components/cycles/dropdowns/estimate-type-dropdown.tsx
@@ -1,5 +1,7 @@
 import React from "react";
+import { observer } from "mobx-react-lite";
 import { TCycleEstimateType } from "@plane/types";
+import { EEstimateSystem } from "@plane/types/src/enums";
 import { CustomSelect } from "@plane/ui";
 import { useCycle, useProjectEstimates } from "@/hooks/store";
 import { cycleEstimateOptions } from "../analytics-sidebar";
@@ -12,12 +14,13 @@ type TProps = {
   cycleId: string;
 };
 
-export const EstimateTypeDropdown = (props: TProps) => {
+export const EstimateTypeDropdown = observer((props: TProps) => {
   const { value, onChange, projectId, cycleId, showDefault = false } = props;
   const { getIsPointsDataAvailable } = useCycle();
-  const { areEstimateEnabledByProjectId } = useProjectEstimates();
+  const { areEstimateEnabledByProjectId, currentProjectEstimate } = useProjectEstimates();
   const isCurrentProjectEstimateEnabled = projectId && areEstimateEnabledByProjectId(projectId) ? true : false;
-  return getIsPointsDataAvailable(cycleId) || isCurrentProjectEstimateEnabled ? (
+  return (getIsPointsDataAvailable(cycleId) || isCurrentProjectEstimateEnabled) &&
+    currentProjectEstimate !== EEstimateSystem.CATEGORIES ? (
     <div className="relative flex items-center gap-2">
       <CustomSelect
         value={value}
@@ -36,4 +39,4 @@ export const EstimateTypeDropdown = (props: TProps) => {
   ) : showDefault ? (
     <span className="capitalize">{value}</span>
   ) : null;
-};
+});

--- a/web/core/store/estimates/project-estimate.store.ts
+++ b/web/core/store/estimates/project-estimate.store.ts
@@ -27,6 +27,7 @@ export interface IProjectEstimateStore {
   currentActiveEstimateId: string | undefined;
   currentActiveEstimate: IEstimate | undefined;
   archivedEstimateIds: string[] | undefined;
+  currentProjectEstimate: TEstimateSystemKeys | undefined;
   areEstimateEnabledByProjectId: (projectId: string) => boolean;
   estimateIdsByProjectId: (projectId: string) => string[] | undefined;
   currentActiveEstimateIdByProjectId: (projectId: string) => string | undefined;
@@ -63,6 +64,7 @@ export class ProjectEstimateStore implements IProjectEstimateStore {
       currentActiveEstimateId: computed,
       currentActiveEstimate: computed,
       archivedEstimateIds: computed,
+      currentProjectEstimate: computed,
       // actions
       getWorkspaceEstimates: action,
       getProjectEstimates: action,
@@ -73,6 +75,11 @@ export class ProjectEstimateStore implements IProjectEstimateStore {
   }
 
   // computed
+
+  get currentProjectEstimate(): TEstimateSystemKeys | undefined {
+    return this.currentActiveEstimateId ? this.estimates[this.currentActiveEstimateId]?.type : undefined;
+  }
+
   /**
    * @description get current active estimate id for a project
    * @returns { string | undefined }


### PR DESCRIPTION
### Description
- Changed points to Estimates in dropdown to be inclusive of all estimate types
- Added computed function for project's estimate type
- Hide the cycle chart estimate type switcher dropdown when estimate type is category

### References
[[WEB-4130]](https://app.plane.so/plane/browse/WEB-4130/)