### PR TITLE
[WEB-5503] fix: enhance error handling for label creation and update operations

### DIFF
--- a/apps/web/core/components/labels/create-update-label-inline.tsx
+++ b/apps/web/core/components/labels/create-update-label-inline.tsx
@@ -66,18 +66,11 @@ export const CreateUpdateLabelInline = observer(
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const getErrorMessage = (error: any, operation: "create" | "update"): string => {
-      const errorData = error?.data ?? error;
+      const errorData = error ?? {};
 
-      // Check field-level errors with array structure
-      if (errorData?.name && Array.isArray(errorData.name)) {
-        const errorCode = errorData.name[0];
-
-        switch (errorCode) {
-          case errorCodes.LABEL_NAME_ALREADY_EXISTS:
-            return t("label.create.already_exists");
-          default:
-            break;
-        }
+      const labelError = errorData.name?.includes(errorCodes.LABEL_NAME_ALREADY_EXISTS);
+      if (labelError) {
+        return t("label.create.already_exists");
       }
 
       // Fallback to general error messages


### PR DESCRIPTION
### Description
enhance error handling for label creation and update operations

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

### Screenshots and Media (if applicable)

### Test Scenarios 

### References

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Centralizes and enhances error handling for label create/update to show clearer, localized toasts, including duplicate-name detection.
> 
> - **Frontend – labels (`apps/web/core/components/labels/create-update-label-inline.tsx`)**:
>   - Add `errorCodes` and a `getErrorMessage` helper to produce localized errors, including detecting `LABEL_NAME_ALREADY_EXISTS`.
>   - Integrate helper in create/update catch blocks to unify toast messages; retain existing success/error tracking and form resets.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 279c5b0fd0ba6fbe5d730e8ae8a3706f94782aef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for label creation and updates to display clearer, localized messages.
  * Better detection and user-friendly notification when a label name already exists.
  * Consistent toast feedback and error logging so failures are easier to understand and track.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->