### PR TITLE
[WEB-4943] refactor: streamline URL construction in authentication views

### DIFF
--- a/apps/api/plane/authentication/views/space/email.py
+++ b/apps/api/plane/authentication/views/space/email.py
@@ -14,7 +14,7 @@ from plane.authentication.adapter.error import (
     AUTHENTICATION_ERROR_CODES,
     AuthenticationException,
 )
-from plane.utils.path_validator import get_safe_redirect_url
+from plane.utils.path_validator import get_safe_redirect_url, validate_next_path
 
 
 class SignInAuthSpaceEndpoint(View):
@@ -198,11 +198,8 @@ class SignUpAuthSpaceEndpoint(View):
             # Login the user and record his device info
             user_login(request=request, user=user, is_space=True)
             # redirect to referer path
-            url = get_safe_redirect_url(
-                base_url=base_host(request=request, is_space=True),
-                next_path=next_path,
-                params={}
-            )
+            next_path = validate_next_path(next_path=next_path)
+            url = f"{base_host(request=request, is_space=True).rstrip("/")}{next_path}"
             return HttpResponseRedirect(url)
         except AuthenticationException as e:
             params = e.get_error_dict()

--- a/apps/api/plane/authentication/views/space/github.py
+++ b/apps/api/plane/authentication/views/space/github.py
@@ -14,7 +14,7 @@ from plane.authentication.adapter.error import (
     AUTHENTICATION_ERROR_CODES,
     AuthenticationException,
 )
-from plane.utils.path_validator import get_safe_redirect_url
+from plane.utils.path_validator import get_safe_redirect_url, validate_next_path
 
 
 class GitHubOauthInitiateSpaceEndpoint(View):
@@ -93,11 +93,8 @@ class GitHubCallbackSpaceEndpoint(View):
             user_login(request=request, user=user, is_space=True)
             # Process workspace and project invitations
             # redirect to referer path
-            url = get_safe_redirect_url(
-                base_url=base_host(request=request, is_space=True),
-                next_path=next_path,
-                params=params
-            )
+            next_path = validate_next_path(next_path=next_path)
+            url = f"{base_host(request=request, is_space=True).rstrip("/")}{next_path}"
             return HttpResponseRedirect(url)
         except AuthenticationException as e:
             params = e.get_error_dict()

--- a/apps/api/plane/authentication/views/space/gitlab.py
+++ b/apps/api/plane/authentication/views/space/gitlab.py
@@ -14,7 +14,7 @@ from plane.authentication.adapter.error import (
     AUTHENTICATION_ERROR_CODES,
     AuthenticationException,
 )
-from plane.utils.path_validator import get_safe_redirect_url
+from plane.utils.path_validator import get_safe_redirect_url, validate_next_path
 
 
 class GitLabOauthInitiateSpaceEndpoint(View):
@@ -94,11 +94,8 @@ class GitLabCallbackSpaceEndpoint(View):
             user_login(request=request, user=user, is_space=True)
             # Process workspace and project invitations
             # redirect to referer path
-            url = get_safe_redirect_url(
-                base_url=base_host(request=request, is_space=True),
-                next_path=next_path,
-                params=params
-            )
+            next_path = validate_next_path(next_path=next_path)
+            url = f"{base_host(request=request, is_space=True).rstrip("/")}{next_path}"
             return HttpResponseRedirect(url)
         except AuthenticationException as e:
             params = e.get_error_dict()

--- a/apps/api/plane/authentication/views/space/google.py
+++ b/apps/api/plane/authentication/views/space/google.py
@@ -14,7 +14,7 @@ from plane.authentication.adapter.error import (
     AuthenticationException,
     AUTHENTICATION_ERROR_CODES,
 )
-from plane.utils.path_validator import get_safe_redirect_url
+from plane.utils.path_validator import get_safe_redirect_url, validate_next_path
 
 
 class GoogleOauthInitiateSpaceEndpoint(View):
@@ -90,11 +90,8 @@ class GoogleCallbackSpaceEndpoint(View):
             # Login the user and record his device info
             user_login(request=request, user=user, is_space=True)
             # redirect to referer path
-            url = get_safe_redirect_url(
-                base_url=base_host(request=request, is_space=True),
-                next_path=next_path,
-                params=params
-            )
+            next_path = validate_next_path(next_path=next_path)
+            url = f"{base_host(request=request, is_space=True).rstrip("/")}{next_path}"
             return HttpResponseRedirect(url)
         except AuthenticationException as e:
             params = e.get_error_dict()

--- a/apps/api/plane/authentication/views/space/magic.py
+++ b/apps/api/plane/authentication/views/space/magic.py
@@ -94,9 +94,7 @@ class MagicSignInSpaceEndpoint(View):
             # Login the user and record his device info
             user_login(request=request, user=user, is_space=True)
             # redirect to referer path
