### PR TITLE
[WEB-5788] fix: board layout group by icon

### DIFF
--- a/apps/web/core/components/issues/issue-layouts/kanban/headers/group-by-card.tsx
+++ b/apps/web/core/components/issues/issue-layouts/kanban/headers/group-by-card.tsx
@@ -1,4 +1,3 @@
-import type { FC } from "react";
 import React from "react";
 import { observer } from "mobx-react";
 import { useParams } from "next/navigation";
@@ -112,7 +111,7 @@ export const HeaderGroupByCard = observer(function HeaderGroupByCard(props: IHea
           verticalAlignPosition ? `w-[44px] flex-col items-center` : `w-full flex-row items-center`
         }`}
       >
-        <div className="flex h-4 w-4 flex-shrink-0 items-center justify-center overflow-hidden rounded-xs">
+        <div className="flex size-5 flex-shrink-0 items-center justify-center overflow-hidden rounded-xs">
           {icon ? icon : <Circle width={14} strokeWidth={2} />}
         </div>
 


### PR DESCRIPTION
### Description
This PR fixes board layout group by icon size.

### Type of Change
- [x] Bug fix

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts the Kanban header group-by icon size for better visibility/alignment.
> 
> - In `group-by-card.tsx`, updates the icon container from `h-4 w-4` to `size-5`, affecting the rendered `icon` or fallback `Circle`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ef2461d2af33869824ebee0479f7d21faeb8d011. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted icon sizing in kanban board group headers for improved visual consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->