### PR TITLE
fix: strip whitespace from instance configuration values

### DIFF
--- a/apps/api/plane/license/api/views/configuration.py
+++ b/apps/api/plane/license/api/views/configuration.py
@@ -45,7 +45,8 @@ class InstanceConfigurationEndpoint(BaseAPIView):
 
         bulk_configurations = []
         for configuration in configurations:
-            value = request.data.get(configuration.key, configuration.value)
+            raw_value = request.data.get(configuration.key, configuration.value)
+            value = "" if raw_value is None else str(raw_value).strip()
             if configuration.is_encrypted:
                 configuration.value = encrypt_data(value)
             else:


### PR DESCRIPTION
Strip whitespace from config values before persisting. Closes #8737

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration values are normalized before saving: missing values become empty strings, inputs are trimmed of surrounding whitespace, and non-null values are coerced to strings prior to storage/encryption—reducing inconsistent formatting and related issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->