### PR TITLE
[WEB-4443] fix: remove scroll-behavior smooth causing Gantt chart continuous scroll

### DIFF
--- a/apps/admin/styles/globals.css
+++ b/apps/admin/styles/globals.css
@@ -332,7 +332,6 @@
   text-rendering: optimizeLegibility;
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
-  scroll-behavior: smooth;
 }
 
 body {

--- a/apps/space/styles/globals.css
+++ b/apps/space/styles/globals.css
@@ -367,7 +367,6 @@
   text-rendering: optimizeLegibility;
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
-  scroll-behavior: smooth;
 }
 
 body {

--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -497,7 +497,6 @@
   text-rendering: optimizeLegibility;
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
-  scroll-behavior: smooth;
 }
 
 body {


### PR DESCRIPTION
### Description
Global scroll-behavior: smooth CSS property interfered with programmatic scroll positioning during Gantt chart initialization, causing timing conflicts between smooth scroll animations and the chart's scroll event handlers.

Removed scroll-behavior: smooth from the global * selector in apps/web/styles/globals.css.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
