### PR TITLE
feat: issue detail keyboard shortcuts

### DIFF
--- a/apps/web/ce/helpers/command-palette.ts
+++ b/apps/web/ce/helpers/command-palette.ts
@@ -119,4 +119,23 @@ export const getCommonShortcutsList = (platform: string): TCommandPaletteShortcu
   },
 ];
 
-export const getAdditionalShortcutsList = (): TCommandPaletteShortcutList[] => [];
+export const getAdditionalShortcutsList = (): TCommandPaletteShortcutList[] => [
+  {
+    key: "issue",
+    title: "Issue detail",
+    shortcuts: [
+      { keys: "A", description: "Assign issue" },
+      { keys: "I", description: "Assign to me" },
+      { keys: "S", description: "Change state/status" },
+      { keys: "P", description: "Set priority" },
+      { keys: "L", description: "Manage labels" },
+      { keys: "Shift,E", description: "Set estimate" },
+      { keys: "Shift,D", description: "Set due date" },
+      { keys: "Ctrl,Shift,D", description: "Clear due date" },
+      { keys: "Shift,C", description: "Add to cycle" },
+      { keys: "Shift,M", description: "Add to module" },
+      { keys: "Ctrl,M", description: "Add a comment on the issue" },
+      { keys: "Ctrl,Delete", description: "Delete issue" },
+    ],
+  },
+];

