### PR TITLE
Fix PATCH project estimate validation bug

### DIFF
--- a/apps/api/plane/api/serializers/project.py
+++ b/apps/api/plane/api/serializers/project.py
@@ -16,7 +16,7 @@ from plane.utils.content_validator import (
 from .base import BaseSerializer
 
 
-class ProjectCreateSerializer(BaseSerializer):
+class  ProjectCreateSerializer(BaseSerializer):
     """
     Serializer for creating projects with workspace validation.
 
@@ -118,7 +118,7 @@ class ProjectUpdateSerializer(ProjectCreateSerializer):
 
         if (
             validated_data.get("estimate", None) is not None
-            and not Estimate.objects.filter(project=instance, id=validated_data.get("estimate")).exists()
+            and not Estimate.objects.filter(project=instance, id=validated_data.get("estimate").id).exists()
         ):
             # Check if the estimate is a estimate in the project
             raise serializers.ValidationError("Estimate should be a estimate in the project")


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
Not applicable.

### Test Scenarios 
Verified that PATCH requests updating the estimate field now succeed when the estimate exists.
Verified that other fields in the Project PATCH still work as expected.

### References
<!-- Link related issues if there are any -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes project update validation to check the estimate by its id, allowing PATCH updates when a valid estimate is provided.
> 
> - **Backend/Serializers**:
>   - `apps/api/plane/api/serializers/project.py`:
>     - In `ProjectUpdateSerializer.update`, validate `estimate` by its `id` when checking project association to allow PATCH updates with an existing estimate.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d10a0bb6d547efb8a581be65ef011dbb4ad27a4e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a validation issue when updating a project’s estimate. The API now correctly handles inputs provided as either an object or an ID, ensuring the correct estimate is referenced. This reduces unexpected 400 errors, improves compatibility with clients sending nested data, and stabilizes project update flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->