### PR TITLE
fix: disable react-in-jsx-scope rule in oxlint config

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -34,16 +34,20 @@
     "storybook-static/**"
   ],
   "rules": {
+    "react/react-in-jsx-scope": "off",
     "react/prop-types": "off",
     "unicorn/filename-case": "off",
     "unicorn/no-null": "off",
     "unicorn/prevent-abbreviations": "off",
-    "no-unused-vars": ["warn", {
-      "argsIgnorePattern": "^_",
-      "varsIgnorePattern": "^_",
-      "caughtErrorsIgnorePattern": "^_",
-      "destructuredArrayIgnorePattern": "^_",
-      "ignoreRestSiblings": true
-    }]
+    "no-unused-vars": [
+      "warn",
+      {
+        "argsIgnorePattern": "^_",
+        "varsIgnorePattern": "^_",
+        "caughtErrorsIgnorePattern": "^_",
+        "destructuredArrayIgnorePattern": "^_",
+        "ignoreRestSiblings": true
+      }
+    ]
   }
 }


### PR DESCRIPTION
## Summary

- Add `"react/react-in-jsx-scope": "off"` to `.oxlintrc.json`
- React 17+ uses automatic JSX runtime, explicit `import React` is not required
- This rule was disabled in the previous ESLint config but was not carried over when migrating to OxLint in #8677

## Problem

After #8677, the pre-commit hook (`oxlint --fix --deny-warnings`) fails on **every commit** that touches a JSX/TSX file:

```
! eslint-plugin-react(react-in-jsx-scope): `React` must be in scope when using JSX.
```

This blocks all local development commits.

## Fix

One-line change in `.oxlintrc.json`:

```json
"react/react-in-jsx-scope": "off"
```

Fixes #8681

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated linter configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->