### PR TITLE
fix: use python3 JSON parser in checkLatestRelease() instead of grep

### DIFF
--- a/deployments/cli/community/install.sh
+++ b/deployments/cli/community/install.sh
@@ -57,13 +57,18 @@ function spinner() {
 
 function checkLatestRelease(){
     echo "Checking for the latest release..." >&2
-    local latest_release=$(curl -sSL https://api.github.com/repos/$GH_REPO/releases/latest | python3 -c "import sys,json; print(json.load(sys.stdin)['tag_name'])" 2>/dev/null)
+    if ! command -v python3 &> /dev/null; then
+        echo "python3 is required but not installed. Please install Python 3 and try again." >&2
+        exit 1
+    fi
+    local latest_release
+    latest_release=$(curl -fsSL "https://api.github.com/repos/$GH_REPO/releases/latest" | python3 -c "import sys,json; print(json.load(sys.stdin)['tag_name'])" 2>/dev/null)
     if [ -z "$latest_release" ]; then
         echo "Failed to check for the latest release. Exiting..." >&2
         exit 1
     fi
 
-    echo $latest_release    
+    echo "$latest_release"
 }
 
 function initialize(){

--- a/deployments/swarm/community/swarm.sh
+++ b/deployments/swarm/community/swarm.sh
@@ -38,13 +38,18 @@ EOF
 
 function checkLatestRelease(){
     echo "Checking for the latest release..." >&2
-    local latest_release=$(curl -s https://api.github.com/repos/$GH_REPO/releases/latest | python3 -c "import sys,json; print(json.load(sys.stdin)['tag_name'])" 2>/dev/null)
+    if ! command -v python3 &> /dev/null; then
+        echo "python3 is required but not installed. Please install Python 3 and try again." >&2
+        exit 1
+    fi
+    local latest_release
+    latest_release=$(curl -fsSL "https://api.github.com/repos/$GH_REPO/releases/latest" | python3 -c "import sys,json; print(json.load(sys.stdin)['tag_name'])" 2>/dev/null)
     if [ -z "$latest_release" ]; then
         echo "Failed to check for the latest release. Exiting..." >&2
         exit 1
     fi
 
-    echo $latest_release    
+    echo "$latest_release"
 }
 
 # Function to read stack name from env file


### PR DESCRIPTION
Closes #8775

  ## Summary
  `checkLatestRelease()` uses a grep pattern that assumes spaces after colons in GitHub API JSON responses. When GitHub
  returns compact/minified JSON, the pattern fails and the install script aborts.

  ## Fix
  Replace `grep` + `sed` with `python3 -c "import sys,json; print(json.load(sys.stdin)['tag_name'])"` which handles both
   compact and formatted JSON. `python3` is already a prerequisite for the Docker setup.

  Applied to both:
  - `deployments/cli/community/install.sh`
  - `deployments/swarm/community/swarm.sh`

  ## Verification
  ```bash
  # Old pattern fails on compact JSON
  echo '{"tag_name":"v1.2.3"}' | grep -o '"tag_name": "[^"]*"'  # no match

  # New pattern works on both formats
  echo '{"tag_name":"v1.2.3"}' | python3 -c "import sys,json; print(json.load(sys.stdin)['tag_name'])"  # v1.2.3
  echo '{"tag_name": "v1.2.3"}' | python3 -c "import sys,json; print(json.load(sys.stdin)['tag_name'])"  # v1.2.3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved release-version detection by switching to robust JSON parsing.
* **Bug Fixes**
  * Installer scripts now require Python 3 and will exit with a clear error if absent.
* **Stability**
  * Output handling tightened (proper quoting) to prevent unexpected parsing or formatting issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->