### PR TITLE
[WIKI-770] fix: update editor ref after editor ready

### DIFF
--- a/apps/web/core/components/editor/lite-text/editor.tsx
+++ b/apps/web/core/components/editor/lite-text/editor.tsx
@@ -73,6 +73,7 @@ export const LiteTextEditor = React.forwardRef<EditorRefApi, LiteTextEditorWrapp
   const isLiteVariant = variant === "lite";
   const isFullVariant = variant === "full";
   const [isFocused, setIsFocused] = useState(isFullVariant ? showToolbarInitially : true);
+  const [editorRef, setEditorRef] = useState<EditorRefApi | null>(null);
   // editor flaggings
   const { liteText: liteTextEditorExtensions } = useEditorFlagging({
     workspaceSlug: workspaceSlug?.toString() ?? "",
@@ -95,7 +96,7 @@ export const LiteTextEditor = React.forwardRef<EditorRefApi, LiteTextEditorWrapp
   }
   // derived values
   const isEmpty = isCommentEmpty(props.initialValue);
-  const editorRef = isMutableRefObject<EditorRefApi>(ref) ? ref.current : null;
+
   return (
     <div
       className={cn(
@@ -123,6 +124,11 @@ export const LiteTextEditor = React.forwardRef<EditorRefApi, LiteTextEditorWrapp
               workspaceId,
               workspaceSlug,
             })}
+            handleEditorReady={(ready) => {
+              if (ready) {
+                setEditorRef(isMutableRefObject<EditorRefApi>(ref) ? ref.current : null);
+              }
+            }}
             mentionHandler={{
               searchCallback: async (query) => {
                 const res = await fetchMentions(query);


### PR DESCRIPTION
### Description
improve how the editor reference (`editorRef`) is managed and initialized, especially when the editor is ready. 

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

### Screenshots and Media (if applicable)
https://github.com/user-attachments/assets/fe2cca22-0821-416b-8ebf-29fc321e84ac


### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
<!-- Link related issues if there are any -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced editor reference management and command execution in the text editor component to improve toolbar interaction handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->