### PR TITLE
[WEB-5447] feat: add dataPreventOutsideClick prop to reafactor: ComboboxOptions for enhanced click handling

### DIFF
--- a/packages/propel/src/combobox/combobox.tsx
+++ b/packages/propel/src/combobox/combobox.tsx
@@ -38,6 +38,7 @@ export interface ComboboxOptionsProps {
   searchQuery?: string;
   onSearchQueryChange?: (query: string) => void;
   onSearchQueryKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+  dataPreventOutsideClick?: boolean;
 }
 
 export interface ComboboxOptionProps {
@@ -111,6 +112,7 @@ function ComboboxOptions({
   searchQuery: controlledSearchQuery,
   onSearchQueryChange,
   onSearchQueryKeyDown,
+  dataPreventOutsideClick,
 }: ComboboxOptionsProps) {
   // const [searchQuery, setSearchQuery] = React.useState("");
   const [internalSearchQuery, setInternalSearchQuery] = React.useState("");
@@ -164,6 +166,7 @@ function ComboboxOptions({
       <BaseCombobox.Positioner sideOffset={8} className={positionerClassName}>
         <BaseCombobox.Popup
           className={cn("rounded-md border border-custom-border-200 bg-custom-background-100 p-1 shadow-lg", className)}
+          data-prevent-outside-click={dataPreventOutsideClick}
         >
           <div className="flex flex-col gap-1">
             {showSearch && (


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->

This PR adds dataPreventOutsideClick in combobox option props

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [x] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional outside-click prevention configuration to the Combobox component, enabling control over whether the options dropdown closes when users interact outside the menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->