### PR TITLE
[WEB-4757] fix: remove project view from workspace level group by options

### DIFF
--- a/apps/web/core/components/issues/issue-layouts/utils.tsx
+++ b/apps/web/core/components/issues/issue-layouts/utils.tsx
@@ -71,7 +71,8 @@ export const isWorkspaceLevel = (type: EIssuesStoreType) =>
     EIssuesStoreType.GLOBAL,
     EIssuesStoreType.TEAM,
     EIssuesStoreType.TEAM_VIEW,
-    EIssuesStoreType.PROJECT_VIEW,
+    EIssuesStoreType.TEAM_PROJECT_WORK_ITEMS,
+    EIssuesStoreType.WORKSPACE_DRAFT,
   ].includes(type)
     ? true
     : false;


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
Grouping by labels isn’t working in project views. This issue arose because project views were considered as workspace-level grouping options. We were attempting to retrieve workspaceLabelIds from the store instead of relying on projectLabelIds. 

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected workspace-level recognition to match actual contexts: now applies to profiles, global, teams, team views, team project work items, and workspace drafts; excludes project views. Improves consistency of navigation, filters, and bulk actions across affected pages, ensuring correct access scopes and UI state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->