### PR TITLE
[WEB-4192]fix: inactive member is hidden in created by

### DIFF
--- a/apps/api/plane/app/views/workspace/member.py
+++ b/apps/api/plane/app/views/workspace/member.py
@@ -33,7 +33,7 @@ class WorkSpaceMemberViewSet(BaseViewSet):
         return self.filter_queryset(
             super()
             .get_queryset()
-            .filter(workspace__slug=self.kwargs.get("slug"), is_active=True)
+            .filter(workspace__slug=self.kwargs.get("slug"))
             .select_related("member", "member__avatar_asset")
         )
 

--- a/apps/web/core/components/workspace/settings/members-list.tsx
+++ b/apps/web/core/components/workspace/settings/members-list.tsx
@@ -47,7 +47,9 @@ export const WorkspaceMembersList: FC<{ searchQuery: string; isAdmin: boolean }>
   // derived values
   const searchedMemberIds = getSearchedWorkspaceMemberIds(searchQuery);
   const searchedInvitationsIds = getSearchedWorkspaceInvitationIds(searchQuery);
-  const memberDetails = searchedMemberIds?.map((memberId) => getWorkspaceMemberDetails(memberId));
+    const memberDetails = searchedMemberIds
+      ?.map((memberId) => getWorkspaceMemberDetails(memberId))
+      .filter((member) => member?.is_active);
 
   return (
     <>

--- a/apps/web/core/store/member/workspace-member.store.ts
+++ b/apps/web/core/store/member/workspace-member.store.ts
@@ -19,6 +19,7 @@ export interface IWorkspaceMembership {
   id: string;
   member: string;
   role: EUserPermissions;
+  is_active?: boolean;
 }
 
 export interface IWorkspaceMemberStore {
@@ -175,6 +176,7 @@ export class WorkspaceMemberStore implements IWorkspaceMemberStore {
       id: workspaceMember.id,
       role: workspaceMember.role,
       member: this.memberRoot?.memberMap?.[workspaceMember.member],
+      is_active: workspaceMember.is_active,
     };
     return memberDetails;
   });
@@ -207,6 +209,7 @@ export class WorkspaceMemberStore implements IWorkspaceMemberStore {
             id: member.id,
             member: member.member.id,
             role: member.role,
+            is_active: member.is_active,
           });
         });
       });

--- a/packages/types/src/workspace.ts
+++ b/packages/types/src/workspace.ts
@@ -83,6 +83,7 @@ export interface IWorkspaceMember {
   joining_date?: string;
   display_name?: string;
   last_login_medium?: string;
+  is_active?: boolean;
 }
 
 export interface IWorkspaceMemberMe {


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
This update fixes the issue where inactive user is hidden from `Created by` in a work item.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracking the active status of workspace members across the app.

* **Bug Fixes**
  * Ensured only active workspace members are displayed in the members list.

* **Chores**
  * Updated data structures to include an optional active status property for workspace members.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->