### PR TITLE
[WEB-4479] feat: enable/disable SMTP configuration

### DIFF
--- a/apps/admin/app/(all)/(dashboard)/email/email-config-form.tsx
+++ b/apps/admin/app/(all)/(dashboard)/email/email-config-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { FC, useEffect, useMemo, useState } from "react";
+import React, { FC, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 // types
 import { IFormattedInstanceConfiguration, TInstanceEmailConfigurationKeys } from "@plane/types";

--- a/apps/admin/app/(all)/(dashboard)/email/email-config-form.tsx
+++ b/apps/admin/app/(all)/(dashboard)/email/email-config-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { FC, useMemo, useState } from "react";
+import React, { FC, useEffect, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 // types
 import { IFormattedInstanceConfiguration, TInstanceEmailConfigurationKeys } from "@plane/types";
@@ -49,9 +49,9 @@ export const InstanceEmailForm: FC<IInstanceEmailForm> = (props) => {
       EMAIL_USE_TLS: config["EMAIL_USE_TLS"],
       EMAIL_USE_SSL: config["EMAIL_USE_SSL"],
       EMAIL_FROM: config["EMAIL_FROM"],
+      ENABLE_SMTP: config["ENABLE_SMTP"],
     },
   });
-
   const emailFormFields: TControllerInputFormField[] = [
     {
       key: "EMAIL_HOST",
@@ -101,7 +101,7 @@ export const InstanceEmailForm: FC<IInstanceEmailForm> = (props) => {
   ];
 
   const onSubmit = async (formData: EmailFormValues) => {
-    const payload: Partial<EmailFormValues> = { ...formData };
+    const payload: Partial<EmailFormValues> = { ...formData, ENABLE_SMTP: "1" };
 
     await updateInstanceConfigurations(payload)
       .then(() =>

--- a/apps/admin/app/(all)/(dashboard)/email/page.tsx
+++ b/apps/admin/app/(all)/(dashboard)/email/page.tsx
@@ -21,14 +21,23 @@ const InstanceEmailPage = observer(() => {
   const handleToggle = async () => {
     if (isSMTPEnabled) {
       setIsSubmitting(true);
-      await disableEmail();
-      setIsSMTPEnabled(false);
-      setIsSubmitting(false);
-      setToast({
-        title: "Email feature disabled",
-        message: "Email feature has been disabled",
-        type: TOAST_TYPE.SUCCESS,
-      });
+      try {
+        await disableEmail();
+        setIsSMTPEnabled(false);
+        setToast({
+          title: "Email feature disabled",
+          message: "Email feature has been disabled",
+          type: TOAST_TYPE.SUCCESS,
+        });
+      } catch (error) {
+        setToast({
+          title: "Error disabling email",
+          message: "Failed to disable email feature. Please try again.",
+          type: TOAST_TYPE.ERROR,
+        });
+      } finally {
+        setIsSubmitting(false);
+      }
       return;
     }
     setIsSMTPEnabled(true);

--- a/apps/admin/app/(all)/(dashboard)/email/page.tsx
+++ b/apps/admin/app/(all)/(dashboard)/email/page.tsx
@@ -41,11 +41,6 @@ const InstanceEmailPage = observer(() => {
       return;
     }
     setIsSMTPEnabled(true);
-    setToast({
-      title: "Email feature enabled",
-      message: "Email feature has been enabled",
-      type: TOAST_TYPE.SUCCESS,
-    });
   };
   useEffect(() => {
     if (formattedConfig) {

--- a/apps/admin/core/store/instance.store.ts
+++ b/apps/admin/core/store/instance.store.ts
@@ -32,6 +32,7 @@ export interface IInstanceStore {
   fetchInstanceAdmins: () => Promise<IInstanceAdmin[] | undefined>;
   fetchInstanceConfigurations: () => Promise<IInstanceConfiguration[] | undefined>;
   updateInstanceConfigurations: (data: Partial<IFormattedInstanceConfiguration>) => Promise<IInstanceConfiguration[]>;
+  disableEmail: () => Promise<void>;
 }
 
 export class InstanceStore implements IInstanceStore {
@@ -185,6 +186,32 @@ export class InstanceStore implements IInstanceStore {
     } catch (error) {
       console.error("Error updating the instance configurations");
       throw error;
+    }
+  };
+
+  disableEmail = async () => {
+    const instanceConfigurations = this.instanceConfigurations;
+    try {
+      runInAction(() => {
+        this.instanceConfigurations = this.instanceConfigurations?.map((config) => {
+          if (
+            [
+              "EMAIL_HOST",
+              "EMAIL_PORT",
+              "EMAIL_HOST_USER",
+              "EMAIL_HOST_PASSWORD",
+              "EMAIL_FROM",
+              "ENABLE_SMTP",
+            ].includes(config.key)
+          )
+            return { ...config, value: "" };
+          return config;
+        });
+      });
+      await this.instanceService.disableEmail();
+    } catch (error) {
+      console.error("Error disabling the email");
+      this.instanceConfigurations = instanceConfigurations;
     }
   };
 }

--- a/apps/api/plane/license/api/views/__init__.py
+++ b/apps/api/plane/license/api/views/__init__.py
@@ -1,7 +1,11 @@
 from .instance import InstanceEndpoint, SignUpScreenVisitedEndpoint
 
 
-from .configuration import EmailCredentialCheckEndpoint, InstanceConfigurationEndpoint
+from .configuration import (
+    EmailCredentialCheckEndpoint,
+    InstanceConfigurationEndpoint,
+    DisableEmailFeatureEndpoint,
+)
 
 
 from .admin import (

--- a/apps/api/plane/license/api/views/configuration.py
+++ b/apps/api/plane/license/api/views/configuration.py
@@ -63,7 +63,12 @@ class DisableEmailFeatureEndpoint(BaseAPIView):
     @invalidate_cache(path="/api/instances/", user=False)
     def delete(self, request):
         instance_configurations = InstanceConfiguration.objects.filter(
-            key__in=["EMAIL_HOST", "EMAIL_HOST_USER", "EMAIL_HOST_PASSWORD"]
+            key__in=[
+                "EMAIL_HOST",
+                "EMAIL_HOST_USER",
+                "EMAIL_HOST_PASSWORD",
+                "ENABLE_SMTP",
+            ]
         )
 
         instance_configurations.update(value="")

--- a/apps/api/plane/license/api/views/configuration.py
+++ b/apps/api/plane/license/api/views/configuration.py
@@ -57,6 +57,19 @@ class InstanceConfigurationEndpoint(BaseAPIView):
         return Response(serializer.data, status=status.HTTP_200_OK)
 
 
+class DisableEmailFeatureEndpoint(BaseAPIView):
+    permission_classes = [InstanceAdminPermission]
+
+    @invalidate_cache(path="/api/instances/", user=False)
+    def delete(self, request):
+        instance_configurations = InstanceConfiguration.objects.filter(
+            key__in=["EMAIL_HOST", "EMAIL_HOST_USER", "EMAIL_HOST_PASSWORD"]
+        )
+
+        instance_configurations.update(value="")
+        return Response(status=status.HTTP_200_OK)
+
+
 class EmailCredentialCheckEndpoint(BaseAPIView):
     def post(self, request):
         receiver_email = request.data.get("receiver_email", False)

--- a/apps/api/plane/license/management/commands/configure_instance.py
+++ b/apps/api/plane/license/management/commands/configure_instance.py
@@ -90,6 +90,12 @@ class Command(BaseCommand):
                 "is_encrypted": False,
             },
             {
+                "key": "ENABLE_SMTP",
+                "value": os.environ.get("ENABLE_SMTP", "0"),
+                "category": "SMTP",
+                "is_encrypted": False,
+            },
+            {
                 "key": "GITLAB_CLIENT_SECRET",
                 "value": os.environ.get("GITLAB_CLIENT_SECRET"),
                 "category": "GITLAB",

--- a/apps/api/plane/license/urls.py
+++ b/apps/api/plane/license/urls.py
@@ -6,6 +6,7 @@ from plane.license.api.views import (
     InstanceAdminSignInEndpoint,
     InstanceAdminSignUpEndpoint,
     InstanceConfigurationEndpoint,
+    DisableEmailFeatureEndpoint,
     InstanceEndpoint,
     SignUpScreenVisitedEndpoint,
     InstanceAdminUserMeEndpoint,
@@ -34,6 +35,11 @@ urlpatterns = [
         "configurations/",
         InstanceConfigurationEndpoint.as_view(),
         name="instance-configuration",
+    ),
+    path(
+        "configurations/disable-email-feature/",
+        DisableEmailFeatureEndpoint.as_view(),
+        name="disable-email-configuration",
     ),
     path(
         "admins/sign-in/",

--- a/packages/services/src/instance/instance.service.ts
+++ b/packages/services/src/instance/instance.service.ts
@@ -122,4 +122,17 @@ export class InstanceService extends APIService {
         throw error?.response?.data;
       });
   }
+
+  /**
+   * Disables the email configuration
+   * @returns {Promise<void>} Promise resolving to void
+   * @throws {Error} If the API request fails
+   */
+  async disableEmail(): Promise<void> {
+    return this.delete("/api/instances/configurations/disable-email-feature/")
+      .then((response) => response?.data)
+      .catch((error) => {
+        throw error?.response?.data;
+      });
+  }
 }

--- a/packages/types/src/instance/email.ts
+++ b/packages/types/src/instance/email.ts
@@ -5,4 +5,5 @@ export type TInstanceEmailConfigurationKeys =
   | "EMAIL_HOST_PASSWORD"
   | "EMAIL_USE_TLS"
   | "EMAIL_USE_SSL"
-  | "EMAIL_FROM";
+  | "EMAIL_FROM"
+  | "ENABALE_SMTP";

--- a/packages/types/src/instance/email.ts
+++ b/packages/types/src/instance/email.ts
@@ -6,4 +6,4 @@ export type TInstanceEmailConfigurationKeys =
   | "EMAIL_USE_TLS"
   | "EMAIL_USE_SSL"
   | "EMAIL_FROM"
-  | "ENABALE_SMTP";
+  | "ENABLE_SMTP";


### PR DESCRIPTION
### Description
Added a toggle button to enable/disable smtp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to enable or disable the email (SMTP) feature from the admin dashboard using a toggle switch.
  * Introduced an API endpoint and backend support to fully disable email by clearing related configuration settings.
  * Added visual feedback and improved UI for managing email configuration, including loading states and success notifications.
  * Ensured the email feature is always enabled upon form submission.

* **Bug Fixes**
  * Ensured the email feature state is accurately reflected and updated in the UI.

* **Chores**
  * Added a new configuration key for controlling SMTP enablement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->