### PR TITLE
[WEB-4371] feat: bar chart component with lollipop shape variant

### DIFF
--- a/packages/propel/src/charts/bar-chart/bar.tsx
+++ b/packages/propel/src/charts/bar-chart/bar.tsx
@@ -141,15 +141,7 @@ const CustomBarLollipop = React.memo((props: TBarProps) => {
         stroke="none"
       />
       {showPercentage && (
-        <text
-          x={x + width / 2}
-          y={y + DEFAULT_LOLLIPOP_CIRCLE_RADIUS}
-          textAnchor="middle"
-          dominantBaseline="middle"
-          className={cn("text-xs font-medium fill-white", textClassName)}
-        >
-          {currentBarPercentage}%
-        </text>
+        <PercentageText x={x + width / 2} y={y} percentage={currentBarPercentage} className={textClassName} />
       )}
     </g>
   );

--- a/packages/propel/src/charts/bar-chart/bar.tsx
+++ b/packages/propel/src/charts/bar-chart/bar.tsx
@@ -122,7 +122,6 @@ const CustomBarLollipop = React.memo((props: TBarProps) => {
 
   const currentBarPercentage = calculatePercentage(payload, stackKeys, dataKey);
 
-  console.log(y, "y", x, "x", width, "width", height, "height");
   return (
     <g>
       <line

--- a/packages/propel/src/charts/bar-chart/bar.tsx
+++ b/packages/propel/src/charts/bar-chart/bar.tsx
@@ -140,7 +140,6 @@ const CustomBarLollipop = React.memo((props: TBarProps) => {
         r={DEFAULT_LOLLIPOP_CIRCLE_RADIUS}
         fill={typeof fill === "function" ? fill(payload) : fill}
         stroke="none"
-        alignmentBaseline="middle"
       />
       {showPercentage && (
         <text

--- a/packages/propel/src/charts/bar-chart/bar.tsx
+++ b/packages/propel/src/charts/bar-chart/bar.tsx
@@ -5,11 +5,11 @@ import { TBarChartShapeVariant, TBarItem, TChartData } from "@plane/types";
 import { cn } from "@plane/utils";
 
 // Constants
-const MIN_BAR_HEIGHT_FOR_INTERNAL_TEXT = 14;
-const BAR_TOP_BORDER_RADIUS = 4;
-const BAR_BOTTOM_BORDER_RADIUS = 4;
-const DEFAULT_LOLLIPOP_LINE_WIDTH = 2;
-const DEFAULT_LOLLIPOP_CIRCLE_RADIUS = 8;
+const MIN_BAR_HEIGHT_FOR_INTERNAL_TEXT = 14; // Minimum height required to show text inside bar
+const BAR_TOP_BORDER_RADIUS = 4; // Border radius for the top of bars
+const BAR_BOTTOM_BORDER_RADIUS = 4; // Border radius for the bottom of bars
+const DEFAULT_LOLLIPOP_LINE_WIDTH = 2; // Width of lollipop stick
+const DEFAULT_LOLLIPOP_CIRCLE_RADIUS = 8; // Radius of lollipop circle
 
 // Types
 interface TShapeProps {
@@ -32,7 +32,7 @@ interface TBarProps extends TShapeProps {
   dotted?: boolean;
 }
 
-// Utilities
+// Helper Functions
 const calculatePercentage = <K extends string, T extends string>(
   data: TChartData<K, T>,
   stackKeys: T[],
@@ -149,7 +149,13 @@ const CustomBarLollipop = React.memo((props: TBarProps) => {
   );
 });
 
-// Shape Variants Factory
+// Shape Variants
+/**
+ * Factory function to create shape variants with consistent props
+ * @param Component - The base component to render
+ * @param factoryProps - Additional props to pass to the component
+ * @returns A function that creates the shape with proper props
+ */
 const createShapeVariant =
   (Component: React.ComponentType<TBarProps>, factoryProps?: Partial<TBarProps>) =>
   (shapeProps: TShapeProps, bar: TBarItem<string>, stackKeys: string[]): JSX.Element => {
@@ -170,14 +176,13 @@ const createShapeVariant =
     );
   };
 
-// Shape Variants
 export const barShapeVariants: Record<
   TBarChartShapeVariant,
   (props: TShapeProps, bar: TBarItem<string>, stackKeys: string[]) => JSX.Element
 > = {
-  bar: createShapeVariant(CustomBar),
-  lollipop: createShapeVariant(CustomBarLollipop),
-  "lollipop-dotted": createShapeVariant(CustomBarLollipop, { dotted: true }),
+  bar: createShapeVariant(CustomBar), // Standard bar with rounded corners
+  lollipop: createShapeVariant(CustomBarLollipop), // Line with circle at top
+  "lollipop-dotted": createShapeVariant(CustomBarLollipop, { dotted: true }), // Dotted line lollipop variant
 };
 
 // Display names

--- a/packages/propel/src/charts/bar-chart/bar.tsx
+++ b/packages/propel/src/charts/bar-chart/bar.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React from "react";
 // plane imports
-import { TBarItem, TChartData } from "@plane/types";
+import { TBarChartShapeVariant, TBarItem, TChartData } from "@plane/types";
 import { cn } from "@plane/utils";
 
 // Constants
@@ -29,6 +29,7 @@ interface TBarProps extends TShapeProps {
   showPercentage?: boolean;
   showTopBorderRadius?: boolean;
   showBottomBorderRadius?: boolean;
+  dotted?: boolean;
 }
 
 // Utilities
@@ -118,7 +119,7 @@ const CustomBar = React.memo((props: TBarProps) => {
 });
 
 const CustomBarLollipop = React.memo((props: TBarProps) => {
-  const { fill, x, y, width, height, dataKey, stackKeys, payload, textClassName, showPercentage } = props;
+  const { fill, x, y, width, height, dataKey, stackKeys, payload, textClassName, showPercentage, dotted } = props;
 
   const currentBarPercentage = calculatePercentage(payload, stackKeys, dataKey);
 
@@ -132,6 +133,7 @@ const CustomBarLollipop = React.memo((props: TBarProps) => {
         stroke={typeof fill === "function" ? fill(payload) : fill}
         strokeWidth={DEFAULT_LOLLIPOP_LINE_WIDTH}
         strokeLinecap="round"
+        strokeDasharray={dotted ? "4 4" : "0"}
       />
       <circle
         cx={x + width / 2}
@@ -149,8 +151,8 @@ const CustomBarLollipop = React.memo((props: TBarProps) => {
 
 // Shape Variants Factory
 const createShapeVariant =
-  (Component: React.ComponentType<TBarProps>) =>
-  (shapeProps: TShapeProps, bar: TBarItem<string>, stackKeys: string[]) => {
+  (Component: React.ComponentType<TBarProps>, factoryProps?: Partial<TBarProps>) =>
+  (shapeProps: TShapeProps, bar: TBarItem<string>, stackKeys: string[]): JSX.Element => {
     const showTopBorderRadius = bar.showTopBorderRadius?.(shapeProps.dataKey, shapeProps.payload);
     const showBottomBorderRadius = bar.showBottomBorderRadius?.(shapeProps.dataKey, shapeProps.payload);
 
@@ -163,14 +165,19 @@ const createShapeVariant =
         showPercentage={bar.showPercentage}
         showTopBorderRadius={!!showTopBorderRadius}
         showBottomBorderRadius={!!showBottomBorderRadius}
+        {...factoryProps}
       />
     );
   };
 
 // Shape Variants
-export const barShapeVariants = {
+export const barShapeVariants: Record<
+  TBarChartShapeVariant,
+  (props: TShapeProps, bar: TBarItem<string>, stackKeys: string[]) => JSX.Element
+> = {
   bar: createShapeVariant(CustomBar),
   lollipop: createShapeVariant(CustomBarLollipop),
+  "lollipop-dotted": createShapeVariant(CustomBarLollipop, { dotted: true }),
 };
 
 // Display names

--- a/packages/propel/src/charts/bar-chart/root.tsx
+++ b/packages/propel/src/charts/bar-chart/root.tsx
@@ -19,7 +19,7 @@ import { TBarChartProps } from "@plane/types";
 import { getLegendProps } from "../components/legend";
 import { CustomXAxisTick, CustomYAxisTick } from "../components/tick";
 import { CustomTooltip } from "../components/tooltip";
-import { CustomBar } from "./bar";
+import { barShapeVariants } from "./bar";
 
 export const BarChart = React.memo(<K extends string, T extends string>(props: TBarChartProps<K, T>) => {
   const {
@@ -36,6 +36,7 @@ export const BarChart = React.memo(<K extends string, T extends string>(props: T
       y: 10,
     },
     showTooltip = true,
+    customTooltipContent,
   } = props;
   // states
   const [activeBar, setActiveBar] = useState<string | null>(null);
@@ -66,20 +67,8 @@ export const BarChart = React.memo(<K extends string, T extends string>(props: T
           stackId={bar.stackId}
           opacity={!!activeLegend && activeLegend !== bar.key ? 0.1 : 1}
           shape={(shapeProps: any) => {
-            const showTopBorderRadius = bar.showTopBorderRadius?.(shapeProps.dataKey, shapeProps.payload);
-            const showBottomBorderRadius = bar.showBottomBorderRadius?.(shapeProps.dataKey, shapeProps.payload);
-
-            return (
-              <CustomBar
-                {...shapeProps}
-                fill={typeof bar.fill === "function" ? bar.fill(shapeProps.payload) : bar.fill}
-                stackKeys={stackKeys}
-                textClassName={bar.textClassName}
-                showPercentage={bar.showPercentage}
-                showTopBorderRadius={!!showTopBorderRadius}
-                showBottomBorderRadius={!!showBottomBorderRadius}
-              />
-            );
+            const shapeVariant = barShapeVariants[bar.shapeVariant ?? "bar"];
+            return shapeVariant(shapeProps, bar, stackKeys);
           }}
           className="[&_path]:transition-opacity [&_path]:duration-200"
           onMouseEnter={() => setActiveBar(bar.key)}
@@ -150,17 +139,20 @@ export const BarChart = React.memo(<K extends string, T extends string>(props: T
               wrapperStyle={{
                 pointerEvents: "auto",
               }}
-              content={({ active, label, payload }) => (
-                <CustomTooltip
-                  active={active}
-                  label={label}
-                  payload={payload}
-                  activeKey={activeBar}
-                  itemKeys={stackKeys}
-                  itemLabels={stackLabels}
-                  itemDotColors={stackDotColors}
-                />
-              )}
+              content={({ active, label, payload }) => {
+                if (customTooltipContent) return customTooltipContent({ active, label, payload });
+                return (
+                  <CustomTooltip
+                    active={active}
+                    label={label}
+                    payload={payload}
+                    activeKey={activeBar}
+                    itemKeys={stackKeys}
+                    itemLabels={stackLabels}
+                    itemDotColors={stackDotColors}
+                  />
+                );
+              }}
             />
           )}
           {renderBars}

--- a/packages/types/src/charts/index.d.ts
+++ b/packages/types/src/charts/index.d.ts
@@ -53,7 +53,7 @@ type TChartProps<K extends string, T extends string> = {
 // Bar Chart
 // ============================================================
 
-export type TBarChartShapeVariant = "bar" | "lollipop";
+export type TBarChartShapeVariant = "bar" | "lollipop" | "lollipop-dotted";
 
 export type TBarItem<T extends string> = {
   key: T;

--- a/packages/types/src/charts/index.d.ts
+++ b/packages/types/src/charts/index.d.ts
@@ -53,6 +53,8 @@ type TChartProps<K extends string, T extends string> = {
 // Bar Chart
 // ============================================================
 
+export type TBarChartShapeVariant = "bar" | "lollipop";
+
 export type TBarItem<T extends string> = {
   key: T;
   label: string;
@@ -62,6 +64,7 @@ export type TBarItem<T extends string> = {
   stackId: string;
   showTopBorderRadius?: (barKey: string, payload: any) => boolean;
   showBottomBorderRadius?: (barKey: string, payload: any) => boolean;
+  shapeVariant?: TBarChartShapeVariant;
 };
 
 export type TBarChartProps<K extends string, T extends string> = TChartProps<K, T> & {


### PR DESCRIPTION
### Description
This PR extends the bar chart  component with lollipop shape variant 



<img width="1230" alt="Screenshot 2025-06-25 at 5 49 43 PM" src="https://github.com/user-attachments/assets/6cc67187-d0f1-44d7-a7c2-e320d54bddb5" />

![image](https://github.com/user-attachments/assets/afcc5e56-ef8e-4b8c-8805-e5fef109a986)


> this image only depicts how it will look like when we use the lollipop variant and not actually modifies anywhere we have used bar chart 


### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Improvement (change that would cause existing functionality to not work as expected)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for a new "lollipop-dotted" bar shape variant in bar charts.
  - Introduced the ability to customize tooltip content in bar charts.
- **Improvements**
  - Enhanced bar chart rendering flexibility with shape variants.
  - Improved percentage label display and bar styling consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->