### PR TITLE
[WEB-5827] fix: persist external cover image URLs (Unsplash) in project updates

### DIFF
--- a/apps/web/helpers/cover-image.helper.ts
+++ b/apps/web/helpers/cover-image.helper.ts
@@ -266,14 +266,18 @@ export const handleCoverImageChange = async (
 
     if (uploadConfig.isUserAsset) {
       return {
-        cover_image_url: uploadedUrl,
+        cover_image: uploadedUrl,
       };
     } else {
       return null;
     }
   }
 
-  return null;
+  // External/uploaded asset (e.g., Unsplash URL, pre-uploaded asset)
+  // Return the URL to be saved in the backend
+  return {
+    cover_image: newImage,
+  };
 };
 
 /**


### PR DESCRIPTION
### Problem
When selecting an Unsplash image (or any external URL) as a project cover image, the URL wasn't being saved to the backend. The `handleCoverImageChange` function was returning `null` for external URLs, causing the update payload to exclude the cover image.

### Root Cause
The `handleCoverImageChange` function only returned a payload for:
1. Image removal (returns null values)
2. Local static images that need upload (for user assets only)

External URLs like Unsplash images are classified as `"uploaded_asset"` type and don't require upload, so the function fell through to `return null`, preventing the URL from being included in the update payload.

### Solution
- Updated `handleCoverImageChange` to return the cover image URL in the payload for external/uploaded assets
- Replaced `cover_image_url` with `cover_image` fields

### Testing
- [x] Verify Unsplash images are saved when selected in project form
- [x] Verify local static images still upload correctly
- [x] Verify image removal still works correctly
- [x] Verify no regressions in existing cover image functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cover image handling for uploaded and external assets to ensure consistent processing across all asset types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->