### PR TITLE
[WEB-4861] fix: update redirection path in MagicSignInEndpoint

### DIFF
--- a/apps/api/plane/authentication/views/app/magic.py
+++ b/apps/api/plane/authentication/views/app/magic.py
@@ -107,7 +107,7 @@ class MagicSignInEndpoint(View):
             # Login the user and record his device info
             user_login(request=request, user=user, is_app=True)
             if user.is_password_autoset and profile.is_onboarded:
-                path = "accounts/set-password"
+                path = f"accounts/set-password?email={email}"
             else:
                 # Get the redirection path
                 path = (


### PR DESCRIPTION
### Description
Add email search param while redirecting to /set-password to populate the page form


### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)