### PR TITLE
[WIKI-705] regression: mentions dropdown selection across editors

### DIFF
--- a/packages/editor/src/core/extensions/slash-commands/command-menu.tsx
+++ b/packages/editor/src/core/extensions/slash-commands/command-menu.tsx
@@ -32,9 +32,8 @@ export const SlashCommandsMenu = forwardRef((props: SlashCommandsMenuProps, ref)
   );
   // handle arrow key navigation
   useEffect(() => {
-    const navigationKeys = ["ArrowUp", "ArrowDown", "Enter"];
     const onKeyDown = (e: KeyboardEvent) => {
-      if (navigationKeys.includes(e.key)) {
+      if (DROPDOWN_NAVIGATION_KEYS.includes(e.key)) {
         e.preventDefault();
         const currentSection = selectedIndex.section;
         const currentItem = selectedIndex.item;


### PR DESCRIPTION
### Description

This PR fixes the following bugs-

1. Mentions dropdown not visible in peek overviews.
2. Mentions command not working.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Mentions dropdown now reliably appears above content and positions correctly.
  - Escape key consistently closes the mentions dropdown with proper cleanup.
  - More predictable keyboard navigation within dropdowns.

- Refactor
  - Standardized dropdown keyboard navigation using a shared key set across components.
  - Streamlined mentions dropdown event handling for more consistent behavior.
  - Reduced coupling and improved consistency in how editor context is passed and used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->