### PR TITLE
[WEB-5211] fix: accessing NoneType current_instance for delete_module_issue_activity bgtask

### DIFF
--- a/apps/api/plane/api/views/module.py
+++ b/apps/api/plane/api/views/module.py
@@ -871,8 +871,8 @@ class ModuleIssueDetailAPIEndpoint(BaseAPIView):
             module_id=module_id,
             issue_id=issue_id,
         )
-        # Get module name before deletion
-        module_name = module_issue.module.name
+
+        module_name = module_issue.module.name if module_issue.module is not None else ""
         module_issue.delete()
         issue_activity.delay(
             type="module.activity.deleted",


### PR DESCRIPTION
### Description
This PR will fix the NoneType error that occurs when accessing NoneType current_instance on delete_module_issue_activity bgtask, which caused the Sentry error mentioned below.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Reference
[Sentry](https://plane-hq.sentry.io/issues/6530384823/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Module deletion activities now properly capture and include the module name in activity logs, ensuring complete records are maintained for audit purposes and better tracking of module deletions across the platform.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->