### PR TITLE
Bug 8726-URL-based layout persistence

### DIFF
--- a/apps/web/core/components/issues/issue-layouts/filters/header/layout-selection.logic.ts
+++ b/apps/web/core/components/issues/issue-layouts/filters/header/layout-selection.logic.ts
@@ -1,0 +1,31 @@
+/**
+ * Extracts the layout value from a URL query string.
+ * Returns null if no valid layout is present.
+ */
+export function getLayoutFromUrl(search: string, validLayouts: string[]): string | null {
+  try {
+    const params = new URLSearchParams(search);
+    const layout = params.get("layout");
+
+    if (!layout) return null;
+    if (!validLayouts.includes(layout)) return null;
+
+    return layout;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Returns a new query string with the layout updated.
+ * Does not touch window or history — pure logic only.
+ */
+export function setLayoutInQuery(search: string, layout: string): string {
+  try {
+    const params = new URLSearchParams(search);
+    params.set("layout", layout);
+    return params.toString();
+  } catch {
+    return search;
+  }
+}

--- a/apps/web/core/components/issues/issue-layouts/filters/header/layout-selection.tsx
+++ b/apps/web/core/components/issues/issue-layouts/filters/header/layout-selection.tsx
@@ -15,6 +15,7 @@ import { IssueLayoutIcon } from "@/components/issues/issue-layouts/layout-icon";
 // hooks
 import { usePlatformOS } from "@/hooks/use-platform-os";
 import { useEffect } from "react";
+import { getLayoutFromUrl, setLayoutInQuery } from "./layout-selection.logic";
 
 type Props = {
   layouts: EIssueLayoutTypes[];
@@ -30,31 +31,22 @@ export function LayoutSelection(props: Props) {
   // Read layout from URL once on mount and apply if valid
   useEffect(() => {
     if (typeof window === "undefined") return;
-    try {
-      const params = new URLSearchParams(window.location.search);
-      const urlLayout = params.get("layout") as EIssueLayoutTypes | null;
-      if (urlLayout && urlLayout !== selectedLayout && layouts.includes(urlLayout)) {
-        onChange(urlLayout);
-      }
-    } catch (e: unknown) {
-      const err = e instanceof Error ? e : new Error(String(e));
-      console.warn("Failed to read layout from URL", err);
+
+    const layout = getLayoutFromUrl(window.location.search, layouts);
+    if (layout && (layout as EIssueLayoutTypes) !== selectedLayout) {
+      onChange(layout as EIssueLayoutTypes);
     }
   }, [layouts, onChange, selectedLayout]);
+
   const handleOnChange = (layoutKey: EIssueLayoutTypes) => {
     if (selectedLayout !== layoutKey) {
       onChange(layoutKey);
+
       if (typeof window !== "undefined") {
-        try {
-          const params = new URLSearchParams(window.location.search);
-          params.set("layout", layoutKey);
-          const newQuery = params.toString();
-          const newUrl = newQuery ? `${window.location.pathname}?${newQuery}` : window.location.pathname;
-          window.history.replaceState({}, "", newUrl);
-        } catch (e: unknown) {
-          const err = e instanceof Error ? e : new Error(String(e));
-          console.warn("Layout URL parsing failed (reported)", err);
-        }
+        const newQuery = setLayoutInQuery(window.location.search, layoutKey);
+        const newUrl = newQuery ? `${window.location.pathname}?${newQuery}` : window.location.pathname;
+
+        window.history.replaceState({}, "", newUrl);
       }
     }
   };

--- a/packages/codemods/tests/layout-selection.logic.test.ts
+++ b/packages/codemods/tests/layout-selection.logic.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import {
+  getLayoutFromUrl,
+  setLayoutInQuery,
+} from "../../../apps/web/core/components/issues/issue-layouts/filters/header/layout-selection.logic";
+
+describe("layout-selection.logic", () => {
+  describe("getLayoutFromUrl", () => {
+    it("returns the layout when valid", () => {
+      const result = getLayoutFromUrl("?layout=list", ["list", "kanban"]);
+      expect(result).toBe("list");
+    });
+
+    it("returns null when layout is missing", () => {
+      const result = getLayoutFromUrl("?foo=bar", ["list"]);
+      expect(result).toBeNull();
+    });
+
+    it("returns null when layout is invalid", () => {
+      const result = getLayoutFromUrl("?layout=unknown", ["list"]);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("setLayoutInQuery", () => {
+    it("updates the layout in the query string", () => {
+      const result = setLayoutInQuery("?foo=bar", "list");
+      expect(result).toBe("foo=bar&layout=list");
+    });
+
+    it("overwrites an existing layout", () => {
+      const result = setLayoutInQuery("?layout=kanban", "list");
+      expect(result).toBe("layout=list");
+    });
+  });
+});


### PR DESCRIPTION
### Description
This PR resolves an issue where the selected layout on the Views page would reset whenever the user clicked outside the browser window or navigated between pages. The previous implementation stored layout state only in local component state, which was overwritten during re‑renders triggered by focus changes or navigation. To ensure predictable behavior and persistent layout selection, the layout state has been moved into a URL‑driven model. The selected layout is now encoded in the query parameters, allowing it to persist across navigation, refreshes, and window focus changes.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [X] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

### Test Scenarios 
Testing focused on verifying that layout selection now persists reliably across all interaction patterns that previously caused resets. Manual testing confirmed that selecting a layout correctly updates the URL and that refreshing the page restores the chosen layout. Additional regression testing validated that clicking outside the browser window no longer triggers a reset and that navigation between different views preserves the layout parameter. Unit tests were added for the updated layout‑selection logic to ensure that URL parsing and query‑parameter updates behave consistently and do not introduce regressions.

### References
https://github.com/makeplane/plane/issues/8726

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Layout preferences are now persisted in the URL, allowing users to bookmark and share links with specific layout configurations.
  * When visiting a shared link with a layout parameter, the app automatically applies that layout on page load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->