### PR TITLE
[WEB-5074] fix: remove the filter conditions check from the defaultOpen property to prevent unwanted popups.

### DIFF
--- a/apps/web/core/components/rich-filters/filters-row.tsx
+++ b/apps/web/core/components/rich-filters/filters-row.tsx
@@ -68,7 +68,6 @@ export const FiltersRow = observer(
               shouldShowIcon: true,
               iconComponent: ListFilterPlus,
             },
-            defaultOpen: buttonConfig?.defaultOpen ?? !hasAnyConditions,
             ...buttonConfig,
             isDisabled: disabledAllOperations,
           }}


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
This PR removes the `hasAnyCondition` check from the add filter button to ensure that it doesn’t open automatically unless explicitly defined. 

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Updated the Add Filter button’s opening behavior to rely on its built‑in default state. It no longer auto-opens based on existing conditions, providing a more consistent and predictable experience when adding filters. All other button settings and interactions remain unchanged. Users should expect the Add Filter menu to stay closed until interacted with, aligning behavior across different filter states without altering visible UI elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->