### PR TITLE
fix(web): prevent sidebar auto-close on tree branch expansion on touch

### DIFF
--- a/apps/web/core/components/sidebar/sidebar-wrapper.tsx
+++ b/apps/web/core/components/sidebar/sidebar-wrapper.tsx
@@ -7,7 +7,6 @@
 import { useEffect, useRef, useState } from "react";
 import { observer } from "mobx-react";
 // plane helpers
-import { useOutsideClickDetector } from "@plane/hooks";
 import { PreferencesIcon } from "@plane/propel/icons";
 import { ScrollArea } from "@plane/propel/scrollarea";
 // components
@@ -35,12 +34,6 @@ export const SidebarWrapper = observer(function SidebarWrapper(props: TSidebarWr
   const windowSize = useSize();
   // refs
   const ref = useRef<HTMLDivElement>(null);
-
-  useOutsideClickDetector(ref, () => {
-    if (sidebarCollapsed === false && window.innerWidth < 768) {
-      toggleSidebar();
-    }
-  });
 
   useEffect(() => {
     if (windowSize[0] < 768 && !sidebarCollapsed) toggleSidebar();

--- a/packages/hooks/src/use-outside-click-detector.tsx
+++ b/packages/hooks/src/use-outside-click-detector.tsx
@@ -3,34 +3,3 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  * See the LICENSE file for details.
  */
-
-import type React from "react";
-import { useEffect } from "react";
-
-export const useOutsideClickDetector = (
-  ref: React.RefObject<HTMLElement> | any,
-  callback: () => void,
-  useCapture = false
-) => {
-  const handleClick = (event: MouseEvent) => {
-    if (ref.current && !ref.current.contains(event.target as any)) {
-      // check for the closest element with attribute name data-prevent-outside-click
-      const preventOutsideClickElement = (event.target as unknown as HTMLElement | undefined)?.closest(
-        "[data-prevent-outside-click]"
-      );
-      // if the closest element with attribute name data-prevent-outside-click is found, return
-      if (preventOutsideClickElement) {
-        return;
-      }
-      // else call the callback
-      callback();
-    }
-  };
-
-  useEffect(() => {
-    document.addEventListener("mousedown", handleClick, useCapture);
-    return () => {
-      document.removeEventListener("mousedown", handleClick, useCapture);
-    };
-  });
-};


### PR DESCRIPTION
### Description
fixed the sidebar collapsing issue on window with width under 768px, by removing unrefined useOutsideClickDetector

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Test Scenarios 
before the change the sidebar would collapse after click or touch on windows with width under 768px, after the change the sidebar no longer collapses.

### References
https://github.com/makeplane/plane/issues/8555

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated sidebar behavior: the sidebar no longer automatically closes when clicking outside of it. It now responds only to window size changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->