### PR TITLE
[WEB-5142] fix: WorkItem Modal Styling

### DIFF
--- a/apps/web/core/components/issues/issue-modal/form.tsx
+++ b/apps/web/core/components/issues/issue-modal/form.tsx
@@ -487,7 +487,7 @@ export const IssueFormRoot: FC<IssueFormProps> = observer((props) => {
                 activeAdditionalPropertiesLength > 0 && "shadow-custom-shadow-xs"
               )}
             >
-              <div>
+              <div className="pb-3">
                 <IssueDefaultProperties
                   control={control}
                   id={data?.id}
@@ -503,7 +503,10 @@ export const IssueFormRoot: FC<IssueFormProps> = observer((props) => {
                 />
               </div>
               {showActionButtons && (
-                <div className="flex items-center justify-end gap-4 py-3" tabIndex={getIndex("create_more")}>
+                <div
+                  className="flex items-center justify-end gap-4 pb-3 pt-6 border-t-[0.5px] border-custom-border-200"
+                  tabIndex={getIndex("create_more")}
+                >
                   {!data?.id && (
                     <div
                       className="inline-flex items-center gap-1.5 cursor-pointer"


### PR DESCRIPTION
### Description
Fixed issue modal css

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined spacing in the issue form for a cleaner layout.
  * Added subtle top divider and balanced padding above action buttons for clearer visual separation.
  * Polished overall visual hierarchy without altering functionality or behavior.
  * Keyboard navigation remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->