### PR TITLE
[WEB-5489] fix: prevent AppRail hook usage outside context in disabled workspace components

### DIFF
--- a/apps/web/app/(all)/[workspaceSlug]/layout.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/layout.tsx
@@ -7,13 +7,13 @@ import { WorkspaceAuthWrapper } from "@/plane-web/layouts/workspace-wrapper";
 export default function WorkspaceLayout() {
   return (
     <AuthenticationWrapper>
-      <WorkspaceAuthWrapper>
-        <AppRailProvider>
+      <AppRailProvider>
+        <WorkspaceAuthWrapper>
           <WorkspaceContentWrapper>
             <Outlet />
           </WorkspaceContentWrapper>
-        </AppRailProvider>
-      </WorkspaceAuthWrapper>
+        </WorkspaceAuthWrapper>
+      </AppRailProvider>
     </AuthenticationWrapper>
   );
 }


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
This PR ensures AppRail hook is only used within its proper context provider to avoid
runtime errors.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reorders providers so `AppRailProvider` wraps `WorkspaceAuthWrapper`, ensuring AppRail context is available to workspace components.
> 
> - **Layout**:
>   - Reorders providers in `apps/web/app/(all)/[workspaceSlug]/layout.tsx`, wrapping `WorkspaceAuthWrapper` with `AppRailProvider` so app-rail context is available to workspace components.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 254e0969a8faca540304a6af51ee49c18846e8ce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved workspace layout component initialization order to enhance context availability during app startup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->