### PR TITLE
[WEB-4899]fix: project member check on IntakeIssueViewset

### DIFF
--- a/apps/api/plane/app/views/intake/base.py
+++ b/apps/api/plane/app/views/intake/base.py
@@ -356,9 +356,9 @@ class IntakeIssueViewSet(BaseViewSet):
             is_active=True,
         )
         # Only project members admins and created_by users can access this endpoint
-        if project_member.role <= 5 and str(intake_issue.created_by_id) != str(
-            request.user.id
-        ):
+        if (project_member and project_member.role <= 5) and str(
+            intake_issue.created_by_id
+        ) != str(request.user.id):
             return Response(
                 {"error": "You cannot edit intake issues"},
                 status=status.HTTP_400_BAD_REQUEST,
@@ -392,7 +392,7 @@ class IntakeIssueViewSet(BaseViewSet):
                 ),
             ).get(pk=intake_issue.issue_id, workspace__slug=slug, project_id=project_id)
             # Only allow guests to edit name and description
-            if project_member.role <= 5:
+            if project_member and project_member.role <= 5:
                 issue_data = {
                     "name": issue_data.get("name", issue.name),
                     "description_html": issue_data.get(
@@ -437,7 +437,7 @@ class IntakeIssueViewSet(BaseViewSet):
                 )
 
         # Only project admins and members can edit intake issue attributes
-        if project_member.role > 15:
+        if project_member and project_member.role > 15:
             serializer = IntakeIssueSerializer(
                 intake_issue, data=request.data, partial=True
             )


### PR DESCRIPTION
### Description
This PR will let project admin to edit intake work items. 

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Fixed occasional errors when updating intake items by handling cases where a user isn’t a project member, preventing crashes during permission checks.
  - Improved reliability of role-based access during partial updates, reducing unexpected failures and error messages.
  - Ensures consistent behavior for all users without changing existing permissions for valid project members.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->