### PR TITLE
[WEB-4974]fix: table column spanning

### DIFF
--- a/apps/web/core/components/issues/issue-layouts/spreadsheet/spreadsheet-header.tsx
+++ b/apps/web/core/components/issues/issue-layouts/spreadsheet/spreadsheet-header.tsx
@@ -45,7 +45,7 @@ export const SpreadsheetHeader = observer((props: Props) => {
     <thead className="sticky top-0 left-0 z-[12] border-b-[0.5px] border-custom-border-100">
       <tr>
         <th
-          className="group/list-header sticky min-w-60 max-w-[30vw] left-0 z-[15] h-11 flex items-center gap-1 bg-custom-background-90 text-sm font-medium before:absolute before:h-full before:right-0 before:border-custom-border-100"
+          className="group/list-header sticky min-w-60 left-0 z-[15] h-11 flex items-center gap-1 bg-custom-background-90 text-sm font-medium before:absolute before:h-full before:right-0 before:border-custom-border-100"
           tabIndex={-1}
         >
           <Row>


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
This update fixes the table column spanning issue in spreadsheet view.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
<!-- Link related issues if there are any -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the spreadsheet view header to remove a fixed max-width on the first column, allowing header text to use available space.
  - Reduces truncation of long titles and improves readability on larger screens.
  - Enhances layout responsiveness and visual consistency across different viewport sizes.
  - No functional behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->