### PR TITLE
[WEB-4956] fix: onboarding redirect with cache busting and code refactor

### DIFF
--- a/apps/web/core/services/user.service.ts
+++ b/apps/web/core/services/user.service.ts
@@ -85,8 +85,9 @@ export class UserService extends APIService {
       });
   }
 
-  async currentUserSettings(): Promise<IUserSettings> {
-    return this.get("/api/users/me/settings/")
+  async currentUserSettings(bustCache: boolean = false): Promise<IUserSettings> {
+    const url = bustCache ? `/api/users/me/settings/?t=${Date.now()}` : "/api/users/me/settings/";
+    return this.get(url)
       .then((response) => response?.data)
       .catch((error) => {
         throw error?.response;

--- a/apps/web/core/store/user/profile.store.ts
+++ b/apps/web/core/store/user/profile.store.ts
@@ -172,6 +172,12 @@ export class ProfileStore implements IUserProfileStore {
       runInAction(() => {
         this.mutateUserProfile({ ...dataToUpdate, is_onboarded: true });
       });
+
+      // Also fetch from backend to ensure consistency and refresh user settings with cache-busting
+      Promise.all([
+        this.fetchUserProfile(),
+        this.store.user.userSettings.fetchCurrentUserSettings(true), // Cache-busting enabled
+      ]);
     } catch (error) {
       runInAction(() => {
         this.error = {

--- a/apps/web/core/store/user/settings.store.ts
+++ b/apps/web/core/store/user/settings.store.ts
@@ -23,7 +23,7 @@ export interface IUserSettingsStore {
   sidebarCollapsed: boolean;
   isScrolled: boolean;
   // actions
-  fetchCurrentUserSettings: () => Promise<IUserSettings | undefined>;
+  fetchCurrentUserSettings: (bustCache?: boolean) => Promise<IUserSettings | undefined>;
   toggleLocalDB: (workspaceSlug: string | undefined, projectId: string | undefined) => Promise<void>;
   toggleSidebar: (collapsed?: boolean) => void;
   toggleIsScrolled: (isScrolled?: boolean) => void;
@@ -113,13 +113,13 @@ export class UserSettingsStore implements IUserSettingsStore {
    * @description fetches user profile information
    * @returns {Promise<IUserSettings | undefined>}
    */
-  fetchCurrentUserSettings = async () => {
+  fetchCurrentUserSettings = async (bustCache: boolean = false) => {
     try {
       runInAction(() => {
         this.isLoading = true;
         this.error = undefined;
       });
-      const userSettings = await this.userService.currentUserSettings();
+      const userSettings = await this.userService.currentUserSettings(bustCache);
       runInAction(() => {
         this.isLoading = false;
         this.data = userSettings;


### PR DESCRIPTION
### Summary
Fix onboarding completion redirect issue where users were sent to `/create-workspace` or `/onboarding` instead of their workspace.

### Problem
Backend API caching (12s) and missing MobX actions prevented proper workspace redirection after onboarding.

### Solution
- Add cache-busting to user settings API calls during onboarding
- Use optimistic updates with background sync for immediate UI response

### Changes
- Modified user service and settings store to support cache-busting
- Enhanced onboarding flow with hybrid optimistic/sync approach

### Result
Users now properly redirect to workspace after onboarding completion.

