### PR TITLE
[WEB-5414] fix: Use correct SWR cache key for fetching project details

### DIFF
--- a/apps/web/core/components/project/project-settings-member-defaults.tsx
+++ b/apps/web/core/components/project/project-settings-member-defaults.tsx
@@ -12,7 +12,7 @@ import { TOAST_TYPE, setToast } from "@plane/propel/toast";
 import type { IProject, IUserLite, IWorkspace } from "@plane/types";
 import { Loader, ToggleSwitch } from "@plane/ui";
 // constants
-import { PROJECT_MEMBERS } from "@/constants/fetch-keys";
+import { PROJECT_DETAILS } from "@/constants/fetch-keys";
 // hooks
 import { useProject } from "@/hooks/store/use-project";
 import { useUserPermissions } from "@/hooks/store/user";
@@ -64,7 +64,7 @@ export const ProjectSettingsMemberDefaults: React.FC<TProjectSettingsMemberDefau
   const { reset, control } = useForm<IProject>({ defaultValues });
   // fetching user members
   useSWR(
-    workspaceSlug && projectId ? PROJECT_MEMBERS(workspaceSlug, projectId) : null,
+    workspaceSlug && projectId ? PROJECT_DETAILS(workspaceSlug, projectId) : null,
     workspaceSlug && projectId ? () => fetchProjectDetails(workspaceSlug, projectId) : null
   );
 


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
This PR resolves an issue where project members lists aren’t being fetched in the project settings page. This was caused by using the incorrect key at `apps/web/core/components/project/project-settings-member-defaults.tsx`. We were using the project members key to fetch project details, which caused SWR to assume that the API call was already in progress. As a result, the actual fetch members API call was skipped. 

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed project member defaults settings to retrieve correct project information instead of member data, ensuring accurate configuration of default member settings and permissions for your projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->