### PR TITLE
Hide suspended members in assignee dropdown

### DIFF
--- a/apps/web/core/components/dropdowns/member/base.tsx
+++ b/apps/web/core/components/dropdowns/member/base.tsx
@@ -177,6 +177,7 @@ export const MemberDropdownBase: React.FC<TMemberDropdownBaseProps> = observer((
           optionsClassName={optionsClassName}
           placement={placement}
           referenceElement={referenceElement}
+          selectedMemberIds={Array.isArray(value) ? value : value ? [value] : []}
         />
       )}
     </ComboDropDown>


### PR DESCRIPTION
## Summary
- hide suspended members from the member selection dropdown unless they are already assigned
- surface assigned members first in the dropdown list to reduce scrolling
- pass selected member ids into the dropdown options so ordering and filtering can be computed

## Testing
- pnpm lint --filter web *(fails: Command "lint" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68fa0d42d260832a88154355df1f4f58

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Member dropdown lists now prioritize previously selected members by displaying them at the top for quicker re-access.
  * Suspended members are filtered from availability except when already selected, improving list clarity and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->