--- a/apps/web/core/components/command-palette/utils/commands.tsx
+++ b/apps/web/core/components/command-palette/utils/commands.tsx
@@ -1,0 +1,152 @@
+import {
+  CYCLE_TRACKER_ELEMENTS,
+  MODULE_TRACKER_ELEMENTS,
+  PROJECT_PAGE_TRACKER_ELEMENTS,
+  PROJECT_TRACKER_ELEMENTS,
+  PROJECT_VIEW_TRACKER_ELEMENTS,
+  WORK_ITEM_TRACKER_ELEMENTS,
+} from "@plane/constants";
+import { captureClick } from "@/helpers/event-tracker.helper";
+import { LayersIcon, DiceIcon } from "@plane/propel/icons";
+import { ContrastIcon, FileText, FolderPlus, Layers } from "lucide-react";
+import { CommandAction } from "./registry";
+
+export interface CommandDeps {
+  toggleCreateIssueModal: (v: boolean) => void;
+  toggleCreateProjectModal: (v: boolean) => void;
+  toggleCreatePageModal: (v: { isOpen: boolean }) => void;
+  toggleCreateModuleModal: (v: boolean) => void;
+  toggleCreateCycleModal: (v: boolean) => void;
+  toggleCreateViewModal: (v: boolean) => void;
+  toggleBulkDeleteIssueModal: (v: boolean) => void;
+  performAnyProjectCreateActions: () => boolean;
+  performWorkspaceCreateActions: () => boolean;
+  performProjectCreateActions: () => boolean;
+  performProjectBulkDeleteActions: () => boolean;
+  workspaceSlug?: string;
+  projectId?: string;
+  hasProjects?: boolean;
+}
+
+export const getDefaultCommands = (deps: CommandDeps): CommandAction[] => {
+  const {
+    toggleCreateIssueModal,
+    toggleCreateProjectModal,
+    toggleCreatePageModal,
+    toggleCreateModuleModal,
+    toggleCreateCycleModal,
+    toggleCreateViewModal,
+    toggleBulkDeleteIssueModal,
+    performAnyProjectCreateActions,
+    performWorkspaceCreateActions,
+    performProjectCreateActions,
+    performProjectBulkDeleteActions,
+    workspaceSlug,
+    projectId,
+    hasProjects,
+  } = deps;
+
+  const commands: CommandAction[] = [
+    {
+      id: "create-issue",
+      keys: ["c"],
+      run: () => {
+        toggleCreateIssueModal(true);
+        captureClick({ elementName: WORK_ITEM_TRACKER_ELEMENTS.COMMAND_PALETTE_ADD_BUTTON });
+      },
+      enabled: () =>
+        (hasProjects ? (!projectId && performAnyProjectCreateActions()) || performProjectCreateActions() : false),
+      group: "Work item",
+      label: "Create new work item",
+      shortcut: "C",
+      icon: <LayersIcon className="h-3.5 w-3.5" />,
+      showInPalette: true,
+    },
+    {
+      id: "create-project",
+      keys: ["p"],
+      run: () => {
+        toggleCreateProjectModal(true);
+        captureClick({ elementName: PROJECT_TRACKER_ELEMENTS.COMMAND_PALETTE_SHORTCUT_CREATE_BUTTON });
+      },
+      enabled: () => !!workspaceSlug && performWorkspaceCreateActions(),
+      group: "Project",
+      label: "Create new project",
+      shortcut: "P",
+      icon: <FolderPlus className="h-3.5 w-3.5" />,
+      showInPalette: true,
+    },
+    {
+      id: "create-cycle",
+      keys: ["q"],
+      run: () => {
+        toggleCreateCycleModal(true);
+        captureClick({ elementName: CYCLE_TRACKER_ELEMENTS.COMMAND_PALETTE_ADD_ITEM });
+      },
+      enabled: () => !!projectId && performProjectCreateActions(),
+      group: "Cycle",
+      label: "Create new cycle",
+      shortcut: "Q",
+      icon: <ContrastIcon className="h-3.5 w-3.5" />,
+      showInPalette: true,
+    },
+    {
+      id: "create-module",
+      keys: ["m"],
+      run: () => {
+        toggleCreateModuleModal(true);
+        captureClick({ elementName: MODULE_TRACKER_ELEMENTS.COMMAND_PALETTE_ADD_ITEM });
+      },
+      enabled: () => !!projectId && performProjectCreateActions(),
+      group: "Module",
+      label: "Create new module",
+      shortcut: "M",
+      icon: <DiceIcon className="h-3.5 w-3.5" />,
+      showInPalette: true,
+    },
+    {
+      id: "create-view",
+      keys: ["v"],
+      run: () => {
+        toggleCreateViewModal(true);
+        captureClick({ elementName: PROJECT_VIEW_TRACKER_ELEMENTS.COMMAND_PALETTE_ADD_ITEM });
+      },
+      enabled: () => !!projectId && performProjectCreateActions(),
+      group: "View",
+      label: "Create new view",
+      shortcut: "V",
+      icon: <Layers className="h-3.5 w-3.5" />,
+      showInPalette: true,
+    },
+    {
+      id: "create-page",
+      keys: ["d"],
+      run: () => {
+        toggleCreatePageModal({ isOpen: true });
+        captureClick({ elementName: PROJECT_PAGE_TRACKER_ELEMENTS.COMMAND_PALETTE_CREATE_BUTTON });
+      },
+      enabled: () => !!projectId && performProjectCreateActions(),
+      group: "Page",
+      label: "Create new page",
+      shortcut: "D",
+      icon: <FileText className="h-3.5 w-3.5" />,
+      showInPalette: true,
+    },
+    {
+      id: "bulk-delete-backspace",
+      keys: ["backspace"],
+      run: () => toggleBulkDeleteIssueModal(true),
+      enabled: () => !!projectId && performProjectBulkDeleteActions(),
+      showInPalette: false,
+    },
+    {
+      id: "bulk-delete-delete",
+      keys: ["delete"],
+      run: () => toggleBulkDeleteIssueModal(true),
+      enabled: () => !!projectId && performProjectBulkDeleteActions(),
+      showInPalette: false,
+    },
+  ];
+
+  return commands;
+};

--- a/apps/web/core/components/command-palette/utils/registry.ts
+++ b/apps/web/core/components/command-palette/utils/registry.ts
@@ -1,0 +1,33 @@
+import type { ReactNode } from "react";
+
+export type CommandAction = {
+  id: string;
+  keys: string[]; // key sequence
+  run: () => void;
+  enabled?: () => boolean;
+  group?: string; // grouping label for palette display
+  label?: string; // user visible label
+  shortcut?: string; // display shortcut key
+  icon?: ReactNode; // optional icon for display
+  showInPalette?: boolean; // show in command modal
+};
+
+export type CommandGroupMap = Record<string, CommandAction[]>;
+
+export const groupCommands = (commands: CommandAction[]): CommandGroupMap =>
+  commands.reduce((acc, cmd) => {
+    if (!cmd.group || cmd.showInPalette === false) return acc;
+    if (!acc[cmd.group]) acc[cmd.group] = [];
+    acc[cmd.group].push(cmd);
+    return acc;
+  }, {} as CommandGroupMap);
+
+export const matchSequence = (sequence: string[], keys: string[]): boolean => {
+  if (sequence.length !== keys.length) return false;
+  return sequence.every((key, idx) => key === keys[idx]);
+};
+
+export const isSequencePrefix = (sequence: string[], keys: string[]): boolean => {
+  if (keys.length > sequence.length) return false;
+  return keys.every((key, idx) => sequence[idx] === key);
+};

