### PR TITLE
[WEB-5449] fix: enhance content check for unique ID generation and update issue loader condition

### DIFF
--- a/apps/web/core/components/inbox/content/issue-root.tsx
+++ b/apps/web/core/components/inbox/content/issue-root.tsx
@@ -191,7 +191,7 @@ export const InboxIssueMainContent: React.FC<Props> = observer((props) => {
           containerClassName="-ml-3"
         />
 
-        {loader === "issue-loading" ? (
+        {loader === "issue-loading" || issue.description_html === undefined ? (
           <DescriptionInputLoader />
         ) : (
           <DescriptionInput

--- a/packages/editor/src/core/extensions/unique-id/extension.ts
+++ b/packages/editor/src/core/extensions/unique-id/extension.ts
@@ -122,11 +122,7 @@ export const UniqueID = Extension.create<UniqueIDOptions>({
       // If not synced, the listener will be registered in the plugin
       // and handled there with proper cleanup
     } else {
-      // size > 2 means more than just the default empty paragraph
-      const hasContent = this.editor.state.doc.content.size > 2;
-      if (hasContent) {
-        createIdsForView(this.editor.view, this.options);
-      }
+      createIdsForView(this.editor.view, this.options);
     }
   },
 

--- a/packages/editor/src/core/extensions/unique-id/utils.ts
+++ b/packages/editor/src/core/extensions/unique-id/utils.ts
@@ -10,6 +10,13 @@ export const createIdsForView = (view: EditorView, options: UniqueIDOptions) => 
   const { state } = view;
   const { tr, doc } = state;
   const { types, attributeName, generateUniqueID } = options;
+
+  // size > 2 means more than just the default empty paragraph
+  const hasContent = doc.content.size > 2;
+  if (!hasContent) {
+    return;
+  }
+
   const nodesWithoutId = findChildren(
     doc,
     (node) => types.includes(node.type.name) && node.attrs[attributeName] === null


### PR DESCRIPTION
### Description
Add check for content size before giving ID to documents 

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

### Screenshots and Media (if applicable)
https://github.com/user-attachments/assets/944e3e33-7bec-47e9-9d53-a7c4d2ce25bc


### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
<!-- Link related issues if there are any -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Avoid unnecessary unique ID processing for empty editor documents to improve performance.
  * Fix issue detail loading behavior so a description loader appears when description content is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->