### PR TITLE
[WIKI-277] fix: unable to delete last table column/row in editor

### DIFF
--- a/packages/editor/src/core/components/menus/bubble-menu/root.tsx
+++ b/packages/editor/src/core/components/menus/bubble-menu/root.tsx
@@ -21,10 +21,11 @@ import {
 import { COLORS_LIST } from "@/constants/common";
 import { CORE_EXTENSIONS } from "@/constants/extension";
 // extensions
-import { isCellSelection } from "@/extensions/table/table/utilities/is-cell-selection";
+import { isCellSelection } from "@/extensions/table/table/utilities/helpers";
+// types
+import { TEditorCommands } from "@/types";
 // local components
 import { TextAlignmentSelector } from "./alignment-selector";
-import { TEditorCommands } from "@/types";
 
 type EditorBubbleMenuProps = Omit<BubbleMenuProps, "children">;
 

--- a/packages/editor/src/core/extensions/table/table/table.ts
+++ b/packages/editor/src/core/extensions/table/table/table.ts
@@ -142,8 +142,38 @@ export const Table = Node.create<TableOptions>({
           addColumnAfter(state, dispatch),
       deleteColumn:
         () =>
-        ({ state, dispatch }) =>
-          deleteColumn(state, dispatch),
+        ({ state, dispatch }) => {
+          const { selection } = state;
+
+          // Check if we're in a table and have a cell selection
+          if (!(selection instanceof CellSelection)) {
+            return false;
+          }
+
+          // Get the ProseMirrorTable and calculate total columns
+          const tableStart = selection.$anchorCell.start(-1);
+          const selectedTable = state.doc.nodeAt(tableStart - 1);
+
+          if (!selectedTable) return false;
+
+          // Count total columns by examining the first row
+          const firstRow = selectedTable.firstChild;
+          if (!firstRow) return false;
+
+          let totalColumns = 0;
+          for (let i = 0; i < firstRow.childCount; i++) {
+            const cell = firstRow.child(i);
+            totalColumns += cell.attrs.colspan || 1;
+          }
+
+          // If only one column exists, delete the entire ProseMirrorTable
+          if (totalColumns === 1) {
+            return deleteTable(state, dispatch);
+          }
+
+          // Otherwise, proceed with normal column deletion
+          return deleteColumn(state, dispatch);
+        },
       addRowBefore:
         () =>
         ({ state, dispatch }) =>

--- a/packages/editor/src/core/extensions/table/table/table.ts
+++ b/packages/editor/src/core/extensions/table/table/table.ts
@@ -7,7 +7,6 @@ import {
   addRowBefore,
   CellSelection,
   columnResizing,
-  deleteRow,
   deleteTable,
   fixTables,
   goToNextCell,
@@ -27,6 +26,7 @@ import { tableControls } from "./table-controls";
 import { TableView } from "./table-view";
 import { createTable } from "./utilities/create-table";
 import { deleteColumnOrTable } from "./utilities/delete-column";
+import { deleteRowOrTable } from "./utilities/delete-row";
 import { deleteTableWhenAllCellsSelected } from "./utilities/delete-table-when-all-cells-selected";
 import { insertLineAboveTableAction } from "./utilities/insert-line-above-table-action";
 import { insertLineBelowTableAction } from "./utilities/insert-line-below-table-action";
@@ -149,10 +149,7 @@ export const Table = Node.create<TableOptions>({
         () =>
         ({ state, dispatch }) =>
           addRowAfter(state, dispatch),
-      deleteRow:
-        () =>
-        ({ state, dispatch }) =>
-          deleteRow(state, dispatch),
+      deleteRow: deleteRowOrTable,
       deleteTable:
         () =>
         ({ state, dispatch }) =>

--- a/packages/editor/src/core/extensions/table/table/table.ts
+++ b/packages/editor/src/core/extensions/table/table/table.ts
@@ -7,7 +7,6 @@ import {
   addRowBefore,
   CellSelection,
   columnResizing,
-  deleteColumn,
   deleteRow,
   deleteTable,
   fixTables,
@@ -27,6 +26,7 @@ import { TableInsertPlugin } from "../plugins/insert-handlers/plugin";
 import { tableControls } from "./table-controls";
 import { TableView } from "./table-view";
 import { createTable } from "./utilities/create-table";
+import { deleteColumnOrTable } from "./utilities/delete-column";
 import { deleteTableWhenAllCellsSelected } from "./utilities/delete-table-when-all-cells-selected";
 import { insertLineAboveTableAction } from "./utilities/insert-line-above-table-action";
 import { insertLineBelowTableAction } from "./utilities/insert-line-below-table-action";
@@ -140,40 +140,7 @@ export const Table = Node.create<TableOptions>({
         () =>
         ({ state, dispatch }) =>
           addColumnAfter(state, dispatch),
-      deleteColumn:
-        () =>
-        ({ state, dispatch }) => {
-          const { selection } = state;
-
-          // Check if we're in a table and have a cell selection
-          if (!(selection instanceof CellSelection)) {
-            return false;
-          }
-
-          // Get the ProseMirrorTable and calculate total columns
-          const tableStart = selection.$anchorCell.start(-1);
-          const selectedTable = state.doc.nodeAt(tableStart - 1);
-
-          if (!selectedTable) return false;
-
-          // Count total columns by examining the first row
-          const firstRow = selectedTable.firstChild;
-          if (!firstRow) return false;
-
-          let totalColumns = 0;
-          for (let i = 0; i < firstRow.childCount; i++) {
-            const cell = firstRow.child(i);
-            totalColumns += cell.attrs.colspan || 1;
-          }
-
-          // If only one column exists, delete the entire ProseMirrorTable
-          if (totalColumns === 1) {
-            return deleteTable(state, dispatch);
-          }
-
-          // Otherwise, proceed with normal column deletion
-          return deleteColumn(state, dispatch);
-        },
+      deleteColumn: deleteColumnOrTable,
       addRowBefore:
         () =>
         ({ state, dispatch }) =>

--- a/packages/editor/src/core/extensions/table/table/utilities/delete-column.ts
+++ b/packages/editor/src/core/extensions/table/table/utilities/delete-column.ts
@@ -1,0 +1,37 @@
+import type { Command } from "@tiptap/core";
+import { deleteColumn, deleteTable, CellSelection } from "@tiptap/pm/tables";
+
+export const deleteColumnOrTable: () => Command =
+  () =>
+  ({ state, dispatch }) => {
+    const { selection } = state;
+
+    // Check if we're in a table and have a cell selection
+    if (!(selection instanceof CellSelection)) {
+      return false;
+    }
+
+    // Get the ProseMirrorTable and calculate total columns
+    const tableStart = selection.$anchorCell.start(-1);
+    const selectedTable = state.doc.nodeAt(tableStart - 1);
+
+    if (!selectedTable) return false;
+
+    // Count total columns by examining the first row
+    const firstRow = selectedTable.firstChild;
+    if (!firstRow) return false;
+
+    let totalColumns = 0;
+    for (let i = 0; i < firstRow.childCount; i++) {
+      const cell = firstRow.child(i);
+      totalColumns += cell.attrs.colspan || 1;
+    }
+
+    // If only one column exists, delete the entire ProseMirrorTable
+    if (totalColumns === 1) {
+      return deleteTable(state, dispatch);
+    }
+
+    // Otherwise, proceed with normal column deletion
+    return deleteColumn(state, dispatch);
+  };

--- a/packages/editor/src/core/extensions/table/table/utilities/delete-column.ts
+++ b/packages/editor/src/core/extensions/table/table/utilities/delete-column.ts
@@ -1,5 +1,7 @@
 import type { Command } from "@tiptap/core";
-import { deleteColumn, deleteTable, CellSelection } from "@tiptap/pm/tables";
+import { deleteColumn, deleteTable } from "@tiptap/pm/tables";
+// local imports
+import { isCellSelection } from "./helpers";
 
 export const deleteColumnOrTable: () => Command =
   () =>
@@ -7,7 +9,7 @@ export const deleteColumnOrTable: () => Command =
     const { selection } = state;
 
     // Check if we're in a table and have a cell selection
-    if (!(selection instanceof CellSelection)) {
+    if (!isCellSelection(selection)) {
       return false;
     }
 

--- a/packages/editor/src/core/extensions/table/table/utilities/delete-row.ts
+++ b/packages/editor/src/core/extensions/table/table/utilities/delete-row.ts
@@ -1,5 +1,7 @@
 import type { Command } from "@tiptap/core";
-import { deleteRow, deleteTable, CellSelection } from "@tiptap/pm/tables";
+import { deleteRow, deleteTable } from "@tiptap/pm/tables";
+// local imports
+import { isCellSelection } from "./helpers";
 
 export const deleteRowOrTable: () => Command =
   () =>
@@ -7,7 +9,7 @@ export const deleteRowOrTable: () => Command =
     const { selection } = state;
 
     // Check if we're in a ProseMirrorTable and have a cell selection
-    if (!(selection instanceof CellSelection)) {
+    if (!isCellSelection(selection)) {
       return false;
     }
 

--- a/packages/editor/src/core/extensions/table/table/utilities/delete-row.ts
+++ b/packages/editor/src/core/extensions/table/table/utilities/delete-row.ts
@@ -18,12 +18,7 @@ export const deleteRowOrTable: () => Command =
     if (!selectedTable) return false;
 
     // Count total rows by examining the table's children
-    let totalRows = 0;
-    for (let i = 0; i < selectedTable.childCount; i++) {
-      const row = selectedTable.child(i);
-      // Count each table row (accounting for potential rowspan)
-      totalRows += row.attrs.rowspan || 1;
-    }
+    const totalRows = selectedTable.childCount;
 
     // If only one row exists, delete the entire ProseMirrorTable
     if (totalRows === 1) {

--- a/packages/editor/src/core/extensions/table/table/utilities/delete-row.ts
+++ b/packages/editor/src/core/extensions/table/table/utilities/delete-row.ts
@@ -1,0 +1,35 @@
+import type { Command } from "@tiptap/core";
+import { deleteRow, deleteTable, CellSelection } from "@tiptap/pm/tables";
+
+export const deleteRowOrTable: () => Command =
+  () =>
+  ({ state, dispatch }) => {
+    const { selection } = state;
+
+    // Check if we're in a ProseMirrorTable and have a cell selection
+    if (!(selection instanceof CellSelection)) {
+      return false;
+    }
+
+    // Get the ProseMirrorTable and calculate total rows
+    const tableStart = selection.$anchorCell.start(-1);
+    const selectedTable = state.doc.nodeAt(tableStart - 1);
+
+    if (!selectedTable) return false;
+
+    // Count total rows by examining the table's children
+    let totalRows = 0;
+    for (let i = 0; i < selectedTable.childCount; i++) {
+      const row = selectedTable.child(i);
+      // Count each table row (accounting for potential rowspan)
+      totalRows += row.attrs.rowspan || 1;
+    }
+
+    // If only one row exists, delete the entire ProseMirrorTable
+    if (totalRows === 1) {
+      return deleteTable(state, dispatch);
+    }
+
+    // Otherwise, proceed with normal row deletion
+    return deleteRow(state, dispatch);
+  };

--- a/packages/editor/src/core/extensions/table/table/utilities/delete-table-when-all-cells-selected.ts
+++ b/packages/editor/src/core/extensions/table/table/utilities/delete-table-when-all-cells-selected.ts
@@ -2,7 +2,7 @@ import { findParentNodeClosestToPos, KeyboardShortcutCommand } from "@tiptap/cor
 // constants
 import { CORE_EXTENSIONS } from "@/constants/extension";
 // extensions
-import { isCellSelection } from "@/extensions/table/table/utilities/is-cell-selection";
+import { isCellSelection } from "@/extensions/table/table/utilities/helpers";
 
 export const deleteTableWhenAllCellsSelected: KeyboardShortcutCommand = ({ editor }) => {
   const { selection } = editor.state;

--- a/packages/editor/src/core/extensions/table/table/utilities/helpers.ts
+++ b/packages/editor/src/core/extensions/table/table/utilities/helpers.ts
@@ -1,0 +1,9 @@
+import type { Selection } from "@tiptap/pm/state";
+import { CellSelection } from "@tiptap/pm/tables";
+
+/**
+ * @description Check if the selection is a cell selection
+ * @param {Selection} selection - The selection to check
+ * @returns {boolean} True if the selection is a cell selection, false otherwise
+ */
+export const isCellSelection = (selection: Selection): selection is CellSelection => selection instanceof CellSelection;

--- a/packages/editor/src/core/extensions/table/table/utilities/is-cell-selection.ts
+++ b/packages/editor/src/core/extensions/table/table/utilities/is-cell-selection.ts
@@ -1,5 +1,0 @@
-import { CellSelection } from "@tiptap/pm/tables";
-
-export function isCellSelection(value: unknown): value is CellSelection {
-  return value instanceof CellSelection;
-}

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -15,7 +15,7 @@ export {
   RichTextEditorWithRef,
 } from "@/components/editors";
 
-export { isCellSelection } from "@/extensions/table/table/utilities/is-cell-selection";
+export { isCellSelection } from "@/extensions/table/table/utilities/helpers";
 
 // constants
 export * from "@/constants/common";


### PR DESCRIPTION
### Description

This PR fixes the bug where users are unable to delete the last column/row of a table.

**Cause:** By default, ProseMirror doesn't allow a table to exist without any column/row.

**Solution:** If the user tries to delete the last column/row, we delete the entire table, bypassing the default logic.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Improved table editing: Deleting the last remaining column or row in a table now removes the entire table automatically.

* **Bug Fixes**
  * Enhanced reliability when deleting columns and rows in tables, ensuring consistent behavior when only one column or row remains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->