### PR TITLE
[WIKI-657] refactor: the page permissions in project

### DIFF
--- a/apps/api/plane/app/permissions/__init__.py
+++ b/apps/api/plane/app/permissions/__init__.py
@@ -13,3 +13,4 @@ from .project import (
     ProjectLitePermission,
 )
 from .base import allow_permission, ROLE
+from .page import ProjectPagePermission

--- a/apps/api/plane/app/permissions/page.py
+++ b/apps/api/plane/app/permissions/page.py
@@ -1,0 +1,134 @@
+from plane.db.models import ProjectMember, Page
+from plane.app.permissions import ROLE
+
+
+from rest_framework.permissions import BasePermission, SAFE_METHODS
+
+
+# Permission Mappings for workspace members
+ADMIN = ROLE.ADMIN.value
+MEMBER = ROLE.MEMBER.value
+GUEST = ROLE.GUEST.value
+
+
+class ProjectPagePermission(BasePermission):
+    """
+    Custom permission to control access to pages within a workspace
+    based on user roles, page visibility (public/private), and feature flags.
+    """
+
+    def has_permission(self, request, view):
+        """
+        Check basic project-level permissions before checking object-level permissions.
+        """
+        if request.user.is_anonymous:
+            return False
+
+        user_id = request.user.id
+        slug = view.kwargs.get("slug")
+        project_id = view.kwargs.get("project_id")
+        page_id = view.kwargs.get("page_id")
+
+        # Hook for extended validation
+        extended_access = self._check_access(
+            request, slug, project_id
+        )
+        if extended_access is False:
+            return False
+
+        if page_id:
+            page = Page.objects.get(id=page_id, workspace__slug=slug)
+
+            # Allow access if the user is the owner of the page
+            if page.owned_by_id == user_id:
+                return True
+
+            # Handle private page access
+            if page.access == Page.PRIVATE_ACCESS:
+                return self._has_private_page_action_access(request, slug, page, project_id)
+
+            # Handle public page access
+            if self._has_public_page_action_access(request, slug, project_id):
+                return True
+        else:
+            return True
+
+    def _check_project_member_access(self, request, slug, project_id):
+        """
+        Check if the user is a project member.
+        """
+        return ProjectMember.objects.filter(
+            member=request.user,
+            workspace__slug=slug,
+            is_active=True,
+            project_id=project_id,
+        ).exists()
+
+    def _check_access(self, request, slug, project_id):
+        """
+        Hook for extended access checking
+        Returns: True (allow), False (deny), None (continue with normal flow)
+        """
+        project_member_exists = self._check_project_member_access(request, slug, project_id)
+        if not project_member_exists:
+            return False
+        return True
+
+    def _has_private_page_action_access(self, request, slug, page, project_id):
+        """
+        Check access to private pages. Override for feature flag logic.
+        """
+        # Base implementation: only owner can access private pages
+        return False
+
+    def _has_public_page_action_access(self, request, slug, project_id):
+        """
+        Check if the user has permission to access a public page
+        and can perform operations on the page.
+        """
+
+        user_id = request.user.id
+        method = request.method
+
+        # Only admins can create (POST) pages
+        if method == "POST":
+            return ProjectMember.objects.filter(
+                member_id=user_id,
+                workspace__slug=slug,
+                project_id=project_id,
+                role__in=[ADMIN, MEMBER],
+                is_active=True,
+            ).exists()
+
+        # Safe methods (GET, HEAD, OPTIONS) allowed for all active roles
+        if method in SAFE_METHODS:
+            return ProjectMember.objects.filter(
+                member_id=user_id,
+                workspace__slug=slug,
+                role__in=[ADMIN, MEMBER, GUEST],
+                project_id=project_id,
+                is_active=True,
+            ).exists()
+
+        # PUT/PATCH: Admins and members can update
+        if method in ["PUT", "PATCH"]:
+            return ProjectMember.objects.filter(
+                member_id=user_id,
+                workspace__slug=slug,
+                role__in=[ADMIN, MEMBER],
+                project_id=project_id,
+                is_active=True,
+            ).exists()
+
+        # DELETE: Only admins can delete
+        if method == "DELETE":
+            return ProjectMember.objects.filter(
+                member_id=user_id,
+                workspace__slug=slug,
+                role=ADMIN,
+                project_id=project_id,
+                is_active=True,
+            ).exists()
+
+        # Deny by default
+        return False

--- a/apps/api/plane/app/permissions/page.py
+++ b/apps/api/plane/app/permissions/page.py
@@ -47,10 +47,9 @@ class ProjectPagePermission(BasePermission):
             if page.access == Page.PRIVATE_ACCESS:
                 return self._has_private_page_action_access(request, slug, page, project_id)
 
