### PR TITLE
[WEB-5001]fix: prop name for sub work permissions

### DIFF
--- a/apps/web/core/components/issues/issue-detail-widgets/sub-issues/content.tsx
+++ b/apps/web/core/components/issues/issue-detail-widgets/sub-issues/content.tsx
@@ -122,7 +122,7 @@ export const SubIssuesCollapsibleContent: FC<Props> = observer((props) => {
           parentIssueId={parentIssueId}
           rootIssueId={parentIssueId}
           spacingLeft={6}
-          disabled={!disabled}
+          canEdit={!disabled}
           handleIssueCrudState={handleIssueCrudState}
           subIssueOperations={subIssueOperations}
           issueServiceType={issueServiceType}

--- a/apps/web/core/components/issues/issue-detail-widgets/sub-issues/issues-list/list-group.tsx
+++ b/apps/web/core/components/issues/issue-detail-widgets/sub-issues/issues-list/list-group.tsx
@@ -13,7 +13,7 @@ interface TSubIssuesListGroupProps {
   workspaceSlug: string;
   group: IGroupByColumn;
   serviceType: TIssueServiceType;
-  disabled: boolean;
+  canEdit: boolean;
   parentIssueId: string;
   rootIssueId: string;
   handleIssueCrudState: (
@@ -30,7 +30,7 @@ export const SubIssuesListGroup: FC<TSubIssuesListGroupProps> = observer((props)
   const {
     group,
     serviceType,
-    disabled,
+    canEdit,
     parentIssueId,
     rootIssueId,
     projectId,
@@ -81,7 +81,7 @@ export const SubIssuesListGroup: FC<TSubIssuesListGroupProps> = observer((props)
             parentIssueId={parentIssueId}
             rootIssueId={rootIssueId}
             issueId={workItemId}
-            disabled={disabled}
+            canEdit={canEdit}
             handleIssueCrudState={handleIssueCrudState}
             subIssueOperations={subIssueOperations}
             issueServiceType={serviceType}

--- a/apps/web/core/components/issues/issue-detail-widgets/sub-issues/issues-list/list-item.tsx
+++ b/apps/web/core/components/issues/issue-detail-widgets/sub-issues/issues-list/list-item.tsx
@@ -28,7 +28,7 @@ type Props = {
   parentIssueId: string;
   rootIssueId: string;
   spacingLeft: number;
-  disabled: boolean;
+  canEdit: boolean;
   handleIssueCrudState: (
     key: "create" | "existing" | "update" | "delete",
     issueId: string,
@@ -48,7 +48,7 @@ export const SubIssuesListItem: React.FC<Props> = observer((props) => {
     rootIssueId,
     issueId,
     spacingLeft = 10,
-    disabled,
+    canEdit,
     handleIssueCrudState,
     subIssueOperations,
     issueServiceType = EIssueServiceType.ISSUES,
@@ -174,7 +174,7 @@ export const SubIssuesListItem: React.FC<Props> = observer((props) => {
                 workspaceSlug={workspaceSlug}
                 parentIssueId={parentIssueId}
                 issueId={issueId}
-                disabled={disabled}
+                canEdit={canEdit}
                 updateSubIssue={subIssueOperations.updateSubIssue}
                 displayProperties={displayProperties}
                 issue={issue}
@@ -183,7 +183,7 @@ export const SubIssuesListItem: React.FC<Props> = observer((props) => {
 
             <div className="flex-shrink-0 text-sm">
               <CustomMenu placement="bottom-end" ellipsis>
-                {disabled && (
+                {canEdit && (
                   <CustomMenu.MenuItem
                     onClick={(e) => {
                       e.preventDefault();
@@ -212,7 +212,7 @@ export const SubIssuesListItem: React.FC<Props> = observer((props) => {
                   </div>
                 </CustomMenu.MenuItem>
 
-                {disabled && (
+                {canEdit && (
                   <CustomMenu.MenuItem
                     onClick={(e) => {
                       e.stopPropagation();
@@ -230,7 +230,7 @@ export const SubIssuesListItem: React.FC<Props> = observer((props) => {
                   </CustomMenu.MenuItem>
                 )}
 
-                {disabled && (
+                {canEdit && (
                   <CustomMenu.MenuItem
                     onClick={(e) => {
                       e.stopPropagation();
@@ -263,7 +263,7 @@ export const SubIssuesListItem: React.FC<Props> = observer((props) => {
             parentIssueId={issue.id}
             rootIssueId={rootIssueId}
             spacingLeft={spacingLeft + 22}
-            disabled={disabled}
+            canEdit={canEdit}
             handleIssueCrudState={handleIssueCrudState}
             subIssueOperations={subIssueOperations}
           />

--- a/apps/web/core/components/issues/issue-detail-widgets/sub-issues/issues-list/properties.tsx
+++ b/apps/web/core/components/issues/issue-detail-widgets/sub-issues/issues-list/properties.tsx
@@ -19,7 +19,7 @@ type Props = {
   workspaceSlug: string;
   parentIssueId: string;
   issueId: string;
-  disabled: boolean;
+  canEdit: boolean;
   updateSubIssue: (
     workspaceSlug: string,
     projectId: string,
@@ -33,7 +33,7 @@ type Props = {
 };
 
 export const SubIssuesListItemProperties: React.FC<Props> = observer((props) => {
-  const { workspaceSlug, parentIssueId, issueId, disabled, updateSubIssue, displayProperties, issue } = props;
+  const { workspaceSlug, parentIssueId, issueId, canEdit, updateSubIssue, displayProperties, issue } = props;
   const { t } = useTranslation();
   const { getStateById } = useProjectState();
 
@@ -94,7 +94,7 @@ export const SubIssuesListItemProperties: React.FC<Props> = observer((props) => 
                 { ...issue }
               )
             }
-            disabled={!disabled}
+            disabled={!canEdit}
             buttonVariant="transparent-without-text"
             buttonClassName="hover:bg-transparent px-0"
             iconSize="size-5"
@@ -113,7 +113,7 @@ export const SubIssuesListItemProperties: React.FC<Props> = observer((props) => 
                 priority: val,
               })
             }
-            disabled={!disabled}
+            disabled={!canEdit}
             buttonVariant="border-without-text"
             buttonClassName="border"
             showTooltip
@@ -144,7 +144,7 @@ export const SubIssuesListItemProperties: React.FC<Props> = observer((props) => 
             mergeDates
             buttonVariant={issue.start_date || issue.target_date ? "border-with-text" : "border-without-text"}
             buttonClassName={shouldHighlight ? "text-red-500" : ""}
-            disabled={!disabled}
+            disabled={!canEdit}
             showTooltip
             customTooltipHeading="Date Range"
             renderPlaceholder={false}
@@ -167,7 +167,7 @@ export const SubIssuesListItemProperties: React.FC<Props> = observer((props) => 
             icon={<CalendarClock className="h-3 w-3 flex-shrink-0" />}
             buttonVariant={issue.start_date ? "border-with-text" : "border-without-text"}
             optionsClassName="z-30"
-            disabled={!disabled}
+            disabled={!canEdit}
             showTooltip
           />
         </div>
@@ -190,7 +190,7 @@ export const SubIssuesListItemProperties: React.FC<Props> = observer((props) => 
             buttonClassName={shouldHighlight ? "text-red-500" : ""}
             clearIconClassName="text-custom-text-100"
             optionsClassName="z-30"
-            disabled={!disabled}
+            disabled={!canEdit}
             showTooltip
           />
         </div>
@@ -207,7 +207,7 @@ export const SubIssuesListItemProperties: React.FC<Props> = observer((props) => 
                 assignee_ids: val,
               })
             }
-            disabled={!disabled}
+            disabled={!canEdit}
             multiple
             buttonVariant={(issue?.assignee_ids || []).length > 0 ? "transparent-without-text" : "border-without-text"}
             buttonClassName={(issue?.assignee_ids || []).length > 0 ? "hover:bg-transparent px-0" : ""}

--- a/apps/web/core/components/issues/issue-detail-widgets/sub-issues/issues-list/root.tsx
+++ b/apps/web/core/components/issues/issue-detail-widgets/sub-issues/issues-list/root.tsx
@@ -24,7 +24,7 @@ type Props = {
   parentIssueId: string;
   rootIssueId: string;
   spacingLeft: number;
-  disabled: boolean;
+  canEdit: boolean;
   handleIssueCrudState: (
     key: "create" | "existing" | "update" | "delete",
     issueId: string,
@@ -41,7 +41,7 @@ export const SubIssuesListRoot: React.FC<Props> = observer((props) => {
     projectId,
     parentIssueId,
     rootIssueId,
-    disabled,
+    canEdit,
     handleIssueCrudState,
     subIssueOperations,
     issueServiceType = EIssueServiceType.ISSUES,
@@ -116,7 +116,7 @@ export const SubIssuesListRoot: React.FC<Props> = observer((props) => {
             workspaceSlug={workspaceSlug}
             group={group}
             serviceType={issueServiceType}
-            disabled={disabled}
+            canEdit={canEdit}
             parentIssueId={parentIssueId}
             rootIssueId={rootIssueId}
             handleIssueCrudState={handleIssueCrudState}


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
This update fixes the misleading prop name for sub work item permissions.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
<!-- Link related issues if there are any -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Standardized sub-issue editing controls to respect edit permissions across the widget.
  - Actions and menus (edit/remove, state, priority, dates, assignees) now consistently appear and are enabled only when the user can edit sub-issues.
  - Improves clarity by aligning interactive elements with permissions without altering existing workflows or data.
  - No visual redesign; behavior is more consistent and predictable for users managing sub-issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->