### PR TITLE
[WEB-3528] fix: correct member id in modules list showing deleted_at members

### DIFF
--- a/apps/api/plane/app/views/module/base.py
+++ b/apps/api/plane/app/views/module/base.py
@@ -232,9 +232,6 @@ class ModuleViewSet(BaseViewSet):
             .filter(project_id=self.kwargs.get("project_id"))
             .filter(workspace__slug=self.kwargs.get("slug"))
             .annotate(is_favorite=Exists(favorite_subquery))
-            .select_related("project")
-            .select_related("workspace")
-            .select_related("lead")
             .prefetch_related("members")
             .prefetch_related(
                 Prefetch(
@@ -315,7 +312,10 @@ class ModuleViewSet(BaseViewSet):
                     ArrayAgg(
                         "members__id",
                         distinct=True,
-                        filter=~Q(members__id__isnull=True),
+                        filter=Q(
+                            members__id__isnull=False,
+                            modulemember__deleted_at__isnull=True,
+                        ),
                     ),
                     Value([], output_field=ArrayField(UUIDField())),
                 )


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
fix: correct member_ids in modules list to filter out deleted_at module members from the response

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->
- remove a member from the module refresh and the member should be removed from the module

### References
[WEB-3528](https://app.plane.so/plane/browse/WEB-3258/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Module member lists now include only active members, preventing deleted or inactive entries from appearing.
  * Improves accuracy of member counts and displays across module views.
  * Enhances reliability of member-related actions (e.g., filtering and exports) by excluding inactive members from results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->