### PR TITLE
[WEB-6037] fix: workitem description input initial load

### DIFF
--- a/apps/web/core/components/editor/rich-text/description-input/root.tsx
+++ b/apps/web/core/components/editor/rich-text/description-input/root.tsx
@@ -119,6 +119,8 @@ export const DescriptionInput = observer(function DescriptionInput(props: Props)
   });
   // ref to track if there are unsaved changes
   const hasUnsavedChanges = useRef(false);
+  // ref to track last saved content (to skip onChange when content hasn't actually changed)
+  const lastSavedContent = useRef(initialValue?.trim() === "" ? "<p></p>" : (initialValue ?? "<p></p>"));
   // store hooks
   const { getWorkspaceBySlug } = useWorkspace();
   const { uploadEditorAsset, duplicateEditorAsset } = useEditorAsset();
@@ -139,6 +141,8 @@ export const DescriptionInput = observer(function DescriptionInput(props: Props)
   const handleDescriptionFormSubmit = useCallback(
     async (formData: TFormData) => {
       await onSubmit(formData.description_html, formData.isMigrationUpdate);
+      // Update lastSavedContent after successful save
+      lastSavedContent.current = formData.description_html;
     },
     [onSubmit]
   );
@@ -146,14 +150,17 @@ export const DescriptionInput = observer(function DescriptionInput(props: Props)
   // reset form values
   useEffect(() => {
     if (!entityId) return;
+    const normalizedValue = initialValue?.trim() === "" ? "<p></p>" : (initialValue ?? "<p></p>");
+    // Update last saved content when entity/initialValue changes
+    lastSavedContent.current = normalizedValue;
     reset({
       id: entityId,
-      description_html: initialValue?.trim() === "" ? "<p></p>" : (initialValue ?? "<p></p>"),
+      description_html: normalizedValue,
       isMigrationUpdate: false,
     });
     setLocalDescription({
       id: entityId,
-      description_html: initialValue?.trim() === "" ? "<p></p>" : (initialValue ?? "<p></p>"),
+      description_html: normalizedValue,
       isMigrationUpdate: false,
     });
     // Reset unsaved changes flag when form is reset
@@ -219,6 +226,8 @@ export const DescriptionInput = observer(function DescriptionInput(props: Props)
               projectId={projectId}
               dragDropEnabled
               onChange={(_description, description_html, options) => {
+                // Skip if content hasn't actually changed (handles editor normalization on init)
+                if (description_html === lastSavedContent.current) return;
                 setIsSubmitting("submitting");
                 onChange(description_html);
                 setValue("isMigrationUpdate", options?.isMigrationUpdate ?? false);


### PR DESCRIPTION
### Description
This PR resolves the browser alert that appears when opening or expanding a work item peek view without making any edits.

### Type of Change
- [x] Bug fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Rich text editor now efficiently detects when content hasn't changed, preventing unnecessary processing and state updates.
* Improved auto-save behavior to skip redundant saves when the description remains unchanged.
* Enhanced stability of empty value handling across different editor states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->