-            url = get_safe_redirect_url(
-                base_url=base_host(request=request, is_space=True), next_path=next_path
-            )
+            url = f"{base_host(request=request, is_space=True).rstrip('/')}{next_path}"
             return HttpResponseRedirect(url)
 
         except AuthenticationException as e:
@@ -154,9 +152,7 @@ class MagicSignUpSpaceEndpoint(View):
             # Login the user and record his device info
             user_login(request=request, user=user, is_space=True)
             # redirect to referer path
-            url = get_safe_redirect_url(
-                base_url=base_host(request=request, is_space=True), next_path=next_path
-            )
+            url = f"{base_host(request=request, is_space=True).rstrip('/')}{next_path}"
             return HttpResponseRedirect(url)
 
         except AuthenticationException as e:

--- a/apps/api/plane/authentication/views/space/magic.py
+++ b/apps/api/plane/authentication/views/space/magic.py
@@ -20,7 +20,7 @@ from plane.authentication.adapter.error import (
     AuthenticationException,
     AUTHENTICATION_ERROR_CODES,
 )
-from plane.utils.path_validator import get_safe_redirect_url
+from plane.utils.path_validator import get_safe_redirect_url, validate_next_path
 
 
 class MagicGenerateSpaceEndpoint(APIView):
@@ -94,7 +94,8 @@ class MagicSignInSpaceEndpoint(View):
             # Login the user and record his device info
             user_login(request=request, user=user, is_space=True)
             # redirect to referer path
-            url = f"{base_host(request=request, is_space=True).rstrip('/')}{next_path}"
+            next_path = validate_next_path(next_path=next_path)
+            url = f"{base_host(request=request, is_space=True).rstrip("/")}{next_path}"
             return HttpResponseRedirect(url)
 
         except AuthenticationException as e:
@@ -152,7 +153,7 @@ class MagicSignUpSpaceEndpoint(View):
             # Login the user and record his device info
             user_login(request=request, user=user, is_space=True)
             # redirect to referer path
-            url = f"{base_host(request=request, is_space=True).rstrip('/')}{next_path}"
+            url = f"{base_host(request=request, is_space=True).rstrip("/")}{next_path}"
             return HttpResponseRedirect(url)
 
         except AuthenticationException as e:

--- a/apps/api/plane/authentication/views/space/magic.py
+++ b/apps/api/plane/authentication/views/space/magic.py
@@ -153,6 +153,7 @@ class MagicSignUpSpaceEndpoint(View):
             # Login the user and record his device info
             user_login(request=request, user=user, is_space=True)
             # redirect to referer path
+            next_path = validate_next_path(next_path=next_path)
             url = f"{base_host(request=request, is_space=True).rstrip("/")}{next_path}"
             return HttpResponseRedirect(url)
 

--- a/apps/api/plane/utils/path_validator.py
+++ b/apps/api/plane/utils/path_validator.py
@@ -1,7 +1,6 @@
 # Python imports
 from urllib.parse import urlparse
 
-
 def _contains_suspicious_patterns(path: str) -> bool:
     """
     Check for suspicious patterns that might indicate malicious intent.
@@ -90,9 +89,10 @@ def get_safe_redirect_url(base_url: str, next_path: str = "", params: dict = {})
     validated_path = validate_next_path(next_path)
     
     # Add the next path to the parameters
-    if validated_path:
-        params["next_path"] = validated_path
+    base_url = base_url.rstrip('/')
+    if params:
+        encoded_params = urlencode(params)
+        return f"{base_url}/?next_path={validated_path}&{encoded_params}"
 
-    # Return the safe redirect URL
-    return f"{base_url.rstrip('/')}?{urlencode(params, quote_via=lambda s, safe, encoding, errors: quote(s, safe="/"))}"
+    return f"{base_url}/?next_path={validated_path}"
     

--- a/apps/api/plane/utils/path_validator.py
+++ b/apps/api/plane/utils/path_validator.py
@@ -84,7 +84,7 @@ def get_safe_redirect_url(base_url: str, next_path: str = "", params: dict = {})
     Returns:
         str: The safe redirect URL
     """
-    from urllib.parse import urlencode
+    from urllib.parse import urlencode, quote
 
     # Validate the next path
     validated_path = validate_next_path(next_path)
@@ -94,5 +94,5 @@ def get_safe_redirect_url(base_url: str, next_path: str = "", params: dict = {})
         params["next_path"] = validated_path
 
     # Return the safe redirect URL
-    return f"{base_url.rstrip('/')}?{urlencode(params)}"
+    return f"{base_url.rstrip('/')}?{urlencode(params, quote_via=lambda s, safe, encoding, errors: quote(s, safe="/"))}"
     


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
* Updated MagicSignInSpaceEndpoint and MagicSignUpSpaceEndpoint to directly construct redirect URLs using formatted strings instead of the get_safe_redirect_url function.
* Enhanced get_safe_redirect_url to use quote for safer URL encoding of parameters.


### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->
- test all space authentication for correct redirection

### References
[WEB-4943](https://app.plane.so/plane/browse/WEB-4943)