### PR TITLE
[WEB-4563]fix: image full screen modal

### DIFF
--- a/packages/editor/src/core/extensions/custom-image/components/toolbar/full-screen/modal.tsx
+++ b/packages/editor/src/core/extensions/custom-image/components/toolbar/full-screen/modal.tsx
@@ -191,7 +191,7 @@ const ImageFullScreenModalWithoutPortal = (props: Props) => {
 
   return (
     <div
-      className={cn("fixed inset-0 size-full z-30 bg-black/90 opacity-0 pointer-events-none transition-opacity", {
+      className={cn("fixed inset-0 size-full z-50 bg-black/90 opacity-0 pointer-events-none transition-opacity", {
         "opacity-100 pointer-events-auto editor-image-full-screen-modal": isFullScreenEnabled,
         "cursor-default": !isDragging,
         "cursor-grabbing": isDragging,


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
This update fixes the `z-index` positioning of image full screen modal with respect to other modals.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update