### PR TITLE
[WEB-5081] fix: selecting Eastern Europe timezone in user settings

### DIFF
--- a/apps/api/plane/app/views/timezone/base.py
+++ b/apps/api/plane/app/views/timezone/base.py
@@ -99,7 +99,7 @@ class TimezoneEndpoint(APIView):
             ("Tunis", "Africa/Tunis"),  # UTC+01:00
             (
                 "Eastern European Time (Cairo, Helsinki, Kyiv)",
-                "Europe/Kiev",
+                "Europe/Kyiv",
             ),  # UTC+02:00 (DST: UTC+03:00)
             ("Athens", "Europe/Athens"),  # UTC+02:00 (DST: UTC+03:00)
             ("Jerusalem", "Asia/Jerusalem"),  # UTC+02:00 (DST: UTC+03:00)


### PR DESCRIPTION
### Description
This PR will fix the `users/me` api failing when updating user's timezone to `Europe/Kyiv`


### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
