### PR TITLE
[WEB-4453] fix: enable revalidation on focus and stale data for current user fetch to handle 401 errors

### DIFF
--- a/apps/space/core/lib/instance-provider.tsx
+++ b/apps/space/core/lib/instance-provider.tsx
@@ -32,8 +32,8 @@ export const InstanceProvider = observer(({ children }: { children: ReactNode })
   });
   useSWR("CURRENT_USER", () => fetchCurrentUser(), {
     shouldRetryOnError: false,
-    revalidateOnFocus: false,
-    revalidateIfStale: false,
+    revalidateOnFocus: true,
+    revalidateIfStale: true,
   });
 
   if (!instance && !error)

--- a/apps/space/core/store/user.store.ts
+++ b/apps/space/core/store/user.store.ts
@@ -1,3 +1,4 @@
+import { AxiosError } from "axios";
 import set from "lodash/set";
 import { action, computed, makeObservable, observable, runInAction } from "mobx";
 // plane imports
@@ -112,6 +113,9 @@ export class UserStore implements IUserStore {
           status: "user-fetch-error",
           message: "Failed to fetch current user",
         };
+        if (error instanceof AxiosError && error.status === 401) {
+          this.data = undefined;
+        }
       });
       throw error;
     }

--- a/packages/services/src/user/user.service.ts
+++ b/packages/services/src/user/user.service.ts
@@ -26,7 +26,7 @@ export class UserService extends APIService {
     return this.get("/api/users/me/")
       .then((response) => response?.data)
       .catch((error) => {
-        throw error?.response;
+        throw error;
       });
   }
 


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
* fix: set revalidateOnFocus and revalidateIfStale to true in InstanceProvider
* fix: handle 401 error in UserStore by clearing user data
* fix: adjust error handling in UserService to throw the original error

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved user data refresh behavior to automatically update when the window regains focus or cached data becomes stale.
  * Enhanced error handling for user authentication issues to ensure user data is properly cleared when unauthorized access is detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->