### PR TITLE
[WEB-5370] fix: cycle and modules not being removed from the work item edit modal

### DIFF
--- a/apps/web/core/components/issues/issue-modal/base.tsx
+++ b/apps/web/core/components/issues/issue-modal/base.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useEffect, useRef, useState } from "react";
+import { xor } from "lodash-es";
 import { observer } from "mobx-react";
 import { useParams } from "next/navigation";
 import { WORK_ITEM_TRACKER_EVENTS } from "@plane/constants";
@@ -272,7 +273,7 @@ export const CreateUpdateIssueModalBase: React.FC<IssuesModalProps> = observer((
       if (isDraft) await draftIssues.updateIssue(workspaceSlug.toString(), data.id, payload);
       else if (updateIssue) await updateIssue(payload.project_id, data.id, payload);
 
-      // check if we should add issue to cycle/module
+      // check if we should add/remove issue to/from cycle
       if (
         payload.cycle_id &&
         payload.cycle_id !== "" &&
@@ -280,12 +281,30 @@ export const CreateUpdateIssueModalBase: React.FC<IssuesModalProps> = observer((
       ) {
         await addIssueToCycle(data as TBaseIssue, payload.cycle_id);
       }
-      if (
-        payload.module_ids &&
-        payload.module_ids.length > 0 &&
-        (!payload.module_ids.includes(moduleId?.toString()) || storeType !== EIssuesStoreType.MODULE)
-      ) {
-        await addIssueToModule(data as TBaseIssue, payload.module_ids);
+      if (data.cycle_id && !payload.cycle_id && data.project_id) {
+        await issues.removeIssueFromCycle(workspaceSlug.toString(), data.project_id, data.cycle_id, data.id);
+        fetchCycleDetails(workspaceSlug.toString(), data.project_id, data.cycle_id);
+      }
+
+      if (data.module_ids && payload.module_ids && data.project_id) {
+        const updatedModuleIds = xor(data.module_ids, payload.module_ids);
+        const modulesToAdd: string[] = [];
+        const modulesToRemove: string[] = [];
+
+        for (const moduleId of updatedModuleIds) {
+          if (data.module_ids.includes(moduleId)) {
+            modulesToRemove.push(moduleId);
+          } else {
+            modulesToAdd.push(moduleId);
+          }
+        }
+        await issues.changeModulesInIssue(
+          workspaceSlug.toString(),
+          data.project_id,
+          data.id,
+          modulesToAdd,
+          modulesToRemove
+        );
       }
 
       // add other property values


### PR DESCRIPTION
### Description

This PR fixes the bug where removing cycle/modules fro the work item edit modal doesn't work.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced issue module management with improved add/remove operations
  * Issues can now be properly removed from cycles when cycle assignments are cleared

<!-- end of auto-generated comment: release notes by coderabbit.ai -->