### PR TITLE
[WEB-4432]fix: webhooks translation

### DIFF
--- a/apps/web/core/components/web-hooks/form/secret-key.tsx
+++ b/apps/web/core/components/web-hooks/form/secret-key.tsx
@@ -96,12 +96,10 @@ export const WebhookSecretKey: FC<Props> = observer((props) => {
       {(data || webhookSecretKey) && (
         <div className="space-y-2">
           {webhookId && (
-            <div className="text-sm font-medium">
-              {t("workspace_settings.settings.webhooks.modal.secret_key.title")}
-            </div>
+            <div className="text-sm font-medium">{t("workspace_settings.settings.webhooks.secret_key.title")}</div>
           )}
           <div className="text-xs text-custom-text-400">
-            {t("workspace_settings.settings.webhooks.modal.secret_key.message")}
+            {t("workspace_settings.settings.webhooks.secret_key.message")}
           </div>
           <div className="flex flex-col md:flex-row md:items-center gap-4">
             <div className="flex flex-grow max-w-lg items-center justify-between self-stretch rounded border border-custom-border-200 px-2 h-8">


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
This update fixes the translation key mismatch for webhooks

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated translation keys for the secret key title and message in the webhooks form to improve consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->