### PR TITLE
[WIKI-530] regression: page version history dropdown item

### DIFF
--- a/apps/web/core/components/pages/editor/toolbar/options-dropdown.tsx
+++ b/apps/web/core/components/pages/editor/toolbar/options-dropdown.tsx
@@ -85,7 +85,7 @@ export const PageOptionsDropdown: React.FC<Props> = observer((props) => {
       {
         key: "version-history",
         action: () => {
-          // add query param, version=current to the route
+          // update query param to show info tab in navigation pane
           const updatedRoute = updateQueryParams({
             paramsToAdd: {
               [PAGE_NAVIGATION_PANE_TABS_QUERY_PARAM]: "info" satisfies TPageNavigationPaneTab,

--- a/apps/web/core/components/pages/editor/toolbar/options-dropdown.tsx
+++ b/apps/web/core/components/pages/editor/toolbar/options-dropdown.tsx
@@ -2,18 +2,22 @@
 
 import { useMemo, useState } from "react";
 import { observer } from "mobx-react";
-import { ArrowUpToLine, Clipboard } from "lucide-react";
+import { ArrowUpToLine, Clipboard, History } from "lucide-react";
 // plane imports
 import { TContextMenuItem, TOAST_TYPE, ToggleSwitch, setToast } from "@plane/ui";
 import { copyTextToClipboard } from "@plane/utils";
 // components
 import { ExportPageModal, PageActions, TPageActions } from "@/components/pages";
 // hooks
+import { useAppRouter } from "@/hooks/use-app-router";
 import { usePageFilters } from "@/hooks/use-page-filters";
+import { useQueryParams } from "@/hooks/use-query-params";
 // plane web imports
+import { TPageNavigationPaneTab } from "@/plane-web/components/pages/navigation-pane";
 import { EPageStoreType } from "@/plane-web/hooks/store";
 // store
 import { TPageInstance } from "@/store/pages/base-page";
+import { PAGE_NAVIGATION_PANE_TABS_QUERY_PARAM } from "../../navigation-pane";
 
 type Props = {
   page: TPageInstance;
@@ -24,6 +28,8 @@ export const PageOptionsDropdown: React.FC<Props> = observer((props) => {
   const { page, storeType } = props;
   // states
   const [isExportModalOpen, setIsExportModalOpen] = useState(false);
+  // navigation
+  const router = useAppRouter();
   // store values
   const {
     name,
@@ -32,6 +38,8 @@ export const PageOptionsDropdown: React.FC<Props> = observer((props) => {
   } = page;
   // page filters
   const { isFullWidth, handleFullWidth, isStickyToolbarEnabled, handleStickyToolbar } = usePageFilters();
+  // query params
+  const { updateQueryParams } = useQueryParams();
   // menu items list
   const EXTRA_MENU_OPTIONS: (TContextMenuItem & { key: TPageActions })[] = useMemo(
     () => [
@@ -75,6 +83,21 @@ export const PageOptionsDropdown: React.FC<Props> = observer((props) => {
         shouldRender: true,
       },
       {
+        key: "version-history",
+        action: () => {
+          // add query param, version=current to the route
+          const updatedRoute = updateQueryParams({
+            paramsToAdd: {
+              [PAGE_NAVIGATION_PANE_TABS_QUERY_PARAM]: "info" satisfies TPageNavigationPaneTab,
+            },
+          });
+          router.push(updatedRoute);
+        },
+        title: "Version history",
+        icon: History,
+        shouldRender: true,
+      },
+      {
         key: "export",
         action: () => setIsExportModalOpen(true),
         title: "Export",
@@ -82,7 +105,16 @@ export const PageOptionsDropdown: React.FC<Props> = observer((props) => {
         shouldRender: true,
       },
     ],
-    [editorRef, handleFullWidth, handleStickyToolbar, isContentEditable, isFullWidth, isStickyToolbarEnabled]
+    [
+      editorRef,
+      handleFullWidth,
+      handleStickyToolbar,
+      isContentEditable,
+      isFullWidth,
+      isStickyToolbarEnabled,
+      router,
+      updateQueryParams,
+    ]
   );
 
   return (


### PR DESCRIPTION
### Description

This PR adds the missing version history option from the page options menu.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

* **New Features**
  * Added a "Version history" option to the editor toolbar's page options dropdown, allowing users to quickly access version history from the navigation pane.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->