### PR TITLE
[WIKI-74] fix: peek overview closing on escape key

### DIFF
--- a/packages/editor/src/core/extensions/custom-image/components/toolbar/full-screen.tsx
+++ b/packages/editor/src/core/extensions/custom-image/components/toolbar/full-screen.tsx
@@ -189,7 +189,7 @@ export const ImageFullScreenAction: React.FC<Props> = (props) => {
     <>
       <div
         className={cn("fixed inset-0 size-full z-20 bg-black/90 opacity-0 pointer-events-none transition-opacity", {
-          "opacity-100 pointer-events-auto": isFullScreenEnabled,
+          "opacity-100 pointer-events-auto editor-image-full-screen-modal": isFullScreenEnabled,
           "cursor-default": !isDragging,
           "cursor-grabbing": isDragging,
         })}

--- a/web/core/components/issues/peek-overview/view.tsx
+++ b/web/core/components/issues/peek-overview/view.tsx
@@ -91,8 +91,9 @@ export const IssueView: FC<IIssueView> = observer((props) => {
 
   const handleKeyDown = () => {
     const slashCommandDropdownElement = document.querySelector("#slash-command");
+    const editorImageFullScreenModalElement = document.querySelector(".editor-image-full-screen-modal");
     const dropdownElement = document.activeElement?.tagName === "INPUT";
-    if (!isAnyModalOpen && !slashCommandDropdownElement && !dropdownElement) {
+    if (!isAnyModalOpen && !slashCommandDropdownElement && !dropdownElement && !editorImageFullScreenModalElement) {
       removeRoutePeekId();
       const issueElement = document.getElementById(`issue-${issueId}`);
       if (issueElement) issueElement?.focus();


### PR DESCRIPTION
### Description

This PR fixes the bug where work item peek overview closes on pressing `Esc` key while the editor image full screen modal is also open.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved fullscreen image viewing in the editor with a dedicated modal style.
- **Bug Fixes**
  - Enhanced keyboard navigation to prevent accidental closing or focus changes when the image fullscreen modal is active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->