### PR TITLE
[WEB-4800]chore: settings header component refactor

### DIFF
--- a/apps/web/core/components/settings/heading.tsx
+++ b/apps/web/core/components/settings/heading.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@plane/ui";
+import { Button, cn } from "@plane/ui";
 
 type Props = {
   title: string | React.ReactNode;
@@ -10,6 +10,7 @@ type Props = {
     label: string;
     onClick: () => void;
   };
+  className?: string;
 };
 
 export const SettingsHeading = ({
@@ -19,8 +20,14 @@ export const SettingsHeading = ({
   appendToRight,
   customButton,
   showButton = true,
+  className,
 }: Props) => (
-  <div className="flex flex-col md:flex-row gap-2 items-start md:items-center justify-between border-b border-custom-border-100 pb-3.5">
+  <div
+    className={cn(
+      "flex flex-col md:flex-row gap-2 items-start md:items-center justify-between border-b border-custom-border-100 pb-3.5",
+      className
+    )}
+  >
     <div className="flex flex-col items-start gap-1">
       {typeof title === "string" ? <h3 className="text-xl font-medium">{title}</h3> : title}
       {description && <div className="text-sm text-custom-text-300">{description}</div>}


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
Adds className prop support to the SettingsHeading component using the `cn` utility from @plane/ui, enabling custom style overrides while preserving default component styles.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [x] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
<!-- Link related issues if there are any -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Settings headings now support custom styling via an optional class, enabling finer control over layout and theming in complex pages. No default visual or behavioral changes; existing button/display logic remains the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->