### PR TITLE
[WIKI-775] fix: remove fallback image from emojis

### DIFF
--- a/packages/editor/src/core/extensions/emoji/components/emojis-list.tsx
+++ b/packages/editor/src/core/extensions/emoji/components/emojis-list.tsx
@@ -10,7 +10,6 @@ export type EmojiItem = {
   emoji: string;
   shortcodes: string[];
   tags: string[];
-  fallbackImage?: string;
 };
 
 export type EmojiListRef = {
@@ -156,13 +155,7 @@ export const EmojisListDropdown = forwardRef<EmojiListRef, EmojisListDropdownPro
                 onClick={() => selectItem(index)}
                 onMouseEnter={() => setSelectedIndex(index)}
               >
-                <span className="size-5 grid place-items-center flex-shrink-0 text-base">
-                  {item.fallbackImage ? (
-                    <img src={item.fallbackImage} alt={item.name} className="size-4 object-contain" />
-                  ) : (
-                    item.emoji
-                  )}
-                </span>
+                <span className="size-5 grid place-items-center flex-shrink-0 text-base">{item.emoji}</span>
                 <span className="flex-grow truncate">
                   <span className="font-medium">:{item.name}:</span>
                 </span>

--- a/packages/editor/src/core/extensions/emoji/extension.ts
+++ b/packages/editor/src/core/extensions/emoji/extension.ts
@@ -16,8 +16,6 @@ export const EmojiExtension = Emoji.extend({
           const emojiItem = shortcodeToEmoji(node.attrs.name, extensionOptions.emojis);
           if (emojiItem?.emoji) {
             state.write(emojiItem?.emoji);
-          } else if (emojiItem?.fallbackImage) {
-            state.write(`\n![${emojiItem.name}-${emojiItem.shortcodes[0]}](${emojiItem?.fallbackImage})\n`);
           } else {
             state.write(`:${node.attrs.name}:`);
           }
@@ -26,7 +24,9 @@ export const EmojiExtension = Emoji.extend({
     };
   },
 }).configure({
-  emojis: gitHubEmojis,
+  // Filter out emojis without emoji value and remove fallbackImage property to prevent CDN calls
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  emojis: gitHubEmojis.filter((item) => item.emoji).map(({ fallbackImage, ...emoji }) => emoji),
   suggestion: emojiSuggestion,
   enableEmoticons: true,
 });

--- a/packages/editor/src/core/extensions/emoji/suggestion.ts
+++ b/packages/editor/src/core/extensions/emoji/suggestion.ts
@@ -16,27 +16,17 @@ const DEFAULT_EMOJIS = ["+1", "-1", "smile", "orange_heart", "eyes"];
 
 export const emojiSuggestion: EmojiOptions["suggestion"] = {
   items: ({ editor, query }: { editor: Editor; query: string }): EmojiItem[] => {
-    const { emojis, isSupported } = editor.storage.emoji as EmojiStorage;
-    const filteredEmojis = emojis.filter((emoji) => {
-      const hasEmoji = !!emoji?.emoji;
-      const hasFallbackImage = !!emoji?.fallbackImage;
-      const renderFallbackImage =
-        (emoji.forceFallbackImages && !hasEmoji) ||
-        (emoji.forceFallbackImages && hasFallbackImage) ||
-        (emoji.forceFallbackImages && !isSupported(emoji) && hasFallbackImage) ||
-        ((!isSupported(emoji) || !hasEmoji) && hasFallbackImage);
-      return !renderFallbackImage;
-    });
+    const { emojis } = editor.storage.emoji as EmojiStorage;
 
     if (query.trim() === "") {
       const defaultEmojis = DEFAULT_EMOJIS.map((name) =>
-        filteredEmojis.find((emoji) => emoji.shortcodes.includes(name) || emoji.name === name)
+        emojis.find((emoji) => emoji.shortcodes.includes(name) || emoji.name === name)
       )
         .filter(Boolean)
         .slice(0, 5);
       return defaultEmojis as EmojiItem[];
     }
-    return filteredEmojis
+    return emojis
       .filter(({ shortcodes, tags }) => {
         const lowerQuery = query.toLowerCase();
         return (


### PR DESCRIPTION
### Description
This pull request simplifies the emoji extension by removing all support for emoji `fallbackImage` property from the emoji data to prevent unnecessary CDN calls.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)


### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
<!-- Link related issues if there are any -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified emoji functionality to improve performance and reduce external dependencies. Streamlined emoji selection, rendering, and suggestion logic with enhanced filtering mechanisms. Removed fallback image support to enhance reliability. Emoji suggestions now operate with refined criteria for better accuracy and responsiveness when inserting and discovering emojis throughout your editing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->