### PR TITLE
[WEB-5156] fix: activity filters bug

### DIFF
--- a/apps/web/core/components/issues/issue-detail/issue-activity/root.tsx
+++ b/apps/web/core/components/issues/issue-detail/issue-activity/root.tsx
@@ -2,6 +2,7 @@
 
 import type { FC } from "react";
 import { useMemo } from "react";
+import uniq from "lodash-es/uniq";
 import { observer } from "mobx-react";
 // plane package imports
 import type { TActivityFilters } from "@plane/constants";
@@ -75,7 +76,7 @@ export const IssueActivity: FC<TIssueActivity> = observer((props) => {
       _filters = [...selectedFilters, filter];
     }
 
-    setFilterValue(_filters);
+    setFilterValue(uniq(_filters));
   };
 
   const toggleSortOrder = () => {

--- a/packages/constants/src/issue/filter.ts
+++ b/packages/constants/src/issue/filter.ts
@@ -344,7 +344,6 @@ export const defaultActivityFilters: TActivityFilters[] = [
   EActivityFilterType.COMMENT,
   EActivityFilterType.STATE,
   EActivityFilterType.ASSIGNEE,
-  EActivityFilterType.DEFAULT,
 ];
 
 export const filterActivityOnSelectedFilters = (


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
This update fixes the duplicate issue in activity filters.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
<!-- Link related issues if there are any -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Streamlined activity filter options by removing the redundant “Default” option from available selections and initial defaults.

* **Bug Fixes**
  * Prevented duplicate activity filters when toggling options, ensuring cleaner and more predictable filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->