### PR TITLE
[WIKI-573] regression: comment card padding

### DIFF
--- a/apps/web/core/components/editor/lite-text/editor.tsx
+++ b/apps/web/core/components/editor/lite-text/editor.tsx
@@ -89,7 +89,13 @@ export const LiteTextEditor = React.forwardRef<EditorRefApi, LiteTextEditorWrapp
 
   return (
     <div
-      className={cn("relative border border-custom-border-200 rounded p-3", parentClassName)}
+      className={cn(
+        "relative border border-custom-border-200 rounded",
+        {
+          "p-3": editable,
+        },
+        parentClassName
+      )}
       onFocus={() => !showToolbarInitially && setIsFocused(true)}
       onBlur={() => !showToolbarInitially && setIsFocused(false)}
     >
@@ -116,7 +122,9 @@ export const LiteTextEditor = React.forwardRef<EditorRefApi, LiteTextEditorWrapp
           }),
         }}
         placeholder={placeholder}
-        containerClassName={cn(containerClassName, "relative")}
+        containerClassName={cn(containerClassName, "relative", {
+          "p-2": !editable,
+        })}
         {...rest}
       />
       {showToolbar && editable && (


### PR DESCRIPTION
### Description

This PR fixes the padding for read only lite text editors.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Padding around the editor now adjusts dynamically based on whether editing is enabled, providing a more consistent visual experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->