### PR TITLE
[WEB-4720] fix: mongo connection class to initialize mongo db

### DIFF
--- a/apps/api/plane/settings/common.py
+++ b/apps/api/plane/settings/common.py
@@ -465,3 +465,7 @@ if ENABLE_DRF_SPECTACULAR:
     REST_FRAMEWORK["DEFAULT_SCHEMA_CLASS"] = "drf_spectacular.openapi.AutoSchema"
     INSTALLED_APPS.append("drf_spectacular")
     from .openapi import SPECTACULAR_SETTINGS  # noqa: F401
+
+# MongoDB Settings
+MONGO_DB_URL = os.environ.get("MONGO_DB_URL", False)
+MONGO_DB_DATABASE = os.environ.get("MONGO_DB_DATABASE", False)

--- a/apps/api/plane/settings/mongo.py
+++ b/apps/api/plane/settings/mongo.py
@@ -118,4 +118,7 @@ class MongoConnection:
         Returns:
             bool: True if MongoDB is configured and connected, False otherwise
         """
+
+        if cls._client is None:
+            cls._instance = cls()
         return cls._client is not None and cls._db is not None


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
- correct mongo connection class to initialize mongo db when `is_configured` is called.
- add mongo url and mongo database environment to settings

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->
- check if mongo db is connected

### References
[WEB-4720](https://app.plane.so/plane/browse/WEB-4720)