### PR TITLE
[WEB-4469] fix: full screen mode visibility

### DIFF
--- a/apps/web/core/components/analytics/work-items/modal/index.tsx
+++ b/apps/web/core/components/analytics/work-items/modal/index.tsx
@@ -32,7 +32,7 @@ export const WorkItemsModal: React.FC<Props> = observer((props) => {
 
   return (
     <Transition.Root appear show={isOpen} as={React.Fragment}>
-      <Dialog as="div" className="relative z-20" onClose={handleClose}>
+      <Dialog as="div" className="relative z-30" onClose={handleClose}>
         <Transition.Child
           as={React.Fragment}
           enter="transition-transform duration-300"

--- a/apps/web/core/components/gantt-chart/chart/root.tsx
+++ b/apps/web/core/components/gantt-chart/chart/root.tsx
@@ -179,7 +179,7 @@ export const ChartViewRoot: FC<ChartViewRootProps> = observer((props) => {
   return (
     <div
       className={cn("relative flex flex-col h-full select-none rounded-sm bg-custom-background-100 shadow", {
-        "fixed inset-0 z-20 bg-custom-background-100": fullScreenMode,
+        "fixed inset-0 z-30 bg-custom-background-100": fullScreenMode,
         "border-[0.5px] border-custom-border-200": border,
       })}
     >


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
This update fixes the `z-index` issue observed in full screen mode for Gantt Chart.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
<!-- Link related issues if there are any -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved modal and full screen component visibility by increasing their stacking order, ensuring they appear above other page elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->