### PR TITLE
[WEB-5772] fix: theme switch flicker

### DIFF
--- a/apps/web/core/lib/wrappers/store-wrapper.tsx
+++ b/apps/web/core/lib/wrappers/store-wrapper.tsx
@@ -55,7 +55,8 @@ function StoreWrapper(props: TStoreWrapper) {
     const userId = userProfile?.id;
 
     // Reset initialization flag when user changes (logout/login)
-    if (userId && userId !== currentUserIdRef.current) {
+    // This handles both logout (userId becomes undefined) and login (userId changes)
+    if (userId !== currentUserIdRef.current) {
       hasInitializedThemeRef.current = false;
       previousThemeRef.current = undefined;
       currentUserIdRef.current = userId;
@@ -71,7 +72,7 @@ function StoreWrapper(props: TStoreWrapper) {
 
     // Mark as initialized - prevents future syncs from server
     hasInitializedThemeRef.current = true;
-  }, [userProfile?.theme?.theme, userProfile?.id, setTheme]);
+  }, [userProfile?.theme?.theme, setTheme]);
 
   /**
    * Effect 2: Custom theme CSS application (runs on every change)


### PR DESCRIPTION
### Description
This PR fixes the flicker when switching themes.

### Type of Change
- [x] Bug fix

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves theme stability and eliminates flicker during switches.
> 
> - Splits theme logic into two effects: (1) one-time server sync via `setTheme` per user session; (2) apply/clear custom theme CSS on every change
> - Adds refs `hasInitializedThemeRef`, `currentUserIdRef`, and `previousThemeRef` to avoid feedback loops and correctly handle login/logout and custom→non-custom transitions
> - Leaves sidebar localStorage restore, language change, and router params effects unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 511639a7c72950e09eb21c41f0e2c9700c620e4c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure server-provided theme is applied once per user on first load and when switching accounts, avoiding repeat syncs.
  * Improve custom theme handling: apply custom styles when selected, remove them when switching away, and prevent style conflicts during theme transitions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->