### PR TITLE
fix: correct capitalization for special cases like GitHub in authenti…

### DIFF
--- a/apps/web/ce/components/workspace/settings/useMemberColumns.tsx
+++ b/apps/web/ce/components/workspace/settings/useMemberColumns.tsx
@@ -29,6 +29,17 @@ export const useMemberColumns = () => {
   const isAdmin = allowPermissions([EUserPermissions.ADMIN], EUserPermissionsLevel.WORKSPACE);
 
   const isSuspended = (rowData: RowData) => rowData.is_active === false;
+
+  const formatAuthMethod = (method: string | undefined): string => {
+    if (!method) return "";
+    const normalized = method.toLowerCase().replace("-", " ");
+    if (normalized === "github") return "GitHub";
+    if (normalized === "gitlab") return "GitLab";
+    // can add more special cases like these
+
+    return normalized.charAt(0).toUpperCase() + normalized.slice(1);
+  };
+
   // handlers
   const handleDisplayFilterUpdate = (filterUpdates: Partial<IMemberFilters>) => {
     updateFilters(filterUpdates);
@@ -109,7 +120,7 @@ export const useMemberColumns = () => {
       content: t("workspace_settings.settings.members.details.authentication"),
       tdRender: (rowData: RowData) =>
         isSuspended(rowData) ? null : (
-          <div className="capitalize">{rowData.member.last_login_medium?.replace("-", " ")}</div>
+          <div>{formatAuthMethod(rowData.member.last_login_medium)}</div>
         ),
     },
 


### PR DESCRIPTION
…cation in workspace/members settings

### Description
This PR fixes an issue where "GitHub" and "GitLab" were displayed incorrectly as "Github" and "Gitlab" in the workspace member settings.

I implemented a new helper function `formatAuthMethod` in `useMemberColumns.tsx` to explicitly handle the casing for these providers while preserving the standard formatting for others.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

### Screenshots and Media
<img width="1920" height="1080" alt="Screenshot (329)" src="https://github.com/user-attachments/assets/a0fa8920-0d7f-4e8b-8c08-cd142d9a751f" />

### Test Scenarios
- Verified that "github" renders as "GitHub".
- Verified that "gitlab" renders as "GitLab".
- Verified that standard providers (e.g., "google") still render as "Google".

### References
Fixes #8170 (https://github.com/makeplane/plane/issues/8170)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Formats the Authentication column via `formatAuthMethod` to properly display providers (e.g., GitHub, GitLab) with correct casing.
> 
> - **UI — Workspace Members**
>   - Add `formatAuthMethod` in `apps/web/ce/components/workspace/settings/useMemberColumns.tsx` to format `member.last_login_medium`.
>   - Render Authentication column using the helper; special-cases `GitHub` and `GitLab`, with sensible defaults for others.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7d42f25747709baedef9b30a8b7d6ba02269aba4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication method display in workspace member settings for better consistency and readability. Authentication methods are now formatted consistently with special handling for GitHub, GitLab, and other providers to ensure proper capitalization and spacing across the interface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->