### PR TITLE
[INFRA-219] fix: update Dockerfile and docker-compose for proxy service

### DIFF
--- a/apps/proxy/Dockerfile.ce
+++ b/apps/proxy/Dockerfile.ce
@@ -5,7 +5,7 @@ RUN xcaddy build \
         --with github.com/caddy-dns/digitalocean@04bde2867106aa1b44c2f9da41a285fa02e629c5 \
         --with github.com/mholt/caddy-l4@4d3c80e89c5f80438a3e048a410d5543ff5fb9f4
 
-FROM caddy:2.10.0-builder-alpine
+FROM caddy:2.10.0-alpine
 
 RUN apk add --no-cache nss-tools bash curl
 

--- a/deployments/cli/community/docker-compose.yml
+++ b/deployments/cli/community/docker-compose.yml
@@ -60,7 +60,7 @@ x-app-env: &app-env
 
 services:
   web:
-    image: artifacts.plane.so/makeplane/plane-frontend:${APP_RELEASE:-v0.28.0}
+    image: artifacts.plane.so/makeplane/plane-frontend:${APP_RELEASE:-stable}
     deploy:
       replicas: ${WEB_REPLICAS:-1}
       restart_policy:
@@ -70,7 +70,7 @@ services:
       - worker
 
   space:
-    image: artifacts.plane.so/makeplane/plane-space:${APP_RELEASE:-v0.28.0}
+    image: artifacts.plane.so/makeplane/plane-space:${APP_RELEASE:-stable}
     deploy:
       replicas: ${SPACE_REPLICAS:-1}
       restart_policy:
@@ -81,7 +81,7 @@ services:
       - web
 
   admin:
-    image: artifacts.plane.so/makeplane/plane-admin:${APP_RELEASE:-v0.28.0}
+    image: artifacts.plane.so/makeplane/plane-admin:${APP_RELEASE:-stable}
     deploy:
       replicas: ${ADMIN_REPLICAS:-1}
       restart_policy:
@@ -91,7 +91,7 @@ services:
       - web
 
   live:
-    image: artifacts.plane.so/makeplane/plane-live:${APP_RELEASE:-v0.28.0}
+    image: artifacts.plane.so/makeplane/plane-live:${APP_RELEASE:-stable}
     environment:
       <<: [*live-env]
     deploy:
@@ -103,7 +103,7 @@ services:
       - web
 
   api:
-    image: artifacts.plane.so/makeplane/plane-backend:${APP_RELEASE:-v0.28.0}
+    image: artifacts.plane.so/makeplane/plane-backend:${APP_RELEASE:-stable}
     command: ./bin/docker-entrypoint-api.sh
     deploy:
       replicas: ${API_REPLICAS:-1}
@@ -119,7 +119,7 @@ services:
       - plane-mq
 
   worker:
-    image: artifacts.plane.so/makeplane/plane-backend:${APP_RELEASE:-v0.28.0}
+    image: artifacts.plane.so/makeplane/plane-backend:${APP_RELEASE:-stable}
     command: ./bin/docker-entrypoint-worker.sh
     deploy:
       replicas: ${WORKER_REPLICAS:-1}
@@ -136,7 +136,7 @@ services:
       - plane-mq
 
   beat-worker:
-    image: artifacts.plane.so/makeplane/plane-backend:${APP_RELEASE:-v0.28.0}
+    image: artifacts.plane.so/makeplane/plane-backend:${APP_RELEASE:-stable}
     command: ./bin/docker-entrypoint-beat.sh
     deploy:
       replicas: ${BEAT_WORKER_REPLICAS:-1}
@@ -153,7 +153,7 @@ services:
       - plane-mq
 
   migrator:
-    image: artifacts.plane.so/makeplane/plane-backend:${APP_RELEASE:-v0.28.0}
+    image: artifacts.plane.so/makeplane/plane-backend:${APP_RELEASE:-stable}
     command: ./bin/docker-entrypoint-migrator.sh
     deploy:
       replicas: 1
@@ -215,7 +215,7 @@ services:
 
   # Comment this if you already have a reverse proxy running
   proxy:
-    image: artifacts.plane.so/makeplane/plane-proxy:${APP_RELEASE:-v0.28.0}
+    image: artifacts.plane.so/makeplane/plane-proxy:${APP_RELEASE:-stable}
     deploy:
       replicas: 1
       restart_policy:

