### PR TITLE
fix ARCH detection and normalization

### DIFF
--- a/deployments/cli/community/install.sh
+++ b/deployments/cli/community/install.sh
@@ -428,7 +428,10 @@ function restartServices() {
 }
 function upgrade() {
     local latest_release=$(checkLatestRelease)
-
+    if [ -z "$latest_release" ]; then
+        echo "Failed to determine the latest release. Exiting..."
+        exit 1
+    fi
     echo ""
     echo "Current release: $APP_RELEASE"
 


### PR DESCRIPTION
### Description

Fixes two bugs in the community self-hosted install script (`deployments/cli/community/install.sh`) that cause installation to fail on x86_64 systems:

**Bug 1: `checkLatestRelease` failure not caught by parent script**

When `checkLatestRelease()` fails (e.g., due to GitHub API rate limiting or no network access), it calls `exit 1` — but because it runs inside a `$(...)` command substitution, that exit only terminates the subshell, not the parent script. The result is `APP_RELEASE` gets set to an empty string, which cascades into a broken `docker manifest inspect` call (`invalid reference format`) and eventually an offer to build images locally against a blank release tag.

**Fix:** Added a guard after the command substitution to check for an empty `APP_RELEASE` and exit cleanly with a clear error message.

**Bug 2: `UPPER_CPU_ARCH` set before CPU architecture normalization**

`UPPER_CPU_ARCH` is derived from `CPU_ARCH` at the top of the script, where `uname -m` returns the raw value (e.g., `x86_64`). The normalization block that maps `x86_64` → `amd64` and `aarch64` → `arm64` runs later near the bottom of the script, but `UPPER_CPU_ARCH` is never recalculated. This causes:
- The `docker manifest inspect` grep to search for `x86_64` instead of `amd64`, which never matches since Docker manifests use `amd64`
- User-facing messages to display `X86_64` instead of the correct `AMD64`

**Fix:** Moved the `UPPER_CPU_ARCH` assignment to after the normalization block so it reflects the corrected architecture name.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)

**Before (x86_64 system):**
```
--------------------------------------------
 ____  _                          /////////
|  _ \| | __ _ _ __   ___         /////////
| |_) | |/ _` | '_ \ / _ \   /////    /////
|  __/| | (_| | | | |  __/   /////    /////
|_|   |_|\__,_|_| |_|\___|        ////
                                  ////
--------------------------------------------
Project management tool from the future
--------------------------------------------

Select a Action you want to perform:
   1) Install
   2) Start
   3) Stop
   4) Restart
   5) Upgrade
   6) View Logs
   7) Backup Data
   8) Exit

Action [2]: 1

Begin Installing Plane

Checking for the latest release...
Failed to check for the latest release. Exiting...
Please wait while we check the availability of Docker images for the selected release () with X86_64 support. [|]  invalid reference format



X86_64 images are not available for selected release ().

Do you want to continue with building the Docker images locally?
Continue? [y/N]:
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added checks to stop and report when the latest stable release cannot be resolved, preventing incorrect install/upgrade attempts.
  * Improved CPU architecture detection and normalization so installations use consistent architecture names and messages across install and upgrade flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->