-            # Handle public page access
-            return self._has_public_page_action_access(request, slug, project_id)
-        else:
-            return self._has_public_page_action_access(request, slug, project_id)
+        # Handle public page access
+        return self._has_public_page_action_access(request, slug, project_id)
+
 
     def _check_project_member_access(self, request, slug, project_id):
         """
@@ -80,12 +79,7 @@ class ProjectPagePermission(BasePermission):
         # Base implementation: only owner can access private pages
         return False
 
-    def _has_public_page_action_access(self, request, slug, project_id):
-        """
-        Check if the user has permission to access a public page
-        and can perform operations on the page.
-        """
-
+    def _check_project_action_access(self, request, slug, project_id):
         user_id = request.user.id
         method = request.method
 
@@ -131,3 +125,13 @@ class ProjectPagePermission(BasePermission):
 
         # Deny by default
         return False
+
+    def _has_public_page_action_access(self, request, slug, project_id):
+        """
+        Check if the user has permission to access a public page
+        and can perform operations on the page.
+        """
+        project_member_exists = self._check_project_action_access(request, slug, project_id)
+        if not project_member_exists:
+            return False
+        return True

--- a/apps/api/plane/app/permissions/page.py
+++ b/apps/api/plane/app/permissions/page.py
@@ -48,10 +48,9 @@ class ProjectPagePermission(BasePermission):
                 return self._has_private_page_action_access(request, slug, page, project_id)
 
             # Handle public page access
-            if self._has_public_page_action_access(request, slug, project_id):
-                return True
+            return self._has_public_page_action_access(request, slug, project_id)
         else:
-            return True
+            return self._has_public_page_action_access(request, slug, project_id)
 
     def _check_project_member_access(self, request, slug, project_id):
         """

