### PR TITLE
fix: eslint warnings and errors in the editor package

### DIFF
--- a/packages/editor/src/core/extensions/code/lowlight-plugin.ts
+++ b/packages/editor/src/core/extensions/code/lowlight-plugin.ts
@@ -1,3 +1,5 @@
+// TODO: check all the type errors and fix them
+
 import { findChildren } from "@tiptap/core";
 import { Node as ProsemirrorNode } from "@tiptap/pm/model";
 import { Plugin, PluginKey } from "@tiptap/pm/state";
@@ -117,19 +119,15 @@ export function LowlightPlugin({
             // Such transactions can happen during collab syncing via y-prosemirror, for example.
             transaction.steps.some(
               (step) =>
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                // @ts-expect-error
+                // @ts-expect-error type error
                 step.from !== undefined &&
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                // @ts-expect-error
+                // @ts-expect-error type error
                 step.to !== undefined &&
                 oldNodes.some(
                   (node) =>
-                    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                    // @ts-expect-error
+                    // @ts-expect-error type error
                     node.pos >= step.from &&
-                    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                    // @ts-expect-error
+                    // @ts-expect-error type error
                     node.pos + node.node.nodeSize <= step.to
                 )
             ))

--- a/packages/editor/src/core/helpers/scroll-to-node.ts
+++ b/packages/editor/src/core/helpers/scroll-to-node.ts
@@ -32,11 +32,8 @@ function scrollToNode(editor: Editor, pos: number): void {
   }
 }
 
-export function scrollToNodeViaDOMCoordinates(
-  editor: Editor,
-  pos: number,
-  behavior?: "auto" | "smooth" | "instant"
-): void {
+// eslint-disable-next-line no-undef
+export function scrollToNodeViaDOMCoordinates(editor: Editor, pos: number, behavior?: ScrollBehavior): void {
   const view = editor.view;
 
   // Get the coordinates of the position

--- a/packages/editor/src/core/types/editor.ts
+++ b/packages/editor/src/core/types/editor.ts
@@ -111,7 +111,8 @@ export interface EditorRefApi extends EditorReadOnlyRefApi {
   onDocumentInfoChange: (callback: (documentInfo: TDocumentInfo) => void) => () => void;
   onHeadingChange: (callback: (headings: IMarking[]) => void) => () => void;
   onStateChange: (callback: () => void) => () => void;
-  scrollToNodeViaDOMCoordinates: (behavior?: "auto" | "smooth" | "instant", position?: number) => void;
+  // eslint-disable-next-line no-undef
+  scrollToNodeViaDOMCoordinates: (behavior?: ScrollBehavior, position?: number) => void;
   setEditorValueAtCursorPosition: (content: string) => void;
   setFocusAtPosition: (position: number) => void;
   setProviderDocument: (value: Uint8Array) => void;

--- a/packages/editor/src/core/types/slash-commands-suggestion.ts
+++ b/packages/editor/src/core/types/slash-commands-suggestion.ts
@@ -1,5 +1,5 @@
-import { Editor, Range } from "@tiptap/core";
-import { CSSProperties } from "react";
+import type { Editor, Range } from "@tiptap/core";
+import type { CSSProperties } from "react";
 // types
 import { TEditorCommands } from "@/types";
 


### PR DESCRIPTION
### Description

This PR refactors the way some eslint and typescript errors and warnings are handled in the editor package.

### Type of Change

- [x] Improvement (change that would cause existing functionality to not work as expected)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated type annotations for scroll behavior to use the standard `ScrollBehavior` type across relevant editor functions and interfaces.
  * Improved clarity and consistency of TypeScript error suppression comments.
  * Switched to type-only imports for certain dependencies to optimize type usage.

* **Style**
  * Added ESLint directives to suppress specific linting warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->