### PR TITLE
[WEB-4435] bug: trigger event for work item comment

### DIFF
--- a/apps/server/plane/api/views/issue.py
+++ b/apps/server/plane/api/views/issue.py
@@ -857,6 +857,16 @@ class IssueCommentAPIEndpoint(BaseAPIView):
                 current_instance=None,
                 epoch=int(timezone.now().timestamp()),
             )
+            # Send the model activity
+            model_activity.delay(
+                model_name="issue_comment",
+                model_id=str(serializer.data["id"]),
+                requested_data=request.data,
+                current_instance=None,
+                actor_id=request.user.id,
+                slug=slug,
+                origin=base_host(request=request, is_app=True),
+            )
             return Response(serializer.data, status=status.HTTP_201_CREATED)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
@@ -903,6 +913,16 @@ class IssueCommentAPIEndpoint(BaseAPIView):
                 project_id=str(project_id),
                 current_instance=current_instance,
                 epoch=int(timezone.now().timestamp()),
+            )
+            # Send the model activity
+            model_activity.delay(
+                model_name="issue_comment",
+                model_id=str(pk),
+                requested_data=request.data,
+                current_instance=current_instance,
+                actor_id=request.user.id,
+                slug=slug,
+                origin=base_host(request=request, is_app=True),
             )
             return Response(serializer.data, status=status.HTTP_200_OK)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/apps/server/plane/app/views/issue/comment.py
+++ b/apps/server/plane/app/views/issue/comment.py
@@ -18,6 +18,7 @@ from plane.app.permissions import allow_permission, ROLE
 from plane.db.models import IssueComment, ProjectMember, CommentReaction, Project, Issue
 from plane.bgtasks.issue_activities_task import issue_activity
 from plane.utils.host import base_host
+from plane.bgtasks.webhook_task import model_activity
 
 
 class IssueCommentViewSet(BaseViewSet):
@@ -90,6 +91,16 @@ class IssueCommentViewSet(BaseViewSet):
                 notification=True,
                 origin=base_host(request=request, is_app=True),
             )
+            # Send the model activity
+            model_activity.delay(
+                model_name="issue_comment",
+                model_id=str(serializer.data["id"]),
+                requested_data=request.data,
+                current_instance=None,
+                actor_id=request.user.id,
+                slug=slug,
+                origin=base_host(request=request, is_app=True),
+            )
             return Response(serializer.data, status=status.HTTP_201_CREATED)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
@@ -122,6 +133,16 @@ class IssueCommentViewSet(BaseViewSet):
                 current_instance=current_instance,
                 epoch=int(timezone.now().timestamp()),
                 notification=True,
+                origin=base_host(request=request, is_app=True),
+            )
+            # Send the model activity
+            model_activity.delay(
+                model_name="issue_comment",
+                model_id=str(pk),
+                requested_data=request.data,
+                current_instance=current_instance,
+                actor_id=request.user.id,
+                slug=slug,
                 origin=base_host(request=request, is_app=True),
             )
             return Response(serializer.data, status=status.HTTP_200_OK)


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
this pull request fixes the issue where the webhook event was not being triggered when adding or updating work item comments.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved tracking of activity related to issue comments, both when creating and updating comments. This enhancement provides more comprehensive activity monitoring for users interacting with issue comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->