### PR TITLE
[WEB-4507] fix: webhooks translation

### DIFF
--- a/apps/web/core/components/web-hooks/generated-hook-details.tsx
+++ b/apps/web/core/components/web-hooks/generated-hook-details.tsx
@@ -21,12 +21,8 @@ export const GeneratedHookDetails: React.FC<Props> = (props) => {
     <>
       <div className="space-y-5 p-5">
         <div className="space-y-3">
-          <h3 className="text-xl font-medium text-custom-text-200">
-            {t("workspace_settings.settings.webhooks.modal.secret_key.created")}
-          </h3>
-          <p className="text-sm text-custom-text-400">
-            {t("workspace_settings.settings.webhooks.modal.secret_key.copy_message")}
-          </p>
+          <h3 className="text-xl font-medium text-custom-text-200">{t("workspace_settings.key_created")}</h3>
+          <p className="text-sm text-custom-text-400">{t("workspace_settings.copy_key")}</p>
         </div>
         <WebhookSecretKey data={webhookDetails} />
       </div>


### PR DESCRIPTION
### Description
This PR fixes a translation issue in the Webhooks modal.

### Type of Change
- [x] Bug fix

### Media
| Before | After |
|--------|--------|
| ![before](https://github.com/user-attachments/assets/65c53c20-d649-4f20-827f-c305f5dd40b5) | ![after](https://github.com/user-attachments/assets/8a25056c-65d6-4470-bf3d-42d9f9e6347f) |

### References
Work-item: [[WEB-4507]](https://app.plane.so/plane/browse/WEB-4507/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated translation keys for headings and messages in the webhooks details section to use simplified labels. No changes to layout or styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->