### PR TITLE
[WEB-5126]fix: suspended user view

### DIFF
--- a/apps/web/core/components/workspace/settings/member-columns.tsx
+++ b/apps/web/core/components/workspace/settings/member-columns.tsx
@@ -49,33 +49,24 @@ export const NameColumn: React.FC<NameProps> = (props) => {
         <div className="relative group">
           <div className="flex items-center gap-x-4 gap-y-2 w-72 justify-between">
             <div className="flex items-center gap-x-2 gap-y-2 flex-1">
-              {avatar_url && avatar_url.trim() !== "" ? (
+              {isSuspended ? (
+                <div className="bg-custom-background-80 rounded-full p-0.5">
+                  <SuspendedUserIcon className="h-4 w-4 text-custom-text-400" />
+                </div>
+              ) : avatar_url && avatar_url.trim() !== "" ? (
                 <Link href={`/${workspaceSlug}/profile/${id}`}>
                   <span className="relative flex h-6 w-6 items-center justify-center rounded-full capitalize text-white">
-                    {isSuspended ? (
-                      <SuspendedUserIcon className="h-4 w-4 text-custom-text-400" />
-                    ) : (
-                      <img
-                        src={getFileURL(avatar_url)}
-                        className="absolute left-0 top-0 h-full w-full rounded-full object-cover"
-                        alt={display_name || email}
-                      />
-                    )}
+                    <img
+                      src={getFileURL(avatar_url)}
+                      className="absolute left-0 top-0 h-full w-full rounded-full object-cover"
+                      alt={display_name || email}
+                    />
                   </span>
                 </Link>
               ) : (
                 <Link href={`/${workspaceSlug}/profile/${id}`}>
-                  <span
-                    className={cn(
-                      "relative flex h-4 w-4 text-xs items-center justify-center rounded-full  capitalize text-white",
-                      isSuspended ? "bg-custom-background-80" : "bg-gray-700"
-                    )}
-                  >
-                    {isSuspended ? (
-                      <SuspendedUserIcon className="h-4 w-4 text-custom-text-400" />
-                    ) : (
-                      (email ?? display_name ?? "?")[0]
-                    )}
+                  <span className="relative flex h-4 w-4 text-xs items-center justify-center rounded-full  capitalize text-white bg-gray-700">
+                    {(email ?? display_name ?? "?")[0]}
                   </span>
                 </Link>
               )}


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
This update fixes the icon inconsistency in members list in workspace.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
<!-- Link related issues if there are any -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a suspended user badge in the Members list to clearly indicate suspended accounts.

- Style
  - Standardized avatar rendering: shows avatar when available; otherwise displays initials on a gray background.
  - Suspended state no longer overlaps with avatar visuals, improving clarity.
  - Refined name text styling for suspended users to maintain consistency and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->