### PR TITLE
[WEB-4808] fix: joinUrlPath utility fn

### DIFF
--- a/packages/utils/src/string.ts
+++ b/packages/utils/src/string.ts
@@ -317,7 +317,7 @@ export const joinUrlPath = (...segments: string[]): string => {
   if (validSegments.length === 0) return "";
 
   // Process segments to normalize slashes
-  const processedSegments = validSegments.map((segment) => {
+  const processedSegments = validSegments.map((segment, index) => {
     let processed = segment;
 
     // Remove leading slashes from all segments except the first
@@ -326,8 +326,10 @@ export const joinUrlPath = (...segments: string[]): string => {
     }
 
     // Remove trailing slashes from all segments except the last
-    while (processed.endsWith("/")) {
-      processed = processed.substring(0, processed.length - 1);
+    if (index < validSegments.length - 1) {
+      while (processed.endsWith("/")) {
+        processed = processed.substring(0, processed.length - 1);
+      }
     }
 
     return processed;


### PR DESCRIPTION
### Description
This PR fixes the joinUrlPath utility function to ensure trailing slashes are removed from all path segments except the final one.

### Type of Change
- [x] Bug fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected URL path joining to preserve trailing slashes on the final segment, ensuring expected URLs when a trailing slash is intentional.
  * Prevents unintended redirects, broken routes, or altered API endpoints caused by stripping the last segment’s trailing slash.
  * Improves link accuracy and compatibility with servers and routers that differentiate between paths with and without a trailing slash.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->