### PR TITLE
[WIKI-497] refactor: table insert handles size

### DIFF
--- a/packages/editor/src/styles/table.css
+++ b/packages/editor/src/styles/table.css
@@ -1,6 +1,6 @@
 .table-wrapper {
   overflow-x: auto;
-  padding-bottom: 30px;
+  padding-bottom: 26px;
 
   table {
     position: relative;
@@ -191,18 +191,20 @@
 
   .table-column-insert-button {
     top: 0;
-    right: -20px;
-    width: 20px;
+    right: -16px;
+    width: 16px;
     height: 100%;
     transform: translateX(50%);
+    cursor: col-resize;
   }
 
   .table-row-insert-button {
-    bottom: -20px;
+    bottom: -16px;
     left: 0;
     width: 100%;
-    height: 20px;
+    height: 16px;
     transform: translateY(50%);
+    cursor: row-resize;
   }
 
   /* Show buttons on table hover */

--- a/packages/editor/src/styles/table.css
+++ b/packages/editor/src/styles/table.css
@@ -168,7 +168,7 @@
     opacity: 0;
     pointer-events: none;
     outline: none;
-    z-index: 1000;
+    z-index: 10;
     transition: all 0.2s ease;
 
     &:hover {


### PR DESCRIPTION
### Description

This PR decreases the size of the table insert handlers from `20px` to `16px`.

### Type of Change

- [x] Performance improvements

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved table controls by refining the sizing and positioning of column and row insert buttons.
  * Updated cursor appearance for insert buttons to indicate resizing capability.
  * Reduced bottom padding of the table wrapper for a more compact layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->