### PR TITLE
fix: docker node_modeles symlink path matching with pnpm path in live server

### DIFF
--- a/apps/live/Dockerfile.live
+++ b/apps/live/Dockerfile.live
@@ -53,11 +53,12 @@ FROM base AS runner
 WORKDIR /app
 
 COPY --from=installer /app/packages ./packages
-COPY --from=installer /app/apps/live/dist ./live
+COPY --from=installer /app/apps/live/dist ./apps/live/dist
+COPY --from=installer /app/apps/live/node_modules ./apps/live/node_modules
 COPY --from=installer /app/node_modules ./node_modules
 
 ENV TURBO_TELEMETRY_DISABLED=1
 
 EXPOSE 3000
 
-CMD ["node", "live/server.js"]
+CMD ["node", "apps/live/dist/server.js"]


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
- Maintain same path as app structure to retain pnpm symlinks

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated live Docker configuration to copy build output and dependencies into apps/live paths and start the service via node ./apps/live/dist/server.js.
  * Ensures the live service runs from the built distribution within apps/live and includes required node_modules for reliable container startup.
  * No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->