### PR TITLE
[WEB-4196]fix: toast message for sub work item quick actions

### DIFF
--- a/apps/web/core/components/issues/issue-detail-widgets/sub-issues/helper.ts
+++ b/apps/web/core/components/issues/issue-detail-widgets/sub-issues/helper.ts
@@ -46,7 +46,10 @@ export const useSubIssueOperations = (issueServiceType: TIssueServiceType): TSub
             type: TOAST_TYPE.SUCCESS,
             title: t("common.link_copied"),
             message: t("entity.link_copied_to_clipboard", {
-              entity: t("epic.label", { count: 1 }),
+              entity:
+                issueServiceType === EIssueServiceType.ISSUES
+                  ? t("common.sub_work_items", { count: 1 })
+                  : t("issue.label", { count: 1 }),
             }),
           });
         });
@@ -77,7 +80,7 @@ export const useSubIssueOperations = (issueServiceType: TIssueServiceType): TSub
               entity:
                 issueServiceType === EIssueServiceType.ISSUES
                   ? t("common.sub_work_items")
-                  : t("issue.label", { count: 2 }),
+                  : t("issue.label", { count: issueIds.length }),
             }),
           });
         } catch {
@@ -88,7 +91,7 @@ export const useSubIssueOperations = (issueServiceType: TIssueServiceType): TSub
               entity:
                 issueServiceType === EIssueServiceType.ISSUES
                   ? t("common.sub_work_items")
-                  : t("issue.label", { count: 2 }),
+                  : t("issue.label", { count: issueIds.length }),
             }),
           });
         }
@@ -169,7 +172,12 @@ export const useSubIssueOperations = (issueServiceType: TIssueServiceType): TSub
           setToast({
             type: TOAST_TYPE.SUCCESS,
             title: t("toast.success"),
-            message: t("sub_work_item.remove.success"),
+            message: t("entity.remove.success", {
+              entity:
+                issueServiceType === EIssueServiceType.ISSUES
+                  ? t("common.sub_work_items")
+                  : t("issue.label", { count: 1 }),
+            }),
           });
           captureSuccess({
             eventName: WORK_ITEM_TRACKER_EVENTS.sub_issue.remove,
@@ -185,7 +193,12 @@ export const useSubIssueOperations = (issueServiceType: TIssueServiceType): TSub
           setToast({
             type: TOAST_TYPE.ERROR,
             title: t("toast.error"),
-            message: t("sub_work_item.remove.error"),
+            message: t("entity.remove.failed", {
+              entity:
+                issueServiceType === EIssueServiceType.ISSUES
+                  ? t("common.sub_work_items")
+                  : t("issue.label", { count: 1 }),
+            }),
           });
         }
       },
@@ -208,7 +221,12 @@ export const useSubIssueOperations = (issueServiceType: TIssueServiceType): TSub
           setToast({
             type: TOAST_TYPE.ERROR,
             title: t("toast.error"),
-            message: t("issue.delete.error"),
+            message: t("entity.delete.failed", {
+              entity:
+                issueServiceType === EIssueServiceType.ISSUES
+                  ? t("common.sub_work_items")
+                  : t("issue.label", { count: 1 }),
+            }),
           });
         }
       },

