### PR TITLE
Fix : Workspace logo , no fallback when image no available

### DIFF
--- a/apps/web/app/(all)/profile/sidebar.tsx
+++ b/apps/web/app/(all)/profile/sidebar.tsx
@@ -64,6 +64,7 @@ const ProjectActionIcons = ({ type, size, className = "" }: { type: string; size
 export const ProfileLayoutSidebar = observer(() => {
   // states
   const [isSigningOut, setIsSigningOut] = useState(false);
+  const [imgError, setImgError] = useState(false);
   // router
   const pathname = usePathname();
   // store hooks
@@ -211,11 +212,12 @@ export const ProfileLayoutSidebar = observer(() => {
                         !workspace?.logo_url && "rounded bg-custom-primary-500 text-white"
                       }`}
                     >
-                      {workspace?.logo_url && workspace.logo_url !== "" ? (
+                      {workspace?.logo_url && workspace.logo_url !== "" && !imgError ? (
                         <img
                           src={getFileURL(workspace.logo_url)}
                           className="absolute left-0 top-0 h-full w-full rounded object-cover"
                           alt="Workspace Logo"
+                          onError={() => setImgError(true)}
                         />
                       ) : (
                         (workspace?.name?.charAt(0) ?? "...")

--- a/apps/web/app/(all)/profile/sidebar.tsx
+++ b/apps/web/app/(all)/profile/sidebar.tsx
@@ -64,7 +64,6 @@ const ProjectActionIcons = ({ type, size, className = "" }: { type: string; size
 export const ProfileLayoutSidebar = observer(() => {
   // states
   const [isSigningOut, setIsSigningOut] = useState(false);
-  const [imgError, setImgError] = useState(false);
   // router
   const pathname = usePathname();
   // store hooks
@@ -74,6 +73,11 @@ export const ProfileLayoutSidebar = observer(() => {
   const { workspaces } = useWorkspace();
   const { isMobile } = usePlatformOS();
   const { t } = useTranslation();
+  // workspace image errors
+  const [imgErrors, setImgErrors] = useState<Set<string>>(new Set());
+    const handleImageError = (workspaceId: string) => {
+    setImgErrors(prev => new Set(prev).add(workspaceId));
+  };
 
   const workspacesList = Object.values(workspaces ?? {});
 
@@ -212,12 +216,12 @@ export const ProfileLayoutSidebar = observer(() => {
                         !workspace?.logo_url && "rounded bg-custom-primary-500 text-white"
                       }`}
                     >
-                      {workspace?.logo_url && workspace.logo_url !== "" && !imgError ? (
+                      {workspace?.logo_url && workspace.logo_url !== "" && !imgErrors.has(workspace.id) ? (
                         <img
                           src={getFileURL(workspace.logo_url)}
                           className="absolute left-0 top-0 h-full w-full rounded object-cover"
                           alt="Workspace Logo"
-                          onError={() => setImgError(true)}
+                          onError={() => handleImageError(workspace.id)}
                         />
                       ) : (
                         (workspace?.name?.charAt(0) ?? "...")


### PR DESCRIPTION
### Description
Fixes #7420 
Fixed alt text showing when the workspace image url was present but broken by throwing a error and then showing the fallback image correctly

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of workspace logo images by displaying the workspace initial if the logo fails to load, preventing broken image icons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->