### PR TITLE
[WEB-4746] fix: position peek view relative to app layout

### DIFF
--- a/apps/web/core/components/analytics/work-items/modal/index.tsx
+++ b/apps/web/core/components/analytics/work-items/modal/index.tsx
@@ -20,7 +20,7 @@ type Props = {
 
 export const WorkItemsModal: React.FC<Props> = observer((props) => {
   const { isOpen, onClose, projectDetails, moduleDetails, cycleDetails, isEpic } = props;
-  const { updateIsEpic } = useAnalytics();
+  const { updateIsEpic, isPeekView } = useAnalytics();
   const [fullScreen, setFullScreen] = useState(false);
 
   const handleClose = () => {
@@ -29,18 +29,18 @@ export const WorkItemsModal: React.FC<Props> = observer((props) => {
   };
 
   useEffect(() => {
-    updateIsEpic(isEpic ?? false);
-  }, [isEpic, updateIsEpic]);
+    updateIsEpic(isPeekView ? (isEpic ?? false) : false);
+  }, [isEpic, updateIsEpic, isPeekView]);
 
   const portalContainer = document.getElementById("full-screen-portal") as HTMLElement;
 
   if (!isOpen) return null;
 
   const content = (
-    <div className={cn("inset-0 z-[25] h-full w-full overflow-y-auto", fullScreen ? "absolute" : "fixed")}>
+    <div className={cn("z-[25] h-full w-full overflow-y-auto absolute")}>
       <div
-        className={`right-0 top-0 z-20 h-full bg-custom-background-100 shadow-custom-shadow-md ${
-          fullScreen ? "w-full p-2 absolute" : "w-full sm:w-full md:w-1/2 fixed"
+        className={`top-0 right-0 z-[25] h-full bg-custom-background-100 shadow-custom-shadow-md absolute ${
+          fullScreen ? "w-full p-2" : "w-1/2"
         }`}
       >
         <div
@@ -67,5 +67,5 @@ export const WorkItemsModal: React.FC<Props> = observer((props) => {
     </div>
   );
 
-  return fullScreen && portalContainer ? createPortal(content, portalContainer) : content;
+  return portalContainer ? createPortal(content, portalContainer) : content;
 });

--- a/apps/web/core/components/issues/peek-overview/view.tsx
+++ b/apps/web/core/components/issues/peek-overview/view.tsx
@@ -110,16 +110,16 @@ export const IssueView: FC<IIssueView> = observer((props) => {
 
   const peekOverviewIssueClassName = cn(
     !embedIssue
-      ? "fixed z-[25] flex flex-col overflow-hidden rounded border border-custom-border-200 bg-custom-background-100 transition-all duration-300"
+      ? "absolute z-[25] flex flex-col overflow-hidden rounded border border-custom-border-200 bg-custom-background-100 transition-all duration-300"
       : `w-full h-full`,
     !embedIssue && {
-      "top-2 bottom-2 right-2 w-full md:w-[50%] border-0 border-l": peekMode === "side-peek",
+      "top-0 bottom-0 right-0 w-full md:w-[50%] border-0 border-l": peekMode === "side-peek",
       "size-5/6 top-[8.33%] left-[8.33%]": peekMode === "modal",
       "inset-0 m-4 absolute": peekMode === "full-screen",
     }
   );
 
-  const shouldUsePortal = !embedIssue && peekMode === "full-screen";
+  const shouldUsePortal = !embedIssue;
 
   const portalContainer = document.getElementById("full-screen-portal") as HTMLElement;
 


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Bug Fixes
  * Peek and analytics overlays render more consistently across modes, with non-embedded views always using a portal to avoid overlap issues.
  * Side-peek overlay now aligns to the top-right, spans full height, and stays above page content.

* Refactor
  * Simplified sizing: full-screen uses full width; otherwise half width for easier readability.
  * Standardized absolute positioning for overlays to improve layout stability and scrolling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->