### PR TITLE
[WEB-4477] fix: sidebar resize behaviour

### DIFF
--- a/apps/web/core/components/sidebar/resizable-sidebar.tsx
+++ b/apps/web/core/components/sidebar/resizable-sidebar.tsx
@@ -50,6 +50,8 @@ export function ResizableSidebar({
   const [isHoveringTrigger, setIsHoveringTrigger] = useState(false);
   // refs
   const peekTimeoutRef = useRef<ReturnType<typeof setTimeout>>();
+  const initialWidthRef = useRef<number>(0);
+  const initialMouseXRef = useRef<number>(0);
 
   // handlers
   const setShowPeek = useCallback(
@@ -62,15 +64,22 @@ export function ResizableSidebar({
   const handleResize = useCallback(
     (e: MouseEvent) => {
       if (!isResizing) return;
-      const newWidth = Math.min(Math.max(e.clientX, minWidth), maxWidth);
+
+      const deltaX = e.clientX - initialMouseXRef.current;
+      const newWidth = Math.min(Math.max(initialWidthRef.current + deltaX, minWidth), maxWidth);
       setWidth(newWidth);
     },
     [isResizing, minWidth, maxWidth, setWidth]
   );
 
-  const startResizing = useCallback(() => {
-    setIsResizing(true);
-  }, []);
+  const startResizing = useCallback(
+    (e: React.MouseEvent) => {
+      setIsResizing(true);
+      initialWidthRef.current = width;
+      initialMouseXRef.current = e.clientX;
+    },
+    [width]
+  );
 
   const stopResizing = useCallback(() => {
     setIsResizing(false);
@@ -199,7 +208,7 @@ export function ResizableSidebar({
       >
         <aside
           className={cn(
-            "group/sidebar h-full w-full bg-custom-background-100 overflow-hidden relative flex flex-col pt-3",
+            "group/sidebar h-full w-full bg-custom-sidebar-background-100 overflow-hidden relative flex flex-col pt-3",
             isAnyExtendedSidebarExpanded && "rounded-none"
           )}
         >
@@ -215,7 +224,7 @@ export function ResizableSidebar({
             )}
             // onDoubleClick toggle sidebar
             onDoubleClick={() => toggleCollapsed()}
-            onMouseDown={startResizing}
+            onMouseDown={(e) => startResizing(e)}
             role="separator"
             aria-label="Resize sidebar"
           />
@@ -273,7 +282,7 @@ export function ResizableSidebar({
             )}
             // onDoubleClick toggle sidebar
             onDoubleClick={() => toggleCollapsed()}
-            onMouseDown={startResizing}
+            onMouseDown={(e) => startResizing(e)}
             role="separator"
             aria-label="Resize sidebar"
           />


### PR DESCRIPTION
### Description
The resize handler was calculating new width using absolute `e.clientX` values, which could cause jumps when the sidebar wasn't positioned at the left edge of the screen or had offsets.

### Type of Change
- [x] Bug fix

### References
[[WEB-4477]](https://app.plane.so/plane/browse/WEB-4477/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved sidebar resizing behavior for smoother and more accurate adjustments.
  * Updated sidebar background color for visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->