### PR TITLE
[WEB-4900] refactor: remove base_host retrieval from authentication views

### DIFF
--- a/apps/api/plane/authentication/views/app/github.py
+++ b/apps/api/plane/authentication/views/app/github.py
@@ -60,7 +60,6 @@ class GitHubCallbackEndpoint(View):
     def get(self, request):
         code = request.GET.get("code")
         state = request.GET.get("state")
-        base_host = request.session.get("host")
         next_path = request.session.get("next_path")
 
         if state != request.session.get("state", ""):

--- a/apps/api/plane/authentication/views/app/gitlab.py
+++ b/apps/api/plane/authentication/views/app/gitlab.py
@@ -61,7 +61,6 @@ class GitLabCallbackEndpoint(View):
     def get(self, request):
         code = request.GET.get("code")
         state = request.GET.get("state")
-        base_host = request.session.get("host")
         next_path = request.session.get("next_path")
 
         if state != request.session.get("state", ""):

--- a/apps/api/plane/authentication/views/app/google.py
+++ b/apps/api/plane/authentication/views/app/google.py
@@ -62,7 +62,6 @@ class GoogleCallbackEndpoint(View):
     def get(self, request):
         code = request.GET.get("code")
         state = request.GET.get("state")
-        base_host = request.session.get("host")
         next_path = request.session.get("next_path")
 
         if state != request.session.get("state", ""):

--- a/apps/api/plane/authentication/views/app/magic.py
+++ b/apps/api/plane/authentication/views/app/magic.py
@@ -160,8 +160,6 @@ class MagicSignUpEndpoint(View):
                 error_message="USER_ALREADY_EXIST",
             )
             params = exc.get_error_dict()
-            if next_path:
-                params["next_path"] = str(next_path)
             url = get_safe_redirect_url(
                 base_url=base_host(request=request, is_app=True),
                 next_path=next_path,

--- a/apps/api/plane/authentication/views/space/magic.py
+++ b/apps/api/plane/authentication/views/space/magic.py
@@ -1,5 +1,3 @@
-from urllib.parse import urljoin, urlencode
-
 # Django imports
 from django.core.validators import validate_email
 from django.http import HttpResponseRedirect
@@ -106,7 +104,11 @@ class MagicSignInSpaceEndpoint(View):
             base_url = get_safe_redirect_url(
                 base_url=base_host(request=request, is_space=True), next_path=next_path
             )
-            url = urljoin(base_url, "?" + urlencode(params))
+            url = get_safe_redirect_url(
+                base_url=base_host(request=request, is_space=True),
+                next_path=next_path,
+                params=params,
+            )
             return HttpResponseRedirect(url)
 
 


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
* Removed unnecessary base_host retrieval from GitHub, GitLab, and Google callback endpoints.
* Updated MagicSignUpEndpoint to use get_safe_redirect_url for URL construction.
* Refactored MagicSignInSpaceEndpoint to streamline URL redirection logic.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->
- test all authentication endpoints specifically all redirections

### References
[WEB-4900](https://app.plane.so/plane/browse/WEB-4900)