### PR TITLE
chore: docker image builts by removing nodeversion in workspace.yml file

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,11 +1,9 @@
 packages:
-  - apps/*
-  - packages/*
-  - "!apps/api"
-  - "!apps/proxy"
+- apps/*
+- packages/*
+- "!apps/api"
+- "!apps/proxy"
 
 onlyBuiltDependencies:
-  - turbo
-  - sharp
-
-useNodeVersion: 22.18.0
+- turbo
+- sharp


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
- fixed docker image builds by removing node version mentioned in `workspace.yml` file 

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
