### PR TITLE
[WEB-4836] fix: work item retrieval in peek overview

### DIFF
--- a/apps/web/core/store/issue/issue-details/issue.store.ts
+++ b/apps/web/core/store/issue/issue-details/issue.store.ts
@@ -107,7 +107,7 @@ export class IssueStore implements IIssueStore {
       this.localDBIssueDescription = issueId;
     }
 
-    await this.issueService.retrieve(workspaceSlug, projectId, issueId, query);
+    issue = await this.issueService.retrieve(workspaceSlug, projectId, issueId, query);
 
     if (!issue) throw new Error("Work item not found");
 


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
This PR resolves the issue of retrieving work items in the peek overview by assigning the issue to a variable after retrieving it from the backend. 

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
