### PR TITLE
[WIKI-811] fix: ensure only non-deleted project pages are retrieved in page queries 

### DIFF
--- a/apps/api/plane/app/views/page/base.py
+++ b/apps/api/plane/app/views/page/base.py
@@ -496,17 +496,14 @@ class PagesDescriptionViewSet(BaseViewSet):
 
     def retrieve(self, request, slug, project_id, page_id):
         page = (
-            Page.objects.filter(
+            Page.objects.get(
+                Q(owned_by=self.request.user) | Q(access=0),
                 pk=page_id,
                 workspace__slug=slug,
                 projects__id=project_id,
                 project_pages__deleted_at__isnull=True,
             )
-            .filter(Q(owned_by=self.request.user) | Q(access=0))
-            .first()
         )
-        if page is None:
-            return Response({"error": "Page not found"}, status=404)
         binary_data = page.description_binary
 
         def stream_data():
@@ -521,18 +518,14 @@ class PagesDescriptionViewSet(BaseViewSet):
 
     def partial_update(self, request, slug, project_id, page_id):
         page = (
-            Page.objects.filter(
+            Page.objects.get(
+                Q(owned_by=self.request.user) | Q(access=0),
                 pk=page_id,
                 workspace__slug=slug,
                 projects__id=project_id,
                 project_pages__deleted_at__isnull=True,
             )
-            .filter(Q(owned_by=self.request.user) | Q(access=0))
-            .first()
         )
-
-        if page is None:
-            return Response({"error": "Page not found"}, status=404)
 
         if page.is_locked:
             return Response(


### PR DESCRIPTION
### Description
adding `project_pages__deleted_at` filter across all relevant database queries,

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)


### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
<!-- Link related issues if there are any -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * All page operations now ignore deleted pages, preventing removed pages from appearing in queries, retrievals, updates, locks/unlocks, access checks, archives/unarchives, and deletes.
  * Parent/child relationships and cascade updates now skip deleted pages to avoid incorrect references or removals.
  * Page descriptions, duplication flows, and permission/existence checks follow the same non-deleted rules for consistent user-facing behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->