### PR TITLE
[WIKI-632] chore: add extended document editor props

### DIFF
--- a/packages/editor/src/core/components/editors/document/collaborative-editor.tsx
+++ b/packages/editor/src/core/components/editors/document/collaborative-editor.tsx
@@ -44,6 +44,7 @@ const CollaborativeDocumentEditor: React.FC<ICollaborativeDocumentEditorProps> =
     serverHandler,
     tabIndex,
     user,
+    extendedDocumentEditorProps,
   } = props;
 
   // use document editor
@@ -71,6 +72,7 @@ const CollaborativeDocumentEditor: React.FC<ICollaborativeDocumentEditorProps> =
     serverHandler,
     tabIndex,
     user,
+    extendedDocumentEditorProps,
   });
 
   const editorContainerClassNames = getEditorClassNames({

--- a/packages/editor/src/core/components/editors/document/collaborative-editor.tsx
+++ b/packages/editor/src/core/components/editors/document/collaborative-editor.tsx
@@ -99,6 +99,7 @@ const CollaborativeDocumentEditor: React.FC<ICollaborativeDocumentEditorProps> =
         tabIndex={tabIndex}
         flaggedExtensions={flaggedExtensions}
         disabledExtensions={disabledExtensions}
+        extendedDocumentEditorProps={extendedDocumentEditorProps}
       />
     </>
   );

--- a/packages/editor/src/core/components/editors/document/page-renderer.tsx
+++ b/packages/editor/src/core/components/editors/document/page-renderer.tsx
@@ -5,7 +5,7 @@ import { cn } from "@plane/utils";
 import { DocumentContentLoader, EditorContainer, EditorContentWrapper } from "@/components/editors";
 import { AIFeaturesMenu, BlockMenu, EditorBubbleMenu } from "@/components/menus";
 // types
-import { IEditorProps, TAIHandler, TDisplayConfig } from "@/types";
+import { ICollaborativeDocumentEditorPropsExtended, IEditorProps, TAIHandler, TDisplayConfig } from "@/types";
 
 type Props = {
   aiHandler?: TAIHandler;
@@ -14,6 +14,7 @@ type Props = {
   documentLoaderClassName?: string;
   editor: Editor;
   editorContainerClassName: string;
+  extendedDocumentEditorProps?: ICollaborativeDocumentEditorPropsExtended;
   id: string;
   isLoading?: boolean;
   isTouchDevice: boolean;

--- a/packages/editor/src/core/components/editors/document/page-renderer.tsx
+++ b/packages/editor/src/core/components/editors/document/page-renderer.tsx
@@ -5,7 +5,7 @@ import { cn } from "@plane/utils";
 import { DocumentContentLoader, EditorContainer, EditorContentWrapper } from "@/components/editors";
 import { AIFeaturesMenu, BlockMenu, EditorBubbleMenu } from "@/components/menus";
 // types
-import { ICollaborativeDocumentEditorPropsExtended, IEditorProps, TAIHandler, TDisplayConfig } from "@/types";
+import type { ICollaborativeDocumentEditorPropsExtended, IEditorProps, TAIHandler, TDisplayConfig } from "@/types";
 
 type Props = {
   aiHandler?: TAIHandler;

--- a/packages/editor/src/core/types/hook.ts
+++ b/packages/editor/src/core/types/hook.ts
@@ -51,4 +51,7 @@ export type TCollaborativeEditorHookProps = TCoreHookProps &
     | "placeholder"
     | "tabIndex"
   > &
-  Pick<ICollaborativeDocumentEditorProps, "dragDropEnabled" | "realtimeConfig" | "serverHandler" | "user">;
+  Pick<
+    ICollaborativeDocumentEditorProps,
+    "dragDropEnabled" | "extendedDocumentEditorProps" | "realtimeConfig" | "serverHandler" | "user"
+  >;


### PR DESCRIPTION
### Description
This PR adds an extended document editor type.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Code refactoring


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional extendedDocumentEditorProps to the collaborative document editor, page renderer, and related hooks to support extended configuration and integrations.
  * Enables passing advanced editing/display options without changing defaults; backward compatible—existing behavior unchanged unless the new prop is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->