### PR TITLE
feat : added Kabul to the list of timezones

### DIFF
--- a/apps/api/plane/app/views/timezone/base.py
+++ b/apps/api/plane/app/views/timezone/base.py
@@ -116,6 +116,7 @@ class TimezoneEndpoint(APIView):
             ("Astrakhan", "Europe/Astrakhan"),  # UTC+04:00
             ("Tbilisi", "Asia/Tbilisi"),  # UTC+04:00
             ("Mauritius", "Indian/Mauritius"),  # UTC+04:00
+            ("Kabul", "Asia/Kabul"),  # UTC+04:30
             ("Islamabad", "Asia/Karachi"),  # UTC+05:00
             ("Karachi", "Asia/Karachi"),  # UTC+05:00
             ("Tashkent", "Asia/Tashkent"),  # UTC+05:00


### PR DESCRIPTION
### Description
This closes #7369  which adds Asia/Kabul timezone to the list of available timezones to support users in Afghanistan. This entry was missing previously, and its inclusion ensures better international coverage and accurate scheduling for users in that region.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Test Scenarios 
* Verified that Asia/Kabul appears in the timezone selection list and migrations.
* Confirmed that selecting this timezone reflects the correct UTC offset (+04:30).

### References
** [IANA Time Zone Database – Asia/Kabul](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Kabul ("Asia/Kabul") timezone with UTC+04:30 offset to the list of available timezones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->