### PR TITLE
[WEB-4881] feat(utils): add URL display formatter 

### DIFF
--- a/packages/utils/src/url.ts
+++ b/packages/utils/src/url.ts
@@ -98,6 +98,24 @@ export function extractHostname(url: string): string {
 }
 
 /**
+ * Returns a readable representation of a URL by stripping the protocol
+ * and any trailing slash. For valid URLs, only the host is returned.
+ * Invalid URLs are sanitized by removing the protocol and trailing slash.
+ *
+ * @param url - The URL string to format
+ * @returns The formatted domain for display
+ */
+export function formatURLForDisplay(url: string): string {
+  if (!url) return "";
+
+  try {
+    return new URL(url).host;
+  } catch (_error) {
+    return extractHostname(url);
+  }
+}
+
+/**
  * Extracts and validates the TLD (Top Level Domain) from a URL string.
  *
  * @param {string} urlString - The string to extract TLD from


### PR DESCRIPTION
## Summary
- add formatURLForDisplay helper to strip protocol and trailing slash from URLs

## Testing
- `pnpm --filter=@plane/utils check:lint`
- `pnpm --filter=@plane/utils check:types` *(fails: Cannot find module '@plane/types')*
- `pnpm --filter=@plane/utils check:format`
- `pnpm --filter=@plane/utils test` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e070b158832a8f20c8484496c613

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a utility to format URLs for display, producing cleaner, readable hosts and gracefully handling invalid inputs.
* **Documentation**
  * Expanded guidance and examples for top-level domain extraction to clarify behavior and usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->