### PR TITLE
[WIKI-704] fix: hocuspocus error handling

### DIFF
--- a/apps/api/plane/utils/content_validator.py
+++ b/apps/api/plane/utils/content_validator.py
@@ -84,6 +84,7 @@ ATTRIBUTES = {
         "style",
         "start",
         "type",
+        "xmlns",
         # common editor data-* attributes seen in stored HTML
         # (wildcards like data-* are NOT supported by nh3; we add known keys
         # here and dynamically include all data-* seen in the input below)

--- a/apps/live/src/extensions/database.ts
+++ b/apps/live/src/extensions/database.ts
@@ -11,6 +11,16 @@ import { getPageService } from "@/services/page/handler";
 // type
 import type { FetchPayloadWithContext, StorePayloadWithContext } from "@/types";
 
+const normalizeToError = (error: unknown, fallbackMessage: string) => {
+  if (error instanceof Error) {
+    return error;
+  }
+
+  const message = typeof error === "string" && error.trim().length > 0 ? error : fallbackMessage;
+
+  return new Error(message);
+};
+
 const fetchDocument = async ({ context, documentName: pageId }: FetchPayloadWithContext) => {
   try {
     const service = getPageService(context.documentType, context);
@@ -29,7 +39,7 @@ const fetchDocument = async ({ context, documentName: pageId }: FetchPayloadWith
     return binaryData;
   } catch (error) {
     logger.error("Error in fetching document", error);
-    throw error;
+    throw normalizeToError(error, `Failed to fetch document: ${pageId}`);
   }
 };
 
@@ -45,10 +55,10 @@ const storeDocument = async ({ context, state: pageBinaryData, documentName: pag
       description_html: contentHTML,
       description: contentJSON,
     };
-    return service.updateDescriptionBinary(pageId, payload);
+    await service.updateDescriptionBinary(pageId, payload);
   } catch (error) {
     logger.error("Error in updating document:", error);
-    throw error;
+    throw normalizeToError(error, `Failed to update document: ${pageId}`);
   }
 };
 

--- a/apps/live/src/services/page/core.service.ts
+++ b/apps/live/src/services/page/core.service.ts
@@ -21,7 +21,7 @@ export abstract class PageCoreService extends APIService {
     })
       .then((response) => response?.data)
       .catch((error) => {
-        throw error?.response?.data;
+        throw error;
       });
   }
 
@@ -35,7 +35,7 @@ export abstract class PageCoreService extends APIService {
     })
       .then((response) => response?.data)
       .catch((error) => {
-        throw error?.response?.data;
+        throw error;
       });
   }
 


### PR DESCRIPTION
### Description
Fixes a bug with html validation with tiptap v3 while saving html

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - HTML sanitization now preserves the xmlns attribute across all tags, preventing unintended stripping of valid SVG/XML content.
  - Improved reliability when fetching and updating documents by standardizing error handling, reducing unexpected crashes and providing clearer error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->