### PR TITLE
[WEB-5606] fix: work item preview word break

### DIFF
--- a/apps/web/core/components/issues/preview-card/root.tsx
+++ b/apps/web/core/components/issues/preview-card/root.tsx
@@ -48,7 +48,7 @@ export const WorkItemPreviewCard = observer(function WorkItemPreviewCard(props: 
         </div>
       </div>
       <div>
-        <h6 className="text-13">{workItem.name}</h6>
+        <h6 className="text-13 wrap-break-word">{workItem.name}</h6>
       </div>
       <div className="flex items-center gap-1 h-5">
         <PriorityIcon priority={workItem.priority} withContainer />


### PR DESCRIPTION
### Description

This PR fixes overflowing work item title in the work item preview card.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved text wrapping for work item names to enhance readability when displaying longer entries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->