### PR TITLE
fix: added workspace member check in allow permission for creator

### DIFF
--- a/apps/api/plane/app/permissions/base.py
+++ b/apps/api/plane/app/permissions/base.py
@@ -22,6 +22,17 @@ def allow_permission(allowed_roles, level="PROJECT", creator=False, model=None):
         def _wrapped_view(instance, request, *args, **kwargs):
             # Check for creator if required
             if creator and model:
+                # check if the user is part of the workspace or not
+                if not WorkspaceMember.objects.filter(
+                    member=request.user,
+                    workspace__slug=kwargs["slug"],
+                    is_active=True,
+                ).exists():
+                    return Response(
+                        {"error": "You don't have the required permissions."},
+                        status=status.HTTP_403_FORBIDDEN,
+                    )
+
                 obj = model.objects.filter(id=kwargs["pk"], created_by=request.user).exists()
                 if obj:
                     return view_func(instance, request, *args, **kwargs)


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
this pull request adds a check to verify whether the creator is part and active in the workspace or not.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced authorization checks to verify workspace membership before allowing access to resources, ensuring unauthorized users receive appropriate error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->