### PR TITLE
fix: Member Information Disclosure via Public Endpoint

### DIFF
--- a/apps/api/plane/space/views/project.py
+++ b/apps/api/plane/space/views/project.py
@@ -67,6 +67,11 @@ class ProjectMembersEndpoint(BaseAPIView):
 
     def get(self, request, anchor):
         deploy_board = DeployBoard.objects.filter(anchor=anchor).first()
+        if not deploy_board:
+            return Response(
+                {"error": "Invalid anchor"},
+                status=status.HTTP_404_NOT_FOUND,
+            )
 
         members = ProjectMember.objects.filter(
             project=deploy_board.project,
@@ -75,10 +80,7 @@ class ProjectMembersEndpoint(BaseAPIView):
         ).values(
             "id",
             "member",
-            "member__first_name",
-            "member__last_name",
             "member__display_name",
-            "project",
-            "workspace",
+            "member__avatar",
         )
         return Response(members, status=status.HTTP_200_OK)

--- a/apps/space/core/types/member.d.ts
+++ b/apps/space/core/types/member.d.ts
@@ -1,10 +1,6 @@
 export type TPublicMember = {
   id: string;
   member: string;
-  member__avatar: string;
-  member__first_name: string;
-  member__last_name: string;
   member__display_name: string;
-  project: string;
-  workspace: string;
+  member__avatar: string;
 };

--- a/packages/types/src/users.ts
+++ b/packages/types/src/users.ts
@@ -194,12 +194,8 @@ export type TProfileViews = "assigned" | "created" | "subscribed";
 export type TPublicMember = {
   id: string;
   member: string;
-  member__avatar: string;
-  member__first_name: string;
-  member__last_name: string;
   member__display_name: string;
-  project: string;
-  workspace: string;
+  member__avatar: string;
 };
 
 // export interface ICurrentUser {


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
1. No deploy board validation — Unlike sibling endpoints (states, labels, cycles), it didn't check if the deploy board exists before using it, causing an AttributeError on invalid anchors
2. Excessive PII exposure — Returned member__first_name, member__last_name, project UUID, and workspace UUID, none of which are used by the frontend

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for invalid project references that returns a 404 error response.

* **Refactor**
  * Streamlined project member data returned in API responses to include only display names and avatars, reducing response payload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->