### PR TITLE
[WIKI-576] fix: trail node

### DIFF
--- a/apps/space/ce/hooks/use-editor-flagging.ts
+++ b/apps/space/ce/hooks/use-editor-flagging.ts
@@ -1,0 +1,35 @@
+// editor
+import { TExtensions } from "@plane/editor";
+
+export type TEditorFlaggingHookReturnType = {
+  document: {
+    disabled: TExtensions[];
+    flagged: TExtensions[];
+  };
+  liteText: {
+    disabled: TExtensions[];
+    flagged: TExtensions[];
+  };
+  richText: {
+    disabled: TExtensions[];
+    flagged: TExtensions[];
+  };
+};
+
+/**
+ * @description extensions disabled in various editors
+ */
+export const useEditorFlagging = (workspaceSlug: string): TEditorFlaggingHookReturnType => ({
+  document: {
+    disabled: ["ai", "collaboration-cursor"],
+    flagged: [],
+  },
+  liteText: {
+    disabled: ["ai", "collaboration-cursor"],
+    flagged: [],
+  },
+  richText: {
+    disabled: ["ai", "collaboration-cursor"],
+    flagged: [],
+  },
+});

--- a/apps/space/ce/hooks/use-editor-flagging.ts
+++ b/apps/space/ce/hooks/use-editor-flagging.ts
@@ -19,17 +19,17 @@ export type TEditorFlaggingHookReturnType = {
 /**
  * @description extensions disabled in various editors
  */
-export const useEditorFlagging = (workspaceSlug: string): TEditorFlaggingHookReturnType => ({
+export const useEditorFlagging = (anchor: string): TEditorFlaggingHookReturnType => ({
   document: {
-    disabled: ["ai", "collaboration-cursor"],
+    disabled: [],
     flagged: [],
   },
   liteText: {
-    disabled: ["ai", "collaboration-cursor"],
+    disabled: [],
     flagged: [],
   },
   richText: {
-    disabled: ["ai", "collaboration-cursor"],
+    disabled: [],
     flagged: [],
   },
 });

--- a/apps/space/core/components/editor/lite-text-editor.tsx
+++ b/apps/space/core/components/editor/lite-text-editor.tsx
@@ -8,6 +8,7 @@ import { EditorMentionsRoot, IssueCommentToolbar } from "@/components/editor";
 // helpers
 import { getEditorFileHandlers } from "@/helpers/editor.helper";
 import { isCommentEmpty } from "@/helpers/string.helper";
+import { useEditorFlagging } from "@/plane-web/hooks/use-editor-flagging";
 
 type LiteTextEditorWrapperProps = MakeOptional<
   Omit<ILiteTextEditorProps, "fileHandler" | "mentionHandler">,
@@ -45,13 +46,14 @@ export const LiteTextEditor = React.forwardRef<EditorRefApi, LiteTextEditorWrapp
   // derived values
   const isEmpty = isCommentEmpty(props.initialValue);
   const editorRef = isMutableRefObject<EditorRefApi>(ref) ? ref.current : null;
+  const { liteText } = useEditorFlagging(anchor);
 
   return (
     <div className="border border-custom-border-200 rounded p-3 space-y-3">
       <LiteTextEditorWithRef
         ref={ref}
         disabledExtensions={disabledExtensions ?? []}
-        flaggedExtensions={flaggedExtensions ?? []}
+        flaggedExtensions={liteText.flagged}
         editable={editable}
         fileHandler={getEditorFileHandlers({
           anchor,

--- a/apps/space/core/components/editor/lite-text-editor.tsx
+++ b/apps/space/core/components/editor/lite-text-editor.tsx
@@ -32,6 +32,7 @@ export const LiteTextEditor = React.forwardRef<EditorRefApi, LiteTextEditorWrapp
   const {
     anchor,
     containerClassName,
+    disabledExtensions: additionalDisabledExtensions = [],
     editable,
     isSubmitting = false,
     showSubmitButton = true,
@@ -44,14 +45,14 @@ export const LiteTextEditor = React.forwardRef<EditorRefApi, LiteTextEditorWrapp
   // derived values
   const isEmpty = isCommentEmpty(props.initialValue);
   const editorRef = isMutableRefObject<EditorRefApi>(ref) ? ref.current : null;
-  const { liteText } = useEditorFlagging(anchor);
+  const { liteText: liteTextEditorExtensions } = useEditorFlagging(anchor);
 
   return (
     <div className="border border-custom-border-200 rounded p-3 space-y-3">
       <LiteTextEditorWithRef
         ref={ref}
-        disabledExtensions={liteText.disabled}
-        flaggedExtensions={liteText.flagged}
+        disabledExtensions={[...liteTextEditorExtensions.disabled, ...additionalDisabledExtensions]}
+        flaggedExtensions={liteTextEditorExtensions.flagged}
         editable={editable}
         fileHandler={getEditorFileHandlers({
           anchor,

--- a/apps/space/core/components/editor/lite-text-editor.tsx
+++ b/apps/space/core/components/editor/lite-text-editor.tsx
@@ -32,7 +32,6 @@ export const LiteTextEditor = React.forwardRef<EditorRefApi, LiteTextEditorWrapp
   const {
     anchor,
     containerClassName,
-    disabledExtensions,
     editable,
     isSubmitting = false,
     showSubmitButton = true,
@@ -51,7 +50,7 @@ export const LiteTextEditor = React.forwardRef<EditorRefApi, LiteTextEditorWrapp
     <div className="border border-custom-border-200 rounded p-3 space-y-3">
       <LiteTextEditorWithRef
         ref={ref}
-        disabledExtensions={disabledExtensions ?? []}
+        disabledExtensions={liteText.disabled}
         flaggedExtensions={liteText.flagged}
         editable={editable}
         fileHandler={getEditorFileHandlers({

--- a/apps/space/core/components/editor/lite-text-editor.tsx
+++ b/apps/space/core/components/editor/lite-text-editor.tsx
@@ -34,7 +34,6 @@ export const LiteTextEditor = React.forwardRef<EditorRefApi, LiteTextEditorWrapp
     containerClassName,
     disabledExtensions,
     editable,
-    flaggedExtensions,
     isSubmitting = false,
     showSubmitButton = true,
     workspaceId,

--- a/apps/space/core/components/editor/rich-text-editor.tsx
+++ b/apps/space/core/components/editor/rich-text-editor.tsx
@@ -1,5 +1,6 @@
 import React, { forwardRef } from "react";
 // plane imports
+import { useEditorFlagging } from "ce/hooks/use-editor-flagging";
 import { EditorRefApi, IRichTextEditorProps, RichTextEditorWithRef, TFileHandler } from "@plane/editor";
 import { MakeOptional } from "@plane/types";
 // components
@@ -26,8 +27,10 @@ type RichTextEditorWrapperProps = MakeOptional<
   );
 
 export const RichTextEditor = forwardRef<EditorRefApi, RichTextEditorWrapperProps>((props, ref) => {
-  const { anchor, containerClassName, editable, workspaceId, disabledExtensions, flaggedExtensions, ...rest } = props;
+  const { anchor, containerClassName, editable, workspaceId, disabledExtensions, ...rest } = props;
   const { getMemberById } = useMember();
+  const { richText } = useEditorFlagging(anchor);
+
   return (
     <RichTextEditorWithRef
       mentionHandler={{
@@ -44,7 +47,7 @@ export const RichTextEditor = forwardRef<EditorRefApi, RichTextEditorWrapperProp
         uploadFile: editable ? props.uploadFile : async () => "",
         workspaceId,
       })}
-      flaggedExtensions={flaggedExtensions ?? []}
+      flaggedExtensions={richText.flagged}
       {...rest}
       containerClassName={containerClassName}
       editorClassName="min-h-[100px] max-h-[200px] border-[0.5px] border-custom-border-300 rounded-md pl-3 py-2 overflow-hidden"

--- a/apps/space/core/components/editor/rich-text-editor.tsx
+++ b/apps/space/core/components/editor/rich-text-editor.tsx
@@ -27,7 +27,7 @@ type RichTextEditorWrapperProps = MakeOptional<
   );
 
 export const RichTextEditor = forwardRef<EditorRefApi, RichTextEditorWrapperProps>((props, ref) => {
-  const { anchor, containerClassName, editable, workspaceId, disabledExtensions, ...rest } = props;
+  const { anchor, containerClassName, editable, workspaceId, ...rest } = props;
   const { getMemberById } = useMember();
   const { richText } = useEditorFlagging(anchor);
 
@@ -40,7 +40,7 @@ export const RichTextEditor = forwardRef<EditorRefApi, RichTextEditorWrapperProp
         }),
       }}
       ref={ref}
-      disabledExtensions={disabledExtensions ?? []}
+      disabledExtensions={richText.disabled}
       editable={editable}
       fileHandler={getEditorFileHandlers({
         anchor,

--- a/apps/space/core/components/editor/rich-text-editor.tsx
+++ b/apps/space/core/components/editor/rich-text-editor.tsx
@@ -27,9 +27,16 @@ type RichTextEditorWrapperProps = MakeOptional<
   );
 
 export const RichTextEditor = forwardRef<EditorRefApi, RichTextEditorWrapperProps>((props, ref) => {
-  const { anchor, containerClassName, editable, workspaceId, ...rest } = props;
+  const {
+    anchor,
+    containerClassName,
+    editable,
+    workspaceId,
+    disabledExtensions: additionalDisabledExtensions = [],
+    ...rest
+  } = props;
   const { getMemberById } = useMember();
-  const { richText } = useEditorFlagging(anchor);
+  const { richText: richTextEditorExtensions } = useEditorFlagging(anchor);
 
   return (
     <RichTextEditorWithRef
@@ -40,14 +47,14 @@ export const RichTextEditor = forwardRef<EditorRefApi, RichTextEditorWrapperProp
         }),
       }}
       ref={ref}
-      disabledExtensions={richText.disabled}
+      disabledExtensions={[...richTextEditorExtensions.disabled, ...additionalDisabledExtensions]}
       editable={editable}
       fileHandler={getEditorFileHandlers({
         anchor,
         uploadFile: editable ? props.uploadFile : async () => "",
         workspaceId,
       })}
-      flaggedExtensions={richText.flagged}
+      flaggedExtensions={richTextEditorExtensions.flagged}
       {...rest}
       containerClassName={containerClassName}
       editorClassName="min-h-[100px] max-h-[200px] border-[0.5px] border-custom-border-300 rounded-md pl-3 py-2 overflow-hidden"

--- a/apps/web/core/store/pages/base-page.ts
+++ b/apps/web/core/store/pages/base-page.ts
@@ -78,6 +78,7 @@ export class BasePage extends ExtendedBasePage implements TBasePage {
   id: string | undefined;
   name: string | undefined;
   logo_props: TLogoProps | undefined;
+  description: object | undefined;
   description_html: string | undefined;
   color: string | undefined;
   label_ids: string[] | undefined;
@@ -113,6 +114,7 @@ export class BasePage extends ExtendedBasePage implements TBasePage {
     this.id = page?.id || undefined;
     this.name = page?.name;
     this.logo_props = page?.logo_props || undefined;
+    this.description = page?.description || undefined;
     this.description_html = page?.description_html || undefined;
     this.color = page?.color || undefined;
     this.label_ids = page?.label_ids || undefined;
@@ -136,6 +138,7 @@ export class BasePage extends ExtendedBasePage implements TBasePage {
       id: observable.ref,
       name: observable.ref,
       logo_props: observable.ref,
+      description: observable,
       description_html: observable.ref,
       color: observable.ref,
       label_ids: observable,
@@ -208,6 +211,7 @@ export class BasePage extends ExtendedBasePage implements TBasePage {
     return {
       id: this.id,
       name: this.name,
+      description: this.description,
       description_html: this.description_html,
       color: this.color,
       label_ids: this.label_ids,

--- a/packages/editor/src/core/components/editors/editor-container.tsx
+++ b/packages/editor/src/core/components/editors/editor-container.tsx
@@ -56,7 +56,7 @@ export const EditorContainer: FC<EditorContainerProps> = (props) => {
       if (lastNode) {
         const isLastNodeParagraph = lastNode.type.name === CORE_EXTENSIONS.PARAGRAPH;
         // Insert a new paragraph if the last node is not a paragraph and not a doc node
-        if (!isLastNodeParagraph && lastNode.type.name !== "doc") {
+        if (!isLastNodeParagraph && lastNode.type.name !== CORE_EXTENSIONS.DOCUMENT) {
           // Only insert a new paragraph if the last node is not an empty paragraph and not a doc node
           const endPosition = editor?.state.doc.content.size;
           editor?.chain().insertContentAt(endPosition, { type: "paragraph" }).focus("end").run();

--- a/packages/editor/src/core/components/editors/editor-container.tsx
+++ b/packages/editor/src/core/components/editors/editor-container.tsx
@@ -48,17 +48,16 @@ export const EditorContainer: FC<EditorContainerProps> = (props) => {
         return;
       }
 
-      // Get the last node in the document
-      const docSize = editor.state.doc.content.size;
-      const lastNodePos = editor.state.doc.resolve(Math.max(0, docSize - 2));
-      const lastNode = lastNodePos.node();
+      // Get the last child node in the document
+      const doc = editor.state.doc;
+      const lastNode = doc.lastChild;
 
       // Check if its last node and add new node
       if (lastNode) {
-        const isLastNodeEmptyParagraph =
-          lastNode.type.name === CORE_EXTENSIONS.PARAGRAPH && lastNode.content.size === 0;
-        // Only insert a new paragraph if the last node is not an empty paragraph and not a doc node
-        if (!isLastNodeEmptyParagraph && lastNode.type.name !== "doc") {
+        const isLastNodeParagraph = lastNode.type.name === CORE_EXTENSIONS.PARAGRAPH;
+        // Insert a new paragraph if the last node is not a paragraph and not a doc node
+        if (!isLastNodeParagraph && lastNode.type.name !== "doc") {
+          // Only insert a new paragraph if the last node is not an empty paragraph and not a doc node
           const endPosition = editor?.state.doc.content.size;
           editor?.chain().insertContentAt(endPosition, { type: "paragraph" }).focus("end").run();
         }

--- a/packages/editor/src/core/extensions/slash-commands/command-menu-item.tsx
+++ b/packages/editor/src/core/extensions/slash-commands/command-menu-item.tsx
@@ -32,6 +32,7 @@ export const CommandMenuItem: React.FC<Props> = (props) => {
         {item.icon}
       </span>
       <p className="flex-grow truncate">{item.title}</p>
+      {item.badge}
     </button>
   );
 };

--- a/packages/editor/src/core/types/slash-commands-suggestion.ts
+++ b/packages/editor/src/core/types/slash-commands-suggestion.ts
@@ -1,7 +1,6 @@
 import type { Editor, Range } from "@tiptap/core";
 import type { CSSProperties } from "react";
-// types
-import { TEditorCommands } from "@/types";
+import type { TEditorCommands } from "@/types";
 
 export type CommandProps = {
   editor: Editor;
@@ -19,4 +18,5 @@ export type ISlashCommandItem = {
   icon: React.ReactNode;
   iconContainerStyle?: CSSProperties;
   command: ({ editor, range }: CommandProps) => void;
+  badge?: React.ReactNode;
 };

--- a/packages/types/src/page/core.ts
+++ b/packages/types/src/page/core.ts
@@ -2,12 +2,13 @@ import { TLogoProps } from "../common";
 import { EPageAccess } from "../enums";
 import { TPageExtended } from "./extended";
 
-export type TPage = TPageExtended & {
+export type TPage = {
   access: EPageAccess | undefined;
   archived_at: string | null | undefined;
   color: string | undefined;
   created_at: Date | undefined;
   created_by: string | undefined;
+  description: object | undefined;
   description_html: string | undefined;
   id: string | undefined;
   is_favorite: boolean;
@@ -20,7 +21,7 @@ export type TPage = TPageExtended & {
   updated_by: string | undefined;
   workspace: string | undefined;
   logo_props: TLogoProps | undefined;
-};
+} & TPageExtended;
 
 // page filters
 export type TPageNavigationTabs = "public" | "private" | "archived";


### PR DESCRIPTION
### Description
This PR fix the issue of not adding a trailing node on click of the editor end.


### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
<!-- Link related issues if there are any -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for displaying optional badges in slash command menu items.
  * Introduced a new hook for managing disabled and flagged editor extensions across different editor types.
  * Added an optional description property to page metadata for improved content details.

* **Refactor**
  * Updated editors to use an internal hook for determining flagged extensions, removing the need to pass this information via props.
  * Simplified logic for inserting new paragraphs at the end of editor documents.

* **Enhancements**
  * Integrated the description property into page state management and serialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->