### PR TITLE
[WIKI-569] regression: parser kit extensions mismatch

### DIFF
--- a/packages/editor/src/core/extensions/core-without-props.ts
+++ b/packages/editor/src/core/extensions/core-without-props.ts
@@ -1,9 +1,6 @@
 import TaskItem from "@tiptap/extension-task-item";
 import TaskList from "@tiptap/extension-task-list";
 import { TextStyle } from "@tiptap/extension-text-style";
-import StarterKit from "@tiptap/starter-kit";
-// helpers
-import { isValidHttpUrl } from "@/helpers/common";
 // plane editor imports
 import { CoreEditorAdditionalExtensionsWithoutProps } from "@/plane-editor/extensions/core/without-props";
 // extensions
@@ -18,61 +15,19 @@ import { CustomHorizontalRule } from "./horizontal-rule";
 import { ImageExtensionConfig } from "./image";
 import { CustomMentionExtensionConfig } from "./mentions/extension-config";
 import { CustomQuoteExtension } from "./quote";
+import { CustomStarterKitExtension } from "./starter-kit";
 import { TableHeader, TableCell, TableRow, Table } from "./table";
 import { CustomTextAlignExtension } from "./text-align";
 import { WorkItemEmbedExtensionConfig } from "./work-item-embed/extension-config";
 
 export const CoreEditorExtensionsWithoutProps = [
-  StarterKit.configure({
-    bulletList: {
-      HTMLAttributes: {
-        class: "list-disc pl-7 space-y-[--list-spacing-y]",
-      },
-    },
-    orderedList: {
-      HTMLAttributes: {
-        class: "list-decimal pl-7 space-y-[--list-spacing-y]",
-      },
-    },
-    listItem: {
-      HTMLAttributes: {
-        class: "not-prose space-y-2",
-      },
-    },
-    code: false,
-    codeBlock: false,
-    horizontalRule: false,
-    blockquote: false,
-    paragraph: {
-      HTMLAttributes: {
-        class: "editor-paragraph-block",
-      },
-    },
-    heading: {
-      HTMLAttributes: {
-        class: "editor-heading-block",
-      },
-    },
-    dropcursor: false,
+  CustomStarterKitExtension({
+    enableHistory: true,
   }),
   EmojiExtension,
   CustomQuoteExtension,
-  CustomHorizontalRule.configure({
-    HTMLAttributes: {
-      class: "py-4 border-custom-border-400",
-    },
-  }),
-  CustomLinkExtension.configure({
-    openOnClick: true,
-    autolink: true,
-    linkOnPaste: true,
-    protocols: ["http", "https"],
-    validate: (url: string) => isValidHttpUrl(url).isValid,
-    HTMLAttributes: {
-      class:
-        "text-custom-primary-300 underline underline-offset-[3px] hover:text-custom-primary-500 transition-colors cursor-pointer",
-    },
-  }),
+  CustomHorizontalRule,
+  CustomLinkExtension,
   ImageExtensionConfig,
   CustomImageExtensionConfig,
   TextStyle,


### PR DESCRIPTION
### Description

This PR fixes the bug where multiple link extensions were being registered via the parser kit.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enabled undo/redo history in the editor for smoother, more reliable editing.
- Refactor
  - Updated editor defaults for common blocks (paragraphs, headings, lists) and elements (code, block quotes, horizontal rules), aligning behavior with standard expectations. Some previously disabled elements may now be available or behave differently.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->