### PR TITLE
[WEB-4339] fix: projects dropdown shows all projects

### DIFF
--- a/web/app/(all)/[workspaceSlug]/(projects)/analytics/header.tsx
+++ b/web/app/(all)/[workspaceSlug]/(projects)/analytics/header.tsx
@@ -1,38 +1,15 @@
 "use client";
 
-import { useEffect } from "react";
 import { observer } from "mobx-react";
-import { useSearchParams } from "next/navigation";
-import { BarChart2, PanelRight } from "lucide-react";
+import { BarChart2 } from "lucide-react";
 // plane imports
 import { useTranslation } from "@plane/i18n";
 import { Breadcrumbs, Header } from "@plane/ui";
-import { cn } from "@plane/utils";
 // components
 import { BreadcrumbLink } from "@/components/common/breadcrumb-link";
-// hooks
-import { useAppTheme } from "@/hooks/store";
 
 export const WorkspaceAnalyticsHeader = observer(() => {
   const { t } = useTranslation();
-  // store hooks
-  const { workspaceAnalyticsSidebarCollapsed, toggleWorkspaceAnalyticsSidebar } = useAppTheme();
-
-  useEffect(() => {
-    const handleToggleWorkspaceAnalyticsSidebar = () => {
-      if (window && window.innerWidth < 768) {
-        toggleWorkspaceAnalyticsSidebar(true);
-      }
-      if (window && workspaceAnalyticsSidebarCollapsed && window.innerWidth >= 768) {
-        toggleWorkspaceAnalyticsSidebar(false);
-      }
-    };
-
-    window.addEventListener("resize", handleToggleWorkspaceAnalyticsSidebar);
-    handleToggleWorkspaceAnalyticsSidebar();
-    return () => window.removeEventListener("resize", handleToggleWorkspaceAnalyticsSidebar);
-  }, [toggleWorkspaceAnalyticsSidebar, workspaceAnalyticsSidebarCollapsed]);
-
   return (
     <Header>
       <Header.LeftItem>

--- a/web/app/(all)/[workspaceSlug]/(projects)/analytics/header.tsx
+++ b/web/app/(all)/[workspaceSlug]/(projects)/analytics/header.tsx
@@ -15,8 +15,6 @@ import { useAppTheme } from "@/hooks/store";
 
 export const WorkspaceAnalyticsHeader = observer(() => {
   const { t } = useTranslation();
-  const searchParams = useSearchParams();
-  const analytics_tab = searchParams.get("analytics_tab");
   // store hooks
   const { workspaceAnalyticsSidebarCollapsed, toggleWorkspaceAnalyticsSidebar } = useAppTheme();
 
@@ -49,23 +47,6 @@ export const WorkspaceAnalyticsHeader = observer(() => {
             }
           />
         </Breadcrumbs>
-        {analytics_tab === "custom" ? (
-          <button
-            className="block md:hidden"
-            onClick={() => {
-              toggleWorkspaceAnalyticsSidebar();
-            }}
-          >
-            <PanelRight
-              className={cn(
-                "block h-4 w-4 md:hidden",
-                !workspaceAnalyticsSidebarCollapsed ? "text-custom-primary-100" : "text-custom-text-200"
-              )}
-            />
-          </button>
-        ) : (
-          <></>
-        )}
       </Header.LeftItem>
     </Header>
   );

--- a/web/core/components/analytics/analytics-filter-actions.tsx
+++ b/web/core/components/analytics/analytics-filter-actions.tsx
@@ -9,7 +9,7 @@ import { ProjectSelect } from "./select/project";
 
 const AnalyticsFilterActions = observer(() => {
   const { selectedProjects, selectedDuration, updateSelectedProjects, updateSelectedDuration } = useAnalytics();
-  const { workspaceProjectIds } = useProject();
+  const { joinedProjectIds } = useProject();
   return (
     <div className="flex items-center justify-end gap-2">
       <ProjectSelect
@@ -17,7 +17,7 @@ const AnalyticsFilterActions = observer(() => {
         onChange={(val) => {
           updateSelectedProjects(val ?? []);
         }}
-        projectIds={workspaceProjectIds}
+        projectIds={joinedProjectIds}
       />
       {/* <DurationDropdown
         buttonVariant="border-with-text"


### PR DESCRIPTION
### Description
- projects dropdown will only show joined project
- removed unnecessary things from analytics headers

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated project selection in analytics filters to include joined projects instead of only workspace-specific projects.

- **Refactor**
	- Removed the sidebar toggle button that was previously shown based on the "analytics_tab" URL parameter in the analytics header.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->