### PR TITLE
[WEB-4515] fix: duplicate work item quick action

### DIFF
--- a/apps/web/ce/components/issues/issue-layouts/quick-action-dropdowns/copy-menu-helper.tsx
+++ b/apps/web/ce/components/issues/issue-layouts/quick-action-dropdowns/copy-menu-helper.tsx
@@ -12,6 +12,7 @@ export interface CopyMenuHelperProps {
   activeLayout: string;
   setCreateUpdateIssueModal: (open: boolean) => void;
   setDuplicateWorkItemModal?: (open: boolean) => void;
+  workspaceSlug?: string;
 }
 
 export const createCopyMenuWithDuplication = (props: CopyMenuHelperProps): TContextMenuItem => {

--- a/apps/web/core/components/issues/issue-layouts/quick-action-dropdowns/helper.tsx
+++ b/apps/web/core/components/issues/issue-layouts/quick-action-dropdowns/helper.tsx
@@ -164,7 +164,7 @@ export const useMenuItemFactory = (props: MenuItemFactoryProps) => {
     shouldRender: isEditingAllowed,
   });
 
-  const createCopyMenuItem = (): TContextMenuItem => {
+  const createCopyMenuItem = (workspaceSlug?: string): TContextMenuItem => {
     const baseItem = {
       key: "make-a-copy",
       title: t("common.actions.make_a_copy"),
@@ -180,6 +180,7 @@ export const useMenuItemFactory = (props: MenuItemFactoryProps) => {
       activeLayout,
       setCreateUpdateIssueModal,
       setDuplicateWorkItemModal,
+      workspaceSlug,
     });
   };
 
@@ -279,7 +280,7 @@ export const useWorkItemDetailMenuItems = (props: MenuItemFactoryProps): TContex
 
   return useMemo(
     () => [
-      factory.createCopyMenuItem(),
+      factory.createCopyMenuItem(props.workspaceSlug),
       factory.createOpenInNewTabMenuItem(),
       factory.createArchiveMenuItem(),
       factory.createRestoreMenuItem(),

--- a/apps/web/core/components/issues/issue-layouts/quick-action-dropdowns/issue-detail.tsx
+++ b/apps/web/core/components/issues/issue-layouts/quick-action-dropdowns/issue-detail.tsx
@@ -217,6 +217,7 @@ export const WorkItemDetailQuickActions: React.FC<TWorkItemDetailQuickActionProp
         }}
         storeType={EIssuesStoreType.PROJECT}
         isDraft={isDraftIssue}
+        fetchIssueDetails={false}
       />
       {issue.project_id && workspaceSlug && (
         <DuplicateWorkItemModal


### PR DESCRIPTION
### Description
This PR addresses the following:
- Fixes flickering issue caused by duplicate work Item quick action in peek view.
- Refactors code related to duplicate Work Item handling.

### Type of Change
- [x] Bug fix 
- [x] Code refactoring

### References
Work-item: [[WEB-4515]](https://app.plane.so/plane/browse/WEB-4515/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced the copy menu functionality to support an optional workspace identifier.

* **Bug Fixes**
  * Improved issue detail modal behavior by preventing unnecessary fetching of issue details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->