### PR TITLE
fix: enable email notification by default for new users

### DIFF
--- a/apps/api/plane/db/models/user.py
+++ b/apps/api/plane/db/models/user.py
@@ -276,9 +276,9 @@ def create_user_notification(sender, instance, created, **kwargs):
 
         UserNotificationPreference.objects.create(
             user=instance,
-            property_change=False,
-            state_change=False,
-            comment=False,
-            mention=False,
-            issue_completed=False,
+            property_change=True,
+            state_change=True,
+            comment=True,
+            mention=True,
+            issue_completed=True,
         )


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
- Enable email notification by default for new users

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Improvement (change that would cause existing functionality to not work as expected)

### References
<!-- Link related issues if there are any -->
#5381 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New users now have all notification preferences enabled by default, ensuring they receive updates on property changes, state changes, comments, mentions, and issue completions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->