### PR TITLE
[WEB-5235] Fix activity timeline ordering for edited comments

### DIFF
--- a/apps/web/ce/store/issue/issue-details/activity.store.ts
+++ b/apps/web/ce/store/issue/issue-details/activity.store.ts
@@ -112,10 +112,11 @@ export class IssueActivityStore implements IIssueActivityStore {
     comments.forEach((commentId) => {
       const comment = currentStore.comment.getCommentById(commentId);
       if (!comment) return;
+      const commentTimestamp = comment.edited_at ?? comment.updated_at ?? comment.created_at;
       activityComments.push({
         id: comment.id,
         activity_type: EActivityFilterType.COMMENT,
-        created_at: comment.created_at,
+        created_at: commentTimestamp,
       });
     });
 


### PR DESCRIPTION
## Summary
- ensure issue activity timeline uses an edited comment's latest timestamp when sorting
- keep activity list order in sync with what the UI displays after a comment update

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fa113a5d5c832a9cc4d2b70dba0ca6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated comment timestamps in issue activity to reflect the most recent edit or update, ensuring the activity history displays the latest relevant time for each comment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->