--- a/packages/i18n/src/locales/cs/translations.json
+++ b/packages/i18n/src/locales/cs/translations.json
@@ -916,6 +916,10 @@
     "add": {
       "success": "{entity} úspěšně přidána",
       "failed": "Chyba při přidávání {entity}"
+    },
+    "remove": {
+      "success": "{entity} úspěšně odebrána",
+      "failed": "Chyba při odebírání {entity}"
     }
   },
   "epic": {

--- a/packages/i18n/src/locales/de/translations.json
+++ b/packages/i18n/src/locales/de/translations.json
@@ -916,6 +916,10 @@
     "add": {
       "success": "{entity} erfolgreich hinzugefügt",
       "failed": "Fehler beim Hinzufügen von {entity}"
+    },
+    "remove": {
+      "success": "{entity} erfolgreich entfernt",
+      "failed": "Fehler beim Entfernen von {entity}"
     }
   },
   "epic": {

--- a/packages/i18n/src/locales/en/translations.json
+++ b/packages/i18n/src/locales/en/translations.json
@@ -759,6 +759,10 @@
     "add": {
       "success": "{entity} added successfully",
       "failed": "Error adding {entity}"
+    },
+    "remove": {
+      "success": "{entity} removed successfully",
+      "failed": "Error removing {entity}"
     }
   },
   "epic": {

--- a/packages/i18n/src/locales/es/translations.json
+++ b/packages/i18n/src/locales/es/translations.json
@@ -919,6 +919,10 @@
     "add": {
       "success": "{entity} agregado correctamente",
       "failed": "Error al agregar {entity}"
+    },
+    "remove": {
+      "success": "{entity} eliminado correctamente",
+      "failed": "Error al eliminar {entity}"
     }
   },
   "epic": {

--- a/packages/i18n/src/locales/fr/translations.json
+++ b/packages/i18n/src/locales/fr/translations.json
@@ -917,6 +917,10 @@
     "add": {
       "success": "{entity} ajouté avec succès",
       "failed": "Erreur lors de l'ajout de {entity}"
+    },
+    "remove": {
+      "success": "{entity} supprimé avec succès",
+      "failed": "Erreur lors de la suppression de {entity}"
     }
   },
   "epic": {

--- a/packages/i18n/src/locales/id/translations.json
+++ b/packages/i18n/src/locales/id/translations.json
@@ -916,6 +916,10 @@
     "add": {
       "success": "{entity} berhasil ditambahkan",
       "failed": "Terjadi kesalahan saat menambahkan {entity}"
+    },
+    "remove": {
+      "success": "{entity} berhasil dihapus",
+      "failed": "Terjadi kesalahan saat menghapus {entity}"
     }
   },
   "epic": {

--- a/packages/i18n/src/locales/it/translations.json
+++ b/packages/i18n/src/locales/it/translations.json
@@ -915,6 +915,10 @@
     "add": {
       "success": "{entity} aggiunto con successo",
       "failed": "Errore nell'aggiunta di {entity}"
+    },
+    "remove": {
+      "success": "{entity} rimosso con successo",
+      "failed": "Errore nella rimozione di {entity}"
     }
   },
   "epic": {

--- a/packages/i18n/src/locales/ja/translations.json
+++ b/packages/i18n/src/locales/ja/translations.json
@@ -917,6 +917,10 @@
     "add": {
       "success": "{entity}を追加しました",
       "failed": "{entity}の追加中にエラーが発生しました"
+    },
+    "remove": {
+      "success": "{entity}を削除しました",
+      "failed": "{entity}の削除中にエラーが発生しました"
     }
   },
   "epic": {

--- a/packages/i18n/src/locales/ko/translations.json
+++ b/packages/i18n/src/locales/ko/translations.json
@@ -918,6 +918,10 @@
     "add": {
       "success": "{entity}가 성공적으로 추가되었습니다",
       "failed": "{entity} 추가 중 오류 발생"
+    },
+    "remove": {
+      "success": "{entity}가 성공적으로 제거되었습니다",
+      "failed": "{entity} 제거 중 오류 발생"
     }
   },
   "epic": {

--- a/packages/i18n/src/locales/pl/translations.json
+++ b/packages/i18n/src/locales/pl/translations.json
@@ -918,6 +918,10 @@
     "add": {
       "success": "{entity} dodano pomyślnie",
       "failed": "Błąd podczas dodawania {entity}"
+    },
+    "remove": {
+      "success": "{entity} usunięto pomyślnie",
+      "failed": "Błąd podczas usuwania {entity}"
     }
   },
   "epic": {

--- a/packages/i18n/src/locales/pt-BR/translations.json
+++ b/packages/i18n/src/locales/pt-BR/translations.json
@@ -918,6 +918,10 @@
     "add": {
       "success": "{entity} adicionado com sucesso",
       "failed": "Erro ao adicionar {entity}"
+    },
+    "remove": {
+      "success": "{entity} removido com sucesso",
+      "failed": "Erro ao remover {entity}"
     }
   },
   "epic": {

--- a/packages/i18n/src/locales/ro/translations.json
+++ b/packages/i18n/src/locales/ro/translations.json
@@ -916,6 +916,10 @@
     "add": {
       "success": "{entity} a fost adăugată cu succes",
       "failed": "Eroare la adăugarea {entity}"
+    },
+    "remove": {
+      "success": "{entity} a fost eliminată cu succes",
+      "failed": "Eroare la eliminarea {entity}"
     }
   },
   "epic": {

--- a/packages/i18n/src/locales/ru/translations.json
+++ b/packages/i18n/src/locales/ru/translations.json
@@ -918,6 +918,10 @@
     "add": {
       "success": "{entity} успешно добавлен",
       "failed": "Ошибка добавления {entity}"
+    },
+    "remove": {
+      "success": "{entity} успешно удален",
+      "failed": "Ошибка удаления {entity}"
     }
   },
   "epic": {

--- a/packages/i18n/src/locales/sk/translations.json
+++ b/packages/i18n/src/locales/sk/translations.json
@@ -918,6 +918,10 @@
     "add": {
       "success": "{entity} bola úspešne pridaná",
       "failed": "Chyba pri pridávaní {entity}"
+    },
+    "remove": {
+      "success": "{entity} bola úspešne odstránená",
+      "failed": "Chyba pri odstrávaní {entity}"
     }
   },
   "epic": {

--- a/packages/i18n/src/locales/tr-TR/translations.json
+++ b/packages/i18n/src/locales/tr-TR/translations.json
@@ -920,6 +920,10 @@
     "add": {
       "success": "{entity} başarıyla eklendi",
       "failed": "{entity} eklenirken hata oluştu"
+    },
+    "remove": {
+      "success": "{entity} başarıyla kaldırıldı",
+      "failed": "{entity} kaldırılırken hata oluştu"
     }
   },
   "epic": {

--- a/packages/i18n/src/locales/ua/translations.json
+++ b/packages/i18n/src/locales/ua/translations.json
@@ -918,6 +918,10 @@
     "add": {
       "success": "{entity} успішно додано",
       "failed": "Помилка під час додавання {entity}"
+    },
+    "remove": {
+      "success": "{entity} успішно видалено",
+      "failed": "Помилка під час видалення {entity}"
     }
   },
   "epic": {

--- a/packages/i18n/src/locales/vi-VN/translations.json
+++ b/packages/i18n/src/locales/vi-VN/translations.json
@@ -917,6 +917,10 @@
     "add": {
       "success": "Đã thêm {entity} thành công",
       "failed": "Đã xảy ra lỗi khi thêm {entity}"
+    },
+    "remove": {
+      "success": "Đã xóa {entity} thành công",
+      "failed": "Đã xảy ra lỗi khi xóa {entity}"
     }
   },
   "epic": {

--- a/packages/i18n/src/locales/zh-CN/translations.json
+++ b/packages/i18n/src/locales/zh-CN/translations.json
@@ -917,6 +917,10 @@
     "add": {
       "success": "{entity}添加成功",
       "failed": "添加{entity}时出错"
+    },
+    "remove": {
+      "success": "{entity}删除成功",
+      "failed": "删除{entity}时出错"
     }
   },
   "epic": {

--- a/packages/i18n/src/locales/zh-TW/translations.json
+++ b/packages/i18n/src/locales/zh-TW/translations.json
@@ -918,6 +918,10 @@
     "add": {
       "success": "{entity} 新增成功",
       "failed": "新增 {entity} 時發生錯誤"
+    },
+    "remove": {
+      "success": "{entity} 刪除成功",
+      "failed": "刪除 {entity} 時發生錯誤"
     }
   },
   "epic": {


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
Improves toast message accuracy and consistency when working with sub-issues and issues by fixing entity labels, adding proper pluralisation, and enhancing error/success message handling. Includes new translation strings for entity remove operations to provide better user feedback.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
<!-- Link related issues if there are any -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added "remove" translations for entities across locales to support consistent removal success/error messages.

- Refactor
  - Standardized toast notifications to use a shared entity-based pattern with dynamic descriptions and counts across sub-issue actions (copy link, fetch, add, remove, delete).
  - Unified messaging between ISSUES and non-ISSUES flows for consistent user feedback.

- Bug Fixes
  - Fixed incorrect hardcoded counts in some error toasts so displayed counts reflect selected items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->