### PR TITLE
fix: add missing model_activity.delay() for API-driven issue webhooks

### DIFF
--- a/apps/api/plane/api/views/issue.py
+++ b/apps/api/plane/api/views/issue.py
@@ -629,6 +629,16 @@ class IssueDetailAPIEndpoint(BaseAPIView):
                         current_instance=current_instance,
                         epoch=int(timezone.now().timestamp()),
                     )
+                    # Send the model activity for webhook dispatch
+                    model_activity.delay(
+                        model_name="issue",
+                        model_id=str(issue.id),
+                        requested_data=request.data,
+                        current_instance=current_instance,
+                        actor_id=request.user.id,
+                        slug=slug,
+                        origin=base_host(request=request, is_app=True),
+                    )
                     return Response(serializer.data, status=status.HTTP_200_OK)
                 return Response(
                     # If the serializer is not valid, respond with 400 bad
@@ -676,6 +686,16 @@ class IssueDetailAPIEndpoint(BaseAPIView):
                         project_id=str(project_id),
                         current_instance=None,
                         epoch=int(timezone.now().timestamp()),
+                    )
+                    # Send the model activity for webhook dispatch
+                    model_activity.delay(
+                        model_name="issue",
+                        model_id=str(serializer.data["id"]),
+                        requested_data=request.data,
+                        current_instance=None,
+                        actor_id=request.user.id,
+                        slug=slug,
+                        origin=base_host(request=request, is_app=True),
                     )
                     return Response(serializer.data, status=status.HTTP_201_CREATED)
                 return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
@@ -751,6 +771,16 @@ class IssueDetailAPIEndpoint(BaseAPIView):
                 project_id=str(project_id),
                 current_instance=current_instance,
                 epoch=int(timezone.now().timestamp()),
+            )
+            # Send the model activity for webhook dispatch
+            model_activity.delay(
+                model_name="issue",
+                model_id=str(pk),
+                requested_data=request.data,
+                current_instance=current_instance,
+                actor_id=request.user.id,
+                slug=slug,
+                origin=base_host(request=request, is_app=True),
             )
             return Response(serializer.data, status=status.HTTP_200_OK)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
## Summary

Fixes #6746 — Webhooks are not triggered when issues are created or updated via the API.

### Problem

The `put()` (update and create-via-upsert) and `partial_update()` methods in `apps/api/plane/api/views/issue.py` only call `issue_activity.delay()` but not `model_activity.delay()`. Since `model_activity` is what triggers `webhook_activity` → `webhook_send_task` in the Celery worker, webhooks are never dispatched for API-driven issue changes.

The web UI code paths (e.g. `post()` at L475) already include `model_activity.delay()`, so this is only missing from the API views.

### Fix

Added `model_activity.delay()` immediately after each existing `issue_activity.delay()` in three locations:
1. **PUT update** — existing issue update via `external_id`
2. **PUT create-via-upsert** — new issue creation via `external_id`
3. **PATCH** — partial issue update

Uses the same function signature as the existing `model_activity.delay()` call in `post()`.

### Testing

Tested on Plane CE v1.2.1 (self-hosted, Docker):

1. Applied patch via bind mount to API container
2. Sent `PATCH` request via API to update issue priority
3. Confirmed Celery worker logs show:
   - `model_activity` task received
   - `webhook_activity` task received
   - `webhook_send_task` sent successfully

Before the fix, none of these tasks were triggered for API-driven updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved webhook event dispatching for issue operations to enhance activity tracking across create, update, and patch workflows, enabling better integration support and data synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->