### PR TITLE
[WEB-5155]refactor: simplify user filtering logic in SearchEndpoint

### DIFF
--- a/apps/api/plane/app/views/search/base.py
+++ b/apps/api/plane/app/views/search/base.py
@@ -294,29 +294,15 @@ class SearchEndpoint(BaseAPIView):
                         .order_by("-created_at")
                     )
 
-                    if issue_id:
-                        issue_created_by = (
-                            Issue.objects.filter(id=issue_id).values_list("created_by_id", flat=True).first()
+                    users = (
+                        users
+                        .distinct()
+                        .values(
+                            "member__avatar_url",
+                            "member__display_name",
+                            "member__id",
                         )
-                        users = (
-                            users.filter(Q(role__gt=10) | Q(member_id=issue_created_by))
-                            .distinct()
-                            .values(
-                                "member__avatar_url",
-                                "member__display_name",
-                                "member__id",
-                            )
-                        )
-                    else:
-                        users = (
-                            users.filter(Q(role__gt=10))
-                            .distinct()
-                            .values(
-                                "member__avatar_url",
-                                "member__display_name",
-                                "member__id",
-                            )
-                        )
+                    )
 
                     response_data["user_mention"] = list(users[:count])
 


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
remove filtering of guests from the entity search endpoint, so that guests can be also mentioned in the workitem 

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Improvement (change that would cause existing functionality to not work as expected)

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->
- verify that we are able to mention guest users in workitem and intake

### References
[WEB-5155](https://app.plane.so/plane/browse/WEB-5155/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated user mention functionality in projects to display all eligible users without previous filtering restrictions, making it easier to mention team members.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->