### PR TITLE
[WIKI-589] fix: update project page creation flow

### DIFF
--- a/apps/web/core/components/pages/pages-list-main-content.tsx
+++ b/apps/web/core/components/pages/pages-list-main-content.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { useState } from "react";
 import { observer } from "mobx-react";
 import Image from "next/image";
@@ -16,7 +17,6 @@ import { setToast, TOAST_TYPE } from "@plane/ui";
 import { DetailedEmptyState } from "@/components/empty-state/detailed-empty-state-root";
 import { PageLoader } from "@/components/pages/loaders/page-loader";
 import { captureClick, captureError, captureSuccess } from "@/helpers/event-tracker.helper";
-import { useCommandPalette } from "@/hooks/store/use-command-palette";
 import { useProject } from "@/hooks/store/use-project";
 import { useUserPermissions } from "@/hooks/store/user";
 import { useResolvedAssetPath } from "@/hooks/use-resolved-asset-path";
@@ -37,7 +37,6 @@ export const PagesListMainContent: React.FC<Props> = observer((props) => {
   const { currentProjectDetails, loader } = useProject();
   const { isAnyPageAvailable, getCurrentProjectFilteredPageIdsByTab, getCurrentProjectPageIdsByTab, filters } =
     usePageStore(storeType);
-  useCommandPalette();
   const { allowPermissions } = useUserPermissions();
   const { createPage } = usePageStore(EPageStoreType.PROJECT);
   // states

--- a/apps/web/core/components/pages/pages-list-main-content.tsx
+++ b/apps/web/core/components/pages/pages-list-main-content.tsx
@@ -116,9 +116,7 @@ export const PagesListMainContent: React.FC<Props> = observer((props) => {
           description={t("project_page.empty_state.general.description")}
           assetPath={generalPageResolvedPath}
           primaryButton={{
-            text: isCreatingPage
-              ? t("project_page.empty_state.general.primary_button.loading")
-              : t("project_page.empty_state.general.primary_button.text"),
+            text: isCreatingPage ? t("creating") : t("project_page.empty_state.general.primary_button.text"),
             onClick: () => {
               handleCreatePage();
               captureClick({ elementName: PROJECT_PAGE_TRACKER_ELEMENTS.EMPTY_STATE_CREATE_BUTTON });
@@ -135,9 +133,7 @@ export const PagesListMainContent: React.FC<Props> = observer((props) => {
           description={t("project_page.empty_state.public.description")}
           assetPath={publicPageResolvedPath}
           primaryButton={{
-            text: isCreatingPage
-              ? t("project_page.empty_state.public.primary_button.loading")
-              : t("project_page.empty_state.public.primary_button.text"),
+            text: isCreatingPage ? t("creating") : t("project_page.empty_state.public.primary_button.text"),
             onClick: () => {
               handleCreatePage();
               captureClick({ elementName: PROJECT_PAGE_TRACKER_ELEMENTS.EMPTY_STATE_CREATE_BUTTON });
@@ -153,9 +149,7 @@ export const PagesListMainContent: React.FC<Props> = observer((props) => {
           description={t("project_page.empty_state.private.description")}
           assetPath={privatePageResolvedPath}
           primaryButton={{
-            text: isCreatingPage
-              ? t("project_page.empty_state.private.primary_button.loading")
-              : t("project_page.empty_state.private.primary_button.text"),
+            text: isCreatingPage ? t("creating") : t("project_page.empty_state.private.primary_button.text"),
             onClick: () => {
               handleCreatePage();
               captureClick({ elementName: PROJECT_PAGE_TRACKER_ELEMENTS.EMPTY_STATE_CREATE_BUTTON });

--- a/apps/web/core/components/pages/pages-list-main-content.tsx
+++ b/apps/web/core/components/pages/pages-list-main-content.tsx
@@ -1,14 +1,23 @@
+import { useState } from "react";
 import { observer } from "mobx-react";
 import Image from "next/image";
 // plane imports
-import { EUserPermissionsLevel, EPageAccess, PROJECT_PAGE_TRACKER_ELEMENTS } from "@plane/constants";
+import { useParams, useRouter } from "next/navigation";
+import {
+  EUserPermissionsLevel,
+  EPageAccess,
+  PROJECT_PAGE_TRACKER_ELEMENTS,
+  PROJECT_PAGE_TRACKER_EVENTS,
+} from "@plane/constants";
 import { useTranslation } from "@plane/i18n";
-import { EUserProjectRoles, TPageNavigationTabs } from "@plane/types";
+import { EUserProjectRoles, TPage, TPageNavigationTabs } from "@plane/types";
 // components
+import { setToast, TOAST_TYPE } from "@plane/ui";
 import { DetailedEmptyState } from "@/components/empty-state/detailed-empty-state-root";
 import { PageLoader } from "@/components/pages/loaders/page-loader";
-import { captureClick } from "@/helpers/event-tracker.helper";
+import { captureClick, captureError, captureSuccess } from "@/helpers/event-tracker.helper";
 import { useCommandPalette } from "@/hooks/store/use-command-palette";
+import { useProject } from "@/hooks/store/use-project";
 import { useUserPermissions } from "@/hooks/store/user";
 import { useResolvedAssetPath } from "@/hooks/use-resolved-asset-path";
 // plane web hooks
@@ -25,10 +34,17 @@ export const PagesListMainContent: React.FC<Props> = observer((props) => {
   // plane hooks
   const { t } = useTranslation();
   // store hooks
-  const { loader, isAnyPageAvailable, getCurrentProjectFilteredPageIdsByTab, getCurrentProjectPageIdsByTab, filters } =
+  const { currentProjectDetails, loader } = useProject();
+  const { isAnyPageAvailable, getCurrentProjectFilteredPageIdsByTab, getCurrentProjectPageIdsByTab, filters } =
     usePageStore(storeType);
-  const { toggleCreatePageModal } = useCommandPalette();
+  useCommandPalette();
   const { allowPermissions } = useUserPermissions();
+  const { createPage } = usePageStore(EPageStoreType.PROJECT);
+  // states
+  const [isCreatingPage, setIsCreatingPage] = useState(false);
+  // router
+  const router = useRouter();
+  const { workspaceSlug } = useParams();
   // derived values
   const pageIds = getCurrentProjectPageIdsByTab(pageType);
   const filteredPageIds = getCurrentProjectFilteredPageIdsByTab(pageType);
@@ -54,6 +70,42 @@ export const PagesListMainContent: React.FC<Props> = observer((props) => {
     extension: "svg",
   });
 
+  // handle page create
+  const handleCreatePage = async () => {
+    setIsCreatingPage(true);
+
+    const payload: Partial<TPage> = {
+      access: pageType === "private" ? EPageAccess.PRIVATE : EPageAccess.PUBLIC,
+    };
+
+    await createPage(payload)
+      .then((res) => {
+        captureSuccess({
+          eventName: PROJECT_PAGE_TRACKER_EVENTS.create,
+          payload: {
+            id: res?.id,
+            state: "SUCCESS",
+          },
+        });
+        const pageId = `/${workspaceSlug}/projects/${currentProjectDetails?.id}/pages/${res?.id}`;
+        router.push(pageId);
+      })
+      .catch((err) => {
+        captureError({
+          eventName: PROJECT_PAGE_TRACKER_EVENTS.create,
+          payload: {
+            state: "ERROR",
+          },
+        });
+        setToast({
+          type: TOAST_TYPE.ERROR,
+          title: "Error!",
+          message: err?.data?.error || "Page could not be created. Please try again.",
+        });
+      })
+      .finally(() => setIsCreatingPage(false));
+  };
+
   if (loader === "init-loader") return <PageLoader />;
   // if no pages exist in the active page type
   if (!isAnyPageAvailable || pageIds?.length === 0) {
@@ -64,12 +116,14 @@ export const PagesListMainContent: React.FC<Props> = observer((props) => {
           description={t("project_page.empty_state.general.description")}
           assetPath={generalPageResolvedPath}
           primaryButton={{
-            text: t("project_page.empty_state.general.primary_button.text"),
+            text: isCreatingPage
+              ? t("project_page.empty_state.general.primary_button.loading")
+              : t("project_page.empty_state.general.primary_button.text"),
             onClick: () => {
-              toggleCreatePageModal({ isOpen: true });
+              handleCreatePage();
               captureClick({ elementName: PROJECT_PAGE_TRACKER_ELEMENTS.EMPTY_STATE_CREATE_BUTTON });
             },
-            disabled: !canPerformEmptyStateActions,
+            disabled: !canPerformEmptyStateActions || isCreatingPage,
           }}
         />
       );
@@ -81,12 +135,14 @@ export const PagesListMainContent: React.FC<Props> = observer((props) => {
           description={t("project_page.empty_state.public.description")}
           assetPath={publicPageResolvedPath}
           primaryButton={{
-            text: t("project_page.empty_state.public.primary_button.text"),
+            text: isCreatingPage
+              ? t("project_page.empty_state.public.primary_button.loading")
+              : t("project_page.empty_state.public.primary_button.text"),
             onClick: () => {
-              toggleCreatePageModal({ isOpen: true, pageAccess: EPageAccess.PUBLIC });
+              handleCreatePage();
               captureClick({ elementName: PROJECT_PAGE_TRACKER_ELEMENTS.EMPTY_STATE_CREATE_BUTTON });
             },
-            disabled: !canPerformEmptyStateActions,
+            disabled: !canPerformEmptyStateActions || isCreatingPage,
           }}
         />
       );
@@ -97,12 +153,14 @@ export const PagesListMainContent: React.FC<Props> = observer((props) => {
           description={t("project_page.empty_state.private.description")}
           assetPath={privatePageResolvedPath}
           primaryButton={{
-            text: t("project_page.empty_state.private.primary_button.text"),
+            text: isCreatingPage
+              ? t("project_page.empty_state.private.primary_button.loading")
+              : t("project_page.empty_state.private.primary_button.text"),
             onClick: () => {
-              toggleCreatePageModal({ isOpen: true, pageAccess: EPageAccess.PRIVATE });
+              handleCreatePage();
               captureClick({ elementName: PROJECT_PAGE_TRACKER_ELEMENTS.EMPTY_STATE_CREATE_BUTTON });
             },
-            disabled: !canPerformEmptyStateActions,
+            disabled: !canPerformEmptyStateActions || isCreatingPage,
           }}
         />
       );

--- a/packages/i18n/src/locales/en/translations.json
+++ b/packages/i18n/src/locales/en/translations.json
@@ -1994,24 +1994,21 @@
         "title": "Write a note, a doc, or a full knowledge base. Get Galileo, Plane's AI assistant, to help you get started",
         "description": "Pages are thoughts potting space in Plane. Take down meeting notes, format them easily, embed work items, lay them out using a library of components, and keep them all in your project's context. To make short work of any doc, invoke Galileo, Plane's AI, with a shortcut or the click of a button.",
         "primary_button": {
-          "text": "Create your first page",
-          "loading": "Creating"
+          "text": "Create your first page"
         }
       },
       "private": {
         "title": "No private pages yet",
         "description": "Keep your private thoughts here. When you're ready to share, the team's just a click away.",
         "primary_button": {
-          "text": "Create your first page",
-          "loading": "Creating"
+          "text": "Create your first page"
         }
       },
       "public": {
         "title": "No public pages yet",
         "description": "See pages shared with everyone in your project right here.",
         "primary_button": {
-          "text": "Create your first page",
-          "loading": "Creating"
+          "text": "Create your first page"
         }
       },
       "archived": {

--- a/packages/i18n/src/locales/en/translations.json
+++ b/packages/i18n/src/locales/en/translations.json
@@ -1994,21 +1994,24 @@
         "title": "Write a note, a doc, or a full knowledge base. Get Galileo, Plane's AI assistant, to help you get started",
         "description": "Pages are thoughts potting space in Plane. Take down meeting notes, format them easily, embed work items, lay them out using a library of components, and keep them all in your project's context. To make short work of any doc, invoke Galileo, Plane's AI, with a shortcut or the click of a button.",
         "primary_button": {
-          "text": "Create your first page"
+          "text": "Create your first page",
+          "loading": "Creating"
         }
       },
       "private": {
         "title": "No private pages yet",
         "description": "Keep your private thoughts here. When you're ready to share, the team's just a click away.",
         "primary_button": {
-          "text": "Create your first page"
+          "text": "Create your first page",
+          "loading": "Creating"
         }
       },
       "public": {
         "title": "No public pages yet",
         "description": "See pages shared with everyone in your project right here.",
         "primary_button": {
-          "text": "Create your first page"
+          "text": "Create your first page",
+          "loading": "Creating"
         }
       },
       "archived": {


### PR DESCRIPTION
### Description
This PR Updates a new page logic for project pages and open that page directly after creation.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
<!-- Link related issues if there are any -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Create pages inline from the list view (no modal) with automatic navigation to the new page.
  * Loading indicators and “creating” labels on create buttons; buttons disable during creation or when permissions are insufficient.
  * Error feedback via a toast if creation fails.

* **Refactor**
  * Streamlined creation flow and routing for a smoother, faster list-to-page experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->