### PR TITLE
[WIKI-735] fix: table insert handle z-index

### DIFF
--- a/packages/editor/src/styles/table.css
+++ b/packages/editor/src/styles/table.css
@@ -160,7 +160,7 @@
     opacity: 0;
     pointer-events: none;
     outline: none;
-    z-index: 10;
+    z-index: 9;
     transition: all 0.2s ease;
 
     &:hover {


### PR DESCRIPTION
### Description

This PR updates the z-index of table insert handles to ensure they don't overlap with the floating toolbar.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the stacking order of table insertion controls to refine layering behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->