### PR TITLE
fix: Collapsible content never renders in controlled mode

### DIFF
--- a/packages/propel/src/collapsible/collapsible.tsx
+++ b/packages/propel/src/collapsible/collapsible.tsx
@@ -47,7 +47,7 @@ const useCollapsible = () => {
 
 // Components
 function Root({ children, className, isOpen: controlledIsOpen, onToggle, defaultOpen }: RootProps) {
-  const [localIsOpen, setLocalIsOpen] = useState<boolean>(controlledIsOpen || defaultOpen || false);
+  const [localIsOpen, setLocalIsOpen] = useState<boolean>(controlledIsOpen !== undefined ? controlledIsOpen : !!defaultOpen);
 
   useEffect(() => {
     if (controlledIsOpen !== undefined) {

--- a/packages/ui/src/collapsible/collapsible.tsx
+++ b/packages/ui/src/collapsible/collapsible.tsx
@@ -39,7 +39,7 @@ export function Collapsible(props: TCollapsibleProps) {
 
   return (
     <div className={className}>
-      <button ref={buttonRef} type="button" className={buttonClassName} onClick={handleOnClick}>
+      <button ref={buttonRef} type="button" className={buttonClassName} onClick={handleOnClick} aria-expanded={localIsOpen}>
         {title}
       </button>
       {localIsOpen && (


### PR DESCRIPTION
## Summary

The `Collapsible` component in `packages/ui` never shows its content when used in controlled mode (`isOpen` prop). This breaks sub-work items on issue detail pages — clicking the toggle arrow changes the arrow direction but the content never appears.

## Root Cause

Two issues in the current implementation:

1. **`Disclosure.Button`** from headlessui has its own internal toggle state that conflicts with the controlled `isOpen` prop — the internal state and `localIsOpen` get out of sync
2. **`Transition`** with `grid-rows-[0fr]`/`grid-rows-[1fr]` animation classes doesn't produce a visible expand/collapse effect

## Fix

Replace `Disclosure`/`Transition` from headlessui with a plain `div`/`button` and simple conditional rendering (`{localIsOpen && ...}`).

## Steps to Reproduce

1. Create an issue with sub-work items (sub-issues)
2. Open the issue detail page
3. Click the sub-work items toggle arrow
4. **Expected:** Sub-work items list appears
5. **Actual:** Arrow toggles but content never shows

## Test Plan

- [x] Sub-work items collapsible expands and shows content on click
- [x] Toggling open/closed works correctly
- [x] Uncontrolled mode (no `isOpen` prop) still works
- [x] No TypeScript errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified collapsible implementation for improved performance and predictability.
  * Improved state handling so explicit open/closed values are respected.
* **Behavior**
  * Panels now mount/unmount immediately (remove animated transitions) for instant expand/collapse.
* **Accessibility**
  * Button now exposes expanded state via aria-expanded for better screen reader support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->