### PR TITLE
[WEB-6794] fix: align profile cover update with correct unsplash and upload handling

### DIFF
--- a/apps/web/core/components/settings/profile/content/pages/general/form.tsx
+++ b/apps/web/core/components/settings/profile/content/pages/general/form.tsx
@@ -157,17 +157,23 @@ export const GeneralProfileSettingsForm = observer(function GeneralProfileSettin
       promises.push(updateCurrentUserProfile);
     }
 
-    const updatePromise = Promise.allSettled(promises).then((results) => {
-      const rejectedResult = results.find((result) => result.status === "rejected") as
-        | PromiseRejectedResult
-        | undefined;
-      if (rejectedResult) {
-        throw rejectedResult.reason ?? new Error("Failed to update profile");
-      }
-      return results.map((result) => (result as PromiseFulfilledResult<IUser | TUserProfile | undefined>).value);
-    });
-
-    updatePromise.finally(() => setIsLoading(false));
+    const updatePromise = Promise.allSettled(promises)
+      .then((results) => {
+        const rejectedResult = results.find((result) => result.status === "rejected") as
+          | PromiseRejectedResult
+          | undefined;
+        if (rejectedResult) {
+          throw rejectedResult.reason ?? new Error("Failed to update profile");
+        }
+        const values = results.map(
+          (result) => (result as PromiseFulfilledResult<IUser | TUserProfile | undefined>).value
+        );
+        if (values.some((v) => v === undefined)) {
+          throw new Error("Failed to update profile");
+        }
+        return values;
+      })
+      .finally(() => setIsLoading(false));
 
     setPromiseToast(updatePromise, {
       loading: "Updating...",

--- a/apps/web/helpers/cover-image.helper.ts
+++ b/apps/web/helpers/cover-image.helper.ts
@@ -276,7 +276,7 @@ export const handleCoverImageChange = async (
     return;
   }
 
-  return;
+  return { cover_image: newImage };
 };
 
 /**


### PR DESCRIPTION
### Description
- Adds Unsplash image type detection so cover images from Unsplash are
   re-uploaded to own storage instead of being hotlinked
- Simplifies the cover image upload flow — backend auto-links assets via
   entity type, no client-side payload needed after upload
- Fixes null image input being misclassified in analyzeCoverImageChange
- Skips redundant profile update API call when role hasn't changed
- Uses Promise.allSettled so a single failed promise doesn't block the
   other update

### Type of Change
- [x] Bug fix

### Test plan
- [ ] Select an Unsplash image as profile cover → save → verify image
        persists after page reload (re-uploaded, not hotlinked)
- [ ] Select a static cover image → save → verify it uploads and displays
- [ ] Upload a custom image via drag-and-drop → save → verify it displays
- [ ] Change cover image back to a previously uploaded asset → verify no
        duplicate upload occurs
- [ ] Save profile without changing cover image → verify no upload or
        cover-related API payload is sent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cover images can now be sourced directly from Unsplash.

* **Refactor**
  * Streamlined profile update flow with conditional updates, consolidated loading state, and improved toast/error handling for more reliable saves.
  * Revised cover-image handling and upload logic with better URL classification, filename extraction, and clearer update behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->