### PR TITLE
[WEB-4834] fix: range date picker weekStartsOn

### DIFF
--- a/apps/web/core/components/dropdowns/date-range.tsx
+++ b/apps/web/core/components/dropdowns/date-range.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useRef, useState } from "react";
 import { Placement } from "@popperjs/core";
+import { observer } from "mobx-react";
 import { DateRange, Matcher } from "react-day-picker";
 import { usePopper } from "react-popper";
 import { ArrowRight, CalendarCheck2, CalendarDays, X } from "lucide-react";
@@ -60,7 +61,7 @@ type Props = {
   customTooltipHeading?: string;
 };
 
-export const DateRangeDropdown: React.FC<Props> = (props) => {
+export const DateRangeDropdown: React.FC<Props> = observer((props) => {
   const { t } = useTranslation();
   const {
     buttonClassName,
@@ -286,4 +287,4 @@ export const DateRangeDropdown: React.FC<Props> = (props) => {
       )}
     </ComboDropDown>
   );
-};
+});

--- a/apps/web/core/components/dropdowns/date-range.tsx
+++ b/apps/web/core/components/dropdowns/date-range.tsx
@@ -13,6 +13,7 @@ import { ComboDropDown, Calendar } from "@plane/ui";
 import { cn, renderFormattedDate } from "@plane/utils";
 // helpers
 // hooks
+import { useUserProfile } from "@/hooks/store/user";
 import { useDropdown } from "@/hooks/use-dropdown";
 // components
 import { DropdownButton } from "./buttons";
@@ -95,6 +96,9 @@ export const DateRangeDropdown: React.FC<Props> = (props) => {
   // states
   const [isOpen, setIsOpen] = useState(false);
   const [dateRange, setDateRange] = useState<DateRange>(value);
+  // hooks
+  const { data } = useUserProfile();
+  const startOfWeek = data?.start_of_the_week;
   // refs
   const dropdownRef = useRef<HTMLDivElement | null>(null);
   // popper-js refs
@@ -274,6 +278,7 @@ export const DateRangeDropdown: React.FC<Props> = (props) => {
               disabled={disabledDays}
               showOutsideDays
               fixedWeeks
+              weekStartsOn={startOfWeek}
               initialFocus
             />
           </div>


### PR DESCRIPTION
### Description
This PR updates the range date picker to respect the user’s `weekStartsOn` preference, ensuring the week now begins according to the user’s chosen setting.

### Type of Change
- [x] Bug fix 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Date Range dropdown calendar now respects your profile’s start-of-week preference (e.g., Monday or Sunday) for a more personalized experience.
  * Changes to your start-of-week preference are reflected immediately in the calendar.
  * Improves consistency with regional norms when viewing and selecting date ranges, reducing confusion and making range selection more intuitive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->