--- a/deployments/cli/community/docker-compose.yml
+++ b/deployments/cli/community/docker-compose.yml
@@ -60,7 +60,7 @@ x-app-env: &app-env
 
 services:
   web:
-    image: artifacts.plane.so/makeplane/plane-frontend:${APP_RELEASE:-stable}
+    image: artifacts.plane.so/makeplane/plane-frontend:${APP_RELEASE:-v0.28.0}
     deploy:
       replicas: ${WEB_REPLICAS:-1}
       restart_policy:
@@ -70,7 +70,7 @@ services:
       - worker
 
   space:
-    image: artifacts.plane.so/makeplane/plane-space:${APP_RELEASE:-stable}
+    image: artifacts.plane.so/makeplane/plane-space:${APP_RELEASE:-v0.28.0}
     deploy:
       replicas: ${SPACE_REPLICAS:-1}
       restart_policy:
@@ -81,7 +81,7 @@ services:
       - web
 
   admin:
-    image: artifacts.plane.so/makeplane/plane-admin:${APP_RELEASE:-stable}
+    image: artifacts.plane.so/makeplane/plane-admin:${APP_RELEASE:-v0.28.0}
     deploy:
       replicas: ${ADMIN_REPLICAS:-1}
       restart_policy:
@@ -91,7 +91,7 @@ services:
       - web
 
   live:
-    image: artifacts.plane.so/makeplane/plane-live:${APP_RELEASE:-stable}
+    image: artifacts.plane.so/makeplane/plane-live:${APP_RELEASE:-v0.28.0}
     environment:
       <<: [*live-env]
     deploy:
@@ -103,7 +103,7 @@ services:
       - web
 
   api:
-    image: artifacts.plane.so/makeplane/plane-backend:${APP_RELEASE:-stable}
+    image: artifacts.plane.so/makeplane/plane-backend:${APP_RELEASE:-v0.28.0}
     command: ./bin/docker-entrypoint-api.sh
     deploy:
       replicas: ${API_REPLICAS:-1}
@@ -119,7 +119,7 @@ services:
       - plane-mq
 
   worker:
-    image: artifacts.plane.so/makeplane/plane-backend:${APP_RELEASE:-stable}
+    image: artifacts.plane.so/makeplane/plane-backend:${APP_RELEASE:-v0.28.0}
     command: ./bin/docker-entrypoint-worker.sh
     deploy:
       replicas: ${WORKER_REPLICAS:-1}
@@ -136,7 +136,7 @@ services:
       - plane-mq
 
   beat-worker:
-    image: artifacts.plane.so/makeplane/plane-backend:${APP_RELEASE:-stable}
+    image: artifacts.plane.so/makeplane/plane-backend:${APP_RELEASE:-v0.28.0}
     command: ./bin/docker-entrypoint-beat.sh
     deploy:
       replicas: ${BEAT_WORKER_REPLICAS:-1}
@@ -153,7 +153,7 @@ services:
       - plane-mq
 
   migrator:
-    image: artifacts.plane.so/makeplane/plane-backend:${APP_RELEASE:-stable}
+    image: artifacts.plane.so/makeplane/plane-backend:${APP_RELEASE:-v0.28.0}
     command: ./bin/docker-entrypoint-migrator.sh
     deploy:
       replicas: 1
@@ -215,16 +215,7 @@ services:
 
   # Comment this if you already have a reverse proxy running
   proxy:
-    image: artifacts.plane.so/makeplane/plane-proxy:${APP_RELEASE:-stable}
-    command:
-      [
-        "caddy",
-        "run",
-        "--config",
-        "/etc/caddy/Caddyfile",
-        "--adapter",
-        "caddyfile",
-      ]
+    image: artifacts.plane.so/makeplane/plane-proxy:${APP_RELEASE:-v0.28.0}
     deploy:
       replicas: 1
       restart_policy:

