### PR TITLE
[WEB-4359] fix: application crash when creating work item via quick add

### DIFF
--- a/packages/utils/src/work-item/base.ts
+++ b/packages/utils/src/work-item/base.ts
@@ -146,6 +146,11 @@ export const createIssuePayload: (projectId: string, formData: Partial<TIssue>) 
     id: uuidv4(),
     project_id: projectId,
     priority: "none",
+    label_ids: [],
+    assignee_ids: [],
+    sub_issues_count: 0,
+    attachment_count: 0,
+    link_count: 0,
     // tempId is used for optimistic updates. It is not a part of the API response.
     tempId: uuidv4(),
     // to be overridden by the form data

--- a/web/core/components/issues/issue-layouts/properties/all-properties.tsx
+++ b/web/core/components/issues/issue-layouts/properties/all-properties.tsx
@@ -503,7 +503,7 @@ export const IssueProperties: React.FC<IIssueProperties> = observer((props) => {
       <WithDisplayPropertiesHOC displayProperties={displayProperties} displayPropertyKey="labels">
         <IssuePropertyLabels
           projectId={issue?.project_id || null}
-          value={issue?.label_ids || null}
+          value={issue?.label_ids || []}
           defaultOptions={defaultLabelOptions}
           onChange={handleLabel}
           disabled={isReadOnly}


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Issue details now include additional fields for labels, assignees, sub-issues count, attachment count, and link count.

- **Bug Fixes**
  - Improved reliability when displaying issue labels, ensuring the label list is always shown as an array.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->