### PR TITLE
[WEB-4274] fix: metadata base url warning

### DIFF
--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -15,6 +15,7 @@ import { AppProvider } from "./provider";
 export const metadata: Metadata = {
   title: "Plane | Simple, extensible, open-source project management tool.",
   description: SITE_DESCRIPTION,
+  metadataBase: new URL("https://app.plane.so"),
   openGraph: {
     title: "Plane | Simple, extensible, open-source project management tool.",
     description: "Open-source project management tool to manage work items, cycles, and product roadmaps easily",


### PR DESCRIPTION
### Description
This PR adds the `metadataBase` property to the Next.js metadata configuration to properly resolve absolute URLs for social media card images.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

### References
[[WEB-4274]](https://app.plane.so/plane/browse/WEB-4274/)