### PR TITLE
[WEB-5120] refactor: add onSearchQueryKeyDown prop to ComboboxOptions for keyboard event handling

### DIFF
--- a/packages/propel/src/combobox/combobox.tsx
+++ b/packages/propel/src/combobox/combobox.tsx
@@ -37,6 +37,7 @@ export interface ComboboxOptionsProps {
   positionerClassName?: string;
   searchQuery?: string;
   onSearchQueryChange?: (query: string) => void;
+  onSearchQueryKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
 }
 
 export interface ComboboxOptionProps {
@@ -109,6 +110,7 @@ function ComboboxOptions({
   positionerClassName,
   searchQuery: controlledSearchQuery,
   onSearchQueryChange,
+  onSearchQueryKeyDown,
 }: ComboboxOptionsProps) {
   // const [searchQuery, setSearchQuery] = React.useState("");
   const [internalSearchQuery, setInternalSearchQuery] = React.useState("");
@@ -172,6 +174,7 @@ function ComboboxOptions({
                   placeholder={searchPlaceholder}
                   value={searchQuery}
                   onChange={(e) => setSearchQuery(e.target.value)}
+                  onKeyDown={onSearchQueryKeyDown}
                   className={cn(
                     "w-full rounded border border-custom-border-100 bg-custom-background-90 py-1.5 pl-8 pr-2 text-sm outline-none placeholder:text-custom-text-400",
                     inputClassName


### PR DESCRIPTION
### Description
This PR adds onSearchQueryKeyDown in the combobox. This will be useful when we want to trigger any event while we are writing a search query like - [+ Add to labels]

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Improvement (change that would cause existing functionality to not work as expected)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Combobox search input now supports custom key press handling, allowing apps to respond to keys like Enter, Escape, or Arrow keys during search.
  - Improves keyboard workflows and accessibility by enabling precise control over input interactions.
  - Backwards compatible: default behavior remains unchanged unless a handler is provided.
  - Enables richer shortcuts (e.g., submit, close, navigate) directly from the search field without leaving the combobox.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->