### PR TITLE
[WEB-5560] fix: restrict guest users to view all details of a workspace members

### DIFF
--- a/apps/api/plane/app/views/project/member.py
+++ b/apps/api/plane/app/views/project/member.py
@@ -191,7 +191,7 @@ class ProjectMemberViewSet(BaseViewSet):
                 status=status.HTTP_404_NOT_FOUND,
             )
 
-        if requesting_project_member.role > 5:
+        if requesting_project_member.role > ROLE.GUEST.value:
             serializer = ProjectMemberAdminSerializer(project_member)
         else:
             serializer = ProjectMemberRoleSerializer(project_member, fields=("id", "member", "role"))

--- a/apps/api/plane/app/views/workspace/member.py
+++ b/apps/api/plane/app/views/workspace/member.py
@@ -63,7 +63,7 @@ class WorkSpaceMemberViewSet(BaseViewSet):
                 status=status.HTTP_404_NOT_FOUND,
             )
 
-        if workspace_member.role > 5:
+        if workspace_member.role > ROLE.GUEST.value:
             serializer = WorkspaceMemberAdminSerializer(member, fields=("id", "member", "role"))
         else:
             serializer = WorkSpaceMemberSerializer(member, fields=("id", "member", "role"))


### PR DESCRIPTION
### Description

- This PR will resolve the issue where a guest user can view the email IDs of workspace members.
- Non-project members accessing project member details

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Retrieve a single project member with 404 handling; shows expanded or limited member details depending on requester role.
  * Retrieve a single workspace member with role-based visibility (admins see expanded info; others see limited data).

* **Chores**
  * No changes to existing list or other member actions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->