### PR TITLE
[WEB-4761] fix: resolve circular import between IssueService and local db

### DIFF
--- a/apps/web/core/services/issue/issue.service.ts
+++ b/apps/web/core/services/issue/issue.service.ts
@@ -1,4 +1,4 @@
-// types
+// plane imports
 import { API_BASE_URL } from "@plane/constants";
 import {
   EIssueServiceType,
@@ -12,12 +12,8 @@ import {
   type TIssuesResponse,
   type TIssueSubIssues,
 } from "@plane/types";
-// helpers
 import { getIssuesShouldFallbackToServer } from "@plane/utils";
-import { persistence } from "@/local-db/storage.sqlite";
 // services
-
-import { addIssuesBulk, deleteIssueFromLocal, updateIssue } from "@/local-db/utils/load-issues";
 import { APIService } from "@/services/api.service";
 
 export class IssueService extends APIService {
@@ -85,7 +81,7 @@ export class IssueService extends APIService {
     if (getIssuesShouldFallbackToServer(queries) || this.serviceType !== EIssueServiceType.ISSUES) {
       return await this.getIssuesFromServer(workspaceSlug, projectId, queries, config);
     }
-
+    const { persistence } = await import("@/local-db/storage.sqlite");
     const response = await persistence.getIssues(workspaceSlug, projectId, queries, config);
     return response as TIssuesResponse;
   }
@@ -118,9 +114,10 @@ export class IssueService extends APIService {
     return this.get(`/api/workspaces/${workspaceSlug}/projects/${projectId}/${this.serviceType}/${issueId}/`, {
       params: queries,
     })
-      .then((response) => {
+      .then(async (response) => {
         // skip issue update when the service type is epic
         if (response.data && this.serviceType === EIssueServiceType.ISSUES) {
+          const { updateIssue } = await import("@/local-db/utils/load-issues");
           updateIssue({ ...response.data, is_local_update: 1 });
         }
         // add is_epic flag when the service type is epic
@@ -138,8 +135,9 @@ export class IssueService extends APIService {
     return this.get(`/api/workspaces/${workspaceSlug}/projects/${projectId}/${this.serviceType}/list/`, {
       params: { issues: issueIds.join(",") },
     })
-      .then((response) => {
+      .then(async (response) => {
         if (response?.data && Array.isArray(response?.data) && this.serviceType === EIssueServiceType.ISSUES) {
+          const { addIssuesBulk } = await import("@/local-db/utils/load-issues");
           addIssuesBulk(response.data);
         }
         return response?.data;
@@ -246,6 +244,7 @@ export class IssueService extends APIService {
 
   async deleteIssue(workspaceSlug: string, projectId: string, issuesId: string): Promise<any> {
     if (this.serviceType === EIssueServiceType.ISSUES) {
+      const { deleteIssueFromLocal } = await import("@/local-db/utils/load-issues");
       deleteIssueFromLocal(issuesId);
     }
     return this.delete(`/api/workspaces/${workspaceSlug}/projects/${projectId}/${this.serviceType}/${issuesId}/`)
@@ -354,8 +353,9 @@ export class IssueService extends APIService {
 
   async bulkOperations(workspaceSlug: string, projectId: string, data: TBulkOperationsPayload): Promise<any> {
     return this.post(`/api/workspaces/${workspaceSlug}/projects/${projectId}/bulk-operation-issues/`, data)
-      .then((response) => {
+      .then(async (response) => {
         if (this.serviceType === EIssueServiceType.ISSUES) {
+          const { persistence } = await import("@/local-db/storage.sqlite");
           persistence.syncIssues(projectId);
         }
         return response?.data;
@@ -373,8 +373,9 @@ export class IssueService extends APIService {
     }
   ): Promise<any> {
     return this.delete(`/api/workspaces/${workspaceSlug}/projects/${projectId}/bulk-delete-issues/`, data)
-      .then((response) => {
+      .then(async (response) => {
         if (this.serviceType === EIssueServiceType.ISSUES) {
+          const { persistence } = await import("@/local-db/storage.sqlite");
           persistence.syncIssues(projectId);
         }
         return response?.data;
@@ -394,8 +395,9 @@ export class IssueService extends APIService {
     archived_at: string;
   }> {
     return this.post(`/api/workspaces/${workspaceSlug}/projects/${projectId}/bulk-archive-issues/`, data)
-      .then((response) => {
+      .then(async (response) => {
         if (this.serviceType === EIssueServiceType.ISSUES) {
+          const { persistence } = await import("@/local-db/storage.sqlite");
           persistence.syncIssues(projectId);
         }
         return response?.data;
@@ -476,9 +478,10 @@ export class IssueService extends APIService {
     return this.get(`/api/workspaces/${workspaceSlug}/work-items/${project_identifier}-${issue_sequence}/`, {
       params: queries,
     })
-      .then((response) => {
+      .then(async (response) => {
         // skip issue update when the service type is epic
         if (response.data && this.serviceType === EIssueServiceType.ISSUES) {
+          const { updateIssue } = await import("@/local-db/utils/load-issues");
           updateIssue({ ...response.data, is_local_update: 1 });
         }
         // add is_epic flag when the service type is epic


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
This PR resolves a circular import issue between **IssueService** and the **local database layer**. The problem occurred when local db utilities imported IssueService while IssueService was also importing those same utilities, creating a `circular dependency`.

**Changes:**
- Converted static imports to dynamic imports in IssueService methods
- This breaks the circular dependency at runtime while maintaining functionality

**Technical Details:**
The circular dependency chain was:
IssueService → local-db utilities → IssueService

By using dynamic imports (`await import()`), we defer the module loading until the method is actually called, breaking the circular reference during module initialization.

**Future Considerations:**
This is a temporary solution. A more robust fix would involve restructuring the architecture to separate concerns between service and persistence layers

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Optimized issue-related operations by loading supporting components on demand, reducing initial load time and improving responsiveness.
  - Enhanced performance for issue retrieval, bulk updates, deletions, archiving, and post-request syncing, resulting in smoother workflows.
  - No changes to visible features or user-facing API; existing behavior remains consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->