### PR TITLE
fix(partial): get dev env working

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -5,8 +5,7 @@
   "license": "AGPL-3.0",
   "private": true,
   "scripts": {
-    "dev": "turbo run develop",
-    "develop": "next dev --port 3001",
+    "dev": "next dev --port 3001",
     "build": "next build",
     "preview": "next build && next start",
     "start": "next start",

--- a/apps/space/package.json
+++ b/apps/space/package.json
@@ -4,8 +4,7 @@
   "private": true,
   "license": "AGPL-3.0",
   "scripts": {
-    "dev": "turbo run develop",
-    "develop": "next dev -p 3002",
+    "dev": "next dev -p 3002",
     "build": "next build",
     "start": "next start",
     "clean": "rm -rf .turbo && rm -rf .next && rm -rf node_modules && rm -rf dist",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,8 +4,7 @@
   "private": true,
   "license": "AGPL-3.0",
   "scripts": {
-    "dev": "turbo run develop",
-    "develop": "next dev --port 3000",
+    "dev": "next dev --port 3000",
     "build": "next build",
     "start": "next start",
     "clean": "rm -rf .turbo && rm -rf .next && rm -rf node_modules && rm -rf dist",


### PR DESCRIPTION
part of #7355

### Description
Dev environment doesn't start up when running `yarn dev`. This patch fixes that step.

Note: There is a ton of TS errors and other noise in the console after fixing this. Needs :eyes: from the rest of the team.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
<!-- Link related issues if there are any -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified development scripts across multiple apps by removing redundant "develop" scripts and updating the "dev" scripts to directly start the development server on the appropriate port. This streamlines the process for starting the development environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->