### PR TITLE
[WIKI-574] fix: disable copy comment link option for intake work item

### DIFF
--- a/apps/web/ce/components/de-dupe/duplicate-popover/root.tsx
+++ b/apps/web/ce/components/de-dupe/duplicate-popover/root.tsx
@@ -18,15 +18,6 @@ type TDeDupeIssuePopoverRootProps = {
 };
 
 export const DeDupeIssuePopoverRoot: FC<TDeDupeIssuePopoverRootProps> = observer((props) => {
-  const {
-    workspaceSlug,
-    projectId,
-    rootIssueId,
-    issues,
-    issueOperations,
-    disabled = false,
-    renderDeDupeActionModals = true,
-    isIntakeIssue = false,
-  } = props;
+  const {} = props;
   return <></>;
 });

--- a/apps/web/core/components/issues/issue-detail/issue-activity/activity-comment-root.tsx
+++ b/apps/web/core/components/issues/issue-detail/issue-activity/activity-comment-root.tsx
@@ -17,6 +17,7 @@ import { IssueActivityLoader } from "./loader";
 type TIssueActivityCommentRoot = {
   workspaceSlug: string;
   projectId: string;
+  isIntakeIssue: boolean;
   issueId: string;
   selectedFilters: TActivityFilters[];
   activityOperations: TCommentsOperations;
@@ -28,6 +29,7 @@ type TIssueActivityCommentRoot = {
 export const IssueActivityCommentRoot: FC<TIssueActivityCommentRoot> = observer((props) => {
   const {
     workspaceSlug,
+    isIntakeIssue,
     issueId,
     selectedFilters,
     activityOperations,
@@ -62,7 +64,7 @@ export const IssueActivityCommentRoot: FC<TIssueActivityCommentRoot> = observer(
             activityOperations={activityOperations}
             ends={index === 0 ? "top" : index === filteredActivityAndComments.length - 1 ? "bottom" : undefined}
             showAccessSpecifier={!!showAccessSpecifier}
-            showCopyLinkOption
+            showCopyLinkOption={!isIntakeIssue}
             disabled={disabled}
             projectId={projectId}
           />

--- a/apps/web/core/components/issues/issue-detail/issue-activity/root.tsx
+++ b/apps/web/core/components/issues/issue-detail/issue-activity/root.tsx
@@ -130,6 +130,7 @@ export const IssueActivity: FC<TIssueActivity> = observer((props) => {
             <IssueActivityCommentRoot
               projectId={projectId}
               workspaceSlug={workspaceSlug}
+              isIntakeIssue={isIntakeIssue}
               issueId={issueId}
               selectedFilters={selectedFilters || defaultActivityFilters}
               activityOperations={activityOperations}


### PR DESCRIPTION
### Description

This PR removes copy comment link option from intake work items.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Comment threads now conditionally show the “Copy link” option. It’s available for standard issues and hidden for intake issues, reducing clutter where sharing isn’t applicable.
- Refactor
  - Cleaned up a duplicate-popover component to remove unused props. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->