### PR TITLE
[WEB-4787] fix: changed issue to work item in cycles dropdown

### DIFF
--- a/apps/web/core/components/cycles/dropdowns/estimate-type-dropdown.tsx
+++ b/apps/web/core/components/cycles/dropdowns/estimate-type-dropdown.tsx
@@ -38,6 +38,6 @@ export const EstimateTypeDropdown = observer((props: TProps) => {
       </CustomSelect>
     </div>
   ) : showDefault ? (
-    <span className="capitalize">{cycleEstimateOptions.find((v) => v.value === value)?.label}</span>
+    <span className="capitalize">{cycleEstimateOptions.find((v) => v.value === value)?.label ?? value}</span>
   ) : null;
 });

--- a/apps/web/core/components/cycles/dropdowns/estimate-type-dropdown.tsx
+++ b/apps/web/core/components/cycles/dropdowns/estimate-type-dropdown.tsx
@@ -38,6 +38,6 @@ export const EstimateTypeDropdown = observer((props: TProps) => {
       </CustomSelect>
     </div>
   ) : showDefault ? (
-    <span className="capitalize">{value}</span>
+    <span className="capitalize">{cycleEstimateOptions.find((v) => v.value === value)?.label}</span>
   ) : null;
 });


### PR DESCRIPTION
### Description
Changed issue to work item in cycle dropdown

### Screenshots and Media (if applicable)
Before
<img width="1122" height="449" alt="image" src="https://github.com/user-attachments/assets/b916fc95-cb1f-43e8-ab43-5c56cee994b4" />
After
<img width="1211" height="458" alt="image" src="https://github.com/user-attachments/assets/68f9f7a1-5036-4b0c-b6fe-ec37c268dd0c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The Estimate Type dropdown now displays the user-friendly label for the selected option when collapsed, matching the label shown in the dropdown header for consistent readability.
  * If no matching label exists, the selected value is shown as a fallback instead of leaving the field empty.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->