### PR TITLE
[WIKI-638] fix: peek overview closing while dropdowns are open

### DIFF
--- a/apps/web/core/components/issues/peek-overview/issue-detail.tsx
+++ b/apps/web/core/components/issues/peek-overview/issue-detail.tsx
@@ -29,7 +29,8 @@ import { IssueTitleInput } from "../title-input";
 // services init
 const workItemVersionService = new WorkItemVersionService();
 
-interface IPeekOverviewIssueDetails {
+type Props = {
+  editorRef: React.RefObject<EditorRefApi>;
   workspaceSlug: string;
   projectId: string;
   issueId: string;
@@ -38,12 +39,11 @@ interface IPeekOverviewIssueDetails {
   isArchived: boolean;
   isSubmitting: TNameDescriptionLoader;
   setIsSubmitting: (value: TNameDescriptionLoader) => void;
-}
+};
 
-export const PeekOverviewIssueDetails: FC<IPeekOverviewIssueDetails> = observer((props) => {
-  const { workspaceSlug, issueId, issueOperations, disabled, isArchived, isSubmitting, setIsSubmitting } = props;
-  // refs
-  const editorRef = useRef<EditorRefApi>(null);
+export const PeekOverviewIssueDetails: FC<Props> = observer((props) => {
+  const { editorRef, workspaceSlug, issueId, issueOperations, disabled, isArchived, isSubmitting, setIsSubmitting } =
+    props;
   // store hooks
   const { data: currentUser } = useUser();
   const {

--- a/apps/web/core/components/issues/peek-overview/view.tsx
+++ b/apps/web/core/components/issues/peek-overview/view.tsx
@@ -2,6 +2,7 @@ import { FC, useRef, useState } from "react";
 import { observer } from "mobx-react";
 import { createPortal } from "react-dom";
 // plane imports
+import type { EditorRefApi } from "@plane/editor";
 import { EIssueServiceType, TNameDescriptionLoader } from "@plane/types";
 import { cn } from "@plane/utils";
 // hooks
@@ -53,6 +54,7 @@ export const IssueView: FC<IIssueView> = observer((props) => {
   const [isEditIssueModalOpen, setIsEditIssueModalOpen] = useState(false);
   // ref
   const issuePeekOverviewRef = useRef<HTMLDivElement>(null);
+  const editorRef = useRef<EditorRefApi>(null);
   // store hooks
   const {
     setPeekIssue,
@@ -80,8 +82,9 @@ export const IssueView: FC<IIssueView> = observer((props) => {
   usePeekOverviewOutsideClickDetector(
     issuePeekOverviewRef,
     () => {
+      const isAnyDropbarOpen = editorRef.current?.isAnyDropbarOpen();
       if (!embedIssue) {
-        if (!isAnyModalOpen && !isAnyEpicModalOpen && !isAnyLocalModalOpen) {
+        if (!isAnyModalOpen && !isAnyEpicModalOpen && !isAnyLocalModalOpen && !isAnyDropbarOpen) {
           removeRoutePeekId();
         }
       }
@@ -90,10 +93,10 @@ export const IssueView: FC<IIssueView> = observer((props) => {
   );
 
   const handleKeyDown = () => {
-    const slashCommandDropdownElement = document.querySelector("#slash-command");
     const editorImageFullScreenModalElement = document.querySelector(".editor-image-full-screen-modal");
     const dropdownElement = document.activeElement?.tagName === "INPUT";
-    if (!isAnyModalOpen && !slashCommandDropdownElement && !dropdownElement && !editorImageFullScreenModalElement) {
+    const isAnyDropbarOpen = editorRef.current?.isAnyDropbarOpen();
+    if (!isAnyModalOpen && !dropdownElement && !isAnyDropbarOpen && !editorImageFullScreenModalElement) {
       removeRoutePeekId();
       const issueElement = document.getElementById(`issue-${issueId}`);
       if (issueElement) issueElement?.focus();
@@ -166,6 +169,7 @@ export const IssueView: FC<IIssueView> = observer((props) => {
                 {["side-peek", "modal"].includes(peekMode) ? (
                   <div className="relative flex flex-col gap-3 px-8 py-5 space-y-3">
                     <PeekOverviewIssueDetails
+                      editorRef={editorRef}
                       workspaceSlug={workspaceSlug}
                       projectId={projectId}
                       issueId={issueId}
@@ -206,6 +210,7 @@ export const IssueView: FC<IIssueView> = observer((props) => {
                     <div className="relative h-full w-full space-y-6 overflow-auto p-4 py-5">
                       <div className="space-y-3">
                         <PeekOverviewIssueDetails
+                          editorRef={editorRef}
                           workspaceSlug={workspaceSlug}
                           projectId={projectId}
                           issueId={issueId}

--- a/packages/editor/src/core/extensions/slash-commands/root.tsx
+++ b/packages/editor/src/core/extensions/slash-commands/root.tsx
@@ -5,7 +5,6 @@ import tippy, { Instance } from "tippy.js";
 // constants
 import { CORE_EXTENSIONS } from "@/constants/extension";
 // helpers
-import { getExtensionStorage } from "@/helpers/get-extension-storage";
 import { CommandListInstance } from "@/helpers/tippy";
 // types
 import { IEditorProps, ISlashCommandItem, TEditorCommands, TSlashCommandSectionKeys } from "@/types";
@@ -62,9 +61,7 @@ const renderItems: SuggestionOptions["render"] = () => {
   return {
     onStart: (props) => {
       // Track active dropdown
-      getExtensionStorage(props.editor, CORE_EXTENSIONS.UTILITY).activeDropbarExtensions.push(
-        CORE_EXTENSIONS.SLASH_COMMANDS
-      );
+      props.editor.commands.addActiveDropbarExtension(CORE_EXTENSIONS.SLASH_COMMANDS);
 
       component = new ReactRenderer<CommandListInstance, SlashCommandsMenuProps>(SlashCommandsMenu, {
         props,
@@ -103,13 +100,7 @@ const renderItems: SuggestionOptions["render"] = () => {
     },
     onExit: ({ editor }) => {
       // Remove from active dropdowns
-      if (editor) {
-        const utilityStorage = getExtensionStorage(editor, CORE_EXTENSIONS.UTILITY);
-        const index = utilityStorage.activeDropbarExtensions.indexOf(CORE_EXTENSIONS.SLASH_COMMANDS);
-        if (index > -1) {
-          utilityStorage.activeDropbarExtensions.splice(index, 1);
-        }
-      }
+      editor?.commands.removeActiveDropbarExtension(CORE_EXTENSIONS.SLASH_COMMANDS);
       popup?.[0].destroy();
       component?.destroy();
     },

--- a/packages/editor/src/core/extensions/slash-commands/root.tsx
+++ b/packages/editor/src/core/extensions/slash-commands/root.tsx
@@ -105,7 +105,7 @@ const renderItems: SuggestionOptions["render"] = () => {
       // Remove from active dropdowns
       if (editor) {
         const utilityStorage = getExtensionStorage(editor, CORE_EXTENSIONS.UTILITY);
-        const index = utilityStorage.activeDropbarExtensions.indexOf(CORE_EXTENSIONS.EMOJI);
+        const index = utilityStorage.activeDropbarExtensions.indexOf(CORE_EXTENSIONS.SLASH_COMMANDS);
         if (index > -1) {
           utilityStorage.activeDropbarExtensions.splice(index, 1);
         }

--- a/packages/editor/src/core/extensions/table/plugins/drag-handles/column/drag-handle.tsx
+++ b/packages/editor/src/core/extensions/table/plugins/drag-handles/column/drag-handle.tsx
@@ -205,7 +205,7 @@ export const ColumnDragHandle: React.FC<ColumnDragHandleProps> = (props) => {
               zIndex: 100,
             }}
           >
-            <ColumnOptionsDropdown editor={editor} onClose={() => setIsDropdownOpen(false)} />
+            <ColumnOptionsDropdown editor={editor} onClose={() => context.onOpenChange(false)} />
           </div>
         </FloatingPortal>
       )}

--- a/packages/editor/src/core/extensions/table/plugins/drag-handles/column/drag-handle.tsx
+++ b/packages/editor/src/core/extensions/table/plugins/drag-handles/column/drag-handle.tsx
@@ -12,9 +12,11 @@ import {
 } from "@floating-ui/react";
 import type { Editor } from "@tiptap/core";
 import { Ellipsis } from "lucide-react";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 // plane imports
 import { cn } from "@plane/utils";
+// constants
+import { CORE_EXTENSIONS } from "@/constants/extension";
 // extensions
 import {
   findTable,
@@ -23,6 +25,8 @@ import {
   isCellSelection,
   selectColumn,
 } from "@/extensions/table/table/utilities/helpers";
+// helpers
+import { getExtensionStorage } from "@/helpers/get-extension-storage";
 // local imports
 import { moveSelectedColumns } from "../actions";
 import {
@@ -157,6 +161,21 @@ export const ColumnDragHandle: React.FC<ColumnDragHandleProps> = (props) => {
     [col, editor]
   );
 
+  // toggle utility storage
+  useEffect(() => {
+    const utilityStorage = getExtensionStorage(editor, CORE_EXTENSIONS.UTILITY);
+    const index = utilityStorage.activeDropbarExtensions.indexOf(CORE_EXTENSIONS.TABLE);
+    if (isDropdownOpen) {
+      if (index === -1) {
+        utilityStorage.activeDropbarExtensions.push(CORE_EXTENSIONS.TABLE);
+      }
+    } else {
+      if (index !== -1) {
+        utilityStorage.activeDropbarExtensions.splice(index, 1);
+      }
+    }
+  }, [editor, isDropdownOpen]);
+
   return (
     <>
       <div className="table-col-handle-container absolute z-20 top-0 left-0 flex justify-center items-center w-full -translate-y-1/2">
@@ -184,8 +203,8 @@ export const ColumnDragHandle: React.FC<ColumnDragHandleProps> = (props) => {
               zIndex: 99,
             }}
             lockScroll
+            data-prevent-outside-click
           />
-
           <div
             className="max-h-[90vh] w-[12rem] overflow-y-auto rounded-md border-[0.5px] border-custom-border-300 bg-custom-background-100 px-2 py-2.5 shadow-custom-shadow-rg"
             ref={refs.setFloating}
@@ -194,6 +213,7 @@ export const ColumnDragHandle: React.FC<ColumnDragHandleProps> = (props) => {
               ...floatingStyles,
               zIndex: 100,
             }}
+            data-prevent-outside-click
           >
             <ColumnOptionsDropdown editor={editor} onClose={() => setIsDropdownOpen(false)} />
           </div>

--- a/packages/editor/src/core/extensions/table/plugins/drag-handles/column/drag-handle.tsx
+++ b/packages/editor/src/core/extensions/table/plugins/drag-handles/column/drag-handle.tsx
@@ -12,7 +12,7 @@ import {
 } from "@floating-ui/react";
 import type { Editor } from "@tiptap/core";
 import { Ellipsis } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 // plane imports
 import { cn } from "@plane/utils";
 // constants
@@ -25,8 +25,6 @@ import {
   isCellSelection,
   selectColumn,
 } from "@/extensions/table/table/utilities/helpers";
-// helpers
-import { getExtensionStorage } from "@/helpers/get-extension-storage";
 // local imports
 import { moveSelectedColumns } from "../actions";
 import {
@@ -63,7 +61,16 @@ export const ColumnDragHandle: React.FC<ColumnDragHandleProps> = (props) => {
       }),
     ],
     open: isDropdownOpen,
-    onOpenChange: setIsDropdownOpen,
+    onOpenChange: (open) => {
+      setIsDropdownOpen(open);
+      if (open) {
+        editor.commands.addActiveDropbarExtension(CORE_EXTENSIONS.TABLE);
+      } else {
+        setTimeout(() => {
+          editor.commands.removeActiveDropbarExtension(CORE_EXTENSIONS.TABLE);
+        }, 0);
+      }
+    },
     whileElementsMounted: autoUpdate,
   });
   const click = useClick(context);
@@ -160,21 +167,6 @@ export const ColumnDragHandle: React.FC<ColumnDragHandleProps> = (props) => {
     },
     [col, editor]
   );
-
-  // toggle utility storage
-  useEffect(() => {
-    const utilityStorage = getExtensionStorage(editor, CORE_EXTENSIONS.UTILITY);
-    const index = utilityStorage.activeDropbarExtensions.indexOf(CORE_EXTENSIONS.TABLE);
-    if (isDropdownOpen) {
-      if (index === -1) {
-        utilityStorage.activeDropbarExtensions.push(CORE_EXTENSIONS.TABLE);
-      }
-    } else {
-      if (index !== -1) {
-        utilityStorage.activeDropbarExtensions.splice(index, 1);
-      }
-    }
-  }, [editor, isDropdownOpen]);
 
   return (
     <>

--- a/packages/editor/src/core/extensions/table/plugins/drag-handles/column/drag-handle.tsx
+++ b/packages/editor/src/core/extensions/table/plugins/drag-handles/column/drag-handle.tsx
@@ -203,7 +203,6 @@ export const ColumnDragHandle: React.FC<ColumnDragHandleProps> = (props) => {
               zIndex: 99,
             }}
             lockScroll
-            data-prevent-outside-click
           />
           <div
             className="max-h-[90vh] w-[12rem] overflow-y-auto rounded-md border-[0.5px] border-custom-border-300 bg-custom-background-100 px-2 py-2.5 shadow-custom-shadow-rg"
@@ -213,7 +212,6 @@ export const ColumnDragHandle: React.FC<ColumnDragHandleProps> = (props) => {
               ...floatingStyles,
               zIndex: 100,
             }}
-            data-prevent-outside-click
           >
             <ColumnOptionsDropdown editor={editor} onClose={() => setIsDropdownOpen(false)} />
           </div>

--- a/packages/editor/src/core/extensions/table/plugins/drag-handles/row/drag-handle.tsx
+++ b/packages/editor/src/core/extensions/table/plugins/drag-handles/row/drag-handle.tsx
@@ -12,9 +12,11 @@ import {
 } from "@floating-ui/react";
 import type { Editor } from "@tiptap/core";
 import { Ellipsis } from "lucide-react";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 // plane imports
 import { cn } from "@plane/utils";
+// constants
+import { CORE_EXTENSIONS } from "@/constants/extension";
 // extensions
 import {
   findTable,
@@ -23,6 +25,8 @@ import {
   isCellSelection,
   selectRow,
 } from "@/extensions/table/table/utilities/helpers";
+// helpers
+import { getExtensionStorage } from "@/helpers/get-extension-storage";
 // local imports
 import { moveSelectedRows } from "../actions";
 import {
@@ -156,6 +160,21 @@ export const RowDragHandle: React.FC<RowDragHandleProps> = (props) => {
     [editor, row]
   );
 
+  // toggle utility storage
+  useEffect(() => {
+    const utilityStorage = getExtensionStorage(editor, CORE_EXTENSIONS.UTILITY);
+    const index = utilityStorage.activeDropbarExtensions.indexOf(CORE_EXTENSIONS.TABLE);
+    if (isDropdownOpen) {
+      if (index === -1) {
+        utilityStorage.activeDropbarExtensions.push(CORE_EXTENSIONS.TABLE);
+      }
+    } else {
+      if (index !== -1) {
+        utilityStorage.activeDropbarExtensions.splice(index, 1);
+      }
+    }
+  }, [editor, isDropdownOpen]);
+
   return (
     <>
       <div className="table-row-handle-container absolute z-20 top-0 left-0 flex justify-center items-center h-full -translate-x-1/2">
@@ -183,8 +202,8 @@ export const RowDragHandle: React.FC<RowDragHandleProps> = (props) => {
               zIndex: 99,
             }}
             lockScroll
+            data-prevent-outside-click
           />
-
           <div
             className="max-h-[90vh] w-[12rem] overflow-y-auto rounded-md border-[0.5px] border-custom-border-300 bg-custom-background-100 px-2 py-2.5 shadow-custom-shadow-rg"
             ref={refs.setFloating}
@@ -193,6 +212,7 @@ export const RowDragHandle: React.FC<RowDragHandleProps> = (props) => {
               ...floatingStyles,
               zIndex: 100,
             }}
+            data-prevent-outside-click
           >
             <RowOptionsDropdown editor={editor} onClose={() => setIsDropdownOpen(false)} />
           </div>

--- a/packages/editor/src/core/extensions/table/plugins/drag-handles/row/drag-handle.tsx
+++ b/packages/editor/src/core/extensions/table/plugins/drag-handles/row/drag-handle.tsx
@@ -204,7 +204,7 @@ export const RowDragHandle: React.FC<RowDragHandleProps> = (props) => {
               zIndex: 100,
             }}
           >
-            <RowOptionsDropdown editor={editor} onClose={() => setIsDropdownOpen(false)} />
+            <RowOptionsDropdown editor={editor} onClose={() => context.onOpenChange(false)} />
           </div>
         </FloatingPortal>
       )}

--- a/packages/editor/src/core/extensions/table/plugins/drag-handles/row/drag-handle.tsx
+++ b/packages/editor/src/core/extensions/table/plugins/drag-handles/row/drag-handle.tsx
@@ -12,7 +12,7 @@ import {
 } from "@floating-ui/react";
 import type { Editor } from "@tiptap/core";
 import { Ellipsis } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 // plane imports
 import { cn } from "@plane/utils";
 // constants
@@ -25,8 +25,6 @@ import {
   isCellSelection,
   selectRow,
 } from "@/extensions/table/table/utilities/helpers";
-// helpers
-import { getExtensionStorage } from "@/helpers/get-extension-storage";
 // local imports
 import { moveSelectedRows } from "../actions";
 import {
@@ -63,7 +61,16 @@ export const RowDragHandle: React.FC<RowDragHandleProps> = (props) => {
       }),
     ],
     open: isDropdownOpen,
-    onOpenChange: setIsDropdownOpen,
+    onOpenChange: (open) => {
+      setIsDropdownOpen(open);
+      if (open) {
+        editor.commands.addActiveDropbarExtension(CORE_EXTENSIONS.TABLE);
+      } else {
+        setTimeout(() => {
+          editor.commands.removeActiveDropbarExtension(CORE_EXTENSIONS.TABLE);
+        }, 0);
+      }
+    },
     whileElementsMounted: autoUpdate,
   });
   const click = useClick(context);
@@ -159,21 +166,6 @@ export const RowDragHandle: React.FC<RowDragHandleProps> = (props) => {
     },
     [editor, row]
   );
-
-  // toggle utility storage
-  useEffect(() => {
-    const utilityStorage = getExtensionStorage(editor, CORE_EXTENSIONS.UTILITY);
-    const index = utilityStorage.activeDropbarExtensions.indexOf(CORE_EXTENSIONS.TABLE);
-    if (isDropdownOpen) {
-      if (index === -1) {
-        utilityStorage.activeDropbarExtensions.push(CORE_EXTENSIONS.TABLE);
-      }
-    } else {
-      if (index !== -1) {
-        utilityStorage.activeDropbarExtensions.splice(index, 1);
-      }
-    }
-  }, [editor, isDropdownOpen]);
 
   return (
     <>

--- a/packages/editor/src/core/extensions/table/plugins/drag-handles/row/drag-handle.tsx
+++ b/packages/editor/src/core/extensions/table/plugins/drag-handles/row/drag-handle.tsx
@@ -202,7 +202,6 @@ export const RowDragHandle: React.FC<RowDragHandleProps> = (props) => {
               zIndex: 99,
             }}
             lockScroll
-            data-prevent-outside-click
           />
           <div
             className="max-h-[90vh] w-[12rem] overflow-y-auto rounded-md border-[0.5px] border-custom-border-300 bg-custom-background-100 px-2 py-2.5 shadow-custom-shadow-rg"
@@ -212,7 +211,6 @@ export const RowDragHandle: React.FC<RowDragHandleProps> = (props) => {
               ...floatingStyles,
               zIndex: 100,
             }}
-            data-prevent-outside-click
           >
             <RowOptionsDropdown editor={editor} onClose={() => setIsDropdownOpen(false)} />
           </div>

--- a/packages/editor/src/core/extensions/utility.ts
+++ b/packages/editor/src/core/extensions/utility.ts
@@ -31,6 +31,8 @@ declare module "@tiptap/core" {
               idToRemove: string;
             }
       ) => () => void;
+      addActiveDropbarExtension: (extension: TActiveDropbarExtensions) => () => void;
+      removeActiveDropbarExtension: (extension: TActiveDropbarExtensions) => () => void;
     };
   }
 }
@@ -106,6 +108,18 @@ export const UtilityExtension = (props: Props) => {
             }
           }
           this.storage.assetsList = Array.from(uniqueAssets);
+        },
+        addActiveDropbarExtension: (extension) => () => {
+          const index = this.storage.activeDropbarExtensions.indexOf(extension);
+          if (index === -1) {
+            this.storage.activeDropbarExtensions.push(extension);
+          }
+        },
+        removeActiveDropbarExtension: (extension) => () => {
+          const index = this.storage.activeDropbarExtensions.indexOf(extension);
+          if (index !== -1) {
+            this.storage.activeDropbarExtensions.splice(index, 1);
+          }
         },
       };
     },

--- a/packages/editor/src/core/extensions/utility.ts
+++ b/packages/editor/src/core/extensions/utility.ts
@@ -9,13 +9,18 @@ import { DropHandlerPlugin } from "@/plugins/drop";
 import { FilePlugins } from "@/plugins/file/root";
 import { MarkdownClipboardPlugin } from "@/plugins/markdown-clipboard";
 // types
-
 import type { IEditorProps, TEditorAsset, TFileHandler } from "@/types";
-type TActiveDropbarExtensions = CORE_EXTENSIONS.MENTION | CORE_EXTENSIONS.EMOJI | TAdditionalActiveDropbarExtensions;
+
+type TActiveDropbarExtensions =
+  | CORE_EXTENSIONS.MENTION
+  | CORE_EXTENSIONS.EMOJI
+  | CORE_EXTENSIONS.SLASH_COMMANDS
+  | CORE_EXTENSIONS.TABLE
+  | TAdditionalActiveDropbarExtensions;
 
 declare module "@tiptap/core" {
   interface Commands {
-    utility: {
+    [CORE_EXTENSIONS.UTILITY]: {
       updateAssetsUploadStatus: (updatedStatus: TFileHandler["assetsUploadStatus"]) => () => void;
       updateAssetsList: (
         args:

--- a/packages/editor/src/core/helpers/editor-ref.ts
+++ b/packages/editor/src/core/helpers/editor-ref.ts
@@ -81,6 +81,11 @@ export const getEditorRefHelpers = (args: TArgs): EditorRefApi => {
       const markdownOutput = editor?.storage?.markdown?.getMarkdown?.();
       return markdownOutput;
     },
+    isAnyDropbarOpen: () => {
+      if (!editor) return false;
+      const utilityStorage = getExtensionStorage(editor, CORE_EXTENSIONS.UTILITY);
+      return utilityStorage.activeDropbarExtensions.length > 0;
+    },
     scrollSummary: (marking) => {
       if (!editor) return;
       scrollSummary(editor, marking);

--- a/packages/editor/src/core/types/editor.ts
+++ b/packages/editor/src/core/types/editor.ts
@@ -119,6 +119,7 @@ export type EditorRefApi = {
   getMarkDown: () => string;
   getSelectedText: () => string | null;
   insertText: (contentHTML: string, insertOnNextLine?: boolean) => void;
+  isAnyDropbarOpen: () => boolean;
   isEditorReadyToDiscard: () => boolean;
   isMenuItemActive: <T extends TEditorCommands>(props: TCommandWithPropsWithItemKey<T>) => boolean;
   listenToRealTimeUpdate: () => TDocumentEventEmitter | undefined;


### PR DESCRIPTION
### Description

This PR fixes the bug where peek overview is getting closed on outside click/pressing the `Esc` key while editor dropdowns are still open.

### Solution:

1. Table dropdowns are now tracked using the utility extension storage.
2. Editor ref now exposes another callback to find if any dropdowns are open or not.
3. Instead of checking for DOM elements before closing the peek overview, we now use the editor ref helper.
4. Created new commands to manage active dropbars instead of manually checking at every instance.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App now tracks editor dropdown/menu state and shares that state with issue peek views.

* **Bug Fixes**
  * Prevents accidental closing or route changes when editor menus/dropbars are open.
  * Improved outside-click and keydown handling to respect active editor menus.

* **Documentation**
  * Editor API expanded with a method to check whether any editor dropdown/menu is currently open.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->