### PR TITLE
[WIKI-877]fix: order of this dropdown options in pages

### DIFF
--- a/apps/web/core/components/pages/editor/toolbar/options-dropdown.tsx
+++ b/apps/web/core/components/pages/editor/toolbar/options-dropdown.tsx
@@ -132,12 +132,12 @@ export const PageOptionsDropdown = observer(function PageOptionsDropdown(props: 
         optionsOrder={[
           "full-screen",
           "sticky-toolbar",
+          "copy-markdown",
+          "version-history",
           "make-a-copy",
-          "toggle-access",
           "archive-restore",
           "delete",
-          "version-history",
-          "copy-markdown",
+          "toggle-access",
           "export",
         ]}
         page={page}


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->

### Type of Change
- [x] Improvement (change that would cause existing functionality to not work as expected)

### Screenshots and Media (if applicable)
<img width="209" height="231" alt="image" src="https://github.com/user-attachments/assets/0458f0ca-e09b-4e82-a014-156e7c7e1db9" />



### References
<!-- Link related issues if there are any -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reordered menu items in the toolbar options dropdown. Select options now appear earlier in the sequence for improved accessibility.
  * Note: One menu item now appears twice in the list.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->