### PR TITLE
[SECUR-116] fix: ssrf webhook url for ip address

### DIFF
--- a/apps/api/plane/app/serializers/webhook.py
+++ b/apps/api/plane/app/serializers/webhook.py
@@ -38,7 +38,7 @@ class WebhookSerializer(DynamicBaseSerializer):
 
         for addr in ip_addresses:
             ip = ipaddress.ip_address(addr[4][0])
-            if ip.is_loopback:
+            if ip.is_private or ip.is_loopback or ip.is_reserved or ip.is_link_local:
                 raise serializers.ValidationError({"url": "URL resolves to a blocked IP address."})
 
         # Additional validation for multiple request domains and their subdomains
@@ -73,7 +73,7 @@ class WebhookSerializer(DynamicBaseSerializer):
 
             for addr in ip_addresses:
                 ip = ipaddress.ip_address(addr[4][0])
-                if ip.is_loopback:
+                if ip.is_private or ip.is_loopback or ip.is_reserved or ip.is_link_local:
                     raise serializers.ValidationError({"url": "URL resolves to a blocked IP address."})
 
             # Additional validation for multiple request domains and their subdomains


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
- Webhook URL validation only checked `ip.is_loopback`, allowing SSRF attacks via private, reserved, and link-local IP ranges (e.g., cloud metadata endpoint `169.254.169.254`, internal services on `10.x.x.x`, `192.168.x.x`)
- Extended the IP check in both `create` and `update` of `WebhookSerializer` to also block `is_private`, `is_reserved`, and `is_link_local` — matching the existing validated pattern in `work_item_link_task.py`

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded webhook IP address validation to block a wider range of IP types, including private, loopback, reserved, and link-local addresses when configuring webhooks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->