### PR TITLE
[WEB-4838] fix: github logo theme

### DIFF
--- a/apps/space/core/components/account/auth-forms/auth-root.tsx
+++ b/apps/space/core/components/account/auth-forms/auth-root.tsx
@@ -172,7 +172,7 @@ export const AuthRoot: FC = observer(() => {
       text: `${content} with GitHub`,
       icon: (
         <Image
-          src={resolvedTheme === "dark" ? GithubDarkLogo : GithubLightLogo}
+          src={resolvedTheme === "dark" ? GithubLightLogo : GithubDarkLogo}
           height={18}
           width={18}
           alt="GitHub Logo"

--- a/apps/web/core/components/account/auth-forms/auth-root.tsx
+++ b/apps/web/core/components/account/auth-forms/auth-root.tsx
@@ -122,7 +122,7 @@ export const AuthRoot: FC<TAuthRoot> = observer((props) => {
       text: `${OauthButtonContent} with GitHub`,
       icon: (
         <Image
-          src={resolvedTheme === "dark" ? GithubLightLogo : GithubDarkLogo}
+          src={resolvedTheme === "dark" ? GithubDarkLogo : GithubLightLogo}
           height={18}
           width={18}
           alt="GitHub Logo"


### PR DESCRIPTION
### Description
This PR updates the GitHub logo to correctly support theme variations.

### Type of Change
- [x] Bug fix

### Media
| Before | After |
|--------|--------|
| ![before](https://github.com/user-attachments/assets/687a1a8f-86db-49b1-accc-146915ccd214) | ![after](https://github.com/user-attachments/assets/c2924a80-a396-4148-a3dc-f709b2f34397) |
| ![before](https://github.com/user-attachments/assets/a0fa1d7b-e0db-4053-b430-26c85de26e6d) | ![after](https://github.com/user-attachments/assets/acf29930-f368-409a-8491-25299362529f) |