--- a/apps/web/core/components/command-palette/utils/use-command-registry.ts
+++ b/apps/web/core/components/command-palette/utils/use-command-registry.ts
@@ -1,0 +1,34 @@
+import { useCallback, useMemo, useRef } from "react";
+import { CommandAction, CommandGroupMap, groupCommands, isSequencePrefix, matchSequence } from "./registry";
+
+export const useCommandRegistry = (commands: CommandAction[]) => {
+  const sequenceRef = useRef<string[]>([]);
+
+  const groups: CommandGroupMap = useMemo(() => groupCommands(commands), [commands]);
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent): boolean => {
+      const key = e.key.toLowerCase();
+      sequenceRef.current.push(key);
+
+      const current = sequenceRef.current;
+      const match = commands.find(
+        (cmd) => matchSequence(cmd.keys, current) && (cmd.enabled ? cmd.enabled() : true)
+      );
+
+      if (match) {
+        e.preventDefault();
+        match.run();
+        sequenceRef.current = [];
+        return true;
+      }
+
+      const hasPrefix = commands.some((cmd) => isSequencePrefix(cmd.keys, current));
+      if (!hasPrefix) sequenceRef.current = [];
+      return false;
+    },
+    [commands]
+  );
+
+  return { groups, handleKeyDown };
+};

