### PR TITLE
[WEB-4357] fix: remove trailing slash from asset url

### DIFF
--- a/packages/utils/src/file.ts
+++ b/packages/utils/src/file.ts
@@ -44,6 +44,8 @@ export const getFileMetaDataForUpload = (file: File): TFileMetaDataLite => ({
  * @returns {string} assetId
  */
 export const getAssetIdFromUrl = (src: string): string => {
+  // remove the last char if it is a slash
+  if (src.charAt(src.length - 1) === "/") src = src.slice(0, -1);
   const sourcePaths = src.split("/");
   const assetUrl = sourcePaths[sourcePaths.length - 1];
   return assetUrl;


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved asset ID extraction from URLs by handling cases where a trailing slash is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->