### PR TITLE
build: add .venv to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 *.pyc
 .env
 venv
+.venv
 node_modules/
 **/node_modules/
 npm-debug.log


### PR DESCRIPTION
### Description
Stay consistent with `.gitignore` on venv handling.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
<!-- Link related issues if there are any -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Docker configuration to ignore both `.venv` and `venv` directories, improving build efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->