### PR TITLE
[WEB-4559] fix: workspace menu item active state

### DIFF
--- a/apps/web/core/components/workspace/sidebar/sidebar-item.tsx
+++ b/apps/web/core/components/workspace/sidebar/sidebar-item.tsx
@@ -48,7 +48,7 @@ export const SidebarItemBase: FC<Props> = observer(({ item, additionalRender, ad
   if (!isPinned && !staticItems.includes(item.key)) return null;
 
   const itemHref = item.key === "your_work" ? `/${slug}${item.href}${data?.id}/` : `/${slug}${item.href}`;
-  const isActive = itemHref === pathname;
+  const isActive = item.key === "home" ? pathname === itemHref : pathname.includes(itemHref);
   const icon = getSidebarNavigationItemIcon(item.key);
 
   return (


### PR DESCRIPTION
### Description
This PR fixes an issue where the workspace menu item was not properly highlighting the current tab.  

### Type of Change
- [x] Bug fix
