### PR TITLE
feat: make webhook SSRF protection configurable for self-hosted deployments

### DIFF
--- a/apps/api/plane/app/serializers/webhook.py
+++ b/apps/api/plane/app/serializers/webhook.py
@@ -3,6 +3,7 @@
 # See the LICENSE file for details.
 
 # Python imports
+import os
 import socket
 import ipaddress
 from urllib.parse import urlparse
@@ -14,6 +15,8 @@ from rest_framework import serializers
 from .base import DynamicBaseSerializer
 from plane.db.models import Webhook, WebhookLog
 from plane.db.models.webhook import validate_domain, validate_schema
+
+ENABLE_WEBHOOK_SSRF_PROTECTION = os.environ.get("ENABLE_WEBHOOK_SSRF_PROTECTION", "1") != "0"
 
 
 class WebhookSerializer(DynamicBaseSerializer):
@@ -36,10 +39,11 @@ class WebhookSerializer(DynamicBaseSerializer):
         if not ip_addresses:
             raise serializers.ValidationError({"url": "No IP addresses found for the hostname."})
 
-        for addr in ip_addresses:
-            ip = ipaddress.ip_address(addr[4][0])
-            if ip.is_private or ip.is_loopback or ip.is_reserved or ip.is_link_local:
-                raise serializers.ValidationError({"url": "URL resolves to a blocked IP address."})
+        if ENABLE_WEBHOOK_SSRF_PROTECTION:
+            for addr in ip_addresses:
+                ip = ipaddress.ip_address(addr[4][0])
+                if ip.is_private or ip.is_loopback or ip.is_reserved or ip.is_link_local:
+                    raise serializers.ValidationError({"url": "URL resolves to a blocked IP address."})
 
         # Additional validation for multiple request domains and their subdomains
         request = self.context.get("request")
@@ -71,10 +75,11 @@ class WebhookSerializer(DynamicBaseSerializer):
             if not ip_addresses:
                 raise serializers.ValidationError({"url": "No IP addresses found for the hostname."})
 
-            for addr in ip_addresses:
-                ip = ipaddress.ip_address(addr[4][0])
-                if ip.is_private or ip.is_loopback or ip.is_reserved or ip.is_link_local:
-                    raise serializers.ValidationError({"url": "URL resolves to a blocked IP address."})
+            if ENABLE_WEBHOOK_SSRF_PROTECTION:
+                for addr in ip_addresses:
+                    ip = ipaddress.ip_address(addr[4][0])
+                    if ip.is_private or ip.is_loopback or ip.is_reserved or ip.is_link_local:
+                        raise serializers.ValidationError({"url": "URL resolves to a blocked IP address."})
 
             # Additional validation for multiple request domains and their subdomains
             request = self.context.get("request")

--- a/apps/api/plane/db/models/webhook.py
+++ b/apps/api/plane/db/models/webhook.py
@@ -3,6 +3,7 @@
 # See the LICENSE file for details.
 
 # Python imports
+import os
 from uuid import uuid4
 from urllib.parse import urlparse
 
@@ -27,8 +28,9 @@ def validate_schema(value):
 def validate_domain(value):
     parsed_url = urlparse(value)
     domain = parsed_url.netloc
-    if domain in ["localhost", "127.0.0.1"]:
-        raise ValidationError("Local URLs are not allowed.")
+    if os.environ.get("ENABLE_WEBHOOK_SSRF_PROTECTION", "1") != "0":
+        if domain in ["localhost", "127.0.0.1"]:
+            raise ValidationError("Local URLs are not allowed.")
 
 
 class Webhook(BaseModel):


### PR DESCRIPTION
## Summary

Self-hosted Plane deployments (Kubernetes, docker-compose on private networks) need webhooks pointing at internal services — for example, `http://my-service.default.svc.cluster.local:9090/webhook`. The current unconditional SSRF check blocks all private/loopback/reserved/link-local IPs, making webhooks unusable for any self-hosted integration without patching the image.

## Changes

- Add `ENABLE_WEBHOOK_SSRF_PROTECTION` environment variable (default: `"1"`, enabled)
- When set to `"0"`, the IP-range check in `WebhookSerializer.create()` and `.update()` is skipped
- Also gates the `validate_domain` model validator that blocks literal `localhost`/`127.0.0.1`
- **Zero behavior change** for Plane Cloud or any deployment that doesn't set the env var

## Motivation

Every self-hosted Plane user who needs webhook integrations with internal services has to patch the Docker image or exec into the container to modify `webhook.py`. The SSRF protection makes sense for Plane Cloud (multi-tenant, untrusted URLs) but is overly restrictive for self-hosted (single-tenant, trusted network).

## Test plan

- [ ] Verify default behavior unchanged: webhook creation with private IP still blocked when env var is unset
- [ ] Set `ENABLE_WEBHOOK_SSRF_PROTECTION=0`, verify webhook creation with private IP succeeds
- [ ] Verify `validate_domain` still blocks `localhost` when protection is enabled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Webhook configuration validation now blocks unsafe targets (private, loopback, reserved, link-local IPs) to prevent SSRF.
  * This protection is enabled by default and can be turned off via configuration if needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->