### PR TITLE
refactor: string url path utility

### DIFF
--- a/packages/utils/src/string.ts
+++ b/packages/utils/src/string.ts
@@ -319,14 +319,15 @@ export const copyTextToClipboard = async (text: string): Promise<void> => {
   await navigator.clipboard.writeText(text);
 };
 
+
 /**
- * @description Joins URL path segments properly, removing duplicate slashes
+ * @description Joins URL path segments properly, removing duplicate slashes using URL encoding
  * @param {...string} segments - URL path segments to join
  * @returns {string} Properly joined URL path
  * @example
  * joinUrlPath("/workspace", "/projects") => "/workspace/projects"
  * joinUrlPath("/workspace", "projects") => "/workspace/projects"
- * joinUrlPath("workspace", "projects") => "workspace/projects"
+ * joinUrlPath("workspace", "projects") => "/workspace/projects"
  * joinUrlPath("/workspace/", "/projects/") => "/workspace/projects/"
  */
 export const joinUrlPath = (...segments: string[]): string => {
@@ -336,21 +337,38 @@ export const joinUrlPath = (...segments: string[]): string => {
   const validSegments = segments.filter((segment) => segment !== "");
   if (validSegments.length === 0) return "";
 
-  // Join segments and normalize slashes
-  const joined = validSegments
-    .map((segment, index) => {
-      // Remove leading slashes from all segments except the first
-      if (index > 0) {
-        segment = segment.replace(/^\/+/, "");
-      }
-      // Remove trailing slashes from all segments except the last
-      if (index < validSegments.length - 1) {
-        segment = segment.replace(/\/+$/, "");
-      }
-      return segment;
-    })
-    .join("/");
+  // Process segments to normalize slashes
+  const processedSegments = validSegments.map((segment, index) => {
+    let processed = segment;
 
-  // Clean up any duplicate slashes that might have been created
-  return joined.replace(/\/+/g, "/");
+    // Remove leading slashes from all segments except the first
+    if (index > 0) {
+      while (processed.startsWith("/")) {
+        processed = processed.substring(1);
+      }
+    }
+
+    // Remove trailing slashes from all segments except the last
+    if (index < validSegments.length - 1) {
+      while (processed.endsWith("/")) {
+        processed = processed.substring(0, processed.length - 1);
+      }
+    }
+
+    return processed;
+  });
+
+  // Join segments with single slash
+  const joined = processedSegments.join("/");
+
+  // Use URL constructor to normalize the path and handle double slashes
+  try {
+    // Create a dummy URL to leverage browser's URL normalization
+    const dummyUrl = new URL(`http://example.com/${joined}`);
+    return dummyUrl.pathname;
+  } catch {
+    // Fallback: manually handle double slashes by splitting and filtering
+    const pathParts = joined.split("/").filter((part) => part !== "");
+    return pathParts.length > 0 ? `/${pathParts.join("/")}` : "";
+  }
 };

--- a/web/core/components/settings/sidebar/nav-item.tsx
+++ b/web/core/components/settings/sidebar/nav-item.tsx
@@ -73,7 +73,7 @@ const SettingsSidebarNavItem = observer((props: TSettingsSidebarNavItemProps) =>
           <div className={buttonClass}>{titleElement}</div>
         ) : (
           <Link
-            href={joinUrlPath("/", workspaceSlug, setting.href)}
+            href={joinUrlPath(workspaceSlug, setting.href)}
             className={buttonClass}
             onClick={() => toggleSidebar(true)}
           >


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
This update refactors the `joinUrlPth` function to use string methods instead of regular expressions.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [x] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update