### PR TITLE
refactor command palette into modular command system

### DIFF
--- a/apps/web/core/components/command-palette/command-config.ts
+++ b/apps/web/core/components/command-palette/command-config.ts
@@ -1,0 +1,135 @@
+import React from "react";
+import { FolderPlus, Settings } from "lucide-react";
+import { LayersIcon } from "@plane/propel/icons";
+import {
+  PROJECT_TRACKER_ELEMENTS,
+  WORK_ITEM_TRACKER_ELEMENTS,
+} from "@plane/constants";
+import { captureClick } from "@/helpers/event-tracker.helper";
+import { PaletteCommandGroup } from "./types";
+
+interface BuildParams {
+  workspaceSlug?: string | string[];
+  pages: string[];
+  workspaceProjectIds?: string[];
+  canPerformAnyCreateAction: boolean;
+  canPerformWorkspaceActions: boolean;
+  closePalette: () => void;
+  toggleCreateIssueModal: (v: boolean) => void;
+  toggleCreateProjectModal: (v: boolean) => void;
+  setPages: React.Dispatch<React.SetStateAction<string[]>>;
+  setPlaceholder: (v: string) => void;
+  setSearchTerm: (v: string) => void;
+  createNewWorkspace: () => void;
+}
+
+export const buildCommandGroups = (params: BuildParams): PaletteCommandGroup[] => {
+  const {
+    workspaceSlug,
+    pages,
+    workspaceProjectIds,
+    canPerformAnyCreateAction,
+    canPerformWorkspaceActions,
+    closePalette,
+    toggleCreateIssueModal,
+    toggleCreateProjectModal,
+    setPages,
+    setPlaceholder,
+    setSearchTerm,
+    createNewWorkspace,
+  } = params;
+
+  const groups: PaletteCommandGroup[] = [];
+
+  if (
+    workspaceSlug &&
+    workspaceProjectIds &&
+    workspaceProjectIds.length > 0 &&
+    canPerformAnyCreateAction
+  ) {
+    groups.push({
+      id: "work-item",
+      heading: "Work item",
+      commands: [
+        {
+          id: "create-work-item",
+          label: "Create new work item",
+          shortcut: "C",
+          icon: LayersIcon,
+          perform: () => {
+            closePalette();
+            captureClick({ elementName: WORK_ITEM_TRACKER_ELEMENTS.COMMAND_PALETTE_ADD_BUTTON });
+            toggleCreateIssueModal(true);
+          },
+          enabled: true,
+        },
+      ],
+    });
+  }
+
+  if (workspaceSlug && canPerformWorkspaceActions) {
+    groups.push({
+      id: "project",
+      heading: "Project",
+      commands: [
+        {
+          id: "create-project",
+          label: "Create new project",
+          shortcut: "P",
+          icon: FolderPlus,
+          perform: () => {
+            closePalette();
+            captureClick({ elementName: PROJECT_TRACKER_ELEMENTS.COMMAND_PALETTE_CREATE_BUTTON });
+            toggleCreateProjectModal(true);
+          },
+          enabled: true,
+        },
+      ],
+    });
+  }
+
+  groups.push({
+    id: "workspace-settings",
+    heading: "Workspace Settings",
+    commands: [
+      {
+        id: "search-settings",
+        label: "Search settings...",
+        icon: Settings,
+        perform: () => {
+          setPlaceholder("Search workspace settings...");
+          setSearchTerm("");
+          setPages((p) => [...p, "settings"]);
+        },
+        enabled: !!(canPerformWorkspaceActions && workspaceSlug),
+      },
+    ],
+  });
+
+  groups.push({
+    id: "account",
+    heading: "Account",
+    commands: [
+      {
+        id: "create-workspace",
+        label: "Create new workspace",
+        icon: FolderPlus,
+        perform: createNewWorkspace,
+        enabled: true,
+      },
+      {
+        id: "change-interface-theme",
+        label: "Change interface theme...",
+        icon: Settings,
+        perform: () => {
+          setPlaceholder("Change interface theme...");
+          setSearchTerm("");
+          setPages((p) => [...p, "change-interface-theme"]);
+        },
+        enabled: true,
+      },
+    ],
+  });
+
+  return groups;
+};

--- a/apps/web/core/components/command-palette/types.ts
+++ b/apps/web/core/components/command-palette/types.ts
@@ -1,0 +1,16 @@
+import React from "react";
+
+export interface PaletteCommand {
+  id: string;
+  label: string;
+  shortcut?: string;
+  icon?: React.ComponentType<{ className?: string }>;
+  perform: () => void;
+  enabled?: boolean;
+}
+
+export interface PaletteCommandGroup {
+  id: string;
+  heading: string;
+  commands: PaletteCommand[];
+}

--- a/apps/web/core/components/command-palette/use-shortcuts.ts
+++ b/apps/web/core/components/command-palette/use-shortcuts.ts
@@ -1,0 +1,67 @@
+import { useCallback, useEffect, useRef } from "react";
+
+export interface Shortcut {
+  keys?: string[]; // simultaneous combination
+  sequence?: string[]; // sequential keys
+  handler: (e: KeyboardEvent) => void;
+  enabled?: (e: KeyboardEvent) => boolean;
+  preventDefault?: boolean;
+}
+
+const matchCombo = (pressed: string[], combo: string[]) => {
+  if (pressed.length !== combo.length) return false;
+  return combo.every((k) => pressed.includes(k));
+};
+
+const matchSequence = (buffer: string[], sequence: string[]) => {
+  if (buffer.length < sequence.length) return false;
+  const start = buffer.length - sequence.length;
+  return sequence.every((k, i) => buffer[start + i] === k);
+};
+
+export const useShortcuts = (
+  shortcuts: Shortcut[],
+  options?: { filter?: (e: KeyboardEvent) => boolean; additional?: (e: KeyboardEvent) => void }
+) => {
+  const bufferRef = useRef<string[]>([]);
+  const timerRef = useRef<NodeJS.Timeout>();
+
+  const listener = useCallback(
+    (e: KeyboardEvent) => {
+      if (options?.filter && !options.filter(e)) return;
+
+      const pressed: string[] = [];
+      if (e.metaKey) pressed.push("meta");
+      if (e.ctrlKey) pressed.push("control");
+      if (e.altKey) pressed.push("alt");
+      if (e.shiftKey) pressed.push("shift");
+      pressed.push(e.key.toLowerCase());
+
+      bufferRef.current.push(e.key.toLowerCase());
+      clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => {
+        bufferRef.current = [];
+      }, 1000);
+
+      shortcuts.forEach((s) => {
+        if (s.enabled && !s.enabled(e)) return;
+        if (s.keys && matchCombo(pressed, s.keys)) {
+          if (s.preventDefault ?? true) e.preventDefault();
+          s.handler(e);
+        } else if (s.sequence && matchSequence(bufferRef.current, s.sequence)) {
+          if (s.preventDefault ?? true) e.preventDefault();
+          bufferRef.current = [];
+          s.handler(e);
+        }
+      });
+
+      options?.additional?.(e);
+    },
+    [shortcuts, options]
+  );
+
+  useEffect(() => {
+    document.addEventListener("keydown", listener);
+    return () => document.removeEventListener("keydown", listener);
+  }, [listener]);
+};


### PR DESCRIPTION
## Summary
- extract command configuration and types for reusable palette commands
- add generic keyboard shortcut hook to support combos and sequences
- refactor command modal and palette to consume new command registry

## Testing
- `pnpm check:lint` *(fails: Unexpected any. Specify a different type; TEmbedConfig is defined but never used)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a3968684832ab61463e8bc947d59