### PR TITLE
Feature/issue edit lock

### DIFF
--- a/apps/web/app/(all)/[workspaceSlug]/(projects)/browse/[workItem]/layout.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/(projects)/browse/[workItem]/layout.tsx
@@ -2,13 +2,14 @@
 
 // components
 import { AppHeader, ContentWrapper } from "@/components/core";
+import IssueEditNotAllowedContextProvider from "@/components/issues/issue-detail/issue-edit-not-allowed-context";
 import { ProjectIssueDetailsHeader } from "./header";
 
 export default function ProjectIssueDetailsLayout({ children }: { children: React.ReactNode }) {
   return (
-    <>
+    <IssueEditNotAllowedContextProvider>
       <AppHeader header={<ProjectIssueDetailsHeader />} />
       <ContentWrapper className="overflow-hidden">{children}</ContentWrapper>
-    </>
+    </IssueEditNotAllowedContextProvider>
   );
 }

--- a/apps/web/core/components/issues/issue-detail/issue-detail-quick-actions.tsx
+++ b/apps/web/core/components/issues/issue-detail/issue-detail-quick-actions.tsx
@@ -161,7 +161,7 @@ export const IssueDetailQuickActions: FC<Props> = observer((props) => {
                 <LinkIcon className="h-4 w-4" />
               </button>
             </Tooltip>
-            <Tooltip tooltipContent={t("common.actions.copy_link")} isMobile={isMobile}>
+            <Tooltip tooltipContent={t("common.actions.edit")} isMobile={isMobile}>
               <button
                 type="button"
                 className="grid h-5 w-5 place-items-center rounded hover:text-custom-text-200 focus:outline-none focus:ring-2 focus:ring-custom-primary"

--- a/apps/web/core/components/issues/issue-detail/issue-detail-quick-actions.tsx
+++ b/apps/web/core/components/issues/issue-detail/issue-detail-quick-actions.tsx
@@ -2,7 +2,7 @@
 
 import React, { FC, useRef } from "react";
 import { observer } from "mobx-react";
-import { LinkIcon } from "lucide-react";
+import { LinkIcon, Pencil, Lock } from "lucide-react";
 import { WORK_ITEM_TRACKER_EVENTS } from "@plane/constants";
 import { useTranslation } from "@plane/i18n";
 import { EIssuesStoreType } from "@plane/types";
@@ -17,6 +17,7 @@ import { useIssueDetail, useIssues, useProject, useUser } from "@/hooks/store";
 import { useAppRouter } from "@/hooks/use-app-router";
 import { usePlatformOS } from "@/hooks/use-platform-os";
 import { WorkItemDetailQuickActions } from "../issue-layouts/quick-action-dropdowns";
+import { useIssueEditNotAllowedContext } from "./issue-edit-not-allowed-context";
 
 type Props = {
   workspaceSlug: string;
@@ -49,6 +50,7 @@ export const IssueDetailQuickActions: FC<Props> = observer((props) => {
   const {
     issues: { removeIssue: removeArchivedIssue },
   } = useIssues(EIssuesStoreType.ARCHIVED);
+  const { isIssueEditNotAllowed, toggleIssueEditAllowed } = useIssueEditNotAllowedContext();
 
   // derived values
   const issue = getIssueById(issueId);
@@ -157,6 +159,16 @@ export const IssueDetailQuickActions: FC<Props> = observer((props) => {
                 onClick={handleCopyText}
               >
                 <LinkIcon className="h-4 w-4" />
+              </button>
+            </Tooltip>
+            <Tooltip tooltipContent={t("common.actions.copy_link")} isMobile={isMobile}>
+              <button
+                type="button"
+                className="grid h-5 w-5 place-items-center rounded hover:text-custom-text-200 focus:outline-none focus:ring-2 focus:ring-custom-primary"
+                onClick={toggleIssueEditAllowed}
+              >
+                {isIssueEditNotAllowed && <Pencil className="h-4 w-4" />}
+                {!isIssueEditNotAllowed && <Lock className="h-4 w-4" />}
               </button>
             </Tooltip>
             <WorkItemDetailQuickActions

--- a/apps/web/core/components/issues/issue-detail/issue-edit-not-allowed-context.tsx
+++ b/apps/web/core/components/issues/issue-detail/issue-edit-not-allowed-context.tsx
@@ -1,0 +1,28 @@
+import React, { createContext, useState, useContext } from "react";
+const IssueEditNotAllowedContext = createContext<{
+  isIssueEditNotAllowed: boolean;
+  toggleIssueEditAllowed: () => void;
+}>({
+  isIssueEditNotAllowed: true,
+  toggleIssueEditAllowed: () => {},
+});
+
+export default function IssueEditNotAllowedContextProvider({ children }: { children: React.ReactNode }) {
+  const [isIssueEditNotAllowed, setIssueEditNotAllowed] = useState(true);
+
+  // 更新值的方法
+  const toggleIssueEditAllowed = () => {
+    setIssueEditNotAllowed(!isIssueEditNotAllowed);
+  };
+
+  // 提供value和updateValue给子组件
+  return (
+    <IssueEditNotAllowedContext.Provider value={{ isIssueEditNotAllowed, toggleIssueEditAllowed }}>
+      {children}
+    </IssueEditNotAllowedContext.Provider>
+  );
+}
+
+export function useIssueEditNotAllowedContext() {
+  return useContext(IssueEditNotAllowedContext);
+}

--- a/apps/web/core/components/issues/issue-detail/issue-edit-not-allowed-context.tsx
+++ b/apps/web/core/components/issues/issue-detail/issue-edit-not-allowed-context.tsx
@@ -10,12 +10,12 @@ const IssueEditNotAllowedContext = createContext<{
 export default function IssueEditNotAllowedContextProvider({ children }: { children: React.ReactNode }) {
   const [isIssueEditNotAllowed, setIssueEditNotAllowed] = useState(true);
 
-  // 更新值的方法
+  // toggle allowed status
   const toggleIssueEditAllowed = () => {
     setIssueEditNotAllowed(!isIssueEditNotAllowed);
   };
 
-  // 提供value和updateValue给子组件
+  // Provider Component
   return (
     <IssueEditNotAllowedContext.Provider value={{ isIssueEditNotAllowed, toggleIssueEditAllowed }}>
       {children}

--- a/apps/web/core/components/issues/issue-detail/root.tsx
+++ b/apps/web/core/components/issues/issue-detail/root.tsx
@@ -19,6 +19,7 @@ import { useAppRouter } from "@/hooks/use-app-router";
 // images
 import emptyIssue from "@/public/empty-state/issue.svg";
 // local components
+import { useIssueEditNotAllowedContext } from "./issue-edit-not-allowed-context";
 import { IssueMainContent } from "./main-content";
 
 export type TIssueOperations = {
@@ -274,6 +275,7 @@ export const IssueDetailRoot: FC<TIssueDetailRoot> = observer((props) => {
       issueId,
     ]
   );
+  const { isIssueEditNotAllowed, toggleIssueEditAllowed } = useIssueEditNotAllowedContext();
 
   // issue details
   const issue = getIssueById(issueId);
@@ -305,7 +307,7 @@ export const IssueDetailRoot: FC<TIssueDetailRoot> = observer((props) => {
               projectId={projectId}
               issueId={issueId}
               issueOperations={issueOperations}
-              isEditable={isEditable}
+              isEditable={isEditable && !isIssueEditNotAllowed}
               isArchived={is_archived}
             />
           </div>
@@ -318,7 +320,7 @@ export const IssueDetailRoot: FC<TIssueDetailRoot> = observer((props) => {
               projectId={projectId}
               issueId={issueId}
               issueOperations={issueOperations}
-              isEditable={!is_archived && isEditable}
+              isEditable={!is_archived && isEditable && !isIssueEditNotAllowed}
             />
           </div>
         </div>

--- a/apps/web/core/components/issues/peek-overview/header.tsx
+++ b/apps/web/core/components/issues/peek-overview/header.tsx
@@ -3,7 +3,7 @@
 import { FC, useRef } from "react";
 import { observer } from "mobx-react";
 import Link from "next/link";
-import { Link2, MoveDiagonal, MoveRight } from "lucide-react";
+import { Link2, MoveDiagonal, MoveRight, Pencil, Lock } from "lucide-react";
 // plane imports
 import { WORK_ITEM_TRACKER_EVENTS } from "@plane/constants";
 import { useTranslation } from "@plane/i18n";
@@ -63,7 +63,9 @@ export type PeekOverviewHeaderProps = {
   toggleDuplicateIssueModal: (value: boolean) => void;
   toggleEditIssueModal: (value: boolean) => void;
   handleRestoreIssue: () => Promise<void>;
+  toggleEditIssueAllowed: () => void;
   isSubmitting: TNameDescriptionLoader;
+  isIssueEditNotAllowed: boolean;
 };
 
 export const IssuePeekOverviewHeader: FC<PeekOverviewHeaderProps> = observer((props) => {
@@ -82,7 +84,9 @@ export const IssuePeekOverviewHeader: FC<PeekOverviewHeaderProps> = observer((pr
     toggleDuplicateIssueModal,
     toggleEditIssueModal,
     handleRestoreIssue,
+    toggleEditIssueAllowed,
     isSubmitting,
+    isIssueEditNotAllowed = true,
   } = props;
   // ref
   const parentRef = useRef<HTMLDivElement>(null);
@@ -230,6 +234,12 @@ export const IssuePeekOverviewHeader: FC<PeekOverviewHeaderProps> = observer((pr
           <Tooltip tooltipContent={t("common.actions.copy_link")} isMobile={isMobile}>
             <button type="button" onClick={handleCopyText}>
               <Link2 className="h-4 w-4 -rotate-45 text-custom-text-300 hover:text-custom-text-200" />
+            </button>
+          </Tooltip>
+          <Tooltip tooltipContent={t("common.actions.edit")} isMobile={isMobile}>
+            <button type="button" onClick={toggleEditIssueAllowed}>
+              {isIssueEditNotAllowed && <Pencil className="h-4 w-4 text-custom-text-300 hover:text-custom-text-200" />}
+              {!isIssueEditNotAllowed && <Lock className="h-4 w-4 text-custom-text-300 hover:text-custom-text-200" />}
             </button>
           </Tooltip>
           {issueDetails && (

--- a/apps/web/core/components/issues/peek-overview/view.tsx
+++ b/apps/web/core/components/issues/peek-overview/view.tsx
@@ -56,6 +56,7 @@ export const IssueView: FC<IIssueView> = observer((props) => {
   const [isArchiveIssueModalOpen, setIsArchiveIssueModalOpen] = useState(false);
   const [isDuplicateIssueModalOpen, setIsDuplicateIssueModalOpen] = useState(false);
   const [isEditIssueModalOpen, setIsEditIssueModalOpen] = useState(false);
+  const [isIssueEditNotAllowed, setIssueEditNotAllowed] = useState(true);
   // ref
   const issuePeekOverviewRef = useRef<HTMLDivElement>(null);
   // store hooks
@@ -78,6 +79,7 @@ export const IssueView: FC<IIssueView> = observer((props) => {
   const toggleArchiveIssueModal = (value: boolean) => setIsArchiveIssueModalOpen(value);
   const toggleDuplicateIssueModal = (value: boolean) => setIsDuplicateIssueModalOpen(value);
   const toggleEditIssueModal = (value: boolean) => setIsEditIssueModalOpen(value);
+  const toggleEditIssueAllowed = () => setIssueEditNotAllowed(!isIssueEditNotAllowed);
 
   const isAnyLocalModalOpen =
     isDeleteIssueModalOpen || isArchiveIssueModalOpen || isDuplicateIssueModalOpen || isEditIssueModalOpen;
@@ -158,13 +160,15 @@ export const IssueView: FC<IIssueView> = observer((props) => {
                 toggleDuplicateIssueModal={toggleDuplicateIssueModal}
                 toggleEditIssueModal={toggleEditIssueModal}
                 handleRestoreIssue={handleRestore}
+                toggleEditIssueAllowed={toggleEditIssueAllowed}
                 isArchived={is_archived}
                 issueId={issueId}
                 workspaceSlug={workspaceSlug}
                 projectId={projectId}
                 isSubmitting={isSubmitting}
-                disabled={disabled}
+                disabled={isIssueEditNotAllowed || disabled}
                 embedIssue={embedIssue}
+                isIssueEditNotAllowed={isIssueEditNotAllowed}
               />
               {/* content */}
               <div className="vertical-scrollbar scrollbar-md relative h-full w-full overflow-hidden overflow-y-auto">
@@ -175,7 +179,7 @@ export const IssueView: FC<IIssueView> = observer((props) => {
                       projectId={projectId}
                       issueId={issueId}
                       issueOperations={issueOperations}
-                      disabled={disabled || isLocalDBIssueDescription}
+                      disabled={isIssueEditNotAllowed || disabled || isLocalDBIssueDescription}
                       isArchived={is_archived}
                       isSubmitting={isSubmitting}
                       setIsSubmitting={(value) => setIsSubmitting(value)}
@@ -186,7 +190,7 @@ export const IssueView: FC<IIssueView> = observer((props) => {
                         workspaceSlug={workspaceSlug}
                         projectId={projectId}
                         issueId={issueId}
-                        disabled={disabled || is_archived}
+                        disabled={isIssueEditNotAllowed || disabled || is_archived}
                         issueServiceType={EIssueServiceType.ISSUES}
                       />
                     </div>
@@ -196,14 +200,14 @@ export const IssueView: FC<IIssueView> = observer((props) => {
                       projectId={projectId}
                       issueId={issueId}
                       issueOperations={issueOperations}
-                      disabled={disabled || is_archived}
+                      disabled={isIssueEditNotAllowed || disabled || is_archived}
                     />
 
                     <IssueActivity
                       workspaceSlug={workspaceSlug}
                       projectId={projectId}
                       issueId={issueId}
-                      disabled={is_archived}
+                      disabled={isIssueEditNotAllowed || is_archived}
                     />
                   </div>
                 ) : (
@@ -215,7 +219,7 @@ export const IssueView: FC<IIssueView> = observer((props) => {
                           projectId={projectId}
                           issueId={issueId}
                           issueOperations={issueOperations}
-                          disabled={disabled || isLocalDBIssueDescription}
+                          disabled={isIssueEditNotAllowed || disabled || isLocalDBIssueDescription}
                           isArchived={is_archived}
                           isSubmitting={isSubmitting}
                           setIsSubmitting={(value) => setIsSubmitting(value)}
@@ -226,7 +230,7 @@ export const IssueView: FC<IIssueView> = observer((props) => {
                             workspaceSlug={workspaceSlug}
                             projectId={projectId}
                             issueId={issueId}
-                            disabled={disabled}
+                            disabled={isIssueEditNotAllowed || disabled}
                             issueServiceType={EIssueServiceType.ISSUES}
                           />
                         </div>
@@ -235,7 +239,7 @@ export const IssueView: FC<IIssueView> = observer((props) => {
                           workspaceSlug={workspaceSlug}
                           projectId={projectId}
                           issueId={issueId}
-                          disabled={is_archived}
+                          disabled={isIssueEditNotAllowed || is_archived}
                         />
                       </div>
                     </div>
@@ -249,7 +253,7 @@ export const IssueView: FC<IIssueView> = observer((props) => {
                         projectId={projectId}
                         issueId={issueId}
                         issueOperations={issueOperations}
-                        disabled={disabled || is_archived}
+                        disabled={isIssueEditNotAllowed || disabled || is_archived}
                       />
                     </div>
                   </div>


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
This PR introduces a change where work items are set to non-editable by default. Users must click an edit button to unlock editing capabilities, preventing accidental modifications.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->
<img width="1506" height="188" alt="image" src="https://github.com/user-attachments/assets/24f35798-c1cd-4b57-991f-8071ac8bfb20" />

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->
1. Verify work items are non-editable by default
2. Verify edit button successfully unlocks editing
3. Verify saving/canceling returns item to non-editable state
4. Verify no accidental modifications can be made without explicit edit mode

### References
<!-- Link related issues if there are any -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a toggle button to enable or disable editing of issue details in both the issue detail and peek overview views.
  * Introduced visual indicators (Pencil and Lock icons) to clearly show when editing is allowed or locked.
  * Editing controls and related actions are now disabled when editing is not allowed, providing clearer feedback to users.

* **Improvements**
  * Centralized and consistent control over issue editing permissions across relevant components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->