### PR TITLE
[WEB-6038] fix: work item empty title flicker

### DIFF
--- a/apps/web/core/components/issues/title-input.tsx
+++ b/apps/web/core/components/issues/title-input.tsx
@@ -45,7 +45,7 @@ export const IssueTitleInput = observer(function IssueTitleInput(props: IssueTit
   } = props;
   const { t } = useTranslation();
   // states
-  const [title, setTitle] = useState("");
+  const [title, setTitle] = useState(value || "");
   const [isLengthVisible, setIsLengthVisible] = useState(false);
   // ref to track if there are unsaved changes
   const hasUnsavedChanges = useRef(false);


### PR DESCRIPTION
### Description
This PR resolves the flickering empty title issue on initial load for the work item.

### Type of Change
- [x] Bug fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved title input component initialization to correctly use provided values on initial render, ensuring proper state synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->