### PR TITLE
fix(editor): prevent premature submission during IME composition

### DIFF
--- a/apps/web/core/components/comments/card/edit-form.tsx
+++ b/apps/web/core/components/comments/card/edit-form.tsx
@@ -71,7 +71,8 @@ export const CommentCardEditForm = observer(function CommentCardEditForm(props: 
     <form className="flex flex-col gap-2">
       <div
         onKeyDown={(e) => {
-          if (e.key === "Enter" && !e.shiftKey && !e.ctrlKey && !e.metaKey && !isEmpty) handleSubmit(onEnter)(e);
+          if (e.key === "Enter" && !e.shiftKey && !e.ctrlKey && !e.metaKey && !e.nativeEvent.isComposing && !isEmpty)
+            handleSubmit(onEnter)(e);
         }}
       >
         <LiteTextEditor

--- a/apps/web/core/components/comments/comment-create.tsx
+++ b/apps/web/core/components/comments/comment-create.tsx
@@ -94,6 +94,7 @@ export const CommentCreate = observer(function CommentCreate(props: TCommentCrea
           !e.shiftKey &&
           !e.ctrlKey &&
           !e.metaKey &&
+          !e.nativeEvent.isComposing &&
           !isEmpty &&
           !isSubmitting &&
           editorRef.current?.isEditorReadyToDiscard()

--- a/packages/editor/src/core/extensions/emoji/emoji.ts
+++ b/packages/editor/src/core/extensions/emoji/emoji.ts
@@ -375,6 +375,11 @@ export const Emoji = Node.create<EmojiOptions, EmojiStorage>({
 
         // replace text emojis with emoji node on any change
         appendTransaction: (transactions, oldState, newState) => {
+          // Skip during IME composition to avoid interfering with Chinese/Japanese/Korean input
+          if (this.editor.view.composing) {
+            return;
+          }
+
           const docChanges =
             transactions.some((transaction) => transaction.docChanged) && !oldState.doc.eq(newState.doc);
 

--- a/packages/editor/src/core/extensions/enter-key.ts
+++ b/packages/editor/src/core/extensions/enter-key.ts
@@ -9,6 +9,11 @@ export const EnterKeyExtension = (onEnterKeyPress?: () => void) =>
     addKeyboardShortcuts(this) {
       return {
         Enter: () => {
+          // Don't trigger submission during IME composition (e.g., Chinese/Japanese input)
+          if (this.editor.view.composing) {
+            return false;
+          }
+
           const { activeDropbarExtensions } = this.editor.storage.utility;
 
           if (activeDropbarExtensions.length === 0) {

--- a/packages/editor/src/core/extensions/trailing-node.ts
+++ b/packages/editor/src/core/extensions/trailing-node.ts
@@ -30,11 +30,17 @@ export const TrailingNode = Extension.create<TrailingNodeOptions>({
     const disabledNodes = Object.entries(this.editor.schema.nodes)
       .map(([, value]) => value)
       .filter((node) => this.options.notAfter.includes(node.name));
+    const editor = this.editor;
 
     return [
       new Plugin({
         key: plugin,
         appendTransaction: (_, __, state) => {
+          // Skip during IME composition to avoid interfering with Chinese/Japanese/Korean input
+          if (editor.view.composing) {
+            return;
+          }
+
           const { doc, tr, schema } = state;
           const shouldInsertNodeAtEnd = plugin.getState(state);
           const endPosition = doc.content.size;

--- a/packages/editor/src/core/extensions/unique-id/extension.ts
+++ b/packages/editor/src/core/extensions/unique-id/extension.ts
@@ -131,6 +131,6 @@ export const UniqueID = Extension.create<UniqueIDOptions>({
       return [];
     }
 
-    return [createUniqueIDPlugin(this.options)];
+    return [createUniqueIDPlugin(this.options, this.editor)];
   },
 });

--- a/packages/editor/src/core/extensions/unique-id/plugin.ts
+++ b/packages/editor/src/core/extensions/unique-id/plugin.ts
@@ -1,4 +1,4 @@
-import { combineTransactionSteps, findChildrenInRange, findDuplicates, getChangedRanges } from "@tiptap/core";
+import { combineTransactionSteps, Editor, findChildrenInRange, findDuplicates, getChangedRanges } from "@tiptap/core";
 import { Fragment, Slice } from "@tiptap/pm/model";
 import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
 import { Plugin, PluginKey } from "@tiptap/pm/state";
@@ -8,7 +8,7 @@ import type { UniqueIDOptions } from "./extension";
 // utils
 import { createIdsForView } from "./utils";
 
-export const createUniqueIDPlugin = (options: UniqueIDOptions) => {
+export const createUniqueIDPlugin = (options: UniqueIDOptions, editor?: Editor) => {
   let dragSourceElement: Element | null = null;
   let transformPasted = false;
   let syncHandler: (() => void) | null = null;
@@ -16,6 +16,11 @@ export const createUniqueIDPlugin = (options: UniqueIDOptions) => {
   return new Plugin({
     key: new PluginKey("uniqueID"),
     appendTransaction: (transactions, oldState, newState) => {
+      // Skip during IME composition to avoid interfering with Chinese/Japanese/Korean input
+      if (editor?.view.composing) {
+        return;
+      }
+
       const hasDocChanges =
         transactions.some((transaction) => transaction.docChanged) && !oldState.doc.eq(newState.doc);
       const filterTransactions =


### PR DESCRIPTION
### Description
Fixes the issue where comments are submitted prematurely when using Chinese/Japanese/Korean input methods (IME). When pressing Enter to select a character from the candidate list, the comment was being submitted instead of completing the character selection.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
https://github.com/user-attachments/assets/39fcfd6f-356d-4b52-9bd2-923e77456b8d

### Test Scenarios 
1. Use Traditional Chinese input method (注音輸入法) or any other IME
2. Go to Work Items and open the comment section
3. Type phonetic symbols and press Enter to select a character
4. Verify the character is selected without submitting the comment
5. Verify emoji suggestions don't interfere with character selection

### References
Fixes #4134

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved input handling for users typing with non-Latin input methods (Chinese, Japanese, Korean, etc.) to prevent premature comment or content submission and ensure text input is properly completed before processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->