### PR TITLE
[WEB-4223] fix: remove build process from utils package

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -4,14 +4,10 @@
   "description": "Helper functions shared across multiple apps internally",
   "license": "AGPL-3.0",
   "private": true,
-  "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
-  "types": "./dist/index.d.ts",
-  "files": [
-    "dist/**"
-  ],
+  "main": "./src/index.ts",
+  "module": "./src/index.ts",
+  "types": "./src/index.ts",
   "scripts": {
-    "build": "tsup ./src/index.ts --format esm,cjs --dts --external react --minify",
     "lint": "eslint src --ext .ts,.tsx",
     "lint:errors": "eslint src --ext .ts,.tsx --quiet"
   },
@@ -29,7 +25,6 @@
     "@types/node": "^22.5.4",
     "@types/react": "^18.3.11",
     "@types/zxcvbn": "^4.4.5",
-    "tsup": "8.4.0",
     "typescript": "^5.3.3"
   }
 }

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,19 +1,16 @@
 export * from "./array";
 export * from "./attachment";
 export * from "./auth";
-export * from "./datetime";
 export * from "./color";
 export * from "./common";
 export * from "./datetime";
 export * from "./emoji";
 export * from "./file";
+export * from "./get-icon-for-link";
 export * from "./issue";
 export * from "./state";
 export * from "./string";
-export * from "./theme";
-export * from "./workspace";
-export * from "./work-item";
-
-export * from "./get-icon-for-link";
-
 export * from "./subscription";
+export * from "./theme";
+export * from "./work-item";
+export * from "./workspace";

--- a/yarn.lock
+++ b/yarn.lock
@@ -4756,9 +4756,9 @@ check-error@^2.1.1:
   resolved "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz#87eb876ae71ee388fa0471fe423f494be1d96ccc"
   integrity sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==
 
-chokidar@^3.3.0, chokidar@^3.5.2, chokidar@^3.5.3, chokidar@^3.6.0:
+chokidar@3.6.0, chokidar@^3.3.0, chokidar@^3.5.2, chokidar@^3.5.3, chokidar@^3.6.0, chokidar@^4.0.3:
   version "3.6.0"
-  resolved "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz#197c6cc669ef2a8dc5e7b4d97ee4e092c3eb0d5b"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.6.0.tgz#197c6cc669ef2a8dc5e7b4d97ee4e092c3eb0d5b"
   integrity sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==
   dependencies:
     anymatch "~3.1.2"
@@ -4770,13 +4770,6 @@ chokidar@^3.3.0, chokidar@^3.5.2, chokidar@^3.5.3, chokidar@^3.6.0:
     readdirp "~3.6.0"
   optionalDependencies:
     fsevents "~2.3.2"
-
-chokidar@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-4.0.3.tgz#7be37a4c03c9aee1ecfe862a4a23b2c70c205d30"
-  integrity sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==
-  dependencies:
-    readdirp "^4.0.1"
 
 chownr@^1.1.1:
   version "1.1.4"
@@ -9823,11 +9816,6 @@ readable-stream@^4.0.0:
     events "^3.3.0"
     process "^0.11.10"
     string_decoder "^1.3.0"
-
-readdirp@^4.0.1:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-4.1.2.tgz#eb85801435fbf2a7ee58f19e0921b068fc69948d"
-  integrity sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==
 
 readdirp@~3.6.0:
   version "3.6.0"


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
This pull request addresses the removal of the build process from the utils package. The build process was deemed unnecessary for this package, as it primarily contains utility functions that do not require compilation or transformation.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [X] Improvement (change that would cause existing functionality to not work as expected)
