### PR TITLE
fix: Allow Docker service names in webhook URLs 

### DIFF
--- a/apps/api/plane/app/serializers/webhook.py
+++ b/apps/api/plane/app/serializers/webhook.py
@@ -1,6 +1,7 @@
 # Python imports
 import socket
 import ipaddress
+import re
 from urllib.parse import urlparse
 
 # Third party imports
@@ -10,6 +11,42 @@ from rest_framework import serializers
 from .base import DynamicBaseSerializer
 from plane.db.models import Webhook, WebhookLog
 from plane.db.models.webhook import validate_domain, validate_schema
+
+
+def is_docker_service_name(hostname):
+    """
+    Check if the hostname appears to be a Docker service name.
+    Docker service names typically:
+    - Don't contain dots (except for custom networks)
+    - Are alphanumeric with hyphens/underscores
+    - Don't have TLD extensions
+    """
+    if not hostname:
+        return False
+    
+    # If hostname contains a dot, check if it looks like a domain
+    if '.' in hostname:
+        parts = hostname.split('.')
+        if len(parts) >= 2:
+            # Check if last part looks like a TLD (2-6 letters) or common pseudo-TLD
+            last_part = parts[-1].lower()
+            # Common TLDs and pseudo-TLDs that indicate it's not a Docker service
+            domain_suffixes = [
+                # Generic TLDs
+                'com', 'net', 'org', 'edu', 'gov', 'mil', 'int',
+                # Country TLDs (common ones)
+                'uk', 'de', 'fr', 'jp', 'cn', 'au', 'ca', 'in', 'br', 'ru',
+                # New gTLDs (common ones)
+                'app', 'dev', 'tech', 'cloud', 'io', 'ai', 'co',
+                # Common pseudo-TLDs/special domains
+                'local', 'localdomain', 'localhost', 'internal', 'corp', 'home'
+            ]
+            
+            if last_part in domain_suffixes or re.match(r'^[a-zA-Z]{2,6}$', last_part):
+                return False
+    
+    # Docker service names are typically alphanumeric with hyphens/underscores/dots
+    return re.match(r'^[a-zA-Z0-9._-]+$', hostname) is not None
 
 
 class WebhookSerializer(DynamicBaseSerializer):
@@ -25,55 +62,9 @@ class WebhookSerializer(DynamicBaseSerializer):
                 {"url": "Invalid URL: No hostname found."}
             )
 
-        # Resolve the hostname to IP addresses
-        try:
-            ip_addresses = socket.getaddrinfo(hostname, None)
-        except socket.gaierror:
-            raise serializers.ValidationError(
-                {"url": "Hostname could not be resolved."}
-            )
-
-        if not ip_addresses:
-            raise serializers.ValidationError(
-                {"url": "No IP addresses found for the hostname."}
-            )
-
-        for addr in ip_addresses:
-            ip = ipaddress.ip_address(addr[4][0])
-            if ip.is_loopback:
-                raise serializers.ValidationError(
-                    {"url": "URL resolves to a blocked IP address."}
-                )
-
-        # Additional validation for multiple request domains and their subdomains
-        request = self.context.get("request")
-        disallowed_domains = ["plane.so"]  # Add your disallowed domains here
-        if request:
-            request_host = request.get_host().split(":")[0]  # Remove port if present
-            disallowed_domains.append(request_host)
-
-        # Check if hostname is a subdomain or exact match of any disallowed domain
-        if any(
-            hostname == domain or hostname.endswith("." + domain)
-            for domain in disallowed_domains
-        ):
-            raise serializers.ValidationError(
-                {"url": "URL domain or its subdomain is not allowed."}
-            )
-
-        return Webhook.objects.create(**validated_data)
-
-    def update(self, instance, validated_data):
-        url = validated_data.get("url", None)
-        if url:
-            # Extract the hostname from the URL
-            hostname = urlparse(url).hostname
-            if not hostname:
-                raise serializers.ValidationError(
-                    {"url": "Invalid URL: No hostname found."}
-                )
-
-            # Resolve the hostname to IP addresses
+        # Skip DNS resolution and IP validation for Docker service names
+        if not is_docker_service_name(hostname):
+            # Only perform DNS resolution for external URLs
             try:
                 ip_addresses = socket.getaddrinfo(hostname, None)
             except socket.gaierror:
@@ -93,6 +84,57 @@ class WebhookSerializer(DynamicBaseSerializer):
                         {"url": "URL resolves to a blocked IP address."}
                     )
 
