### PR TITLE
[WEB-4861] fix: update redirection path in MagicSignInEndpoint to home page

### DIFF
--- a/apps/api/plane/authentication/views/app/magic.py
+++ b/apps/api/plane/authentication/views/app/magic.py
@@ -108,7 +108,7 @@ class MagicSignInEndpoint(View):
             user_login(request=request, user=user, is_app=True)
             if user.is_password_autoset and profile.is_onboarded:
                 # Redirect to the home page
-                path = ""
+                path = "/"
             else:
                 # Get the redirection path
                 path = (


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
This fix will redirect the user to home page when they login via magic sign-in option.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->
1. Navigate to the Plane sign-up page and create a new account using an email address (e.g., [[user@company.com](mailto:user@company.com)](mailto:user@company.com)), but skip the password setup during the onboarding process. (This may involve selecting an option to defer password creation or using magic link/email verification to proceed without setting a password immediately.)
2. Complete the initial onboarding (e.g., create workspace, etc.) without setting a password.
3. Sign out of the account.
4. Sign in again using the same email address via magic link flow.
5. Upon redirection, the user will be taken to home page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Post–magic-link sign-in now redirects users who have an auto-set password and have completed onboarding directly to the home page instead of the set-password screen. This removes an unnecessary step and streamlines first-access after sign-in; custom next-links and other redirect behaviors are preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->