### PR TITLE
[WEB-4899] fix: workspace admin cannot delete intake and cycle

### DIFF
--- a/apps/api/plane/app/views/cycle/base.py
+++ b/apps/api/plane/app/views/cycle/base.py
@@ -504,19 +504,6 @@ class CycleViewSet(BaseViewSet):
     @allow_permission([ROLE.ADMIN], creator=True, model=Cycle)
     def destroy(self, request, slug, project_id, pk):
         cycle = Cycle.objects.get(workspace__slug=slug, project_id=project_id, pk=pk)
-        if cycle.owned_by_id != request.user.id and not (
-            ProjectMember.objects.filter(
-                workspace__slug=slug,
-                member=request.user,
-                role=20,
-                project_id=project_id,
-                is_active=True,
-            ).exists()
-        ):
-            return Response(
-                {"error": "Only admin or owner can delete the cycle"},
-                status=status.HTTP_403_FORBIDDEN,
-            )
 
         cycle_issues = list(
             CycleIssue.objects.filter(cycle_id=self.kwargs.get("pk")).values_list(

--- a/apps/api/plane/app/views/intake/base.py
+++ b/apps/api/plane/app/views/intake/base.py
@@ -28,6 +28,7 @@ from plane.db.models import (
     ProjectMember,
     CycleIssue,
     IssueDescriptionVersion,
+    WorkspaceMember,
 )
 from plane.app.serializers import (
     IssueCreateSerializer,
@@ -348,13 +349,20 @@ class IntakeIssueViewSet(BaseViewSet):
             project_id=project_id,
             intake_id=intake_id,
         )
-        # Get the project member
-        project_member = ProjectMember.objects.get(
+
+        project_member = ProjectMember.objects.filter(
             workspace__slug=slug,
             project_id=project_id,
             member=request.user,
             is_active=True,
-        )
+        ).first()
+
+        if project_member is None:
+            project_member = WorkspaceMember.objects.get(
+                workspace__slug=slug,
+                is_active=True,
+                member=request.user,
+            )
         # Only project members admins and created_by users can access this endpoint
         if project_member.role <= 5 and str(intake_issue.created_by_id) != str(
             request.user.id


### PR DESCRIPTION
### Description
This PR modifies the permission checks in the intake and cycle viewsets, since these are already handled in the decorator.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
