### PR TITLE
[WIKI-419] chore: new asset duplicate endpoint added

### DIFF
--- a/apiserver/plane/app/urls/asset.py
+++ b/apiserver/plane/app/urls/asset.py
@@ -13,6 +13,7 @@ from plane.app.views import (
     ProjectAssetEndpoint,
     ProjectBulkAssetEndpoint,
     AssetCheckEndpoint,
+    DuplicateAssetEndpoint,
 )
 
 
@@ -88,5 +89,10 @@ urlpatterns = [
         "assets/v2/workspaces/<str:slug>/check/<uuid:asset_id>/",
         AssetCheckEndpoint.as_view(),
         name="asset-check",
+    ),
+    path(
+        "assets/v2/workspaces/<slug:slug>/duplicate-assets/",
+        DuplicateAssetEndpoint.as_view(),
+        name="duplicate-assets",
     ),
 ]

--- a/apiserver/plane/app/views/__init__.py
+++ b/apiserver/plane/app/views/__init__.py
@@ -107,6 +107,7 @@ from .asset.v2 import (
     ProjectAssetEndpoint,
     ProjectBulkAssetEndpoint,
     AssetCheckEndpoint,
+    DuplicateAssetEndpoint,
 )
 from .issue.base import (
     IssueListEndpoint,

--- a/apiserver/plane/app/views/asset/v2.py
+++ b/apiserver/plane/app/views/asset/v2.py
@@ -718,3 +718,93 @@ class AssetCheckEndpoint(BaseAPIView):
             id=asset_id, workspace__slug=slug, deleted_at__isnull=True
         ).exists()
         return Response({"exists": asset}, status=status.HTTP_200_OK)
+
+
+class DuplicateAssetEndpoint(BaseAPIView):
+    def get_entity_id_field(self, entity_type, entity_id):
+        # Workspace Logo
+        if entity_type == FileAsset.EntityTypeContext.WORKSPACE_LOGO:
+            return {"workspace_id": entity_id}
+
+        # Project Cover
+        if entity_type == FileAsset.EntityTypeContext.PROJECT_COVER:
+            return {"project_id": entity_id}
+
+        # User Avatar and Cover
+        if entity_type in [
+            FileAsset.EntityTypeContext.USER_AVATAR,
+            FileAsset.EntityTypeContext.USER_COVER,
+        ]:
+            return {"user_id": entity_id}
+
+        # Issue Attachment and Description
+        if entity_type in [
+            FileAsset.EntityTypeContext.ISSUE_ATTACHMENT,
+            FileAsset.EntityTypeContext.ISSUE_DESCRIPTION,
+        ]:
+            return {"issue_id": entity_id}
+
+        # Page Description
+        if entity_type == FileAsset.EntityTypeContext.PAGE_DESCRIPTION:
+            return {"page_id": entity_id}
+
+        # Comment Description
+        if entity_type == FileAsset.EntityTypeContext.COMMENT_DESCRIPTION:
+            return {"comment_id": entity_id}
+
+        return {}
+
+    @allow_permission([ROLE.ADMIN, ROLE.MEMBER], level="WORKSPACE")
+    def post(self, request, slug):
+        project_id = request.data.get("project_id", None)
+        asset_ids = request.data.get("asset_ids", None)
+        entity_id = request.data.get("entity_id", None)
+        entity_type = request.data.get("entity_type", None)
+
+        if not asset_ids:
+            return Response(
+                {"error": "asset_ids is required"}, status=status.HTTP_400_BAD_REQUEST
+            )
+
+        workspace = Workspace.objects.get(slug=slug)
+        if project_id:
+            # check if project exists in the workspace
+            if not Project.objects.filter(id=project_id, workspace=workspace).exists():
+                return Response(
+                    {"error": "Project not found"}, status=status.HTTP_404_NOT_FOUND
+                )
+        duplicated_assets = {}
+
+        storage = S3Storage()
+        original_assets = FileAsset.objects.filter(
+            workspace=workspace, id__in=asset_ids
+        )
+        for original_asset in original_assets:
+            destination_key = f"{workspace.id}/{uuid.uuid4().hex}-{original_asset.attributes.get('name')}"
+            duplicated_asset = FileAsset.objects.create(
+                attributes={
+                    "name": original_asset.attributes.get("name"),
+                    "type": original_asset.attributes.get("type"),
+                    "size": original_asset.attributes.get("size"),
+                },
+                asset=destination_key,
+                size=original_asset.size,
+                workspace=workspace,
+                created_by_id=request.user.id,
+                entity_type=entity_type,
+                project_id=project_id if project_id else None,
+                storage_metadata=original_asset.storage_metadata,
+                **self.get_entity_id_field(
+                    entity_type=entity_type, entity_id=entity_id
+                ),
+            )
+            storage.copy_object(original_asset.asset, destination_key)
+            duplicated_assets[str(original_asset.id)] = str(duplicated_asset.id)
+
+        if duplicated_assets:
+            # Update the is_uploaded field for all newly created assets
+            FileAsset.objects.filter(id__in=duplicated_assets.values()).update(
+                is_uploaded=True
+            )
+
+        return Response(duplicated_assets, status=status.HTTP_200_OK)

--- a/web/core/services/file.service.ts
+++ b/web/core/services/file.service.ts
@@ -1,6 +1,7 @@
 import { AxiosRequestConfig } from "axios";
-// plane types
+// plane imports
 import { TFileEntityInfo, TFileSignedURLResponse } from "@plane/types";
+import { EFileAssetType } from "@plane/types/src/enums";
 // helpers
 import { API_BASE_URL } from "@/helpers/common.helper";
 import { generateFileUploadPayload, getAssetIdFromUrl, getFileMetaDataForUpload } from "@/helpers/file.helper";
@@ -252,6 +253,22 @@ export class FileService extends APIService {
   async restoreOldEditorAsset(workspaceId: string, src: string): Promise<void> {
     const assetKey = getAssetIdFromUrl(src);
     return this.post(`/api/workspaces/file-assets/${workspaceId}/${assetKey}/restore/`)
+      .then((response) => response?.data)
+      .catch((error) => {
+        throw error?.response?.data;
+      });
+  }
+
+  async duplicateAssets(
+    workspaceSlug: string,
+    data: {
+      entity_id: string;
+      entity_type: EFileAssetType;
+      project_id?: string;
+      asset_ids: string[];
+    }
+  ): Promise<Record<string, string>> {
+    return this.post(`/api/assets/v2/workspaces/${workspaceSlug}/duplicate-assets/`, data)
       .then((response) => response?.data)
       .catch((error) => {
         throw error?.response?.data;


### PR DESCRIPTION
### Description

This PR introduces a new endpoint to duplicate assets and attach them to an entiyt without the need to re-upload them.

### Type of Change

- [x] Improvement (change that would cause existing functionality to not work as expected)