### PR TITLE
[WEB-2576] fix: inactive members as issue assignees

### DIFF
--- a/apps/api/plane/app/views/cycle/base.py
+++ b/apps/api/plane/app/views/cycle/base.py
@@ -174,6 +174,14 @@ class CycleViewSet(BaseViewSet):
                             Q(
                                 issue_cycle__issue__issue_assignee__deleted_at__isnull=True
                             )
+                        )
+                        & Q(
+                            issue_cycle__issue__assignees__member_project__project_id=self.kwargs.get(
+                                "project_id"
+                            )
+                        )
+                        & Q(
+                            issue_cycle__issue__assignees__member_project__is_active=True
                         ),
                     ),
                     Value([], output_field=ArrayField(UUIDField())),

--- a/apps/api/plane/app/views/issue/base.py
+++ b/apps/api/plane/app/views/issue/base.py
@@ -505,6 +505,7 @@ class IssueViewSet(BaseViewSet):
                         filter=Q(
                             ~Q(assignees__id__isnull=True)
                             & Q(assignees__member_project__is_active=True)
+                            & Q(assignees__member_project__project_id=project_id)
                             & Q(issue_assignee__deleted_at__isnull=True)
                         ),
                     ),
@@ -914,6 +915,7 @@ class IssuePaginatedViewSet(BaseViewSet):
                         ~Q(assignees__id__isnull=True)
                         & Q(assignees__member_project__is_active=True)
                         & Q(issue_assignee__deleted_at__isnull=True)
+                        & Q(assignees__member_project__project_id=project_id)
                     ),
                 ),
                 Value([], output_field=ArrayField(UUIDField())),
@@ -1253,6 +1255,7 @@ class IssueDetailIdentifierEndpoint(BaseAPIView):
                             ~Q(assignees__id__isnull=True)
                             & Q(assignees__member_project__is_active=True)
                             & Q(issue_assignee__deleted_at__isnull=True)
+                            & Q(assignees__member_project__project_id=project.id)
                         ),
                     ),
                     Value([], output_field=ArrayField(UUIDField())),

--- a/apps/api/plane/app/views/issue/relation.py
+++ b/apps/api/plane/app/views/issue/relation.py
@@ -149,6 +149,7 @@ class IssueRelationViewSet(BaseViewSet):
                             ~Q(assignees__id__isnull=True)
                             & Q(assignees__member_project__is_active=True)
                             & Q(issue_assignee__deleted_at__isnull=True)
+                            & Q(assignees__member_project__project_id=project_id)
                         ),
                     ),
                     Value([], output_field=ArrayField(UUIDField())),

--- a/apps/api/plane/app/views/issue/sub_issue.py
+++ b/apps/api/plane/app/views/issue/sub_issue.py
@@ -83,6 +83,7 @@ class SubIssuesEndpoint(BaseAPIView):
                             ~Q(assignees__id__isnull=True)
                             & Q(assignees__member_project__is_active=True)
                             & Q(issue_assignee__deleted_at__isnull=True)
+                            & Q(assignees__member_project__project_id=project_id)
                         ),
                     ),
                     Value([], output_field=ArrayField(UUIDField())),

--- a/apps/api/plane/app/views/project/base.py
+++ b/apps/api/plane/app/views/project/base.py
@@ -219,7 +219,20 @@ class ProjectViewSet(BaseViewSet):
             )
             .filter(archived_at__isnull=True)
             .filter(pk=pk)
+            .prefetch_related("project_projectmember")
         ).first()
+
+        project_member_ids = ProjectMember.objects.filter(
+            project_id=pk, is_active=True
+        ).values_list("member_id", flat=True)
+
+        members_ids = set(project_member_ids)
+
+        if project.project_lead_id not in members_ids:
+            project.project_lead = None
+
+        if project.default_assignee_id not in members_ids:
+            project.default_assignee = None
 
         if project is None:
             return Response(

--- a/apps/api/plane/app/views/project/base.py
+++ b/apps/api/plane/app/views/project/base.py
@@ -222,6 +222,11 @@ class ProjectViewSet(BaseViewSet):
             .prefetch_related("project_projectmember")
         ).first()
 
+        if project is None:
+            return Response(
+                {"error": "Project does not exist"}, status=status.HTTP_404_NOT_FOUND
+            )
+
         project_member_ids = ProjectMember.objects.filter(
             project_id=pk, is_active=True
         ).values_list("member_id", flat=True)
@@ -233,11 +238,6 @@ class ProjectViewSet(BaseViewSet):
 
         if project.default_assignee_id not in members_ids:
             project.default_assignee = None
-
-        if project is None:
-            return Response(
-                {"error": "Project does not exist"}, status=status.HTTP_404_NOT_FOUND
-            )
 
         recent_visited_task.delay(
             slug=slug,


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
<!-- Link related issues if there are any -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filtering of assignees to include only active members of the current project across issue, cycle, sub-issue, and relation views.
  * Project details now correctly reflect the active status of the project lead and default assignee.

* **Performance**
  * Optimized project detail retrieval by prefetching related project members for faster access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->