### PR TITLE
[WEB-4597]fix: project icon render in switcher

### DIFF
--- a/apps/web/ce/components/breadcrumbs/project.tsx
+++ b/apps/web/ce/components/breadcrumbs/project.tsx
@@ -37,7 +37,9 @@ export const ProjectBreadcrumb = observer((props: TProjectBreadcrumbProps) => {
       return {
         value: projectId,
         query: project?.name,
-        content: <SwitcherLabel name={project?.name} logo_props={project?.logo_props} LabelIcon={Briefcase} />,
+        content: (
+          <SwitcherLabel name={project?.name} logo_props={project?.logo_props} LabelIcon={Briefcase} type="material" />
+        ),
       };
     })
     .filter((option) => option !== undefined) as ICustomSearchSelectOption[];

--- a/apps/web/core/components/common/switcher-label.tsx
+++ b/apps/web/core/components/common/switcher-label.tsx
@@ -8,11 +8,18 @@ type TSwitcherIconProps = {
   logo_url?: string;
   LabelIcon: FC<ISvgIcons>;
   size?: number;
+  type?: "lucide" | "material";
 };
 
-export const SwitcherIcon: FC<TSwitcherIconProps> = ({ logo_props, logo_url, LabelIcon, size = 12 }) => {
+export const SwitcherIcon: FC<TSwitcherIconProps> = ({
+  logo_props,
+  logo_url,
+  LabelIcon,
+  size = 12,
+  type = "lucide",
+}) => {
   if (logo_props?.in_use) {
-    return <Logo logo={logo_props} size={size} type="lucide" />;
+    return <Logo logo={logo_props} size={size} type={type} />;
   }
 
   if (logo_url) {
@@ -33,13 +40,14 @@ type TSwitcherLabelProps = {
   logo_url?: string;
   name?: string;
   LabelIcon: FC<ISvgIcons>;
+  type?: "lucide" | "material";
 };
 
 export const SwitcherLabel: FC<TSwitcherLabelProps> = (props) => {
-  const { logo_props, name, LabelIcon, logo_url } = props;
+  const { logo_props, name, LabelIcon, logo_url, type = "lucide" } = props;
   return (
     <div className="flex items-center gap-1 text-custom-text-200">
-      <SwitcherIcon logo_props={logo_props} logo_url={logo_url} LabelIcon={LabelIcon} />
+      <SwitcherIcon logo_props={logo_props} logo_url={logo_url} LabelIcon={LabelIcon} type={type} />
       {truncateText(name ?? "", 40)}
     </div>
   );


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
This update fixes the issue where project switcher option is not rendering project icons.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
<!-- Link related issues if there are any -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting between "lucide" and "material" icon styles in switcher components, allowing for more flexible icon appearance in the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->