### PR TITLE
[WIKI-520] fix: update content disposition handling in asset download endpoints

### DIFF
--- a/apps/api/plane/app/views/asset/v2.py
+++ b/apps/api/plane/app/views/asset/v2.py
@@ -740,7 +740,8 @@ class WorkspaceAssetDownloadEndpoint(BaseAPIView):
         storage = S3Storage(request=request)
         signed_url = storage.generate_presigned_url(
             object_name=asset.asset.name,
-            disposition=f"attachment; filename={asset.asset.name}",
+            disposition="attachment",
+            filename=asset.attributes.get("name", uuid.uuid4().hex),
         )
 
         return HttpResponseRedirect(signed_url)
@@ -767,7 +768,8 @@ class ProjectAssetDownloadEndpoint(BaseAPIView):
         storage = S3Storage(request=request)
         signed_url = storage.generate_presigned_url(
             object_name=asset.asset.name,
-            disposition=f"attachment; filename={asset.asset.name}",
+            disposition="attachment",
+            filename=asset.attributes.get("name", uuid.uuid4().hex),
         )
 
         return HttpResponseRedirect(signed_url)

--- a/apps/api/plane/settings/storage.py
+++ b/apps/api/plane/settings/storage.py
@@ -1,5 +1,6 @@
 # Python imports
 import os
+import uuid
 
 # Third party imports
 import boto3
@@ -99,7 +100,7 @@ class S3Storage(S3Boto3Storage):
 
         return response
 
-    def _get_content_disposition(self, disposition, filename=None):
+    def _get_content_disposition(self, disposition, filename=uuid.uuid4().hex):
         """Helper method to generate Content-Disposition header value"""
         if filename:
             # Encode the filename to handle special characters


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
- update content disposition headers to support filename with spaces

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->
- upload image with spaces should download without any s3 errors

### References
[WIKI-520](https://app.plane.so/plane/browse/WIKI-520/)