### PR TITLE
fix: Updated translation key usage in change password error scenario

### DIFF
--- a/apps/web/app/(all)/[workspaceSlug]/(settings)/settings/account/security/page.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/(settings)/settings/account/security/page.tsx
@@ -99,9 +99,9 @@ function SecurityPage() {
 
       setToast({
         type: TOAST_TYPE.ERROR,
-        title: errorInfo?.title ?? t("auth.common.password.toast.error.title"),
+        title: errorInfo?.title ?? t("auth.common.password.toast.change_password.error.title"),
         message:
-          typeof errorInfo?.message === "string" ? errorInfo.message : t("auth.common.password.toast.error.message"),
+          typeof errorInfo?.message === "string" ? errorInfo.message : t("auth.common.password.toast.change_password.error.message"),
       });
     }
   };


### PR DESCRIPTION
### Description
Updated translation keys being used in toast component invokation in change password catch block. Fixes #8082 

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
<!-- Link related issues if there are any -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use change_password-specific i18n keys for error toast in the account security password change flow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 76028319a24dd4409c7b47bde08f0a924e5c05c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error message accuracy during password change operations by displaying more contextually relevant authentication error notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->