### PR TITLE
fix: disable port_in_redirect and absolute_redirect in nginx configs

### DIFF
--- a/apps/admin/nginx/nginx.conf
+++ b/apps/admin/nginx/nginx.conf
@@ -20,6 +20,9 @@ http {
   server {
     listen 3000;
 
+    absolute_redirect off;
+    port_in_redirect  off;
+
     # Security headers
     add_header X-Frame-Options "DENY" always;
     add_header X-Content-Type-Options "nosniff" always;

--- a/apps/space/nginx/nginx.conf
+++ b/apps/space/nginx/nginx.conf
@@ -20,6 +20,9 @@ http {
   server {
     listen 3000;
 
+    absolute_redirect off;
+    port_in_redirect  off;
+
     location / {
       root   /usr/share/nginx/html;
       index  index.html index.htm;

--- a/apps/web/nginx/nginx.conf
+++ b/apps/web/nginx/nginx.conf
@@ -20,6 +20,9 @@ http {
   server {
     listen 3000;
 
+    absolute_redirect off;
+    port_in_redirect  off;
+
     # Security headers
     add_header X-Frame-Options "DENY" always;
     add_header X-Content-Type-Options "nosniff" always;


### PR DESCRIPTION
## Problem

When nginx performs a redirect (e.g., a trailing-slash redirect from `/settings` to `/settings/`), it by default generates an **absolute `Location` URL** that includes the host and the port it is listening on internally (`3000`).

When Plane is deployed behind a reverse proxy (e.g., Caddy, nginx, Traefik) on the standard ports 80/443, this behaviour leaks the internal container port to end users:

```
< HTTP/1.1 301 Moved Permanently
< Location: http://plane.example.com:3000/settings/
```

Instead of the expected:

```
< HTTP/1.1 301 Moved Permanently
< Location: /settings/
```

This breaks navigation in all three frontend apps (`web`, `admin`, `space`) whenever nginx issues a redirect.

## Root Cause

nginx's [`port_in_redirect`](https://nginx.org/en/docs/http/ngx_http_core_module.html#port_in_redirect) directive (default: `on`) appends the server's listen port to the `Location` header. nginx's [`absolute_redirect`](https://nginx.org/en/docs/http/ngx_http_core_module.html#absolute_redirect) directive (default: `on`) generates a fully-qualified absolute URL rather than a relative path.

Both defaults are appropriate for standalone nginx, but are incorrect when nginx sits behind a reverse proxy.

> **From the nginx docs:**
> `port_in_redirect` — Enables or disables specifying the port in absolute redirects issued by nginx.
> `absolute_redirect` — If disabled, redirects issued by nginx will be relative.

## Fix

Added the following two directives to the `server {}` block of all three frontend nginx configs:

```nginx
absolute_redirect off;
port_in_redirect  off;
```

This ensures that any redirect nginx generates is a **relative URL**, completely unaffected by the internal listen port. The reverse proxy's own port and host are preserved end-to-end.

## Files Changed

- `apps/web/nginx/nginx.conf`
- `apps/admin/nginx/nginx.conf`
- `apps/space/nginx/nginx.conf`

## Testing

Trigger a trailing-slash redirect against the container directly:

```bash
# Without fix
curl -sv http://localhost:3000/god-mode 2>&1 | grep -i location
# Location: http://localhost:3000/god-mode/   ❌ internal port leaks

# With fix
curl -sv http://localhost:3000/god-mode 2>&1 | grep -i location
# Location: /god-mode/                        ✅ relative, proxy-safe
```

Fixes: #8814 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated server redirect configuration across admin, space, and web applications to adjust how URLs are handled during server redirects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->