### PR TITLE
[WEB-4875] fix: unsubscribed work items on workspace subscribed work item filter

### DIFF
--- a/apps/api/plane/utils/issue_filters.py
+++ b/apps/api/plane/utils/issue_filters.py
@@ -476,6 +476,8 @@ def filter_subscribed_issues(params, issue_filter, method, prefix=""):
             issue_filter[f"{prefix}issue_subscribers__subscriber_id__in"] = params.get(
                 "subscriber"
             )
+    issue_filter[f"{prefix}issue_subscribers__deleted_at__isnull"] = True
+
     return issue_filter
 
 


### PR DESCRIPTION
### Description
This PR fixes unsubscribed work items showing up in the workspace subscribed view and in other places where only subscribed issues should be filtered.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Subscribed-issues results now exclude deleted subscriptions, preventing stale or misleading entries.
  * Consistent filtering applied across request methods, ensuring uniform behavior in lists and counts.
  * Improves data accuracy and reliability for users viewing their subscribed issues.
  * No API or error-handling changes; existing clients benefit automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->