--- a/deployments/cli/community/install.sh
+++ b/deployments/cli/community/install.sh
@@ -57,7 +57,7 @@ function spinner() {
 
 function checkLatestRelease(){
     echo "Checking for the latest release..." >&2
-    local latest_release=$(curl -s https://api.github.com/repos/$GH_REPO/releases/latest |  grep -o '"tag_name": "[^"]*"' | sed 's/"tag_name": "//;s/"//g')
+    local latest_release=$(curl -fsSL https://api.github.com/repos/$GH_REPO/releases/latest |  grep -o '"tag_name": "[^"]*"' | sed 's/"tag_name": "//;s/"//g')
     if [ -z "$latest_release" ]; then
         echo "Failed to check for the latest release. Exiting..." >&2
         exit 1
@@ -247,7 +247,7 @@ function download() {
         mv $PLANE_INSTALL_DIR/docker-compose.yaml $PLANE_INSTALL_DIR/archive/$TS.docker-compose.yaml
     fi
 
-    RESPONSE=$(curl -H 'Cache-Control: no-cache, no-store' -s -w "HTTPSTATUS:%{http_code}" "$RELEASE_DOWNLOAD_URL/$APP_RELEASE/docker-compose.yml?$(date +%s)")
+    RESPONSE=$(curl -fsSL -H 'Cache-Control: no-cache, no-store' -s -w "HTTPSTATUS:%{http_code}" "$RELEASE_DOWNLOAD_URL/$APP_RELEASE/docker-compose.yml?$(date +%s)")
     BODY=$(echo "$RESPONSE" | sed -e 's/HTTPSTATUS\:.*//g')
     STATUS=$(echo "$RESPONSE" | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
 
@@ -255,7 +255,7 @@ function download() {
         echo "$BODY" > $PLANE_INSTALL_DIR/docker-compose.yaml
     else
         # Fallback to download from the raw github url
-        RESPONSE=$(curl -H 'Cache-Control: no-cache, no-store' -s -w "HTTPSTATUS:%{http_code}" "$FALLBACK_DOWNLOAD_URL/docker-compose.yml?$(date +%s)")
+        RESPONSE=$(curl -fsSL -H 'Cache-Control: no-cache, no-store' -s -w "HTTPSTATUS:%{http_code}" "$FALLBACK_DOWNLOAD_URL/docker-compose.yml?$(date +%s)")
         BODY=$(echo "$RESPONSE" | sed -e 's/HTTPSTATUS\:.*//g')
         STATUS=$(echo "$RESPONSE" | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
 
@@ -269,7 +269,7 @@ function download() {
         fi
     fi
 
-    RESPONSE=$(curl -H 'Cache-Control: no-cache, no-store' -s -w "HTTPSTATUS:%{http_code}" "$RELEASE_DOWNLOAD_URL/$APP_RELEASE/variables.env?$(date +%s)")
+    RESPONSE=$(curl -fsSL -H 'Cache-Control: no-cache, no-store' -s -w "HTTPSTATUS:%{http_code}" "$RELEASE_DOWNLOAD_URL/$APP_RELEASE/variables.env?$(date +%s)")
     BODY=$(echo "$RESPONSE" | sed -e 's/HTTPSTATUS\:.*//g')
     STATUS=$(echo "$RESPONSE" | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
 
@@ -277,7 +277,7 @@ function download() {
         echo "$BODY" > $PLANE_INSTALL_DIR/variables-upgrade.env
     else
         # Fallback to download from the raw github url
-        RESPONSE=$(curl -H 'Cache-Control: no-cache, no-store' -s -w "HTTPSTATUS:%{http_code}" "$FALLBACK_DOWNLOAD_URL/variables.env?$(date +%s)")
+        RESPONSE=$(curl -fsSL -H 'Cache-Control: no-cache, no-store' -s -w "HTTPSTATUS:%{http_code}" "$FALLBACK_DOWNLOAD_URL/variables.env?$(date +%s)")
         BODY=$(echo "$RESPONSE" | sed -e 's/HTTPSTATUS\:.*//g')
         STATUS=$(echo "$RESPONSE" | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
 

--- a/deployments/cli/community/install.sh
+++ b/deployments/cli/community/install.sh
@@ -57,7 +57,7 @@ function spinner() {
 
 function checkLatestRelease(){
     echo "Checking for the latest release..." >&2
-    local latest_release=$(curl -fsSL https://api.github.com/repos/$GH_REPO/releases/latest |  grep -o '"tag_name": "[^"]*"' | sed 's/"tag_name": "//;s/"//g')
+    local latest_release=$(curl -sSL https://api.github.com/repos/$GH_REPO/releases/latest |  grep -o '"tag_name": "[^"]*"' | sed 's/"tag_name": "//;s/"//g')
     if [ -z "$latest_release" ]; then
         echo "Failed to check for the latest release. Exiting..." >&2
         exit 1
@@ -247,7 +247,7 @@ function download() {
         mv $PLANE_INSTALL_DIR/docker-compose.yaml $PLANE_INSTALL_DIR/archive/$TS.docker-compose.yaml
     fi
 
-    RESPONSE=$(curl -fsSL -H 'Cache-Control: no-cache, no-store' -s -w "HTTPSTATUS:%{http_code}" "$RELEASE_DOWNLOAD_URL/$APP_RELEASE/docker-compose.yml?$(date +%s)")
+    RESPONSE=$(curl -sSL -H 'Cache-Control: no-cache, no-store' -w "HTTPSTATUS:%{http_code}" "$RELEASE_DOWNLOAD_URL/$APP_RELEASE/docker-compose.yml?$(date +%s)")
     BODY=$(echo "$RESPONSE" | sed -e 's/HTTPSTATUS\:.*//g')
     STATUS=$(echo "$RESPONSE" | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
 
@@ -255,7 +255,7 @@ function download() {
         echo "$BODY" > $PLANE_INSTALL_DIR/docker-compose.yaml
     else
         # Fallback to download from the raw github url
-        RESPONSE=$(curl -fsSL -H 'Cache-Control: no-cache, no-store' -s -w "HTTPSTATUS:%{http_code}" "$FALLBACK_DOWNLOAD_URL/docker-compose.yml?$(date +%s)")
+        RESPONSE=$(curl -sSL -H 'Cache-Control: no-cache, no-store' -w "HTTPSTATUS:%{http_code}" "$FALLBACK_DOWNLOAD_URL/docker-compose.yml?$(date +%s)")
         BODY=$(echo "$RESPONSE" | sed -e 's/HTTPSTATUS\:.*//g')
         STATUS=$(echo "$RESPONSE" | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
 
@@ -269,7 +269,7 @@ function download() {
         fi
     fi
 
-    RESPONSE=$(curl -fsSL -H 'Cache-Control: no-cache, no-store' -s -w "HTTPSTATUS:%{http_code}" "$RELEASE_DOWNLOAD_URL/$APP_RELEASE/variables.env?$(date +%s)")
+    RESPONSE=$(curl -sSL -H 'Cache-Control: no-cache, no-store' -w "HTTPSTATUS:%{http_code}" "$RELEASE_DOWNLOAD_URL/$APP_RELEASE/variables.env?$(date +%s)")
     BODY=$(echo "$RESPONSE" | sed -e 's/HTTPSTATUS\:.*//g')
     STATUS=$(echo "$RESPONSE" | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
 
@@ -277,7 +277,7 @@ function download() {
         echo "$BODY" > $PLANE_INSTALL_DIR/variables-upgrade.env
     else
         # Fallback to download from the raw github url
-        RESPONSE=$(curl -fsSL -H 'Cache-Control: no-cache, no-store' -s -w "HTTPSTATUS:%{http_code}" "$FALLBACK_DOWNLOAD_URL/variables.env?$(date +%s)")
+        RESPONSE=$(curl -sSL -H 'Cache-Control: no-cache, no-store' -w "HTTPSTATUS:%{http_code}" "$FALLBACK_DOWNLOAD_URL/variables.env?$(date +%s)")
         BODY=$(echo "$RESPONSE" | sed -e 's/HTTPSTATUS\:.*//g')
         STATUS=$(echo "$RESPONSE" | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
 


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
  * Updated the Dockerfile to use a slimmer runtime image for the proxy service.
  * Removed the explicit startup command for the proxy service in Docker Compose, relying on the image’s default behavior.
  * Improved reliability of installation script downloads by enhancing curl commands to better handle HTTP errors.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Dockerfile to use a slimmer runtime image for the proxy service.
  * Removed explicit startup command for the proxy service in Docker Compose, now relying on the image’s default behavior.
  * Improved reliability of installation script by ensuring curl follows HTTP redirects when fetching files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->