### PR TITLE
[WEB-4890]fix: dropdown width

### DIFF
--- a/apps/web/core/components/integration/github/single-user-select.tsx
+++ b/apps/web/core/components/integration/github/single-user-select.tsx
@@ -92,7 +92,6 @@ export const SingleUserSelect: React.FC<Props> = ({ collaborator, index, users, 
             newUsers[index].email = "";
             setUsers(newUsers);
           }}
-          optionsClassName="w-full"
           noChevron
         >
           {importOptions.map((option) => (

--- a/apps/web/core/components/integration/jira/give-details.tsx
+++ b/apps/web/core/components/integration/jira/give-details.tsx
@@ -181,7 +181,6 @@ export const JiraGetImportDetail: React.FC = observer(() => {
                     )}
                   </span>
                 }
-                optionsClassName="w-full"
               >
                 {workspaceProjectIds && workspaceProjectIds.length > 0 ? (
                   workspaceProjectIds.map((projectId) => {

--- a/apps/web/core/components/integration/jira/import-users.tsx
+++ b/apps/web/core/components/integration/jira/import-users.tsx
@@ -96,7 +96,6 @@ export const JiraImportUsers: FC = () => {
                         input
                         value={value}
                         onChange={onChange}
-                        optionsClassName="w-full"
                         label={<span className="capitalize">{Boolean(value) ? value : ("Ignore" as any)}</span>}
                       >
                         <CustomSelect.Option value="invite">Invite by email</CustomSelect.Option>

--- a/apps/web/core/components/onboarding/create-workspace.tsx
+++ b/apps/web/core/components/onboarding/create-workspace.tsx
@@ -268,7 +268,6 @@ export const CreateWorkspace: React.FC<Props> = observer((props) => {
                   }
                   buttonClassName="!border-[0.5px] !border-custom-border-300 !shadow-none !rounded-md"
                   input
-                  optionsClassName="w-full"
                 >
                   {ORGANIZATION_SIZE.map((item) => (
                     <CustomSelect.Option key={item} value={item}>

--- a/apps/web/core/components/profile/preferences/language-timezone.tsx
+++ b/apps/web/core/components/profile/preferences/language-timezone.tsx
@@ -126,7 +126,6 @@ export const LanguageTimezone = observer(() => {
                 onChange={handleLanguageChange}
                 buttonClassName={"border-none"}
                 className="rounded-md border !border-custom-border-200"
-                optionsClassName="w-full"
                 input
               >
                 {SUPPORTED_LANGUAGES.map((item) => (

--- a/apps/web/core/components/project/send-project-invitation-modal.tsx
+++ b/apps/web/core/components/project/send-project-invitation-modal.tsx
@@ -293,7 +293,6 @@ export const SendProjectInvitationModal: React.FC<Props> = observer((props) => {
                                       </div>
                                     }
                                     input
-                                    optionsClassName="w-full"
                                   >
                                     {Object.entries(
                                       checkCurrentOptionWorkspaceRole(watch(`members.${index}.member_id`))

--- a/apps/web/core/components/project/settings/member-columns.tsx
+++ b/apps/web/core/components/project/settings/member-columns.tsx
@@ -168,7 +168,6 @@ export const AccountTypeColumn: React.FC<AccountTypeProps> = observer((props) =>
               }
               buttonClassName={`!px-0 !justify-start hover:bg-custom-background-100 ${errors.role ? "border-red-500" : "border-none"}`}
               className="rounded-md p-0 w-32"
-              optionsClassName="w-full"
               input
             >
               {Object.entries(checkCurrentOptionWorkspaceRole(rowData.member.id)).map(([key, label]) => (

--- a/apps/web/core/components/workspace-notifications/sidebar/notification-card/options/snooze/modal.tsx
+++ b/apps/web/core/components/workspace-notifications/sidebar/notification-card/options/snooze/modal.tsx
@@ -195,7 +195,6 @@ export const NotificationSnoozeModal: FC<TNotificationSnoozeModal> = (props) => 
                                 )}
                               </div>
                             }
-                            optionsClassName="w-full"
                             input
                           >
                             <div className="mb-2 flex h-9 w-full overflow-hidden rounded">

--- a/apps/web/core/components/workspace/create-workspace-form.tsx
+++ b/apps/web/core/components/workspace/create-workspace-form.tsx
@@ -228,7 +228,6 @@ export const CreateWorkspaceForm: FC<Props> = observer((props) => {
                   }
                   buttonClassName="!border-[0.5px] !border-custom-border-200 !shadow-none"
                   input
-                  optionsClassName="w-full"
                 >
                   {ORGANIZATION_SIZE.map((item) => (
                     <CustomSelect.Option key={item} value={item}>

--- a/apps/web/core/components/workspace/invite-modal/fields.tsx
+++ b/apps/web/core/components/workspace/invite-modal/fields.tsx
@@ -83,7 +83,6 @@ export const InvitationFields = observer((props: TInvitationFieldsProps) => {
                     value={value}
                     label={<span className="text-xs sm:text-sm">{ROLE[value]}</span>}
                     onChange={onChange}
-                    optionsClassName="w-full"
                     className="flex-grow w-24"
                     input
                   >

--- a/apps/web/core/components/workspace/settings/member-columns.tsx
+++ b/apps/web/core/components/workspace/settings/member-columns.tsx
@@ -146,7 +146,6 @@ export const AccountTypeColumn: React.FC<AccountTypeProps> = observer((props) =>
               }
               buttonClassName={`!px-0 !justify-start hover:bg-custom-background-100 ${errors.role ? "border-red-500" : "border-none"}`}
               className="rounded-md p-0 w-32"
-              optionsClassName="w-full"
               input
             >
               {Object.keys(ROLE).map((item) => (

--- a/apps/web/core/components/workspace/settings/workspace-details.tsx
+++ b/apps/web/core/components/workspace/settings/workspace-details.tsx
@@ -241,7 +241,6 @@ export const WorkspaceDetails: FC = observer(() => {
                       ORGANIZATION_SIZE.find((c) => c === value) ??
                       t("workspace_settings.settings.general.errors.company_size.select_a_range")
                     }
-                    optionsClassName="w-full"
                     buttonClassName="!border-[0.5px] !border-custom-border-200 !shadow-none"
                     input
                     disabled={!isAdmin}


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
This PR cleans up CustomSelect components by removing unnecessary width styling props that were redundantly applied across multiple files. The dropdown components already handle proper sizing through their default implementation.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
<!-- Link related issues if there are any -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Standardized select dropdown option widths across the app by removing forced full-width styling. Options now use default sizing for a cleaner, more consistent UI.
  - Affected areas include: GitHub user selection; Jira import/details; onboarding/create workspace and workspace details; workspace creation form; invitations and member role columns; project invitation modal; notification snooze time picker; and language/timezone preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->