### PR TITLE
[WIKI-391] chore: handle deactivated user display name in version history

### DIFF
--- a/web/core/components/core/description-versions/dropdown-item.tsx
+++ b/web/core/components/core/description-versions/dropdown-item.tsx
@@ -31,7 +31,7 @@ export const DescriptionVersionsDropdownItem: React.FC<Props> = observer((props)
         />
       </span>
       <p className="text-xs text-custom-text-200 flex items-center gap-1.5">
-        <span className="font-medium">{versionCreator?.display_name}</span>
+        <span className="font-medium">{versionCreator?.display_name ?? t("common.deactivated_user")}</span>
         <span>{calculateTimeAgo(version.last_saved_at)}</span>
       </p>
     </CustomMenu.MenuItem>

--- a/web/core/components/core/description-versions/dropdown.tsx
+++ b/web/core/components/core/description-versions/dropdown.tsx
@@ -40,7 +40,8 @@ export const DescriptionVersionsDropdown: React.FC<Props> = observer((props) => 
           </span>
           <p className="text-xs">
             {t("description_versions.last_edited_by")}{" "}
-            <span className="font-medium">{lastUpdatedByUserDisplayName}</span> {calculateTimeAgo(lastUpdatedAt)}
+            <span className="font-medium">{lastUpdatedByUserDisplayName ?? t("common.deactivated_user")}</span>{" "}
+            {calculateTimeAgo(lastUpdatedAt)}
           </p>
         </div>
       }

--- a/web/core/components/pages/version/sidebar-list-item.tsx
+++ b/web/core/components/pages/version/sidebar-list-item.tsx
@@ -1,8 +1,8 @@
 import { observer } from "mobx-react";
 import Link from "next/link";
-// plane types
+// plane imports
+import { useTranslation } from "@plane/i18n";
 import { TPageVersion } from "@plane/types";
-// plane ui
 import { Avatar } from "@plane/ui";
 // helpers
 import { cn } from "@/helpers/common.helper";
@@ -23,6 +23,8 @@ export const PlaneVersionsSidebarListItem: React.FC<Props> = observer((props) =>
   const { getUserDetails } = useMember();
   // derived values
   const ownerDetails = getUserDetails(version.owned_by);
+  // translation
+  const { t } = useTranslation();
 
   return (
     <Link
@@ -42,7 +44,7 @@ export const PlaneVersionsSidebarListItem: React.FC<Props> = observer((props) =>
           size="sm"
           className="flex-shrink-0"
         />
-        <span className="text-custom-text-300">{ownerDetails?.display_name}</span>
+        <span className="text-custom-text-300">{ownerDetails?.display_name ?? t("common.deactivated_user")}</span>
       </p>
     </Link>
   );


### PR DESCRIPTION
### Description

This PR fixes version history user display name when the version was created by a deactivated user.

Now, the text `Deactivated user` is rendered instead of the current implementation of an empty space.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a localized fallback text for user display names in version history and dropdowns, ensuring "deactivated user" is shown when the creator or owner is missing or deactivated.
- **Bug Fixes**
  - Improved consistency in displaying user information by preventing empty or missing names in relevant UI components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->