--- a/apps/web/core/components/issues/issue-detail/cycle-select.tsx
+++ b/apps/web/core/components/issues/issue-detail/cycle-select.tsx
@@ -50,7 +50,7 @@ export const IssueCycleSelect: React.FC<TIssueCycleSelect> = observer((props) =>
         disabled={disableSelect}
         buttonVariant="transparent-with-text"
         className="group w-full"
-        buttonContainerClassName="w-full text-left rounded"
+        buttonContainerClassName="w-full text-left rounded js-issue-cycle"
         buttonClassName={`text-sm justify-between  ${issue?.cycle_id ? "" : "text-custom-text-400"}`}
         placeholder={t("cycle.no_cycle")}
         hideIcon

--- a/apps/web/core/components/issues/issue-detail/label/root.tsx
+++ b/apps/web/core/components/issues/issue-detail/label/root.tsx
@@ -24,6 +24,7 @@ export type TIssueLabel = {
   isInboxIssue?: boolean;
   onLabelUpdate?: (labelIds: string[]) => void;
   issueServiceType?: TIssueServiceType;
+  triggerClassName?: string;
 };
 
 export type TLabelOperations = {
@@ -40,6 +41,7 @@ export const IssueLabel: FC<TIssueLabel> = observer((props) => {
     isInboxIssue = false,
     onLabelUpdate,
     issueServiceType = EIssueServiceType.ISSUES,
+    triggerClassName,
   } = props;
   const { t } = useTranslation();
   // hooks
@@ -111,6 +113,7 @@ export const IssueLabel: FC<TIssueLabel> = observer((props) => {
           issueId={issueId}
           values={issue?.label_ids || []}
           labelOperations={labelOperations}
+          triggerClassName={triggerClassName}
         />
       )}
     </div>

--- a/apps/web/core/components/issues/issue-detail/label/select/label-select.tsx
+++ b/apps/web/core/components/issues/issue-detail/label/select/label-select.tsx
@@ -8,7 +8,7 @@ import { EUserPermissionsLevel, getRandomLabelColor } from "@plane/constants";
 import { useTranslation } from "@plane/i18n";
 import { EUserProjectRoles, IIssueLabel } from "@plane/types";
 // helpers
-import { getTabIndex } from "@plane/utils";
+import { cn, getTabIndex } from "@plane/utils";
 // hooks
 import { useLabel } from "@/hooks/store/use-label";
 import { useUserPermissions } from "@/hooks/store/user";
@@ -21,10 +21,11 @@ export interface IIssueLabelSelect {
   values: string[];
   onSelect: (_labelIds: string[]) => void;
   onAddLabel: (workspaceSlug: string, projectId: string, data: Partial<IIssueLabel>) => Promise<any>;
+  triggerClassName?: string;
 }
 
 export const IssueLabelSelect: React.FC<IIssueLabelSelect> = observer((props) => {
-  const { workspaceSlug, projectId, issueId, values, onSelect, onAddLabel } = props;
+  const { workspaceSlug, projectId, issueId, values, onSelect, onAddLabel, triggerClassName } = props;
   const { t } = useTranslation();
   // store hooks
   const { isMobile } = usePlatformOS();
@@ -130,7 +131,7 @@ export const IssueLabelSelect: React.FC<IIssueLabelSelect> = observer((props) =>
           <button
             ref={setReferenceElement}
             type="button"
-            className="cursor-pointer rounded"
+            className={cn("cursor-pointer rounded", triggerClassName)}
             onClick={() => !projectLabels && fetchLabels()}
           >
             {label}

--- a/apps/web/core/components/issues/issue-detail/label/select/root.tsx
+++ b/apps/web/core/components/issues/issue-detail/label/select/root.tsx
@@ -10,10 +10,11 @@ type TIssueLabelSelectRoot = {
   issueId: string;
   values: string[];
   labelOperations: TLabelOperations;
+  triggerClassName?: string;
 };
 
 export const IssueLabelSelectRoot: FC<TIssueLabelSelectRoot> = (props) => {
-  const { workspaceSlug, projectId, issueId, values, labelOperations } = props;
+  const { workspaceSlug, projectId, issueId, values, labelOperations, triggerClassName } = props;
 
   const handleLabel = async (_labelIds: string[]) => {
     await labelOperations.updateIssue(workspaceSlug, projectId, issueId, { label_ids: _labelIds });
@@ -27,6 +28,7 @@ export const IssueLabelSelectRoot: FC<TIssueLabelSelectRoot> = (props) => {
       values={values}
       onSelect={handleLabel}
       onAddLabel={labelOperations.createLabel}
+      triggerClassName={triggerClassName}
     />
   );
 };

--- a/apps/web/core/components/issues/issue-detail/module-select.tsx
+++ b/apps/web/core/components/issues/issue-detail/module-select.tsx
@@ -64,7 +64,7 @@ export const IssueModuleSelect: React.FC<TIssueModuleSelect> = observer((props) 
         placeholder={t("module.no_module")}
         disabled={disableSelect}
         className="group h-full w-full"
-        buttonContainerClassName="w-full rounded"
+        buttonContainerClassName="w-full rounded js-issue-module"
         buttonClassName={`min-h-8 text-sm justify-between ${issue?.module_ids?.length ? "" : "text-custom-text-400"}`}
         buttonVariant="transparent-with-text"
         hideIcon

--- a/apps/web/core/components/issues/issue-detail/root.tsx
+++ b/apps/web/core/components/issues/issue-detail/root.tsx
@@ -16,6 +16,7 @@ import { useIssueDetail } from "@/hooks/store/use-issue-detail";
 import { useIssues } from "@/hooks/store/use-issues";
 import { useUserPermissions } from "@/hooks/store/user";
 import { useAppRouter } from "@/hooks/use-app-router";
+import { useIssueDetailShortcuts } from "@/hooks/use-issue-detail-shortcuts";
 // images
 import emptyIssue from "@/public/empty-state/issue.svg";
 // local components
@@ -278,14 +279,16 @@ export const IssueDetailRoot: FC<TIssueDetailRoot> = observer((props) => {
   );
 
   // issue details
-  const issue = getIssueById(issueId);
-  // checking if issue is editable, based on user role
-  const isEditable = allowPermissions(
-    [EUserPermissions.ADMIN, EUserPermissions.MEMBER],
-    EUserPermissionsLevel.PROJECT,
-    workspaceSlug,
-    projectId
-  );
+    const issue = getIssueById(issueId);
+    // checking if issue is editable, based on user role
+    const isEditable = allowPermissions(
+      [EUserPermissions.ADMIN, EUserPermissions.MEMBER],
+      EUserPermissionsLevel.PROJECT,
+      workspaceSlug,
+      projectId
+    );
+
+    useIssueDetailShortcuts({ workspaceSlug, projectId, issueId, issueOperations });
 
   return (
     <>

--- a/apps/web/core/components/issues/issue-detail/sidebar.tsx
+++ b/apps/web/core/components/issues/issue-detail/sidebar.tsx
@@ -77,18 +77,18 @@ export const IssueDetailsSidebar: React.FC<Props> = observer((props) => {
                 <DoubleCircleIcon className="h-4 w-4 flex-shrink-0" />
                 <span>{t("common.state")}</span>
               </div>
-              <StateDropdown
-                value={issue?.state_id}
-                onChange={(val) => issueOperations.update(workspaceSlug, projectId, issueId, { state_id: val })}
-                projectId={projectId?.toString() ?? ""}
-                disabled={!isEditable}
-                buttonVariant="transparent-with-text"
-                className="group w-3/5 flex-grow"
-                buttonContainerClassName="w-full text-left"
-                buttonClassName="text-sm"
-                dropdownArrow
-                dropdownArrowClassName="h-3.5 w-3.5 hidden group-hover:inline"
-              />
+                <StateDropdown
+                  value={issue?.state_id}
+                  onChange={(val) => issueOperations.update(workspaceSlug, projectId, issueId, { state_id: val })}
+                  projectId={projectId?.toString() ?? ""}
+                  disabled={!isEditable}
+                  buttonVariant="transparent-with-text"
+                  className="group w-3/5 flex-grow"
+                  buttonContainerClassName="w-full text-left js-issue-state"
+                  buttonClassName="text-sm"
+                  dropdownArrow
+                  dropdownArrowClassName="h-3.5 w-3.5 hidden group-hover:inline"
+                />
             </div>
 
             <div className="flex h-8 items-center gap-2">
@@ -96,23 +96,23 @@ export const IssueDetailsSidebar: React.FC<Props> = observer((props) => {
                 <Users className="h-4 w-4 flex-shrink-0" />
                 <span>{t("common.assignees")}</span>
               </div>
-              <MemberDropdown
-                value={issue?.assignee_ids ?? undefined}
-                onChange={(val) => issueOperations.update(workspaceSlug, projectId, issueId, { assignee_ids: val })}
-                disabled={!isEditable}
-                projectId={projectId?.toString() ?? ""}
-                placeholder={t("issue.add.assignee")}
-                multiple
-                buttonVariant={issue?.assignee_ids?.length > 1 ? "transparent-without-text" : "transparent-with-text"}
-                className="group w-3/5 flex-grow"
-                buttonContainerClassName="w-full text-left"
-                buttonClassName={`text-sm justify-between ${
-                  issue?.assignee_ids?.length > 0 ? "" : "text-custom-text-400"
-                }`}
-                hideIcon={issue.assignee_ids?.length === 0}
-                dropdownArrow
-                dropdownArrowClassName="h-3.5 w-3.5 hidden group-hover:inline"
-              />
+                <MemberDropdown
+                  value={issue?.assignee_ids ?? undefined}
+                  onChange={(val) => issueOperations.update(workspaceSlug, projectId, issueId, { assignee_ids: val })}
+                  disabled={!isEditable}
+                  projectId={projectId?.toString() ?? ""}
+                  placeholder={t("issue.add.assignee")}
+                  multiple
+                  buttonVariant={issue?.assignee_ids?.length > 1 ? "transparent-without-text" : "transparent-with-text"}
+                  className="group w-3/5 flex-grow"
+                  buttonContainerClassName="w-full text-left js-issue-assignee"
+                  buttonClassName={`text-sm justify-between ${
+                    issue?.assignee_ids?.length > 0 ? "" : "text-custom-text-400"
+                  }`}
+                  hideIcon={issue.assignee_ids?.length === 0}
+                  dropdownArrow
+                  dropdownArrowClassName="h-3.5 w-3.5 hidden group-hover:inline"
+                />
             </div>
 
             <div className="flex h-8 items-center gap-2">
@@ -120,15 +120,15 @@ export const IssueDetailsSidebar: React.FC<Props> = observer((props) => {
                 <Signal className="h-4 w-4 flex-shrink-0" />
                 <span>{t("common.priority")}</span>
               </div>
-              <PriorityDropdown
-                value={issue?.priority}
-                onChange={(val) => issueOperations.update(workspaceSlug, projectId, issueId, { priority: val })}
-                disabled={!isEditable}
-                buttonVariant="border-with-text"
-                className="w-3/5 flex-grow rounded px-2 hover:bg-custom-background-80"
-                buttonContainerClassName="w-full text-left"
-                buttonClassName="w-min h-auto whitespace-nowrap"
-              />
+                <PriorityDropdown
+                  value={issue?.priority}
+                  onChange={(val) => issueOperations.update(workspaceSlug, projectId, issueId, { priority: val })}
+                  disabled={!isEditable}
+                  buttonVariant="border-with-text"
+                  className="w-3/5 flex-grow rounded px-2 hover:bg-custom-background-80"
+                  buttonContainerClassName="w-full text-left js-issue-priority"
+                  buttonClassName="w-min h-auto whitespace-nowrap"
+                />
             </div>
 
             {createdByDetails && (
@@ -175,28 +175,28 @@ export const IssueDetailsSidebar: React.FC<Props> = observer((props) => {
                 <CalendarCheck2 className="h-4 w-4 flex-shrink-0" />
                 <span>{t("common.order_by.due_date")}</span>
               </div>
-              <DateDropdown
-                placeholder={t("issue.add.due_date")}
-                value={issue.target_date}
-                onChange={(val) =>
-                  issueOperations.update(workspaceSlug, projectId, issueId, {
-                    target_date: val ? renderFormattedPayloadDate(val) : null,
-                  })
-                }
-                minDate={minDate ?? undefined}
-                disabled={!isEditable}
-                buttonVariant="transparent-with-text"
-                className="group w-3/5 flex-grow"
-                buttonContainerClassName="w-full text-left"
-                buttonClassName={cn("text-sm", {
-                  "text-custom-text-400": !issue.target_date,
-                  "text-red-500": shouldHighlightIssueDueDate(issue.target_date, stateDetails?.group),
-                })}
-                hideIcon
-                clearIconClassName="h-3 w-3 hidden group-hover:inline !text-custom-text-100"
-                // TODO: add this logic
-                // showPlaceholderIcon
-              />
+                <DateDropdown
+                  placeholder={t("issue.add.due_date")}
+                  value={issue.target_date}
+                  onChange={(val) =>
+                    issueOperations.update(workspaceSlug, projectId, issueId, {
+                      target_date: val ? renderFormattedPayloadDate(val) : null,
+                    })
+                  }
+                  minDate={minDate ?? undefined}
+                  disabled={!isEditable}
+                  buttonVariant="transparent-with-text"
+                  className="group w-3/5 flex-grow"
+                  buttonContainerClassName="w-full text-left js-issue-due-date"
+                  buttonClassName={cn("text-sm", {
+                    "text-custom-text-400": !issue.target_date,
+                    "text-red-500": shouldHighlightIssueDueDate(issue.target_date, stateDetails?.group),
+                  })}
+                  hideIcon
+                  clearIconClassName="h-3 w-3 hidden group-hover:inline !text-custom-text-100"
+                  // TODO: add this logic
+                  // showPlaceholderIcon
+                />
             </div>
 
             {projectId && areEstimateEnabledByProjectId(projectId) && (
@@ -205,22 +205,22 @@ export const IssueDetailsSidebar: React.FC<Props> = observer((props) => {
                   <Triangle className="h-4 w-4 flex-shrink-0" />
                   <span>{t("common.estimate")}</span>
                 </div>
-                <EstimateDropdown
-                  value={issue?.estimate_point ?? undefined}
-                  onChange={(val: string | undefined) =>
-                    issueOperations.update(workspaceSlug, projectId, issueId, { estimate_point: val })
-                  }
-                  projectId={projectId}
-                  disabled={!isEditable}
-                  buttonVariant="transparent-with-text"
-                  className="group w-3/5 flex-grow"
-                  buttonContainerClassName="w-full text-left"
-                  buttonClassName={`text-sm ${issue?.estimate_point !== null ? "" : "text-custom-text-400"}`}
-                  placeholder={t("common.none")}
-                  hideIcon
-                  dropdownArrow
-                  dropdownArrowClassName="h-3.5 w-3.5 hidden group-hover:inline"
-                />
+                  <EstimateDropdown
+                    value={issue?.estimate_point ?? undefined}
+                    onChange={(val: string | undefined) =>
+                      issueOperations.update(workspaceSlug, projectId, issueId, { estimate_point: val })
+                    }
+                    projectId={projectId}
+                    disabled={!isEditable}
+                    buttonVariant="transparent-with-text"
+                    className="group w-3/5 flex-grow"
+                    buttonContainerClassName="w-full text-left js-issue-estimate"
+                    buttonClassName={`text-sm ${issue?.estimate_point !== null ? "" : "text-custom-text-400"}`}
+                    placeholder={t("common.none")}
+                    hideIcon
+                    dropdownArrow
+                    dropdownArrowClassName="h-3.5 w-3.5 hidden group-hover:inline"
+                  />
               </div>
             )}
 
@@ -284,6 +284,7 @@ export const IssueDetailsSidebar: React.FC<Props> = observer((props) => {
                   projectId={projectId}
                   issueId={issueId}
                   disabled={!isEditable}
+                  triggerClassName="js-issue-label"
                 />
               </div>
             </div>

--- a/apps/web/core/hooks/use-issue-detail-shortcuts.ts
+++ b/apps/web/core/hooks/use-issue-detail-shortcuts.ts
@@ -29,6 +29,12 @@ export const useIssueDetailShortcuts = ({
   }, [currentUser, issueOperations, workspaceSlug, projectId, issueId]);
 
   useEffect(() => {
+    const stopEvent = (e: KeyboardEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      e.stopImmediatePropagation();
+    };
+
     const handler = (e: KeyboardEvent) => {
       const target = e.target as HTMLElement;
       if (
@@ -49,81 +55,81 @@ export const useIssueDetailShortcuts = ({
         el?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
       };
 
-      if (cmdOrCtrl && key === "delete") {
-        e.preventDefault();
+      if (cmdOrCtrl && (key === "delete" || key === "backspace")) {
+        stopEvent(e);
         toggleDeleteIssueModal(true);
         return;
       }
 
       if (cmdOrCtrl && key === "m") {
-        e.preventDefault();
+        stopEvent(e);
         const editor = document.querySelector(`#add_comment_${issueId} .ProseMirror`) as HTMLElement | null;
         editor?.focus();
         return;
       }
 
       if (cmdOrCtrl && shift && key === "d") {
-        e.preventDefault();
+        stopEvent(e);
         issueOperations.update(workspaceSlug, projectId, issueId, { target_date: null });
         return;
       }
 
       if (shift && key === "d") {
-        e.preventDefault();
+        stopEvent(e);
         clickByClass("js-issue-due-date");
         return;
       }
 
       if (shift && key === "e") {
-        e.preventDefault();
+        stopEvent(e);
         clickByClass("js-issue-estimate");
         return;
       }
 
       if (shift && key === "c") {
-        e.preventDefault();
+        stopEvent(e);
         clickByClass("js-issue-cycle");
         return;
       }
 
       if (shift && key === "m") {
-        e.preventDefault();
+        stopEvent(e);
         clickByClass("js-issue-module");
         return;
       }
 
       if (key === "a") {
-        e.preventDefault();
+        stopEvent(e);
         clickByClass("js-issue-assignee");
         return;
       }
 
       if (key === "i") {
-        e.preventDefault();
+        stopEvent(e);
         assignToMe();
         return;
       }
 
       if (key === "s") {
-        e.preventDefault();
+        stopEvent(e);
         clickByClass("js-issue-state");
         return;
       }
 
       if (key === "p") {
-        e.preventDefault();
+        stopEvent(e);
         clickByClass("js-issue-priority");
         return;
       }
 
       if (key === "l") {
-        e.preventDefault();
+        stopEvent(e);
         clickByClass("js-issue-label");
       }
     };
 
-    document.addEventListener("keydown", handler);
-    return () => document.removeEventListener("keydown", handler);
+    document.addEventListener("keydown", handler, true);
+    return () => document.removeEventListener("keydown", handler, true);
   }, [
     assignToMe,
     issueOperations,

--- a/apps/web/core/hooks/use-issue-detail-shortcuts.ts
+++ b/apps/web/core/hooks/use-issue-detail-shortcuts.ts
@@ -1,0 +1,137 @@
+import { useEffect, useCallback } from "react";
+// hooks
+import { useCommandPalette } from "@/hooks/store/use-command-palette";
+import { useUser } from "@/hooks/store/user";
+// types
+import type { TIssueOperations } from "@/components/issues/issue-detail/root";
+
+interface IUseIssueDetailShortcuts {
+  workspaceSlug: string;
+  projectId: string;
+  issueId: string;
+  issueOperations: TIssueOperations;
+}
+
+export const useIssueDetailShortcuts = ({
+  workspaceSlug,
+  projectId,
+  issueId,
+  issueOperations,
+}: IUseIssueDetailShortcuts) => {
+  const { data: currentUser } = useUser();
+  const { toggleDeleteIssueModal, isAnyModalOpen } = useCommandPalette();
+
+  const assignToMe = useCallback(() => {
+    if (!currentUser) return;
+    issueOperations.update(workspaceSlug, projectId, issueId, {
+      assignee_ids: [currentUser.id],
+    });
+  }, [currentUser, issueOperations, workspaceSlug, projectId, issueId]);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement;
+      if (
+        isAnyModalOpen ||
+        target instanceof HTMLInputElement ||
+        target instanceof HTMLTextAreaElement ||
+        target.isContentEditable ||
+        target.closest(".ProseMirror")
+      )
+        return;
+
+      const key = e.key.toLowerCase();
+      const cmdOrCtrl = e.metaKey || e.ctrlKey;
+      const shift = e.shiftKey;
+
+      const clickByClass = (className: string) => {
+        const el = document.querySelector(`.${className}`) as HTMLElement | null;
+        el?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      };
+
+      if (cmdOrCtrl && key === "delete") {
+        e.preventDefault();
+        toggleDeleteIssueModal(true);
+        return;
+      }
+
+      if (cmdOrCtrl && key === "m") {
+        e.preventDefault();
+        const editor = document.querySelector(`#add_comment_${issueId} .ProseMirror`) as HTMLElement | null;
+        editor?.focus();
+        return;
+      }
+
+      if (cmdOrCtrl && shift && key === "d") {
+        e.preventDefault();
+        issueOperations.update(workspaceSlug, projectId, issueId, { target_date: null });
+        return;
+      }
+
+      if (shift && key === "d") {
+        e.preventDefault();
+        clickByClass("js-issue-due-date");
+        return;
+      }
+
+      if (shift && key === "e") {
+        e.preventDefault();
+        clickByClass("js-issue-estimate");
+        return;
+      }
+
+      if (shift && key === "c") {
+        e.preventDefault();
+        clickByClass("js-issue-cycle");
+        return;
+      }
+
+      if (shift && key === "m") {
+        e.preventDefault();
+        clickByClass("js-issue-module");
+        return;
+      }
+
+      if (key === "a") {
+        e.preventDefault();
+        clickByClass("js-issue-assignee");
+        return;
+      }
+
+      if (key === "i") {
+        e.preventDefault();
+        assignToMe();
+        return;
+      }
+
+      if (key === "s") {
+        e.preventDefault();
+        clickByClass("js-issue-state");
+        return;
+      }
+
+      if (key === "p") {
+        e.preventDefault();
+        clickByClass("js-issue-priority");
+        return;
+      }
+
+      if (key === "l") {
+        e.preventDefault();
+        clickByClass("js-issue-label");
+      }
+    };
+
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [
+    assignToMe,
+    issueOperations,
+    workspaceSlug,
+    projectId,
+    issueId,
+    toggleDeleteIssueModal,
+    isAnyModalOpen,
+  ]);
+};
+


### PR DESCRIPTION
## Summary
- add hook for issue detail keyboard shortcuts (assignee, priority, etc.)
- expose issue properties to keyboard navigation
- document issue shortcuts in command palette

## Testing
- `pnpm run check:lint --filter web`


------
https://chatgpt.com/codex/tasks/task_e_68c1eb696c2c832ab45588585609dd18