### PR TITLE
[WEB-6739] fix: color inside of active projects of analytics overview tab

### DIFF
--- a/apps/web/core/components/analytics/overview/active-project-item.tsx
+++ b/apps/web/core/components/analytics/overview/active-project-item.tsx
@@ -23,7 +23,7 @@ type Props = {
 
 function CompletionPercentage({ percentage }: { percentage: number }) {
   const percentageColor =
-    percentage > 50 ? "bg-success-primary text-success-primary" : "bg-danger-primary text-danger-primary";
+    percentage > 50 ? "bg-success-subtle text-success-primary" : "bg-danger-subtle text-danger-primary";
   return (
     <div className={cn("flex items-center gap-2 rounded-sm p-1 text-11", percentageColor)}>
       <span>{percentage}%</span>


### PR DESCRIPTION
### Description
fixed color inside of active projects of analytics overview tab

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

### Screenshots and Media (if applicable)
Before
<img width="424" height="181" alt="image" src="https://github.com/user-attachments/assets/71abefa5-5293-4dd3-a2fd-68ce60766939" />
After
<img width="424" height="181" alt="image" src="https://github.com/user-attachments/assets/63dc7479-5aca-4892-9730-c0ce70baab8e" />


### Test Scenarios 


### References
<!-- Link related issues if there are any -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the visual styling of completion percentage indicators in the analytics overview to use softer background colors for improved visual hierarchy and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->