### PR TITLE
[WEB-4898] fix: extended sidebar toggle

### DIFF
--- a/apps/web/core/components/command-palette/command-palette.tsx
+++ b/apps/web/core/components/command-palette/command-palette.tsx
@@ -38,7 +38,7 @@ export const CommandPalette: FC = observer(() => {
   const { workspaceSlug, projectId: paramsProjectId, workItem } = useParams();
   // store hooks
   const { fetchIssueWithIdentifier } = useIssueDetail();
-  const { toggleSidebar } = useAppTheme();
+  const { toggleSidebar, toggleExtendedSidebar } = useAppTheme();
   const { platform } = usePlatformOS();
   const { data: currentUser, canPerformAnyCreateAction } = useUser();
   const { toggleCommandPaletteModal, isShortcutModalOpen, toggleShortcutModal, isAnyModalOpen } = useCommandPalette();
@@ -197,6 +197,7 @@ export const CommandPalette: FC = observer(() => {
         } else if (keyPressed === "b") {
           e.preventDefault();
           toggleSidebar();
+          toggleExtendedSidebar(false);
         }
       } else if (!isAnyModalOpen) {
         captureClick({ elementName: COMMAND_PALETTE_TRACKER_ELEMENTS.COMMAND_PALETTE_SHORTCUT_KEY });
@@ -242,6 +243,7 @@ export const CommandPalette: FC = observer(() => {
       toggleCommandPaletteModal,
       toggleShortcutModal,
       toggleSidebar,
+      toggleExtendedSidebar,
       workspaceSlug,
     ]
   );


### PR DESCRIPTION
### Description
This PR fixes the behavior of the extended sidebar toggle shortcut. Previously, when pressing `cmd+b` with the extended sidebar open, it only closed the main app sidebar while leaving the extended sidebar open. This update ensures both sidebars toggle correctly together.

### Type of Change
- [x] Bug fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved sidebar behavior: toggling the main sidebar (including via the B shortcut) now also closes any extended/sidebar panel for a cleaner workspace.
  * Command palette actions now keep the extended sidebar state in sync with main sidebar toggles for consistent navigation.
  * More reliable keyboard shortcut handling ensures sidebar state updates correctly during rapid toggling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->