### PR TITLE
[WEB-4547]fix: archived work item redirection

### DIFF
--- a/apps/web/core/components/issues/issue-detail/issue-detail-quick-actions.tsx
+++ b/apps/web/core/components/issues/issue-detail/issue-detail-quick-actions.tsx
@@ -106,9 +106,8 @@ export const IssueDetailQuickActions: FC<Props> = observer((props) => {
 
   const handleArchiveIssue = async () => {
     try {
-      await archiveIssue(workspaceSlug, projectId, issueId).then(() => {
-        router.push(`/${workspaceSlug}/projects/${projectId}/archives/issues/${issue.id}`);
-      });
+      await archiveIssue(workspaceSlug, projectId, issueId);
+      router.push(`/${workspaceSlug}/projects/${projectId}/issues`);
       captureSuccess({
         eventName: WORK_ITEM_TRACKER_EVENTS.archive,
         payload: { id: issueId },

--- a/apps/web/core/components/issues/peek-overview/header.tsx
+++ b/apps/web/core/components/issues/peek-overview/header.tsx
@@ -86,8 +86,6 @@ export const IssuePeekOverviewHeader: FC<PeekOverviewHeaderProps> = observer((pr
   } = props;
   // ref
   const parentRef = useRef<HTMLDivElement>(null);
-  // router
-  const router = useAppRouter();
   const { t } = useTranslation();
   // store hooks
   const { data: currentUser } = useUser();
@@ -96,6 +94,7 @@ export const IssuePeekOverviewHeader: FC<PeekOverviewHeaderProps> = observer((pr
     setPeekIssue,
     removeIssue,
     archiveIssue,
+    getIsIssuePeeked,
   } = useIssueDetail();
   const { isMobile } = usePlatformOS();
   const { getProjectIdentifierById } = useProject();
@@ -155,9 +154,11 @@ export const IssuePeekOverviewHeader: FC<PeekOverviewHeaderProps> = observer((pr
 
   const handleArchiveIssue = async () => {
     try {
-      await archiveIssue(workspaceSlug, projectId, issueId).then(() => {
-        router.push(`/${workspaceSlug}/projects/${projectId}/archives/issues/${issueDetails?.id}`);
-      });
+      await archiveIssue(workspaceSlug, projectId, issueId);
+      // check and remove if issue is peeked
+      if (getIsIssuePeeked(issueId)) {
+        removeRoutePeekId();
+      }
       captureSuccess({
         eventName: WORK_ITEM_TRACKER_EVENTS.archive,
         payload: { id: issueId },


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
This update fixes the work item redirection after archiving.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the issue archiving process to improve navigation and state handling after an issue is archived.
  * Navigation after archiving now directs to the active issues list or conditionally clears peeked issue state, providing a smoother user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->