### PR TITLE
[WIKI-577] fix: unexpected emoji input

### DIFF
--- a/packages/editor/src/core/extensions/emoji/components/emojis-list.tsx
+++ b/packages/editor/src/core/extensions/emoji/components/emojis-list.tsx
@@ -61,6 +61,9 @@ export const EmojiList = forwardRef<EmojiListRef, EmojiListProps>((props, ref) =
 
   const handleKeyDown = useCallback(
     (event: KeyboardEvent): boolean => {
+      if (query.length <= 0) {
+        return false;
+      }
       if (event.key === "Escape") {
         event.preventDefault();
         return true;

--- a/packages/editor/src/core/extensions/emoji/components/emojis-list.tsx
+++ b/packages/editor/src/core/extensions/emoji/components/emojis-list.tsx
@@ -89,7 +89,7 @@ export const EmojiList = forwardRef<EmojiListRef, EmojiListProps>((props, ref) =
 
       return false;
     },
-    [items.length, selectedIndex, selectItem]
+    [query.length, items.length, selectItem, selectedIndex]
   );
 
   // Update position when items change


### PR DESCRIPTION
### Description
After inputing `:` when someone press enter its considered as a emoji input and enter and default emoji its now fixed to add proper check before doing insertion

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)

https://github.com/user-attachments/assets/f7e663bf-da27-4cf4-8086-71d7d7e529c7


### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
<!-- Link related issues if there are any -->