### PR TITLE
[WIKI-622] fix: update space work item description styles

### DIFF
--- a/apps/space/core/components/editor/rich-text-editor.tsx
+++ b/apps/space/core/components/editor/rich-text-editor.tsx
@@ -58,7 +58,7 @@ export const RichTextEditor = forwardRef<EditorRefApi, RichTextEditorWrapperProp
       flaggedExtensions={richTextEditorExtensions.flagged}
       {...rest}
       containerClassName={containerClassName}
-      editorClassName="min-h-[100px] max-h-[200px] border-[0.5px] border-custom-border-300 rounded-md pl-3 py-2 overflow-hidden"
+      editorClassName="min-h-[100px] py-2 overflow-hidden"
       displayConfig={{ fontSize: "large-font" }}
     />
   );


### PR DESCRIPTION
### Description
Fix Read-Only RichEditor Editor for work item description

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)


### Screenshots and Media (if applicable)
<img width="469" height="803" alt="image" src="https://github.com/user-attachments/assets/6a14ff59-ebdd-452c-ac19-119515061918" />

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
<!-- Link related issues if there are any -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated rich text editor to a cleaner, borderless look for a more distraction-free experience.
  * Editor now expands with content instead of being capped, reducing the need for internal scrolling.
  * Adjusted padding for improved content alignment while maintaining consistent vertical spacing and a sensible minimum height.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->