### PR TITLE
regression: fallback base url for redirection

### DIFF
--- a/apps/admin/app/compat/next/helper.ts
+++ b/apps/admin/app/compat/next/helper.ts
@@ -4,9 +4,10 @@
  * @returns The URL with a trailing slash added to the pathname (if not already present)
  */
 export function ensureTrailingSlash(url: string): string {
-  const fallbackBaseUrl = window.location.origin;
   try {
-    // Handle relative URLs by creating a URL object with a dummy base
+    const fallbackBaseUrl =
+      typeof window !== "undefined" && window.location.origin ? window.location.origin : "http://dummy.com";
+    // Handle relative URLs by creating a URL object with a fallback base URL
     const urlObj = new URL(url, fallbackBaseUrl);
 
     // Don't modify root path

--- a/apps/space/app/compat/next/helper.ts
+++ b/apps/space/app/compat/next/helper.ts
@@ -4,9 +4,10 @@
  * @returns The URL with a trailing slash added to the pathname (if not already present)
  */
 export function ensureTrailingSlash(url: string): string {
-  const fallbackBaseUrl = window.location.origin;
   try {
-    // Handle relative URLs by creating a URL object with a dummy base
+    const fallbackBaseUrl =
+      typeof window !== "undefined" && window.location.origin ? window.location.origin : "http://dummy.com";
+    // Handle relative URLs by creating a URL object with a fallback base URL
     const urlObj = new URL(url, fallbackBaseUrl);
 
     // Don't modify root path

--- a/apps/web/app/compat/next/helper.ts
+++ b/apps/web/app/compat/next/helper.ts
@@ -4,9 +4,10 @@
  * @returns The URL with a trailing slash added to the pathname (if not already present)
  */
 export function ensureTrailingSlash(url: string): string {
-  const fallbackBaseUrl = window.location.origin;
   try {
-    // Handle relative URLs by creating a URL object with a dummy base
+    const fallbackBaseUrl =
+      typeof window !== "undefined" && window.location.origin ? window.location.origin : "http://dummy.com";
+    // Handle relative URLs by creating a URL object with a fallback base URL
     const urlObj = new URL(url, fallbackBaseUrl);
 
     // Don't modify root path


### PR DESCRIPTION
### Description

This PR fixes the bug where redirection helpers's fallback base URL was hardcoded to a dummy URL.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved relative URL resolution across apps by using the browser's actual origin as the fallback base instead of a placeholder, ensuring links and redirects resolve correctly in browser environments while preserving existing behavior for absolute URLs and error fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->