### PR TITLE
Potential fix for code scanning alert no. 631: Incomplete URL scheme check

### DIFF
--- a/apps/web/core/lib/n-progress/AppProgressBar.tsx
+++ b/apps/web/core/lib/n-progress/AppProgressBar.tsx
@@ -113,6 +113,7 @@ export const AppProgressBar = React.memo(
 
     useEffect(() => {
       if (progressDoneTimer) clearTimeout(progressDoneTimer);
+      // eslint-disable-next-line react-hooks/exhaustive-deps
       progressDoneTimer = setTimeout(() => {
         NProgress.done();
       }, stopDelay);
@@ -141,6 +142,7 @@ export const AppProgressBar = React.memo(
         }, stopDelay);
       };
 
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const handleAnchorClick: any = (event: MouseEvent) => {
         // Skip preventDefault
         if (event.defaultPrevented) return;
@@ -213,6 +215,7 @@ export const AppProgressBar = React.memo(
         elementsWithAttachedHandlers.current = [];
         window.history.pushState = originalWindowHistoryPushState;
       };
+      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
     return styles;
@@ -252,6 +255,7 @@ export function useRouter() {
       if (startPosition && startPosition > 0) NProgress.set(startPosition);
       NProgress.start();
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [router]
   );
 
@@ -269,6 +273,7 @@ export function useRouter() {
 
       startProgress(NProgressOptions?.startPosition);
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [router]
   );
 
@@ -277,6 +282,7 @@ export function useRouter() {
       progress(href, options, NProgressOptions);
       return router.push(href, options);
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [router, startProgress]
   );
 
@@ -285,6 +291,7 @@ export function useRouter() {
       progress(href, options, NProgressOptions);
       return router.replace(href, options);
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [router, startProgress]
   );
 
@@ -296,6 +303,7 @@ export function useRouter() {
 
       return router.back();
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [router]
   );
 

--- a/apps/web/core/lib/n-progress/AppProgressBar.tsx
+++ b/apps/web/core/lib/n-progress/AppProgressBar.tsx
@@ -182,7 +182,9 @@ export const AppProgressBar = React.memo(
             !href.startsWith("tel:") &&
             !href.startsWith("mailto:") &&
             !href.startsWith("blob:") &&
-            !href.startsWith("javascript:");
+            !href.startsWith("javascript:") &&
+            !href.startsWith("data:") &&
+            !href.startsWith("vbscript:");
 
           return !isNProgressDisabled && isNotTelOrMailto && getAnchorProperty(anchor, "target") !== "_blank";
         });


### PR DESCRIPTION
Potential fix for [https://github.com/makeplane/plane/security/code-scanning/631](https://github.com/makeplane/plane/security/code-scanning/631)

To fix the problem, update the filter logic in the `validAnchorElements` definition (line 185) to also exclude anchors whose `href` starts with `"data:"` or `"vbscript:"`, in addition to `"javascript:"`. This can be done by extending the conditional to check for all three schemes. No additional imports or major refactoring are needed; just update the relevant line in the filter function.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved link handling to prevent the progress bar from starting when clicking on links with "data:" and "vbscript:" schemes, in addition to previously excluded schemes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->