### PR TITLE
[WEB-4820] fix: incorrect logging of description activity for work items and epics

### DIFF
--- a/apps/web/core/components/issues/issue-modal/form.tsx
+++ b/apps/web/core/components/issues/issue-modal/form.tsx
@@ -232,7 +232,6 @@ export const IssueFormRoot: FC<IssueFormProps> = observer((props) => {
           ...getChangedIssuefields(formData, dirtyFields as { [key: string]: boolean | undefined }),
           project_id: getValues<"project_id">("project_id"),
           id: data.id,
-          description_html: formData.description_html ?? "<p></p>",
           type_id: getValues<"type_id">("type_id"),
         };
 


### PR DESCRIPTION
### Description
This PR addresses an issue where description update activity was being logged for work items even when unrelated operations were performed.

### Type of Change
- [x] Bug fix