### PR TITLE
[WEB-5285] feat: enhance ChangeTrackerMixin to capture changed fields on save

### DIFF
--- a/apps/api/plane/db/models/issue.py
+++ b/apps/api/plane/db/models/issue.py
@@ -513,10 +513,12 @@ class IssueComment(ChangeTrackerMixin, ProjectBaseModel):
                     "comment_json": "description_json",
                 }
 
+                # Use _changes_on_save which is captured by ChangeTrackerMixin.save()
+                # before the tracked fields are reset
                 changed_fields = {
                     desc_field: getattr(self, comment_field)
                     for comment_field, desc_field in field_mapping.items()
-                    if self.has_changed(comment_field)
+                    if comment_field in self._changes_on_save
                 }
 
                 # Update description only if comment fields changed


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
- Added an override for the save method in ChangeTrackerMixin to store changed fields before resetting tracking.
- Implemented a new method, _reset_tracked_fields, to ensure subsequent saves detect changes relative to the last saved state.
- Updated IssueComment to utilize _changes_on_save for determining changed fields, improving accuracy in tracking modifications.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->
- Tested comment creation and updation and it's syncing to the description table properly.

### References
<!-- Link related issues if there are any -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced change detection during save operations to accurately track which fields have been modified, ensuring updates only include genuinely changed data.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->