### PR TITLE
[WEB-3863] fix: links error handling

### DIFF
--- a/web/core/store/issue/issue-details/link.store.ts
+++ b/web/core/store/issue/issue-details/link.store.ts
@@ -141,7 +141,7 @@ export class IssueLinkStore implements IIssueLinkStore {
           set(this.linkMap, [linkId, key], initialData[key as keyof TIssueLink]);
         });
       });
-      return initialData;
+      throw error;
     }
   };
 


### PR DESCRIPTION
### Description
For issue links the success toast was getting displayed even on failure. Thrown error for the toast to display correctly. 

### References
[[WEB-3863]](https://app.plane.so/plane/browse/WEB-3863/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for issue link updates, ensuring errors are now properly reported to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->