### PR TITLE
chore: add chevronIconClassName prop to CustomMenu

### DIFF
--- a/packages/ui/src/dropdowns/custom-menu.tsx
+++ b/packages/ui/src/dropdowns/custom-menu.tsx
@@ -30,6 +30,7 @@ const CustomMenu = (props: ICustomMenuDropdownProps) => {
     noChevron = false,
     optionsClassName = "",
     menuItemsClassName = "",
+    chevronClassName = "",
     verticalEllipsis = false,
     portalElement,
     menuButtonOnClick,
@@ -168,7 +169,9 @@ const CustomMenu = (props: ICustomMenuDropdownProps) => {
                     tabIndex={customButtonTabIndex}
                     aria-label={ariaLabel}
                   >
-                    <MoreHorizontal className={`h-3.5 w-3.5 ${verticalEllipsis ? "rotate-90" : ""}`} />
+                    <MoreHorizontal
+                      className={cn(`h-3.5 w-3.5 ${verticalEllipsis ? "rotate-90" : ""}`, chevronClassName)}
+                    />
                   </button>
                 </Menu.Button>
               ) : (
@@ -189,7 +192,7 @@ const CustomMenu = (props: ICustomMenuDropdownProps) => {
                     aria-label={ariaLabel}
                   >
                     {label}
-                    {!noChevron && <ChevronDown className="h-3.5 w-3.5" />}
+                    {!noChevron && <ChevronDown className={cn("h-3.5 w-3.5", chevronClassName)} />}
                   </button>
                 </Menu.Button>
               )}


### PR DESCRIPTION
### Description
add chevronIconClassName prop to CustomMenu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for custom CSS classes on chevron icons in dropdown menus, allowing for enhanced icon styling options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->