### PR TITLE
WEB-4485 - fix(dev): get local dev migrator working again

### DIFF
--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -192,7 +192,7 @@ services:
       - ./apps/api:/code
     command: ./bin/docker-entrypoint-migrator.sh --settings=plane.settings.local
     env_file:
-      - .env
+      - ./apps/api/.env
     depends_on:
       - plane-db
       - plane-redis


### PR DESCRIPTION
### Description
In local development environments, the migrator was failing to start due to a misconfiguration of env variables (REDIS settings were unavailable).

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
<!-- Link related issues if there are any -->