### PR TITLE
[WEB-4807] fix: workspace menu item highlight

### DIFF
--- a/packages/constants/src/workspace.ts
+++ b/packages/constants/src/workspace.ts
@@ -312,7 +312,7 @@ export const WORKSPACE_SIDEBAR_STATIC_NAVIGATION_ITEMS: Record<string, IWorkspac
     labelTranslationKey: "projects",
     href: `/projects/`,
     access: [EUserWorkspaceRoles.ADMIN, EUserWorkspaceRoles.MEMBER, EUserWorkspaceRoles.GUEST],
-    highlight: (pathname: string, url: string) => pathname.includes(url),
+    highlight: (pathname: string, url: string) => pathname === url,
   },
 };
 


### PR DESCRIPTION
### Description
This PR resolves the issue with the project workspace menu item not highlighting correctly in the sidebar.

### Type of Change
- [x] Bug fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected sidebar highlight behavior for the “Projects” item to trigger only on the exact “/projects/” path, preventing it from highlighting on nested or unrelated pages containing “/projects”.
  * Ensures more accurate visual feedback in navigation without affecting other sidebar items or public functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->