### PR TITLE
[WEB-4915]fix: redirection after onboarding completion

### DIFF
--- a/apps/web/core/store/user/profile.store.ts
+++ b/apps/web/core/store/user/profile.store.ts
@@ -168,17 +168,15 @@ export class ProfileStore implements IUserProfileStore {
       // update user onboarding status
       await this.userService.updateUserOnBoard();
 
-      // update the user profile store
-      runInAction(() => {
-        this.mutateUserProfile({ ...dataToUpdate, is_onboarded: true });
-      });
-
-      // Also fetch from backend to ensure consistency and refresh user settings with cache-busting
-      Promise.all([
+      // Wait for user settings to be refreshed with cache-busting before updating onboarding status
+      await Promise.all([
         this.fetchUserProfile(),
         this.store.user.userSettings.fetchCurrentUserSettings(true), // Cache-busting enabled
-      ]).catch((error) => {
-        console.error("Background sync failed:", error);
+      ]);
+
+      // Only after settings are refreshed, update the user profile store to mark as onboarded
+      runInAction(() => {
+        this.mutateUserProfile({ ...dataToUpdate, is_onboarded: true });
       });
     } catch (error) {
       runInAction(() => {


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
After completing onboarding, users were not being redirected to their workspace correctly. Instead, they were being redirected to the workspace creation page, breaking the expected user flow.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
<!-- Link related issues if there are any -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures onboarding completes only after server sync, preventing local “onboarded” status from appearing prematurely.
  * Improves reliability of profile, settings, and workspace data right after onboarding.
  * Surfaces errors during onboarding sync instead of silently ignoring them, giving clearer feedback if something goes wrong.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->