### PR TITLE
[GIT-45] fix: allow markdown file attachments

### DIFF
--- a/apps/api/plane/settings/common.py
+++ b/apps/api/plane/settings/common.py
@@ -380,6 +380,7 @@ ATTACHMENT_MIME_TYPES = [
     "application/vnd.ms-powerpoint",
     "application/vnd.openxmlformats-officedocument.presentationml.presentation",
     "text/plain",
+    "text/markdown",
     "application/rtf",
     "application/vnd.oasis.opendocument.spreadsheet",
     "application/vnd.oasis.opendocument.text",

--- a/packages/editor/src/core/constants/config.ts
+++ b/packages/editor/src/core/constants/config.ts
@@ -26,6 +26,7 @@ export const ACCEPTED_ATTACHMENT_MIME_TYPES = [
   "application/vnd.ms-powerpoint",
   "application/vnd.openxmlformats-officedocument.presentationml.presentation",
   "text/plain",
+  "text/markdown",
   "application/rtf",
   "audio/mpeg",
   "audio/wav",


### PR DESCRIPTION
### Description
- Added text/markdown to ATTACHMENT_MIME_TYPES
- Fixes issue where .md files were rejected with 'Invalid file type' error

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### References
- fixes #8519 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Allow markdown attachments**
> 
> - Adds `text/markdown` to `ATTACHMENT_MIME_TYPES` in `apps/api/plane/settings/common.py` and to `ACCEPTED_ATTACHMENT_MIME_TYPES` in `packages/editor/src/core/constants/config.ts`
> - Enables uploading `.md` files that were previously rejected as invalid
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aa6e3a49c0fe48c655e5c0183a144bece06f85c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for markdown file attachments (recognizes text/markdown), expanding accepted upload formats.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->