### PR TITLE
[WEB-6610] Fix work item drag handle hover gap

### DIFF
--- a/apps/web/core/components/issues/issue-detail/main-content.tsx
+++ b/apps/web/core/components/issues/issue-detail/main-content.tsx
@@ -134,7 +134,7 @@ export const IssueMainContent = observer(function IssueMainContent(props: Props)
 
         <DescriptionInput
           issueSequenceId={issue.sequence_id}
-          containerClassName="p-0! pl-6! border-none"
+          containerClassName="-ml-6 border-none p-0! pl-6!"
           disabled={isArchived || !isEditable}
           editorRef={editorRef}
           entityId={issue.id}


### PR DESCRIPTION
## Summary
- extend the work item description editor hover area to the left
- keep the description text visually aligned while bringing the drag handle inside the editor container

## Video
https://github.com/user-attachments/assets/82a76a8b-8022-4c16-b352-b89c4604cabc

## Testing
- confirmed the drag handle stays visible when moving the cursor slowly from the editor content toward the handle

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the spacing and alignment of the description input component for improved visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->