### PR TITLE
[WEB-5245] fix: add is_time_tracking_enabled field in project serializer

### DIFF
--- a/apps/api/plane/api/serializers/project.py
+++ b/apps/api/plane/api/serializers/project.py
@@ -89,6 +89,7 @@ class ProjectCreateSerializer(BaseSerializer):
             "external_source",
             "external_id",
             "is_issue_type_enabled",
+            "is_time_tracking_enabled",
         ]
 
         read_only_fields = [


### PR DESCRIPTION
### Description
- without this we won't be able to enable work logs on project

### Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)

### References
WEB-5245

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Projects can now be configured with time tracking enabled or disabled during creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->