### PR TITLE
[WEB-6763] fix: date range dropdown clipped in sub-issues list

### DIFF
--- a/apps/web/core/components/issues/issue-detail-widgets/sub-issues/issues-list/properties.tsx
+++ b/apps/web/core/components/issues/issue-detail-widgets/sub-issues/issues-list/properties.tsx
@@ -139,6 +139,7 @@ export const SubIssuesListItemProperties = observer(function SubIssuesListItemPr
               from: getDate(issue.start_date) || undefined,
               to: getDate(issue.target_date) || undefined,
             }}
+            placement="top-end"
             onSelect={(range) => {
               handleStartDate(range?.from ?? null);
               handleTargetDate(range?.to ?? null);
@@ -154,6 +155,7 @@ export const SubIssuesListItemProperties = observer(function SubIssuesListItemPr
             showTooltip
             customTooltipHeading="Date Range"
             renderPlaceholder={false}
+            renderInPortal
           />
         </div>
       </WithDisplayPropertiesHOC>


### PR DESCRIPTION
### Description
- The date range dropdown in the sub-issues list was rendering behind
  other elements due to the parent CollapsibleContent's `overflow-hidden`
- Added `renderInPortal` prop to render the dropdown via `createPortal()`
  to `document.body`, matching how other dropdowns (Date, Priority) already work

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

### Screenshots and Media (if applicable)
Before
<img width="1509" height="520" alt="image" src="https://github.com/user-attachments/assets/b79cfb49-8d53-482b-9d29-8526992f25ab" />

After
<img width="1509" height="512" alt="image" src="https://github.com/user-attachments/assets/c86b9927-46e4-40e6-9971-c9fa0f05859e" />


### Test Scenarios 


### References


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved dropdown positioning for start date and due date fields in issue details, ensuring better visibility and placement on the screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->