### PR TITLE
[WEB-4722]fix: fixed draft state update

### DIFF
--- a/apps/api/plane/app/views/workspace/draft.py
+++ b/apps/api/plane/app/views/workspace/draft.py
@@ -172,12 +172,14 @@ class WorkspaceDraftIssueViewSet(BaseViewSet):
                 {"error": "Issue not found"}, status=status.HTTP_404_NOT_FOUND
             )
 
+        project_id = request.data.get("project_id", issue.project_id)
+
         serializer = DraftIssueCreateSerializer(
             issue,
             data=request.data,
             partial=True,
             context={
-                "project_id": request.data.get("project_id", None),
+                "project_id": project_id,
                 "cycle_id": request.data.get("cycle_id", "not_provided"),
             },
         )


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
This PR fixes an issue with state validation in draft issues where the project context was not being properly maintained during updates. The changes ensure consistent state validation behaviour between regular issues and draft issues.

- Fixed `project_id` context handling in `DraftIssueCreateSerializer` for partial updates
- Added fallback to existing issue's `project_id` when no new `project_id` is provided in the request
- Ensures state validation uses the correct project context for both new and updated draft issues

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->
https://github.com/user-attachments/assets/2ea8ebfc-3ee8-4967-b6ee-cf0c487a99a4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where updating a draft issue could pass a null project to validation, triggering errors. The update now reliably uses the provided project or the issue’s current project, preventing 400 responses and ensuring correct association during partial updates. This improves reliability when changing projects or leaving them unchanged; no UI changes required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->