### PR TITLE
[WEB-5352] fix: layout selection icon

### DIFF
--- a/apps/web/core/components/issues/issue-layouts/filters/header/mobile-layout-selection.tsx
+++ b/apps/web/core/components/issues/issue-layouts/filters/header/mobile-layout-selection.tsx
@@ -23,17 +23,12 @@ export const MobileLayoutSelection = ({
       className="flex flex-grow justify-center text-sm text-custom-text-200"
       placement="bottom-start"
       customButton={
-        activeLayout ? (
-          <Button variant="neutral-primary" size="sm" className="relative px-2">
+        <Button variant="neutral-primary" size="sm" className="relative px-2">
+          {activeLayout && (
             <IssueLayoutIcon layout={activeLayout} size={14} strokeWidth={2} className={`h-3.5 w-3.5`} />
-            <ChevronDownIcon className="size-3 text-custom-text-200 my-auto" strokeWidth={2} />
-          </Button>
-        ) : (
-          <div className="flex flex-start text-sm text-custom-text-200">
-            {t("common.layout")}
-            <ChevronDownIcon className="ml-2  h-4 w-4 text-custom-text-200 my-auto" strokeWidth={2} />
-          </div>
-        )
+          )}
+          <ChevronDownIcon className="size-3 text-custom-text-200 my-auto" strokeWidth={2} />
+        </Button>
       }
       customButtonClassName="flex flex-grow justify-center text-custom-text-200 text-sm"
       closeOnSelect


### PR DESCRIPTION
### Description

This PR fixes the bug where-
In smaller screen, the layout selection dropdown displays the text `Layout` until the active layout has been fetched.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **UI Improvements**
  * Refined the mobile layout selection interface with a streamlined button design that now maintains consistent appearance across all layout states. This enhancement provides improved visual clarity and a more intuitive user experience when managing different layout options on mobile devices, effectively eliminating potential confusion from inconsistent interface state variations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->