### PR TITLE
feat: added support for expanding `updated_by` in work item

### DIFF
--- a/apps/api/plane/api/serializers/base.py
+++ b/apps/api/plane/api/serializers/base.py
@@ -96,6 +96,7 @@ class BaseSerializer(serializers.ModelSerializer):
                         "actor": UserLiteSerializer,
                         "owned_by": UserLiteSerializer,
                         "members": UserLiteSerializer,
+                        "type": IssueTypeLiteSerializer,
                         "parent": IssueLiteSerializer,
                         "estimate_point": EstimatePointSerializer,
                     }

--- a/apps/api/plane/api/serializers/base.py
+++ b/apps/api/plane/api/serializers/base.py
@@ -91,6 +91,7 @@ class BaseSerializer(serializers.ModelSerializer):
                         "project_lead": UserLiteSerializer,
                         "state": StateLiteSerializer,
                         "created_by": UserLiteSerializer,
+                        "updated_by": UserLiteSerializer,
                         "issue": IssueSerializer,
                         "actor": UserLiteSerializer,
                         "owned_by": UserLiteSerializer,

--- a/apps/api/plane/api/serializers/base.py
+++ b/apps/api/plane/api/serializers/base.py
@@ -96,7 +96,6 @@ class BaseSerializer(serializers.ModelSerializer):
                         "actor": UserLiteSerializer,
                         "owned_by": UserLiteSerializer,
                         "members": UserLiteSerializer,
-                        "type": IssueTypeLiteSerializer,
                         "parent": IssueLiteSerializer,
                         "estimate_point": EstimatePointSerializer,
                     }

--- a/apps/api/plane/api/serializers/issue.py
+++ b/apps/api/plane/api/serializers/issue.py
@@ -32,7 +32,6 @@ from .cycle import CycleLiteSerializer, CycleSerializer
 from .module import ModuleLiteSerializer, ModuleSerializer
 from .state import StateLiteSerializer
 from .user import UserLiteSerializer
-from .issue_type import IssueTypeAPISerializer
 
 # Django imports
 from django.core.exceptions import ValidationError

--- a/apps/api/plane/api/serializers/issue.py
+++ b/apps/api/plane/api/serializers/issue.py
@@ -32,6 +32,7 @@ from .cycle import CycleLiteSerializer, CycleSerializer
 from .module import ModuleLiteSerializer, ModuleSerializer
 from .state import StateLiteSerializer
 from .user import UserLiteSerializer
+from .issue_type import IssueTypeAPISerializer
 
 # Django imports
 from django.core.exceptions import ValidationError
@@ -341,6 +342,10 @@ class IssueSerializer(BaseSerializer):
                         "label_id", flat=True
                     )
                 ]
+
+         if "type" in self.fields:
+            if "type" in self.expand:
+                data["type"] = IssueTypeAPISerializer(instance.type).data
 
         return data
 

--- a/apps/api/plane/api/serializers/issue.py
+++ b/apps/api/plane/api/serializers/issue.py
@@ -343,10 +343,6 @@ class IssueSerializer(BaseSerializer):
                     )
                 ]
 
-         if "type" in self.fields:
-            if "type" in self.expand:
-                data["type"] = IssueTypeAPISerializer(instance.type).data
-
         return data
 
 


### PR DESCRIPTION
### Description
This PR includes changes to expand `updated_by` by including the field in base serializer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - You can now expand the updated_by field in API responses using the expand query parameter (e.g., expand=updated_by) to receive full user details instead of just an ID. This is backward-compatible and only applies when requested, reducing additional requests for clients needing information about the last user who updated a resource.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->