### PR TITLE
[WEB-5775] fix: mentions search on empty query

### DIFF
--- a/packages/editor/src/core/extensions/mentions/mentions-list-dropdown.tsx
+++ b/packages/editor/src/core/extensions/mentions/mentions-list-dropdown.tsx
@@ -79,7 +79,6 @@ export const MentionsListDropdown = forwardRef(function MentionsListDropdown(pro
   // debounced search callback
   const debouncedSearchCallback = useCallback(
     debounce(async (searchQuery: string) => {
-      setIsLoading(true);
       try {
         const sectionsResponse = await searchCallback?.(searchQuery);
         if (sectionsResponse) {
@@ -96,7 +95,8 @@ export const MentionsListDropdown = forwardRef(function MentionsListDropdown(pro
 
   // trigger debounced search when query changes
   useEffect(() => {
-    if (query) {
+    if (query !== undefined && query !== null) {
+      setIsLoading(true);
       void debouncedSearchCallback(query);
     }
   }, [query, debouncedSearchCallback]);


### PR DESCRIPTION
### Description

This PR ensures mentions dropdown calls the search callback on empty query as well.

### Type of Change

- [x] Improvement (change that would cause existing functionality to not work as expected)