### PR TITLE
[WEB-4196]fix: sub work item copy link message

### DIFF
--- a/web/core/components/issues/issue-detail-widgets/sub-issues/helper.ts
+++ b/web/core/components/issues/issue-detail-widgets/sub-issues/helper.ts
@@ -46,10 +46,7 @@ export const useSubIssueOperations = (issueServiceType: TIssueServiceType): TSub
             type: TOAST_TYPE.SUCCESS,
             title: t("common.link_copied"),
             message: t("entity.link_copied_to_clipboard", {
-              entity:
-                issueServiceType === EIssueServiceType.ISSUES
-                  ? t("issue.label", { count: 1 })
-                  : t("epic.label", { count: 1 }),
+              entity: t("epic.label", { count: 1 }),
             }),
           });
         });


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
This PR fixes the incorrect alert message when the work item link is copied.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the toast message shown after copying a link to always display the localized "epic" label for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->