### PR TITLE
[WEB-5228] chore: IssueLink.DoesNotExist on crawl_work_item_link_title

### DIFF
--- a/apps/api/plane/bgtasks/work_item_link_task.py
+++ b/apps/api/plane/bgtasks/work_item_link_task.py
@@ -175,7 +175,7 @@ def crawl_work_item_link_title(id: str, url: str) -> None:
     try:
         issue_link = IssueLink.objects.get(id=id)
     except IssueLink.DoesNotExist:
-        logger.warning("IssueLink not found")
+        logger.warning(f"IssueLink not found for the id {id} and the url {url}")
         return
 
     issue_link.metadata = meta_data


### PR DESCRIPTION
### Description
Added a try-except block on crawl_work_item_link_title, which handles DoesNotExist error for IssueLink

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)

### References
[Sentry](https://plane-hq.sentry.io/issues/6956103929/?project=4505441149714432&query=assigned%3Ame&referrer=issue-stream)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for background work item link title updates: when a referenced link is missing, the system now logs the event and exits that update path gracefully instead of failing. This prevents unnecessary errors, reduces noise in logs, and improves stability and reliability of background processing that updates link titles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->