### PR TITLE
[WEB-4510] fix: peek view ui layout

### DIFF
--- a/apps/web/core/components/issues/peek-overview/view.tsx
+++ b/apps/web/core/components/issues/peek-overview/view.tsx
@@ -118,7 +118,7 @@ export const IssueView: FC<IIssueView> = observer((props) => {
       ? "fixed z-[25] flex flex-col overflow-hidden rounded border border-custom-border-200 bg-custom-background-100 transition-all duration-300"
       : `w-full h-full`,
     !embedIssue && {
-      "bottom-0 top-2 bottom-2 right-2 w-full md:w-[50%] border-0 border-l": peekMode === "side-peek",
+      "top-2 bottom-2 right-2 w-full md:w-[50%] border-0 border-l": peekMode === "side-peek",
       "size-5/6 top-[8.33%] left-[8.33%]": peekMode === "modal",
       "inset-0 m-4 absolute": peekMode === "full-screen",
     }

--- a/apps/web/core/components/issues/peek-overview/view.tsx
+++ b/apps/web/core/components/issues/peek-overview/view.tsx
@@ -118,7 +118,7 @@ export const IssueView: FC<IIssueView> = observer((props) => {
       ? "fixed z-[25] flex flex-col overflow-hidden rounded border border-custom-border-200 bg-custom-background-100 transition-all duration-300"
       : `w-full h-full`,
     !embedIssue && {
-      "bottom-0 right-0 top-0 w-full md:w-[50%] border-0 border-l": peekMode === "side-peek",
+      "bottom-0 top-2 bottom-2 right-2 w-full md:w-[50%] border-0 border-l": peekMode === "side-peek",
       "size-5/6 top-[8.33%] left-[8.33%]": peekMode === "modal",
       "inset-0 m-4 absolute": peekMode === "full-screen",
     }


### PR DESCRIPTION
### Description
Addresses a rendering bug in the Peek View UI, ensuring it stays within the canvas bounds.

### Type of Change
- [x] Bug fix 

### Media
| Before | After |
|--------|--------|
| ![WEB-4510-Before](https://github.com/user-attachments/assets/ce24f1a1-2df3-442f-8f57-10d3df9e803a) | ![WEB-4510-After](https://github.com/user-attachments/assets/74ed79a8-d9fd-42c6-9c20-6f6d08a8857a) |

### References
Work-item: [[WEB-4510]](https://app.plane.so/plane/browse/WEB-4510/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Adjusted spacing and positioning of the side-peek container for improved layout and appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->