### PR TITLE
[WEB-4781]fix: add peek view get to store

### DIFF
--- a/apps/web/core/store/issue/issue-details/root.store.ts
+++ b/apps/web/core/store/issue/issue-details/root.store.ts
@@ -95,6 +95,7 @@ export interface IIssueDetail
   attachmentDeleteModalId: string | null;
   // computed
   isAnyModalOpen: boolean;
+  isPeekOpen: boolean;
   // helper actions
   getIsIssuePeeked: (issueId: string) => boolean;
   // actions
@@ -188,6 +189,7 @@ export abstract class IssueDetail implements IIssueDetail {
       lastWidgetAction: observable.ref,
       // computed
       isAnyModalOpen: computed,
+      isPeekOpen: computed,
       // action
       setPeekIssue: action,
       setIssueLinkData: action,
@@ -233,6 +235,10 @@ export abstract class IssueDetail implements IIssueDetail {
       !!this.isSubIssuesModalOpen ||
       !!this.attachmentDeleteModalId
     );
+  }
+
+  get isPeekOpen() {
+    return !!this.peekIssue;
   }
 
   // helper actions


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
This update adds peek view get method to store. This let's us check if peek is open.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
<!-- Link related issues if there are any -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Improvements
  - The app now accurately recognizes when an issue peek is open, ensuring the UI consistently reflects its open/closed state alongside modals.
  - Provides clearer status indicators and conditional controls for issue previews, improving interaction clarity between quick peek and full-detail views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->