### PR TITLE
[WEB-4795] chore: remove caching decorator from WorkspaceStatesEndpoint

### DIFF
--- a/apps/api/plane/app/views/workspace/state.py
+++ b/apps/api/plane/app/views/workspace/state.py
@@ -7,7 +7,6 @@ from plane.app.serializers import StateSerializer
 from plane.app.views.base import BaseAPIView
 from plane.db.models import State
 from plane.app.permissions import WorkspaceEntityPermission
-from plane.utils.cache import cache_response
 from collections import defaultdict
 
 
@@ -15,7 +14,6 @@ class WorkspaceStatesEndpoint(BaseAPIView):
     permission_classes = [WorkspaceEntityPermission]
     use_read_replica = True
 
-    @cache_response(60 * 60 * 2)
     def get(self, request, slug):
         states = State.objects.filter(
             workspace__slug=slug,


### PR DESCRIPTION
### Description
fix: remove caching decorator from workspace states endpoint

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->
- Delete the state and it should appear deleted on refresh

### References
[WEB-4795](https://app.plane.so/plane/browse/WEB-4795)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Workspace state listings now update immediately, preventing stale results that could appear due to previously cached responses. Users should see the most current state information without delay after changes are made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->