### PR TITLE
feat: enhance notification sidebar header with back navigation and st…

### DIFF
--- a/apps/web/core/components/workspace-notifications/sidebar/header/root.tsx
+++ b/apps/web/core/components/workspace-notifications/sidebar/header/root.tsx
@@ -1,8 +1,11 @@
 import { observer } from "mobx-react";
+import Link from "next/link";
 // plane imports
 import { useTranslation } from "@plane/i18n";
-import { InboxIcon } from "@plane/propel/icons";
+import { getButtonStyling } from "@plane/propel/button";
+import { ChevronLeftIcon, InboxIcon } from "@plane/propel/icons";
 import { Breadcrumbs, Header } from "@plane/ui";
+import { cn } from "@plane/utils";
 // components
 import { BreadcrumbLink } from "@/components/common/breadcrumb-link";
 // local imports
@@ -22,17 +25,28 @@ export const NotificationSidebarHeader = observer(function NotificationSidebarHe
   return (
     <Header className="my-auto bg-surface-1">
       <Header.LeftItem>
-        <Breadcrumbs>
-          <Breadcrumbs.Item
-            component={
-              <BreadcrumbLink
-                label={t("notification.label")}
-                icon={<InboxIcon className="h-4 w-4 text-primary" />}
-                disableTooltip
-              />
-            }
-          />
-        </Breadcrumbs>
+        <div className="flex items-center gap-2">
+          <Link
+            href={`/${workspaceSlug}`}
+            className={cn(
+              getButtonStyling("secondary", "base"),
+              "flex items-center justify-center gap-2 text-tertiary rounded-lg h-6 w-6 p-1 hover:bg-surface-2 hover:text-secondary"
+            )}
+          >
+            <ChevronLeftIcon className="h-4 w-4" />
+          </Link>
+          <Breadcrumbs>
+            <Breadcrumbs.Item
+              component={
+                <BreadcrumbLink
+                  label={t("notification.label")}
+                  icon={<InboxIcon className="h-4 w-4 text-primary" />}
+                  disableTooltip
+                />
+              }
+            />
+          </Breadcrumbs>
+        </div>
       </Header.LeftItem>
       <Header.RightItem>
         <NotificationSidebarHeaderOptions workspaceSlug={workspaceSlug} />


### PR DESCRIPTION
### Description
Added a Back to workspace button to the notifications sidebar header so users can easily navigate from /[workspaceSlug]/notifications back to the workspace home.

The back button:

- Uses ChevronLeftIcon from @plane/propel/icons
- Navigates via next/link to /${workspaceSlug}
- Reuses getButtonStyling("secondary", "base") and cn to match existing button and header styling
- Is aligned inline with the notifications breadcrumb to maintain visual consistency

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x ] Feature (non-breaking change which adds functionality)
- [ x ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update


### Test Scenarios 
- Navigated to /[workspaceSlug]/notifications and verified:
- The back button is visible in the notifications sidebar header.
- Clicking the back button navigates to `/${workspaceSlug}`.
- Header layout and alignment remain correct on different viewport widths.
- Ran linting for the updated file to ensure no new lint errors:
  `apps/web/core/components/workspace-notifications/sidebar/header/root.tsx`

