### PR TITLE
[WEB-4602] fix: 500 error on draft wi labels update

### DIFF
--- a/apps/api/plane/app/serializers/draft.py
+++ b/apps/api/plane/app/serializers/draft.py
@@ -260,7 +260,7 @@ class DraftIssueCreateSerializer(BaseSerializer):
             DraftIssueLabel.objects.bulk_create(
                 [
                     DraftIssueLabel(
-                        label=label,
+                        label_id=label,
                         draft_issue=instance,
                         workspace_id=workspace_id,
                         project_id=project_id,


### PR DESCRIPTION
### Description
This PR will resolve the 500 internal server error that occurs when updating labels for draft WIs. 

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### References

[Sentry Error](https://plane-hq.sentry.io/issues/6779104938/?alert_rule_id=14717135&alert_type=issue&environment=production&notification_uuid=c3398a07-fe52-415b-8930-06ac5e2796e6&project=4505441149714432&referrer=slack)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when updating draft issue labels to ensure correct label assignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->