+        # Additional validation for multiple request domains and their subdomains
+        request = self.context.get("request")
+        disallowed_domains = ["plane.so"]  # Add your disallowed domains here
+        if request:
+            request_host = request.get_host().split(":")[0]  # Remove port if present
+            disallowed_domains.append(request_host)
+
+        # Check if hostname is a subdomain or exact match of any disallowed domain
+        # Skip this check for Docker service names as they won't match external domains
+        if not is_docker_service_name(hostname) and any(
+            hostname == domain or hostname.endswith("." + domain)
+            for domain in disallowed_domains
+        ):
+            raise serializers.ValidationError(
+                {"url": "URL domain or its subdomain is not allowed."}
+            )
+
+        return Webhook.objects.create(**validated_data)
+
+    def update(self, instance, validated_data):
+        url = validated_data.get("url", None)
+        if url:
+            # Extract the hostname from the URL
+            hostname = urlparse(url).hostname
+            if not hostname:
+                raise serializers.ValidationError(
+                    {"url": "Invalid URL: No hostname found."}
+                )
+
+            # Skip DNS resolution and IP validation for Docker service names
+            if not is_docker_service_name(hostname):
+                # Only perform DNS resolution for external URLs
+                try:
+                    ip_addresses = socket.getaddrinfo(hostname, None)
+                except socket.gaierror:
+                    raise serializers.ValidationError(
+                        {"url": "Hostname could not be resolved."}
+                    )
+
+                if not ip_addresses:
+                    raise serializers.ValidationError(
+                        {"url": "No IP addresses found for the hostname."}
+                    )
+
+                for addr in ip_addresses:
+                    ip = ipaddress.ip_address(addr[4][0])
+                    if ip.is_loopback:
+                        raise serializers.ValidationError(
+                            {"url": "URL resolves to a blocked IP address."}
+                        )
+
             # Additional validation for multiple request domains and their subdomains
             request = self.context.get("request")
             disallowed_domains = ["plane.so"]  # Add your disallowed domains here
@@ -103,7 +145,8 @@ class WebhookSerializer(DynamicBaseSerializer):
                 disallowed_domains.append(request_host)
 
             # Check if hostname is a subdomain or exact match of any disallowed domain
-            if any(
+            # Skip this check for Docker service names as they won't match external domains
+            if not is_docker_service_name(hostname) and any(
                 hostname == domain or hostname.endswith("." + domain)
                 for domain in disallowed_domains
             ):

--- a/apps/api/plane/db/models/webhook.py
+++ b/apps/api/plane/db/models/webhook.py
@@ -23,7 +23,24 @@ def validate_schema(value):
 def validate_domain(value):
     parsed_url = urlparse(value)
     domain = parsed_url.netloc
-    if domain in ["localhost", "127.0.0.1"]:
+    hostname = parsed_url.hostname
+    
+    # More comprehensive localhost validation
+    localhost_variants = [
+        "localhost", 
+        "127.0.0.1", 
+        "0.0.0.0",
+        "::1",  # IPv6 localhost
+        "0:0:0:0:0:0:0:1"  # IPv6 localhost expanded
+    ]
+    
+    # Only block explicit localhost variants, allow Docker service names
+    if hostname and hostname.lower() in localhost_variants:
+        raise ValidationError("Local URLs are not allowed.")
+    
+    # Also check the full netloc for cases like localhost:8080
+    domain_host = domain.split(':')[0] if ':' in domain else domain
+    if domain_host.lower() in localhost_variants:
         raise ValidationError("Local URLs are not allowed.")
 
 


### PR DESCRIPTION
### Description

fix: #7555

- Fixed webhook URL validation to allow Docker service names while maintaining security. The validation was previously failing for URLs like........  because it attempted DNS resolution on Docker service names that are only resolvable within the Docker network. Added smart detection to differentiate between Docker service names and external domains, skipping DNS validation for Docker services while preserving all security checks for external URLs.

### Type of Change

[x] Bug fix (non-breaking change which fixes an issue)
[ ] Feature (non-breaking change which adds functionality)
[ ] Improvement (change that would cause existing functionality to not work as expected)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation to more accurately block local addresses (e.g., localhost, 127.0.0.1, IPv6 variants) in webhook URLs, including cases with ports.
  * Docker service names are now properly detected and exempted from certain DNS and domain validation checks, reducing false validation errors when using Docker-based hostnames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->