### PR TITLE
[WEB-5224] chore: raise warning instead of logging an exception for webhook_send_task

### DIFF
--- a/apps/api/plane/bgtasks/webhook_task.py
+++ b/apps/api/plane/bgtasks/webhook_task.py
@@ -316,7 +316,7 @@ def webhook_send_task(
             signature = hmac_signature.hexdigest()
             headers["X-Plane-Signature"] = signature
     except Exception as e:
-        log_exception(e, warning=True)
+        log_exception(e)
         logger.error(f"Failed to send webhook: {e}")
         return
 
@@ -366,7 +366,7 @@ def webhook_send_task(
         raise requests.RequestException()
 
     except Exception as e:
-        log_exception(e, warning=True)
+        log_exception(e)
         return
 
 
@@ -452,7 +452,7 @@ def webhook_activity(
             return
         if settings.DEBUG:
             print(e)
-        log_exception(e, warning=True)
+        log_exception(e)
         return
 
 


### PR DESCRIPTION
### Description
This PR will raise warning instead of logging an exception in sentry for webhook_send_task

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Sentry
[Sentry
](https://plane-hq.sentry.io/issues/6764251612/?project=4505441149714432&query=assigned%3Ame&referrer=issue-stream)