### PR TITLE
[WEB-5523] fix: Even without edit access, the timezone is still interactive.

### DIFF
--- a/apps/web/core/components/project/form.tsx
+++ b/apps/web/core/components/project/form.tsx
@@ -411,6 +411,7 @@ export function ProjectDetailsForm(props: IProjectDetailsForm) {
                     }}
                     error={Boolean(errors.timezone)}
                     buttonClassName="border-none"
+                    disabled={!isAdmin}
                   />
                 </>
               )}

--- a/apps/web/core/hooks/use-timezone.tsx
+++ b/apps/web/core/hooks/use-timezone.tsx
@@ -59,11 +59,6 @@ const useTimezone = () => {
       query: "utc, coordinated universal time",
       content: "UTC",
     },
-    {
-      value: "Universal",
-      query: "universal, coordinated universal time",
-      content: "Universal",
-    },
   ];
 
   const selectedTimezone = (value: string | undefined) => options.find((option) => option.value === value)?.content;


### PR DESCRIPTION
### Description
fix: disable timezone selection button for non-admin users
removed Universal option from timezone selection

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

### Screenshots and Media (if applicable)

### Test Scenarios 

### References

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Changes

* **Changes**
  * Project timezone settings now have administrator-level access controls. Non-administrative users will find the timezone selector disabled in the project details form, preventing modifications to the timezone configuration. Administrative users retain full editing capabilities.
  * The "Universal" timezone option has been removed from the timezone selection list.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->