### PR TITLE
[WEB-5103] fix: custom menu event propagation

### DIFF
--- a/packages/ui/src/dropdowns/custom-menu.tsx
+++ b/packages/ui/src/dropdowns/custom-menu.tsx
@@ -222,7 +222,7 @@ const CustomMenu = (props: ICustomMenuDropdownProps) => {
       tabIndex={tabIndex}
       className={cn("relative w-min text-left", className)}
       onKeyDownCapture={handleKeyDown}
-        onClick={(e) => {
+      onClick={(e) => {
         e.stopPropagation();
         e.preventDefault();
         handleOnClick();


### PR DESCRIPTION
### Description
This PR addresses the custom menu event propagation bug, where clicking a menu item triggered the parent event.

### Type of Change
- [x] Bug fix 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed unintended click behavior in custom dropdown menus so clicks inside the menu no longer bubble to parent elements or trigger default browser actions.
  - Preserves existing menu item behavior while preventing accidental closures and conflicting interactions.
  - Users will see more predictable, stable interactions when opening and selecting items within custom menus.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->