### PR TITLE
[WEB-4693] fix: remove initial load flicker on auto-archive and auto-close automation page

### DIFF
--- a/apps/web/core/components/automation/auto-archive-automation.tsx
+++ b/apps/web/core/components/automation/auto-archive-automation.tsx
@@ -49,7 +49,7 @@ export const AutoArchiveAutomation: React.FC<Props> = observer((props) => {
   );
 
   const autoArchiveStatus = useMemo(() => {
-    if (currentProjectDetails === undefined || currentProjectDetails.archive_in === undefined) return false;
+    if (currentProjectDetails?.archive_in === undefined) return false;
     return currentProjectDetails.archive_in !== 0;
   }, [currentProjectDetails]);
 

--- a/apps/web/core/components/automation/auto-archive-automation.tsx
+++ b/apps/web/core/components/automation/auto-archive-automation.tsx
@@ -48,6 +48,11 @@ export const AutoArchiveAutomation: React.FC<Props> = observer((props) => {
     currentProjectDetails?.id
   );
 
+  const getAutoArchiveStatus = () => {
+    if (currentProjectDetails === undefined || currentProjectDetails.archive_in === undefined) return false;
+    return currentProjectDetails.archive_in !== 0;
+  };
+
   return (
     <>
       <SelectMonthModal
@@ -71,7 +76,7 @@ export const AutoArchiveAutomation: React.FC<Props> = observer((props) => {
             </div>
           </div>
           <ToggleSwitch
-            value={currentProjectDetails?.archive_in !== 0}
+            value={getAutoArchiveStatus()}
             onChange={async () => {
               if (currentProjectDetails?.archive_in === 0) {
                 await handleChange({ archive_in: 1 });
@@ -94,7 +99,7 @@ export const AutoArchiveAutomation: React.FC<Props> = observer((props) => {
         </div>
 
         {currentProjectDetails ? (
-          currentProjectDetails.archive_in !== 0 && (
+          getAutoArchiveStatus() && (
             <div className="mx-6">
               <div className="flex w-full items-center justify-between gap-2 rounded border border-custom-border-200 bg-custom-background-90 px-5 py-4">
                 <div className="w-1/2 text-sm font-medium">

--- a/apps/web/core/components/automation/auto-archive-automation.tsx
+++ b/apps/web/core/components/automation/auto-archive-automation.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
 import { observer } from "mobx-react";
 import { useParams } from "next/navigation";
 import { ArchiveRestore } from "lucide-react";
@@ -48,10 +48,10 @@ export const AutoArchiveAutomation: React.FC<Props> = observer((props) => {
     currentProjectDetails?.id
   );
 
-  const getAutoArchiveStatus = () => {
+  const autoArchiveStatus = useMemo(() => {
     if (currentProjectDetails === undefined || currentProjectDetails.archive_in === undefined) return false;
     return currentProjectDetails.archive_in !== 0;
-  };
+  }, [currentProjectDetails]);
 
   return (
     <>
@@ -76,7 +76,7 @@ export const AutoArchiveAutomation: React.FC<Props> = observer((props) => {
             </div>
           </div>
           <ToggleSwitch
-            value={getAutoArchiveStatus()}
+            value={autoArchiveStatus}
             onChange={async () => {
               if (currentProjectDetails?.archive_in === 0) {
                 await handleChange({ archive_in: 1 });
@@ -99,7 +99,7 @@ export const AutoArchiveAutomation: React.FC<Props> = observer((props) => {
         </div>
 
         {currentProjectDetails ? (
-          getAutoArchiveStatus() && (
+          autoArchiveStatus && (
             <div className="mx-6">
               <div className="flex w-full items-center justify-between gap-2 rounded border border-custom-border-200 bg-custom-background-90 px-5 py-4">
                 <div className="w-1/2 text-sm font-medium">

--- a/apps/web/core/components/automation/auto-close-automation.tsx
+++ b/apps/web/core/components/automation/auto-close-automation.tsx
@@ -76,7 +76,7 @@ export const AutoCloseAutomation: React.FC<Props> = observer((props) => {
   );
 
   const autoCloseStatus = useMemo(() => {
-    if (currentProjectDetails === undefined || currentProjectDetails.close_in === undefined) return false;
+    if (currentProjectDetails?.close_in === undefined) return false;
     return currentProjectDetails.close_in !== 0;
   }, [currentProjectDetails]);
 

--- a/apps/web/core/components/automation/auto-close-automation.tsx
+++ b/apps/web/core/components/automation/auto-close-automation.tsx
@@ -75,6 +75,11 @@ export const AutoCloseAutomation: React.FC<Props> = observer((props) => {
     currentProjectDetails?.id
   );
 
+  const getAutoCloseStatus = () => {
+    if (currentProjectDetails === undefined || currentProjectDetails.close_in === undefined) return false;
+    return currentProjectDetails.close_in !== 0;
+  };
+
   return (
     <>
       <SelectMonthModal
@@ -98,7 +103,7 @@ export const AutoCloseAutomation: React.FC<Props> = observer((props) => {
             </div>
           </div>
           <ToggleSwitch
-            value={currentProjectDetails?.close_in !== 0}
+            value={getAutoCloseStatus()}
             onChange={async () => {
               if (currentProjectDetails?.close_in === 0) {
                 await handleChange({ close_in: 1, default_state: defaultState });
@@ -121,7 +126,7 @@ export const AutoCloseAutomation: React.FC<Props> = observer((props) => {
         </div>
 
         {currentProjectDetails ? (
-          currentProjectDetails.close_in !== 0 && (
+          getAutoCloseStatus() && (
             <div className="mx-6">
               <div className="flex flex-col rounded border border-custom-border-200 bg-custom-background-90">
                 <div className="flex w-full items-center justify-between gap-2 px-5 py-4">

--- a/apps/web/core/components/automation/auto-close-automation.tsx
+++ b/apps/web/core/components/automation/auto-close-automation.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
 import { observer } from "mobx-react";
 import { useParams } from "next/navigation";
 // icons
@@ -75,10 +75,10 @@ export const AutoCloseAutomation: React.FC<Props> = observer((props) => {
     currentProjectDetails?.id
   );
 
-  const getAutoCloseStatus = () => {
+  const autoCloseStatus = useMemo(() => {
     if (currentProjectDetails === undefined || currentProjectDetails.close_in === undefined) return false;
     return currentProjectDetails.close_in !== 0;
-  };
+  }, [currentProjectDetails]);
 
   return (
     <>
@@ -103,7 +103,7 @@ export const AutoCloseAutomation: React.FC<Props> = observer((props) => {
             </div>
           </div>
           <ToggleSwitch
-            value={getAutoCloseStatus()}
+            value={autoCloseStatus}
             onChange={async () => {
               if (currentProjectDetails?.close_in === 0) {
                 await handleChange({ close_in: 1, default_state: defaultState });
@@ -126,7 +126,7 @@ export const AutoCloseAutomation: React.FC<Props> = observer((props) => {
         </div>
 
         {currentProjectDetails ? (
-          getAutoCloseStatus() && (
+          autoCloseStatus && (
             <div className="mx-6">
               <div className="flex flex-col rounded border border-custom-border-200 bg-custom-background-90">
                 <div className="flex w-full items-center justify-between gap-2 px-5 py-4">


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
Updated the `ToggleSwitch` components in both `auto-archive-automation.tsx` and `auto-close-automation.tsx` to resolve the flickering issue that occurred during the initial page load. 

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

Here are the updated release notes:

- **Bug Fixes**
  - Auto-archive and auto-close toggles now default to off when settings are unset.
  - Prevents unintended display of duration/details sections when project data is missing.
  - Ensures UI doesn't show active automation states based on undefined values.

- **Refactor**
  - Consolidated status logic for auto-archive and auto-close to ensure consistent behavior and simpler maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->