### PR TITLE
[WIKI-556]  fix : invert tracking logic

### DIFF
--- a/apps/api/plane/app/views/page/base.py
+++ b/apps/api/plane/app/views/page/base.py
@@ -198,7 +198,7 @@ class PageViewSet(BaseViewSet):
     def retrieve(self, request, slug, project_id, pk=None):
         page = self.get_queryset().filter(pk=pk).first()
         project = Project.objects.get(pk=project_id)
-        track_visit = request.query_params.get("track_visit", "false").lower() == "true"
+        track_visit = request.query_params.get("track_visit", "true").lower() == "true"
 
         """
         if the role is guest and guest_view_all_features is false and owned by is not

--- a/apps/web/app/(all)/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/pages/(detail)/[pageId]/page.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/pages/(detail)/[pageId]/page.tsx
@@ -58,10 +58,7 @@ const PageDetailsPage = observer(() => {
   const { error: pageDetailsError } = useSWR(
     workspaceSlug && projectId && pageId ? `PAGE_DETAILS_${pageId}` : null,
     workspaceSlug && projectId && pageId
-      ? () =>
-          fetchPageDetails(workspaceSlug?.toString(), projectId?.toString(), pageId.toString(), {
-            trackVisit: true,
-          })
+      ? () => fetchPageDetails(workspaceSlug?.toString(), projectId?.toString(), pageId.toString())
       : null,
     {
       revalidateIfStale: true,

--- a/apps/web/core/store/pages/project-page.store.ts
+++ b/apps/web/core/store/pages/project-page.store.ts
@@ -53,7 +53,7 @@ export interface IProjectPageStore {
     workspaceSlug: string,
     projectId: string,
     pageId: string,
-    { trackVisit }: { trackVisit: boolean }
+    options?: { trackVisit?: boolean }
   ) => Promise<TPage | undefined>;
   createPage: (pageData: Partial<TPage>) => Promise<TPage | undefined>;
   removePage: (pageId: string) => Promise<void>;
@@ -244,12 +244,9 @@ export class ProjectPageStore implements IProjectPageStore {
    * @description fetch the details of a page
    * @param {string} pageId
    */
-  fetchPageDetails = async (
-    workspaceSlug: string,
-    projectId: string,
-    pageId: string,
-    { trackVisit }: { trackVisit: boolean }
-  ) => {
+  fetchPageDetails = async (...args: Parameters<IProjectPageStore["fetchPageDetails"]>) => {
+    const [workspaceSlug, projectId, pageId, options] = args;
+    const { trackVisit } = options || {};
     try {
       if (!workspaceSlug || !projectId || !pageId) return undefined;
 
@@ -259,7 +256,7 @@ export class ProjectPageStore implements IProjectPageStore {
         this.error = undefined;
       });
 
-      const page = await this.service.fetchById(workspaceSlug, projectId, pageId, trackVisit);
+      const page = await this.service.fetchById(workspaceSlug, projectId, pageId, trackVisit ?? true);
 
       runInAction(() => {
         if (page?.id) {


### PR DESCRIPTION
### Description
this PR invert the tracking logic we have for pages

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)


### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
<!-- Link related issues if there are any -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Page visits are now tracked by default when viewing a page, ensuring recent activity and analytics update automatically without extra settings.

* **Refactor**
  * Simplified page data fetching by making visit-tracking optional with a sensible default, reducing the need for explicit parameters and streamlining calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->