### PR TITLE
[WIKI-695] fix: tippy width fix

### DIFF
--- a/packages/editor/src/core/components/menus/bubble-menu/root.tsx
+++ b/packages/editor/src/core/components/menus/bubble-menu/root.tsx
@@ -155,7 +155,7 @@ export const EditorBubbleMenu: FC<EditorBubbleMenuProps> = (props: { editor: Edi
       {!isSelecting && (
         <div
           ref={menuRef}
-          className="flex py-2 divide-x divide-custom-border-200 rounded-lg border border-custom-border-200 bg-custom-background-100 shadow-custom-shadow-rg max-w-[500px] overflow-x-scroll horizontal-scrollbar scrollbar-xs"
+          className="flex py-2 divide-x divide-custom-border-200 rounded-lg border border-custom-border-200 bg-custom-background-100 shadow-custom-shadow-rg overflow-x-scroll horizontal-scrollbar scrollbar-xs"
         >
           <div className="px-2">
             <BubbleMenuNodeSelector

--- a/packages/editor/src/styles/editor.css
+++ b/packages/editor/src/styles/editor.css
@@ -205,7 +205,7 @@ ul[data-type="taskList"] li[data-checked="true"] {
 /* Overwrite tippy-box original max-width */
 
 .tippy-box {
-  max-width: 600px !important;
+  max-width: 800px !important;
 }
 
 .fade-in {


### PR DESCRIPTION
### Description
Fixes the unnecessary scrollbar issue in tippy boxes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Increased tooltip/popover maximum width to 800px to reduce wrapping and truncation, improving readability on larger screens.
  * Removed the width cap from the inline formatting menu so it can expand with content while maintaining proper overflow and scroll behavior.
  * Polished menu/popover presentation to better accommodate long text, code, and links without clipping.
  * No functional changes; visual-only update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->