### PR TITLE
[PAI-785] fix: custom select auto close on select

### DIFF
--- a/packages/ui/src/dropdowns/custom-select.tsx
+++ b/packages/ui/src/dropdowns/custom-select.tsx
@@ -29,6 +29,7 @@ const CustomSelect = (props: ICustomSelectProps) => {
     optionsClassName = "",
     value,
     tabIndex,
+    closeOnSelect = true,
   } = props;
   // states
   const [referenceElement, setReferenceElement] = useState<HTMLButtonElement | null>(null);
@@ -62,7 +63,7 @@ const CustomSelect = (props: ICustomSelectProps) => {
       value={value}
       onChange={(val) => {
         onChange?.(val);
-        closeDropdown();
+        if (closeOnSelect) closeDropdown();
       }}
       className={cn("relative flex-shrink-0 text-left", className)}
       onKeyDown={handleKeyDown}

--- a/packages/ui/src/dropdowns/custom-select.tsx
+++ b/packages/ui/src/dropdowns/custom-select.tsx
@@ -60,7 +60,10 @@ const CustomSelect = (props: ICustomSelectProps) => {
       ref={dropdownRef}
       tabIndex={tabIndex}
       value={value}
-      onChange={onChange}
+      onChange={(val) => {
+        onChange?.(val);
+        closeDropdown();
+      }}
       className={cn("relative flex-shrink-0 text-left", className)}
       onKeyDown={handleKeyDown}
       disabled={disabled}
@@ -71,7 +74,7 @@ const CustomSelect = (props: ICustomSelectProps) => {
             <button
               ref={setReferenceElement}
               type="button"
-              className={`flex items-center justify-between gap-1 text-xs ${
+              className={`flex items-center justify-between gap-1 text-xs rounded ${
                 disabled ? "cursor-not-allowed text-custom-text-200" : "cursor-pointer hover:bg-custom-background-80"
               } ${customButtonClassName}`}
               onClick={toggleDropdown}

--- a/packages/ui/src/dropdowns/helper.tsx
+++ b/packages/ui/src/dropdowns/helper.tsx
@@ -59,6 +59,7 @@ export interface ICustomSelectProps extends IDropdownProps {
   children: React.ReactNode;
   value: any;
   onChange: any;
+  closeOnSelect?: boolean;
 }
 
 interface CustomSearchSelectProps {


### PR DESCRIPTION
### Description
Custom select will now auto close on select

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The custom select now closes automatically after an option is selected by default, preventing it from remaining open and reducing unintended extra clicks. It can also be configured to remain open when desired.
* **Style**
  * The custom select trigger button now has rounded corners for a cleaner, more modern appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->