--- a/apps/api/plane/app/serializers/__init__.py
+++ b/apps/api/plane/app/serializers/__init__.py
@@ -92,7 +92,6 @@ from .importer import ImporterSerializer
 
 from .page import (
     PageSerializer,
-    PageLogSerializer,
     PageDetailSerializer,
     PageVersionSerializer,
     PageBinaryUpdateSerializer,

--- a/apps/api/plane/app/serializers/__init__.py
+++ b/apps/api/plane/app/serializers/__init__.py
@@ -93,7 +93,6 @@ from .importer import ImporterSerializer
 from .page import (
     PageSerializer,
     PageLogSerializer,
-    SubPageSerializer,
     PageDetailSerializer,
     PageVersionSerializer,
     PageBinaryUpdateSerializer,

--- a/apps/api/plane/app/serializers/page.py
+++ b/apps/api/plane/app/serializers/page.py
@@ -130,32 +130,6 @@ class PageDetailSerializer(PageSerializer):
         fields = PageSerializer.Meta.fields + ["description_html"]
 
 
-class SubPageSerializer(BaseSerializer):
-    entity_details = serializers.SerializerMethodField()
-
-    class Meta:
-        model = PageLog
-        fields = "__all__"
-        read_only_fields = ["workspace", "page"]
-
-    def get_entity_details(self, obj):
-        entity_name = obj.entity_name
-        if entity_name == "forward_link" or entity_name == "back_link":
-            try:
-                page = Page.objects.get(pk=obj.entity_identifier)
-                return PageSerializer(page).data
-            except Page.DoesNotExist:
-                return None
-        return None
-
-
-class PageLogSerializer(BaseSerializer):
-    class Meta:
-        model = PageLog
-        fields = "__all__"
-        read_only_fields = ["workspace", "page"]
-
-
 class PageVersionSerializer(BaseSerializer):
     class Meta:
         model = PageVersion

--- a/apps/api/plane/app/urls/page.py
+++ b/apps/api/plane/app/urls/page.py
@@ -4,13 +4,10 @@ from django.urls import path
 from plane.app.views import (
     PageViewSet,
     PageFavoriteViewSet,
-    PageLogEndpoint,
-    SubPagesEndpoint,
     PagesDescriptionViewSet,
     PageVersionEndpoint,
     PageDuplicateEndpoint,
 )
-
 
 urlpatterns = [
     path(
@@ -19,7 +16,7 @@ urlpatterns = [
         name="project-pages",
     ),
     path(
-        "workspaces/<str:slug>/projects/<uuid:project_id>/pages/<uuid:pk>/",
+        "workspaces/<str:slug>/projects/<uuid:project_id>/pages/<uuid:page_id>/",
         PageViewSet.as_view(
             {"get": "retrieve", "patch": "partial_update", "delete": "destroy"}
         ),
@@ -27,45 +24,30 @@ urlpatterns = [
     ),
     # favorite pages
     path(
-        "workspaces/<str:slug>/projects/<uuid:project_id>/favorite-pages/<uuid:pk>/",
+        "workspaces/<str:slug>/projects/<uuid:project_id>/favorite-pages/<uuid:page_id>/",
         PageFavoriteViewSet.as_view({"post": "create", "delete": "destroy"}),
         name="user-favorite-pages",
     ),
     # archived pages
     path(
-        "workspaces/<str:slug>/projects/<uuid:project_id>/pages/<uuid:pk>/archive/",
+        "workspaces/<str:slug>/projects/<uuid:project_id>/pages/<uuid:page_id>/archive/",
         PageViewSet.as_view({"post": "archive", "delete": "unarchive"}),
         name="project-page-archive-unarchive",
     ),
     # lock and unlock
     path(
-        "workspaces/<str:slug>/projects/<uuid:project_id>/pages/<uuid:pk>/lock/",
+        "workspaces/<str:slug>/projects/<uuid:project_id>/pages/<uuid:page_id>/lock/",
         PageViewSet.as_view({"post": "lock", "delete": "unlock"}),
         name="project-pages-lock-unlock",
     ),
     # private and public page
     path(
-        "workspaces/<str:slug>/projects/<uuid:project_id>/pages/<uuid:pk>/access/",
+        "workspaces/<str:slug>/projects/<uuid:project_id>/pages/<uuid:page_id>/access/",
         PageViewSet.as_view({"post": "access"}),
         name="project-pages-access",
     ),
     path(
-        "workspaces/<str:slug>/projects/<uuid:project_id>/pages/<uuid:pk>/transactions/",
-        PageLogEndpoint.as_view(),
-        name="page-transactions",
-    ),
-    path(
-        "workspaces/<str:slug>/projects/<uuid:project_id>/pages/<uuid:pk>/transactions/<uuid:transaction>/",
-        PageLogEndpoint.as_view(),
-        name="page-transactions",
-    ),
-    path(
-        "workspaces/<str:slug>/projects/<uuid:project_id>/pages/<uuid:pk>/sub-pages/",
-        SubPagesEndpoint.as_view(),
-        name="sub-page",
-    ),
-    path(
-        "workspaces/<str:slug>/projects/<uuid:project_id>/pages/<uuid:pk>/description/",
+        "workspaces/<str:slug>/projects/<uuid:project_id>/pages/<uuid:page_id>/description/",
         PagesDescriptionViewSet.as_view({"get": "retrieve", "patch": "partial_update"}),
         name="page-description",
     ),

--- a/apps/api/plane/app/views/__init__.py
+++ b/apps/api/plane/app/views/__init__.py
@@ -165,8 +165,6 @@ from .api import ApiTokenEndpoint, ServiceApiTokenEndpoint
 from .page.base import (
     PageViewSet,
     PageFavoriteViewSet,
-    PageLogEndpoint,
-    SubPagesEndpoint,
     PagesDescriptionViewSet,
     PageDuplicateEndpoint,
 )

--- a/apps/api/plane/app/views/page/base.py
+++ b/apps/api/plane/app/views/page/base.py
@@ -487,7 +487,7 @@ class PagesDescriptionViewSet(BaseViewSet):
             # Capture the page transaction
             if request.data.get("description_html"):
                 page_transaction.delay(
-                    new_value=request.data, old_value=existing_instance, page_id=pk
+                    new_value=request.data, old_value=existing_instance, page_id=page_id
                 )
 
             # Update the page using serializer

--- a/apps/api/plane/app/views/page/base.py
+++ b/apps/api/plane/app/views/page/base.py
@@ -7,8 +7,6 @@ from django.core.serializers.json import DjangoJSONEncoder
 # Django imports
 from django.db import connection
 from django.db.models import Exists, OuterRef, Q, Value, UUIDField
-from django.utils.decorators import method_decorator
-from django.views.decorators.gzip import gzip_page
 from django.http import StreamingHttpResponse
 from django.contrib.postgres.aggregates import ArrayAgg
 from django.contrib.postgres.fields import ArrayField
@@ -21,9 +19,7 @@ from rest_framework.response import Response
 # Module imports
 from plane.app.permissions import allow_permission, ROLE
 from plane.app.serializers import (
-    PageLogSerializer,
     PageSerializer,
-    SubPageSerializer,
     PageDetailSerializer,
     PageBinaryUpdateSerializer,
 )

--- a/apps/api/plane/app/views/page/version.py
+++ b/apps/api/plane/app/views/page/version.py
@@ -7,10 +7,12 @@ from plane.db.models import PageVersion
 from ..base import BaseAPIView
 from plane.app.serializers import PageVersionSerializer, PageVersionDetailSerializer
 from plane.app.permissions import allow_permission, ROLE
-
+from plane.app.permissions import ProjectPagePermission
 
 class PageVersionEndpoint(BaseAPIView):
-    @allow_permission(allowed_roles=[ROLE.ADMIN, ROLE.MEMBER, ROLE.GUEST])
+
+    permission_classes = [ProjectPagePermission]
+
     def get(self, request, slug, project_id, page_id, pk=None):
         # Check if pk is provided
         if pk:


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
this pull request refactors the page permission in project level.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Improvement (change that would cause existing functionality to not work as expected)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified permission model for workspace pages and page versions with Admin/Member/Guest roles; the permission class is now publicly available.

* **Refactor**
  * Replaced per-endpoint role checks with class-level permissions across page endpoints and standardized API paths/handlers to use page_id.

* **Chores**
  * Removed legacy page-transaction, page-log and sub-pages endpoints and their related serializers from the public API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->