### PR TITLE
[WIKI-557] fix: keyboard navigation in tables

### DIFF
--- a/packages/editor/src/core/extensions/table/table/table.ts
+++ b/packages/editor/src/core/extensions/table/table/table.ts
@@ -219,23 +219,23 @@ export const Table = Node.create<TableOptions>({
   addKeyboardShortcuts() {
     return {
       Tab: () => {
-        if (this.editor.isActive(CORE_EXTENSIONS.TABLE)) {
-          if (this.editor.isActive(CORE_EXTENSIONS.LIST_ITEM) || this.editor.isActive(CORE_EXTENSIONS.TASK_ITEM)) {
-            return false;
-          }
-          if (this.editor.commands.goToNextCell()) {
-            return true;
-          }
+        if (!this.editor.isActive(CORE_EXTENSIONS.TABLE)) return false;
 
-          if (!this.editor.can().addRowAfter()) {
-            return false;
-          }
-
-          return this.editor.chain().addRowAfter().goToNextCell().run();
+        if (this.editor.isActive(CORE_EXTENSIONS.LIST_ITEM) || this.editor.isActive(CORE_EXTENSIONS.TASK_ITEM)) {
+          return false;
         }
-        return false;
+
+        return this.editor.chain().addRowAfter().goToNextCell().run();
       },
-      "Shift-Tab": () => this.editor.commands.goToPreviousCell(),
+      "Shift-Tab": () => {
+        if (!this.editor.isActive(CORE_EXTENSIONS.TABLE)) return false;
+
+        if (this.editor.isActive(CORE_EXTENSIONS.LIST_ITEM) || this.editor.isActive(CORE_EXTENSIONS.TASK_ITEM)) {
+          return false;
+        }
+
+        return this.editor.commands.goToPreviousCell();
+      },
       Backspace: handleDeleteKeyOnTable,
       "Mod-Backspace": handleDeleteKeyOnTable,
       Delete: handleDeleteKeyOnTable,


### PR DESCRIPTION
### Description

This PR fixes the logic to navigate in tables using `Tab` and `Shift+Tab` keys.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)