### PR TITLE
[WIKI-710] [WIKI-717] fix: slash commands and mentions in comments

### DIFF
--- a/packages/editor/src/core/extensions/mentions/utils.ts
+++ b/packages/editor/src/core/extensions/mentions/utils.ts
@@ -19,7 +19,6 @@ export const renderMentionsDropdown =
     return {
       onStart: (props) => {
         if (!searchCallback) return;
-        if (!props.clientRect) return;
         component = new ReactRenderer<CommandListInstance, MentionsListDropdownProps>(MentionsListDropdown, {
           props: {
             ...props,
@@ -27,20 +26,18 @@ export const renderMentionsDropdown =
           },
           editor: props.editor,
         });
+        if (!props.clientRect) return;
         props.editor.commands.addActiveDropbarExtension(CORE_EXTENSIONS.MENTION);
         const element = component.element as HTMLElement;
         element.style.position = "absolute";
         element.style.zIndex = "100";
-
-        document.body.appendChild(element);
         updateFloatingUIFloaterPosition(props.editor, element);
       },
       onUpdate: (props) => {
-        component?.updateProps(props);
+        if (!component || !component.element) return;
+        component.updateProps(props);
         if (!props.clientRect) return;
-        if (component?.element) {
-          updateFloatingUIFloaterPosition(props.editor, component?.element as HTMLElement);
-        }
+        updateFloatingUIFloaterPosition(props.editor, component.element);
       },
       onKeyDown: ({ event }) => {
         if (event.key === "Escape") {

--- a/packages/editor/src/core/extensions/slash-commands/root.tsx
+++ b/packages/editor/src/core/extensions/slash-commands/root.tsx
@@ -54,33 +54,22 @@ const Command = Extension.create<SlashCommandOptions>({
           return {
             onStart: (props) => {
               // Track active dropdown
-              props.editor.commands.addActiveDropbarExtension(CORE_EXTENSIONS.SLASH_COMMANDS);
               component = new ReactRenderer<CommandListInstance, SlashCommandsMenuProps>(SlashCommandsMenu, {
                 props,
                 editor: props.editor,
               });
-
-              if (!props.clientRect) {
-                return;
-              }
-
+              if (!props.clientRect) return;
+              props.editor.commands.addActiveDropbarExtension(CORE_EXTENSIONS.SLASH_COMMANDS);
               const element = component.element as HTMLElement;
               element.style.position = "absolute";
               element.style.zIndex = "100";
-              document.body.appendChild(element);
-
               updateFloatingUIFloaterPosition(props.editor, element);
             },
 
             onUpdate: (props) => {
               if (!component || !component.element) return;
-
               component.updateProps(props);
-
-              if (!props.clientRect) {
-                return;
-              }
-
+              if (!props.clientRect) return;
               const element = component.element as HTMLElement;
               updateFloatingUIFloaterPosition(props.editor, element);
             },

--- a/packages/editor/src/core/helpers/floating-ui.ts
+++ b/packages/editor/src/core/helpers/floating-ui.ts
@@ -11,7 +11,18 @@ export const updateFloatingUIFloaterPosition = (
     strategy?: Strategy;
   }
 ) => {
-  ((editor.options.element || document.body) as Element).appendChild(element);
+  const editorElement = editor.options.element;
+  let container: Element | HTMLElement = document.body;
+
+  if (editorElement instanceof Element) {
+    container = editorElement;
+  } else if (editorElement && typeof editorElement === "object" && "mount" in editorElement) {
+    container = editorElement.mount;
+  } else if (typeof editorElement === "function") {
+    container = document.body;
+  }
+
+  container.appendChild(element);
 
   const virtualElement = {
     getBoundingClientRect: () => posToDOMRect(editor.view, editor.state.selection.from, editor.state.selection.to),

--- a/packages/editor/src/core/helpers/floating-ui.ts
+++ b/packages/editor/src/core/helpers/floating-ui.ts
@@ -11,6 +11,8 @@ export const updateFloatingUIFloaterPosition = (
     strategy?: Strategy;
   }
 ) => {
+  ((editor.options.element || document.body) as Element).appendChild(element);
+
   const virtualElement = {
     getBoundingClientRect: () => posToDOMRect(editor.view, editor.state.selection.from, editor.state.selection.to),
   };


### PR DESCRIPTION
### Description
Floating ui - slash commands and mentions in pi chat editor/comments fixed overflow

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - Prevented dropdowns from rendering when the selection position is unavailable, improving stability.
  - Fixed floating element positioning by attaching them to the editor container, reducing z-index and scroll issues.
  - Avoided duplicate or orphaned dropdown elements during updates.

- Refactor
  - Streamlined dropdown lifecycle and position updates; removed redundant per-update syncing and manual DOM insertion for better reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->