### PR TITLE
[WEB-4468] fix: setting sidebar truncate

### DIFF
--- a/apps/web/core/components/settings/sidebar/root.tsx
+++ b/apps/web/core/components/settings/sidebar/root.tsx
@@ -1,6 +1,5 @@
 import { observer } from "mobx-react";
 import { useTranslation } from "@plane/i18n";
-import { ScrollArea } from "@plane/ui";
 import { cn } from "@plane/utils";
 import { SettingsSidebarHeader } from "./header";
 import SettingsSidebarNavItem, { TSettingItem } from "./nav-item";
@@ -46,10 +45,7 @@ export const SettingsSidebar = observer((props: SettingsSidebarProps) => {
       {/* Header */}
       <SettingsSidebarHeader customHeader={customHeader} />
       {/* Navigation */}
-      <ScrollArea
-        className="divide-y divide-custom-border-100 overflow-x-hidden w-full h-full overflow-y-scroll"
-        type="hover"
-      >
+      <div className="divide-y divide-custom-border-100 overflow-x-hidden w-full h-full overflow-y-scroll vertical-scrollbar scrollbar-sm">
         {categories.map((category) => {
           if (groupedSettings[category].length === 0) return null;
           return (
@@ -74,7 +70,7 @@ export const SettingsSidebar = observer((props: SettingsSidebarProps) => {
             </div>
           );
         })}
-      </ScrollArea>
+      </div>
     </div>
   );
 });


### PR DESCRIPTION
### Description
This PR fixes an issue on the Settings page where sidebar items with long text were not truncating properly, causing horizontal overflow. The necessary adjustments have been made to ensure long text is truncated and the layout remains intact.

### Type of Change
- [x] Bug fix

### Media
| Before | After |
|--------|--------|
| ![WEB-4468-Before](https://github.com/user-attachments/assets/138c929f-3650-4e1f-a8a5-201503db418e) | ![WEB-4468-After](https://github.com/user-attachments/assets/42e05280-313b-43c5-b968-83c35ac85c06) |

### References
[[WEB-4468]](https://app.plane.so/plane/browse/WEB-4468/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Replaced the scrollable navigation container with a standard div using custom scrollbar styling for improved consistency.
* **Style**
  * Updated scrollbar appearance in the settings sidebar for a more streamlined look.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->