### PR TITLE
[WEB-4272] fix: remove duplicate CommandPalette instances from settings layouts to prevent modal conflicts

### DIFF
--- a/web/app/(all)/[workspaceSlug]/(settings)/settings/(workspace)/layout.tsx
+++ b/web/app/(all)/[workspaceSlug]/(settings)/settings/(workspace)/layout.tsx
@@ -7,7 +7,6 @@ import { usePathname } from "next/navigation";
 import { EUserWorkspaceRoles, WORKSPACE_SETTINGS_ACCESS } from "@plane/constants";
 // components
 import { NotAuthorizedView } from "@/components/auth-screens";
-import { CommandPalette } from "@/components/command-palette";
 import { SettingsMobileNav } from "@/components/settings";
 import { getWorkspaceActivePath, pathnameToAccessKey } from "@/components/settings/helper";
 // hooks
@@ -36,7 +35,6 @@ const WorkspaceSettingLayout: FC<IWorkspaceSettingLayout> = observer((props) => 
 
   return (
     <>
-      <CommandPalette />
       <SettingsMobileNav
         hamburgerContent={WorkspaceSettingsSidebar}
         activePath={getWorkspaceActivePath(pathname) || ""}


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Removed the Command Palette from the workspace settings layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->