### PR TITLE
Bug: Fix modules dropdown height inconsistency(#8635)

### DIFF
--- a/apps/web/core/components/issues/issue-detail/module-select.tsx
+++ b/apps/web/core/components/issues/issue-detail/module-select.tsx
@@ -4,7 +4,7 @@
  * See the LICENSE file for details.
  */
 
-import React, { useState } from "react";
+import { useState } from "react";
 import { xor } from "lodash-es";
 import { observer } from "mobx-react";
 import { useTranslation } from "@plane/i18n";
@@ -66,11 +66,13 @@ export const IssueModuleSelect = observer(function IssueModuleSelect(props: TIss
       <ModuleDropdown
         projectId={projectId}
         value={issue?.module_ids ?? []}
-        onChange={handleIssueModuleChange}
+        onChange={(moduleIds) => {
+          void handleIssueModuleChange(moduleIds);
+        }}
         placeholder={t("module.no_module")}
         disabled={disableSelect}
         className="group h-full w-full"
-        buttonContainerClassName="w-full text-left rounded-sm"
+        buttonContainerClassName="w-full text-left h-7.5 rounded-sm"
         buttonClassName={`text-body-xs-medium justify-between ${issue?.module_ids?.length ? "" : "text-placeholder"}`}
         buttonVariant="transparent-with-text"
         hideIcon


### PR DESCRIPTION
### Description
Adjusted dropdown height styling for Modules field to match other fields like Due date and Cycle, ensuring consistent UI alignment.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<img width="932" height="417" alt="Screenshot from 2026-02-16 18-08-45" src="https://github.com/user-attachments/assets/fe46a51b-0b3f-4d0c-93c1-e28b777ce952" />


### Test Scenarios 
- Tested locally in development environment
- Verified consistent height across all dropdown fields

### References
Fixes #8635 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated button container dimensions in the module select interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->