### PR TITLE
[WEB-4698]fix: work items modal select/deselect button

### DIFF
--- a/apps/web/core/components/core/modals/existing-issues-list-modal.tsx
+++ b/apps/web/core/components/core/modals/existing-issues-list-modal.tsx
@@ -20,6 +20,7 @@ import { IssueIdentifier } from "@/plane-web/components/issues/issue-details/iss
 import { ProjectService } from "@/services/project";
 // components
 import { IssueSearchModalEmptyState } from "./issue-search-modal-empty-state";
+import { filter } from "lodash";
 
 type Props = {
   workspaceSlug: string | undefined;
@@ -320,18 +321,19 @@ export const ExistingIssuesListModal: React.FC<Props> = (props) => {
                     )}
                   </Combobox.Options>
                 </Combobox>
-                <div className="flex justify-between items-center">
+                <div className="flex justify-between items-center p-3">
                   <Button
                     variant="link-primary"
                     size="sm"
                     onClick={handleSelectIssues}
                     disabled={filteredIssues.length === 0}
+                    className={filteredIssues.length === 0 ? "p-0" : ""}
                   >
                     {selectedIssues.length === issues.length
                       ? t("issue.select.deselect_all")
                       : t("issue.select.select_all")}
                   </Button>
-                  <div className="flex items-center justify-end gap-2 p-3">
+                  <div className="flex items-center justify-end gap-2">
                     <Button variant="neutral-primary" size="sm" onClick={handleClose}>
                       {t("common.cancel")}
                     </Button>


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
This update fixes the `Select/Deselect` button is work items selection modal.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
<!-- Link related issues if there are any -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved spacing in the Existing Issues list modal by adding padding to the bottom action bar and aligning right-side controls.
  * Updated the “Select all / Deselect all” button to remove padding when no issues are available, creating a cleaner empty state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->