### PR TITLE
fix: get work item activity external endpoint

### DIFF
--- a/apps/api/plane/api/views/issue.py
+++ b/apps/api/plane/api/views/issue.py
@@ -1696,14 +1696,16 @@ class IssueActivityDetailAPIEndpoint(BaseAPIView):
         Excludes comment, vote, reaction, and draft activities.
         """
         issue_activity = (
-            IssueActivity.objects.filter(issue_id=issue_id, workspace__slug=slug, project_id=project_id)
-            .filter(
-                ~Q(field__in=["comment", "vote", "reaction", "draft"]),
-                project__project_projectmember__member=self.request.user,
-                project__project_projectmember__is_active=True,
+            (
+                IssueActivity.objects.filter(issue_id=issue_id, workspace__slug=slug, project_id=project_id, id=pk)
+                .filter(
+                    ~Q(field__in=["comment", "vote", "reaction", "draft"]),
+                    project__project_projectmember__member=self.request.user,
+                    project__project_projectmember__is_active=True,
+                )
+                .filter(project__archived_at__isnull=True)
+                .select_related("actor", "workspace", "issue", "project")
             )
-            .filter(project__archived_at__isnull=True)
-            .select_related("actor", "workspace", "issue", "project")
             .order_by(request.GET.get("order_by", "created_at"))
             .first()
         )


### PR DESCRIPTION

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Issue activity detail endpoints now return 404 when a requested activity is not found.

* **Improvements**
  * Label updates now require both external ID and source together to avoid ambiguous updates.
  * Issue activity detail views now return a single item (not a paginated list) for clearer, faster responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->