### PR TITLE
[WIKI-421] fix: Toolbar not reflecting strikethrough state

### DIFF
--- a/packages/editor/src/core/components/menus/bubble-menu/root.tsx
+++ b/packages/editor/src/core/components/menus/bubble-menu/root.tsx
@@ -10,6 +10,7 @@ import {
   BubbleMenuLinkSelector,
   BubbleMenuNodeSelector,
   CodeItem,
+  EditorMenuItem,
   ItalicItem,
   StrikeThroughItem,
   TextAlignItem,
@@ -23,6 +24,7 @@ import { CORE_EXTENSIONS } from "@/constants/extension";
 import { isCellSelection } from "@/extensions/table/table/utilities/is-cell-selection";
 // local components
 import { TextAlignmentSelector } from "./alignment-selector";
+import { TEditorCommands } from "@/types";
 
 type EditorBubbleMenuProps = Omit<BubbleMenuProps, "children">;
 
@@ -37,13 +39,13 @@ export interface EditorStateType {
   center: boolean;
   color: { key: string; label: string; textColor: string; backgroundColor: string } | undefined;
   backgroundColor:
-    | {
-        key: string;
-        label: string;
-        textColor: string;
-        backgroundColor: string;
-      }
-    | undefined;
+  | {
+    key: string;
+    label: string;
+    textColor: string;
+    backgroundColor: string;
+  }
+  | undefined;
 }
 
 export const EditorBubbleMenu: FC<EditorBubbleMenuProps> = (props: { editor: Editor }) => {
@@ -59,7 +61,9 @@ export const EditorBubbleMenu: FC<EditorBubbleMenuProps> = (props: { editor: Edi
     italic: ItalicItem(props.editor),
     underline: UnderLineItem(props.editor),
     strikethrough: StrikeThroughItem(props.editor),
-    textAlign: TextAlignItem(props.editor),
+    "text-align": TextAlignItem(props.editor),
+  } satisfies {
+    [K in TEditorCommands]?: EditorMenuItem<K>;
   };
 
   const editorState: EditorStateType = useEditorState({
@@ -70,9 +74,9 @@ export const EditorBubbleMenu: FC<EditorBubbleMenuProps> = (props: { editor: Edi
       italic: formattingItems.italic.isActive(),
       underline: formattingItems.underline.isActive(),
       strikethrough: formattingItems.strikethrough.isActive(),
-      left: formattingItems.textAlign.isActive({ alignment: "left" }),
-      right: formattingItems.textAlign.isActive({ alignment: "right" }),
-      center: formattingItems.textAlign.isActive({ alignment: "center" }),
+      left: formattingItems["text-align"].isActive({ alignment: "left" }),
+      right: formattingItems["text-align"].isActive({ alignment: "right" }),
+      center: formattingItems["text-align"].isActive({ alignment: "center" }),
       color: COLORS_LIST.find((c) => TextColorItem(editor).isActive({ color: c.key })),
       backgroundColor: COLORS_LIST.find((c) => BackgroundColorItem(editor).isActive({ color: c.key })),
     }),

--- a/packages/editor/src/core/components/menus/bubble-menu/root.tsx
+++ b/packages/editor/src/core/components/menus/bubble-menu/root.tsx
@@ -31,7 +31,7 @@ export interface EditorStateType {
   bold: boolean;
   italic: boolean;
   underline: boolean;
-  strike: boolean;
+  strikethrough: boolean;
   left: boolean;
   right: boolean;
   center: boolean;
@@ -58,7 +58,7 @@ export const EditorBubbleMenu: FC<EditorBubbleMenuProps> = (props: { editor: Edi
     bold: BoldItem(props.editor),
     italic: ItalicItem(props.editor),
     underline: UnderLineItem(props.editor),
-    strike: StrikeThroughItem(props.editor),
+    strikethrough: StrikeThroughItem(props.editor),
     textAlign: TextAlignItem(props.editor),
   };
 
@@ -69,7 +69,7 @@ export const EditorBubbleMenu: FC<EditorBubbleMenuProps> = (props: { editor: Edi
       bold: formattingItems.bold.isActive(),
       italic: formattingItems.italic.isActive(),
       underline: formattingItems.underline.isActive(),
-      strike: formattingItems.strike.isActive(),
+      strikethrough: formattingItems.strikethrough.isActive(),
       left: formattingItems.textAlign.isActive({ alignment: "left" }),
       right: formattingItems.textAlign.isActive({ alignment: "right" }),
       center: formattingItems.textAlign.isActive({ alignment: "center" }),
@@ -80,7 +80,7 @@ export const EditorBubbleMenu: FC<EditorBubbleMenuProps> = (props: { editor: Edi
 
   const basicFormattingOptions = editorState.code
     ? [formattingItems.code]
-    : [formattingItems.bold, formattingItems.italic, formattingItems.underline, formattingItems.strike];
+    : [formattingItems.bold, formattingItems.italic, formattingItems.underline, formattingItems.strikethrough];
 
   const bubbleMenuProps: EditorBubbleMenuProps = {
     ...props,


### PR DESCRIPTION
### Description
This pull request updates the `EditorBubbleMenu` component in `packages/editor/src/core/components/menus/bubble-menu/root.tsx` to rename the `strike` property to `strikethrough` for better clarity and consistency. The changes ensure that all references to the property are updated across the component.

### Property renaming for clarity:

* Renamed the `strike` property to `strikethrough` in the `EditorStateType` interface to improve naming consistency.
* Updated the `EditorBubbleMenu` component to use `strikethrough` instead of `strike` in the `formattingItems` object for menu item creation.
* Modified the active state check for the `strikethrough` formatting option in the `EditorBubbleMenu`.
* Adjusted the `basicFormattingOptions` array to include `strikethrough` instead of `strike` when the `code` state is inactive.

### Screenshots and Media (if applicable)

https://github.com/user-attachments/assets/68a7b9c2-b520-40b6-8162-30723b05c1ce



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated the naming of the strikethrough formatting option for improved clarity. No changes to functionality or user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->