### PR TITLE
[WEB-4829] refactor: remove `start us` CTA from header

### DIFF
--- a/apps/web/app/(all)/[workspaceSlug]/(projects)/header.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/(projects)/header.tsx
@@ -1,26 +1,17 @@
 "use client";
 
 import { observer } from "mobx-react";
-import Image from "next/image";
-import { useTheme } from "next-themes";
 import { Home, Shapes } from "lucide-react";
-// images
-import githubBlackImage from "/public/logos/github-black.png";
-import githubWhiteImage from "/public/logos/github-white.png";
-// ui
-import { GITHUB_REDIRECTED_TRACKER_EVENT, HEADER_GITHUB_ICON } from "@plane/constants";
+// plane imports
 import { useTranslation } from "@plane/i18n";
 import { Breadcrumbs, Button, Header } from "@plane/ui";
 // components
 import { BreadcrumbLink } from "@/components/common/breadcrumb-link";
-// constants
 // hooks
-import { captureElementAndEvent } from "@/helpers/event-tracker.helper";
 import { useHome } from "@/hooks/store/use-home";
 
 export const WorkspaceDashboardHeader = observer(() => {
   // hooks
-  const { resolvedTheme } = useTheme();
   const { toggleWidgetSettings } = useHome();
   const { t } = useTranslation();
 
@@ -48,31 +39,6 @@ export const WorkspaceDashboardHeader = observer(() => {
             <Shapes size={16} />
             <div className="hidden text-xs font-medium sm:hidden md:block">{t("home.manage_widgets")}</div>
           </Button>
-          <a
-            onClick={() =>
-              captureElementAndEvent({
-                element: {
-                  elementName: HEADER_GITHUB_ICON,
-                },
-                event: {
-                  eventName: GITHUB_REDIRECTED_TRACKER_EVENT,
-                  state: "SUCCESS",
-                },
-              })
-            }
-            className="flex flex-shrink-0 items-center gap-1.5 rounded bg-custom-background-80 px-3 py-1.5"
-            href="https://github.com/makeplane/plane"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              src={resolvedTheme === "dark" ? githubWhiteImage : githubBlackImage}
-              height={16}
-              width={16}
-              alt="GitHub Logo"
-            />
-            <span className="hidden text-xs font-medium sm:hidden md:block">{t("home.star_us_on_github")}</span>
-          </a>
         </Header.RightItem>
       </Header>
     </>

--- a/packages/constants/src/event-tracker/core.ts
+++ b/packages/constants/src/event-tracker/core.ts
@@ -6,8 +6,6 @@ import { EProductSubscriptionEnum } from "@plane/types";
  * ===========================================================================
  */
 export const GROUP_WORKSPACE_TRACKER_EVENT = "workspace_metrics";
-export const GITHUB_REDIRECTED_TRACKER_EVENT = "github_redirected";
-export const HEADER_GITHUB_ICON = "header_github_icon";
 
 /**
  * ===========================================================================

--- a/packages/i18n/src/locales/cs/translations.json
+++ b/packages/i18n/src/locales/cs/translations.json
@@ -605,8 +605,7 @@
       "reordering_failed": "Při přesouvání widgetu došlo k chybě."
     },
     "manage_widgets": "Spravovat widgety",
-    "title": "Domů",
-    "star_us_on_github": "Ohodnoťte nás na GitHubu"
+    "title": "Domů"
   },
   "link": {
     "modal": {

--- a/packages/i18n/src/locales/de/translations.json
+++ b/packages/i18n/src/locales/de/translations.json
@@ -605,8 +605,7 @@
       "reordering_failed": "Beim Verschieben des Widgets ist ein Fehler aufgetreten."
     },
     "manage_widgets": "Widgets verwalten",
-    "title": "Startseite",
-    "star_us_on_github": "Geben Sie uns einen Stern auf GitHub"
+    "title": "Startseite"
   },
   "link": {
     "modal": {

--- a/packages/i18n/src/locales/en/translations.json
+++ b/packages/i18n/src/locales/en/translations.json
@@ -446,8 +446,7 @@
       "reordering_failed": "Error occurred while reordering widget."
     },
     "manage_widgets": "Manage widgets",
-    "title": "Home",
-    "star_us_on_github": "Star us on GitHub"
+    "title": "Home"
   },
   "link": {
     "modal": {

--- a/packages/i18n/src/locales/es/translations.json
+++ b/packages/i18n/src/locales/es/translations.json
@@ -609,8 +609,7 @@
       "reordering_failed": "Ocurrió un error al reordenar el widget."
     },
     "manage_widgets": "Gestionar widgets",
-    "title": "Inicio",
-    "star_us_on_github": "Danos una estrella en GitHub"
+    "title": "Inicio"
   },
   "link": {
     "modal": {

--- a/packages/i18n/src/locales/fr/translations.json
+++ b/packages/i18n/src/locales/fr/translations.json
@@ -607,8 +607,7 @@
       "reordering_failed": "Une erreur s'est produite lors de la réorganisation du widget."
     },
     "manage_widgets": "Gérer les widgets",
-    "title": "Accueil",
-    "star_us_on_github": "Donnez-nous une étoile sur GitHub"
+    "title": "Accueil"
   },
   "link": {
     "modal": {

--- a/packages/i18n/src/locales/id/translations.json
+++ b/packages/i18n/src/locales/id/translations.json
@@ -605,8 +605,7 @@
       "reordering_failed": "Kesalahan terjadi saat mengurutkan ulang widget."
     },
     "manage_widgets": "Kelola widget",
-    "title": "Beranda",
-    "star_us_on_github": "Bintang kami di GitHub"
+    "title": "Beranda"
   },
   "link": {
     "modal": {

--- a/packages/i18n/src/locales/it/translations.json
+++ b/packages/i18n/src/locales/it/translations.json
@@ -607,8 +607,7 @@
       "reordering_failed": "Si è verificato un errore durante il riordino del widget."
     },
     "manage_widgets": "Gestisci widget",
-    "title": "Home",
-    "star_us_on_github": "Metti una stella su GitHub"
+    "title": "Home"
   },
   "link": {
     "modal": {

--- a/packages/i18n/src/locales/ja/translations.json
+++ b/packages/i18n/src/locales/ja/translations.json
@@ -607,8 +607,7 @@
       "reordering_failed": "ウィジェットの並び替え中にエラーが発生しました。"
     },
     "manage_widgets": "ウィジェットを管理",
-    "title": "ホーム",
-    "star_us_on_github": "GitHubでスターをつける"
+    "title": "ホーム"
   },
   "link": {
     "modal": {

--- a/packages/i18n/src/locales/ko/translations.json
+++ b/packages/i18n/src/locales/ko/translations.json
@@ -607,8 +607,7 @@
       "reordering_failed": "위젯 재정렬 중 오류가 발생했습니다."
     },
     "manage_widgets": "위젯 관리",
-    "title": "홈",
-    "star_us_on_github": "GitHub에서 별표"
+    "title": "홈"
   },
   "link": {
     "modal": {

--- a/packages/i18n/src/locales/pl/translations.json
+++ b/packages/i18n/src/locales/pl/translations.json
@@ -607,8 +607,7 @@
       "reordering_failed": "Wystąpił błąd podczas przenoszenia widżetu."
     },
     "manage_widgets": "Zarządzaj widżetami",
-    "title": "Strona główna",
-    "star_us_on_github": "Oceń nas na GitHubie"
+    "title": "Strona główna"
   },
   "link": {
     "modal": {

--- a/packages/i18n/src/locales/pt-BR/translations.json
+++ b/packages/i18n/src/locales/pt-BR/translations.json
@@ -607,8 +607,7 @@
       "reordering_failed": "Ocorreu um erro ao reordenar o widget."
     },
     "manage_widgets": "Gerenciar widgets",
-    "title": "Página inicial",
-    "star_us_on_github": "Nos dê uma estrela no GitHub"
+    "title": "Página inicial"
   },
   "link": {
     "modal": {

--- a/packages/i18n/src/locales/ro/translations.json
+++ b/packages/i18n/src/locales/ro/translations.json
@@ -605,8 +605,7 @@
       "reordering_failed": "Eroare la reordonarea mini-aplicației."
     },
     "manage_widgets": "Gestionează mini-aplicațiile",
-    "title": "Acasă",
-    "star_us_on_github": "Dă-ne o stea pe GitHub"
+    "title": "Acasă"
   },
   "link": {
     "modal": {

--- a/packages/i18n/src/locales/ru/translations.json
+++ b/packages/i18n/src/locales/ru/translations.json
@@ -607,8 +607,7 @@
       "reordering_failed": "Ошибка при изменении порядка виджетов."
     },
     "manage_widgets": "Управление виджетами",
-    "title": "Главная",
-    "star_us_on_github": "Оцените нас на GitHub"
+    "title": "Главная"
   },
   "link": {
     "modal": {

--- a/packages/i18n/src/locales/sk/translations.json
+++ b/packages/i18n/src/locales/sk/translations.json
@@ -607,8 +607,7 @@
       "reordering_failed": "Pri presúvaní widgetu došlo k chybe."
     },
     "manage_widgets": "Spravovať widgety",
-    "title": "Domov",
-    "star_us_on_github": "Ohodnoťte nás na GitHube"
+    "title": "Domov"
   },
   "link": {
     "modal": {

--- a/packages/i18n/src/locales/tr-TR/translations.json
+++ b/packages/i18n/src/locales/tr-TR/translations.json
@@ -608,8 +608,7 @@
       "reordering_failed": "Widget yeniden sıralanırken hata oluştu."
     },
     "manage_widgets": "Widget'ları yönet",
-    "title": "Ana Sayfa",
-    "star_us_on_github": "Bizi GitHub'da yıldızlayın"
+    "title": "Ana Sayfa"
   },
   "link": {
     "modal": {

--- a/packages/i18n/src/locales/ua/translations.json
+++ b/packages/i18n/src/locales/ua/translations.json
@@ -607,8 +607,7 @@
       "reordering_failed": "Сталася помилка під час переміщення віджета."
     },
     "manage_widgets": "Керувати віджетами",
-    "title": "Головна",
-    "star_us_on_github": "Оцініть нас на GitHub"
+    "title": "Головна"
   },
   "link": {
     "modal": {

--- a/packages/i18n/src/locales/vi-VN/translations.json
+++ b/packages/i18n/src/locales/vi-VN/translations.json
@@ -607,8 +607,7 @@
       "reordering_failed": "Đã xảy ra lỗi khi sắp xếp lại tiện ích."
     },
     "manage_widgets": "Quản lý tiện ích",
-    "title": "Trang chủ",
-    "star_us_on_github": "Gắn sao cho chúng tôi trên GitHub"
+    "title": "Trang chủ"
   },
   "link": {
     "modal": {

--- a/packages/i18n/src/locales/zh-CN/translations.json
+++ b/packages/i18n/src/locales/zh-CN/translations.json
@@ -607,8 +607,7 @@
       "reordering_failed": "重新排序小部件时出错。"
     },
     "manage_widgets": "管理小部件",
-    "title": "首页",
-    "star_us_on_github": "在GitHub上为我们加星"
+    "title": "首页"
   },
   "link": {
     "modal": {

--- a/packages/i18n/src/locales/zh-TW/translations.json
+++ b/packages/i18n/src/locales/zh-TW/translations.json
@@ -607,8 +607,7 @@
       "reordering_failed": "重新排序小工具時發生錯誤。"
     },
     "manage_widgets": "管理小工具",
-    "title": "首頁",
-    "star_us_on_github": "在 GitHub 上給我們星星"
+    "title": "首頁"
   },
   "link": {
     "modal": {


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
This PR removes `Star us on GitHub` CTA from header. 

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Code refactoring

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the workspace header by removing the GitHub link and icon; the right side now only shows “Manage Widgets.” Breadcrumbs are unchanged. Removed theme-based icon swapping to improve consistency and reduce visual clutter.
* **Chores**
  * Removed unused analytics events tied to the GitHub header link.
  * Cleaned up translations by deleting the “Star us on GitHub” string across all supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->