### PR TITLE
fix: replace .npmrc node version with engines in package.json

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -18,9 +18,6 @@ public-hoist-pattern[]=eslint
 public-hoist-pattern[]=prettier
 public-hoist-pattern[]=typescript
 
-# Enforce Node version for consistent installs
-use-node-version=22.18.0
-
 # Reproducible installs across CI and dev
 prefer-frozen-lockfile=true
 

--- a/package.json
+++ b/package.json
@@ -39,5 +39,8 @@
       "sharp": "0.33.5"
     }
   },
-  "packageManager": "pnpm@10.12.1"
+  "packageManager": "pnpm@10.12.1",
+  "engines": {
+    "node": ">=22.18.0"
+  }
 }


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
- replace .npmrc node version with engines in package.json

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Improvement (change that would cause existing functionality to not work as expected)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Declared a minimum Node.js version (>=22.18.0) in the project manifest to standardize the environment across installs.
  - Removed the previous Node version enforcement from configuration to avoid duplication.
  - Minor formatting update in the manifest to accommodate the new setting.
  - Impact: Users on older Node.js versions will be prompted to upgrade during installation. No functional changes to the app; this only affects setup and compatibility checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->