### PR TITLE
Potential fix for code scanning alert no. 646: Server-side request forgery

### DIFF
--- a/apps/space/app/issues/[anchor]/layout.tsx
+++ b/apps/space/app/issues/[anchor]/layout.tsx
@@ -13,6 +13,11 @@ export async function generateMetadata({ params }: Props) {
   const { anchor } = params;
   const DEFAULT_TITLE = "Plane";
   const DEFAULT_DESCRIPTION = "Made with Plane, an AI-powered work management platform with publishing capabilities.";
+  // Validate anchor before using in request (only allow alphanumeric, -, _)
+  const ANCHOR_REGEX = /^[a-zA-Z0-9_-]+$/;
+  if (!ANCHOR_REGEX.test(anchor)) {
+    return { title: DEFAULT_TITLE, description: DEFAULT_DESCRIPTION };
+  }
   try {
     const response = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/api/public/anchor/${anchor}/meta/`);
     const data = await response.json();


### PR DESCRIPTION
Potential fix for [https://github.com/makeplane/plane/security/code-scanning/646](https://github.com/makeplane/plane/security/code-scanning/646)

To fix this SSRF issue, the user input (`anchor`) should not be incorporated directly into a request path without validation. The best mitigation is to strictly validate or sanitize `anchor` before using it in the URL. The recommended approach is:

- Define a regular expression or an allow-list for permitted anchor values. For example, allow only slugs matching `[a-zA-Z0-9_-]+`.
- Prevent path traversal by ensuring the anchor matches the expected format and does not contain dangerous characters like slashes, backslashes, question marks, etc.
- If anchors are expected to be chosen from a set of known values, validate against an explicit allow-list; otherwise, use a conservative regex.
- If an invalid anchor is provided, avoid making the fetch request (return defaults instead).

**Required changes:**  
- Add validation for `anchor` on line 13/14.
- Fail early or return default metadata if `anchor` is invalid.
- No need for extra imports as JS/TS's RegExp is sufficient.
- Only edit inside `generateMetadata`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
