### PR TITLE
Fix duplicate conditions in S3 presigned POST policy generation

### DIFF
--- a/apps/api/plane/settings/storage.py
+++ b/apps/api/plane/settings/storage.py
@@ -62,20 +62,15 @@ class S3Storage(S3Boto3Storage):
         """Generate a presigned URL to upload an S3 object"""
         if expiration is None:
             expiration = self.signed_url_expiration
-        fields = {"Content-Type": file_type}
+        fields = {
+            "Content-Type": file_type,
+            "bucket": self.aws_storage_bucket_name,
+        }
 
         conditions = [
-            {"bucket": self.aws_storage_bucket_name},
             ["content-length-range", 1, file_size],
             {"Content-Type": file_type},
         ]
-
-        # Add condition for the object name (key)
-        if object_name.startswith("${filename}"):
-            conditions.append(["starts-with", "$key", object_name[: -len("${filename}")]])
-        else:
-            fields["key"] = object_name
-            conditions.append({"key": object_name})
 
         # Generate the presigned POST URL
         try:


### PR DESCRIPTION
Fix duplicate conditions in S3 presigned POST policy generation

### Description

During testing with [Garage](https://garagehq.deuxfleurs.fr/) (a stricter S3-compatible object store alternative to MinIO), we discovered that the `generate_presigned_post` policy contains duplicate conditions. This occurs because the boto3 library automatically includes certain conditions, while the application code was manually adding them as well.

The generated policy contains redundant `bucket`, `key`, and field conditions:

```json
{
  "expiration": "<exp date>",
  "conditions": [
    { "bucket": "<bucket name>" },          // ← duplicate
    ["content-length-range", 1, 24928],
    { "Content-Type": "image/jpeg" },
    { "key": "<key value>" },               // ← duplicate
    { "bucket": "<bucket name>" },          // ← duplicate
    { "key": "<key value>" },               // ← duplicate
    { "x-amz-algorithm": "AWS4-HMAC-SHA256" },
    { "x-amz-credential": "<cred>" },
    { "x-amz-date": "<date>" }
  ]
}
```

According to the [boto3 documentation](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3/client/generate_presigned_post.html):
- bucket related conditions should not be included in the `conditions` parameter
- key related conditions and fields are filled out for you and should not be included in the `Fields` or `Conditions` parameter

This fix removes the manually-set `bucket` and `key` from conditions and the `key` from fields, letting boto3 handle them. This approach aligns with the [boto3 implementation](https://github.com/boto/botocore/blob/a26a2c6d0ddf7ebbd60825833b54188bad955173/botocore/signers.py#L961).

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [X] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
<!-- Link related issues if there are any -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Streamlines presigned POST policy creation to prevent duplicate conditions and align with boto3 behavior.
> 
> - In `generate_presigned_post`, remove manual `bucket`/`key` entries from `Conditions` and stop setting `key` in `Fields`; rely on boto3 to supply them
> - `Fields` now only includes `Content-Type` and `bucket`; `Conditions` limited to `content-length-range` and `Content-Type`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4143cb23c1f18344e7b4dbe3b3c275e452bc80a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved storage handling in file upload operations by refining presigned URL generation logic for AWS S3 integration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->