### PR TITLE
fix: removed sticky from first column header cell and data cell

### DIFF
--- a/apps/web/core/components/issues/issue-layouts/spreadsheet/issue-row.tsx
+++ b/apps/web/core/components/issues/issue-layouts/spreadsheet/issue-row.tsx
@@ -260,7 +260,7 @@ const IssueRowDetails = observer((props: IssueRowDetailsProps) => {
         id={`issue-${issueId}`}
         ref={cellRef}
         tabIndex={0}
-        className="relative md:sticky left-0 z-10 group/list-block bg-custom-background-100 min-w-60 max-w-[30vw]"
+        className="relative group/list-block bg-custom-background-100 min-w-60 max-w-[30vw]"
       >
         <ControlLink
           href={workItemLink}

--- a/apps/web/core/components/issues/issue-layouts/spreadsheet/spreadsheet-header.tsx
+++ b/apps/web/core/components/issues/issue-layouts/spreadsheet/spreadsheet-header.tsx
@@ -45,7 +45,7 @@ export const SpreadsheetHeader = observer((props: Props) => {
     <thead className="sticky top-0 left-0 z-[12] border-b-[0.5px] border-custom-border-100">
       <tr>
         <th
-          className="group/list-header sticky min-w-60 left-0 z-[15] h-11 flex items-center gap-1 bg-custom-background-90 text-sm font-medium before:absolute before:h-full before:right-0 before:border-custom-border-100"
+          className="group/list-header min-w-60 h-11 flex items-center gap-1 bg-custom-background-90 text-sm font-medium before:absolute before:h-full before:right-0 before:border-custom-border-100"
           tabIndex={-1}
         >
           <Row>


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
Removed sticky from first header cell and table data cells of first column.

Solves below issue:
https://github.com/makeplane/plane/issues/7894

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

https://github.com/user-attachments/assets/a154d823-0499-4567-b9f1-45891b9867ad


### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
<!-- Link related issues if there are any -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Adjusted spreadsheet header and first-column positioning and stacking behavior. This changes how header and row cells align and overlap during scrolling, reducing previous sticky offset and z-index stacking so cells remain relatively positioned and alter visual stacking order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->