### PR TITLE
[GIT-40]fix: apply sub-issue display filter when adding work items

### DIFF
--- a/apps/web/core/store/issue/helpers/base-issues.store.ts
+++ b/apps/web/core/store/issue/helpers/base-issues.store.ts
@@ -1198,6 +1198,9 @@ export abstract class BaseIssuesStore implements IBaseIssuesStore {
     const issueId = issue?.id ?? issueBeforeUpdate?.id;
     if (!issueId) return;
 
+    // Get display filters to check if 'Show sub Work items' is enabled - Donot add Work item to main list if disabled.
+    const isShowWorkItemsEnabled = this.issueFilterStore.issueFilters?.displayFilters?.sub_issue ?? false;
+
     // get issueUpdates from another method by passing down the three arguments
     // issueUpdates is nothing but an array of objects that contain the path of the issueId list that need updating and also the action that needs to be performed at the path
     const issueUpdates = this.getUpdateDetails(issue, issueBeforeUpdate, action);
@@ -1207,6 +1210,8 @@ export abstract class BaseIssuesStore implements IBaseIssuesStore {
       for (const issueUpdate of issueUpdates) {
         //if update is add, add it at a particular path
         if (issueUpdate.action === EIssueGroupedAction.ADD) {
+          const isSubIssue = issue?.parent_id;
+          if (isSubIssue && !isShowWorkItemsEnabled) continue;
           // add issue Id at the path
           update(this, ["groupedIssueIds", ...issueUpdate.path], (issueIds: string[] = []) =>
             this.issuesSortWithOrderBy(uniq(concat(issueIds, issueId)), this.orderBy)


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
This fix ensures that Sub-work items are not added to the main issue list when the user has disabled the "Show sub Work items" display filter. Previously, work items would still appear in the list regardless of this setting.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
<!-- Link related issues if there are any -->
https://github.com/makeplane/plane/issues/8505

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Sub-issues now properly respect the sub-work item display filter setting. When the display of sub-work items is disabled in your filter settings, sub-issues will no longer appear in grouped issue lists, providing better control over your workspace organization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->