### PR TITLE
fix: power k page search redirection

### DIFF
--- a/web/ce/components/command-palette/helpers.tsx
+++ b/web/ce/components/command-palette/helpers.tsx
@@ -93,7 +93,9 @@ export const commandGroups: TCommandGroups = {
     path: (page: IWorkspacePageSearchResult, projectId: string | undefined) => {
       let redirectProjectId = page?.project_ids?.[0];
       if (!!projectId && page?.project_ids?.includes(projectId)) redirectProjectId = projectId;
-      return `/${page?.workspace__slug}/projects/${redirectProjectId}/pages/${page?.id}`;
+      return redirectProjectId
+        ? `/${page?.workspace__slug}/projects/${redirectProjectId}/pages/${page?.id}`
+        : `/${page?.workspace__slug}/pages/${page?.id}`;
     },
     title: "Pages",
   },


### PR DESCRIPTION
### Description

Redirection is broken in Power K modal for pages without a project id.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)