### PR TITLE
[WIKI-642] fix: editor bubble menu overflow issues

### DIFF
--- a/packages/editor/src/core/components/menus/bubble-menu/root.tsx
+++ b/packages/editor/src/core/components/menus/bubble-menu/root.tsx
@@ -155,7 +155,7 @@ export const EditorBubbleMenu: FC<EditorBubbleMenuProps> = (props: { editor: Edi
       {!isSelecting && (
         <div
           ref={menuRef}
-          className="flex py-2 divide-x divide-custom-border-200 rounded-lg border border-custom-border-200 bg-custom-background-100 shadow-custom-shadow-rg"
+          className="flex py-2 divide-x divide-custom-border-200 rounded-lg border border-custom-border-200 bg-custom-background-100 shadow-custom-shadow-rg max-w-[500px] overflow-x-scroll horizontal-scrollbar scrollbar-xs"
         >
           <div className="px-2">
             <BubbleMenuNodeSelector


### PR DESCRIPTION
### Description

This PR fixes the issue where the editor floating bubble menu's options overflow in some rare cases. Changes made-

1. Added a `max-width` to the bubble menu container.
2. Added `overflow-x: scroll`.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the editor bubble menu layout: capped the menu’s width at 500px and enabled horizontal scrolling with a compact scrollbar for overflow content.
  * Prevents oversized popovers and keeps the menu within the viewport on smaller screens.
  * Ensures long items don’t stretch the menu; users can scroll horizontally to access hidden options.
  * Visual/UI polish only; no changes to behavior, shortcuts, or actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->