### PR TITLE
fix: prevent privilege escalation in project member role updates

### DIFF
--- a/apps/api/plane/app/views/project/member.py
+++ b/apps/api/plane/app/views/project/member.py
@@ -226,21 +226,36 @@ class ProjectMemberViewSet(BaseViewSet):
             is_active=True,
         )
 
-        if workspace_role in [5] and int(request.data.get("role", project_member.role)) in [15, 20]:
-            return Response(
-                {"error": "You cannot add a user with role higher than the workspace role"},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
+        if "role" in request.data:
+            # Only Admins can modify roles
+            if requested_project_member.role < ROLE.ADMIN.value and not is_workspace_admin:
+                return Response(
+                    {"error": "You do not have permission to update roles"},
+                    status=status.HTTP_403_FORBIDDEN,
+                )
 
-        if (
-            "role" in request.data
-            and int(request.data.get("role", project_member.role)) > requested_project_member.role
-            and not is_workspace_admin
-        ):
-            return Response(
-                {"error": "You cannot update a role that is higher than your own role"},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
+            # Cannot modify a member whose role is equal to or higher than your own
+            if project_member.role >= requested_project_member.role and not is_workspace_admin:
+                return Response(
+                    {"error": "You cannot update the role of a member with a role equal to or higher than your own"},
+                    status=status.HTTP_403_FORBIDDEN,
+                )
+
+            new_role = int(request.data.get("role"))
+
+            # Cannot assign a role equal to or higher than your own
+            if new_role >= requested_project_member.role and not is_workspace_admin:
+                return Response(
+                    {"error": "You cannot assign a role equal to or higher than your own"},
+                    status=status.HTTP_403_FORBIDDEN,
+                )
+
+            # Cannot assign a role higher than the target's workspace role
+            if workspace_role in [5] and new_role in [15, 20]:
+                return Response(
+                    {"error": "You cannot add a user with role higher than the workspace role"},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
 
         serializer = ProjectMemberSerializer(project_member, data=request.data, partial=True)
 


### PR DESCRIPTION
## Summary
- **Fixes GHSA-494h-3rcq-5g3c** — a Guest (role=5) could demote Admins/Members to Guest by exploiting a missing lower-bound check in `ProjectMemberViewSet.partial_update`
- Restricts role modification to project Admins only (workspace admins bypass as before)
- Adds checks that the requester cannot modify a member with an equal/higher role, nor assign a role equal to or higher than their own

## Test plan
- [ ] Verify a Guest cannot change any member's role (expect 403)
- [ ] Verify a Member cannot change any member's role (expect 403)
- [ ] Verify an Admin can demote a Member to Guest
- [ ] Verify an Admin cannot demote another Admin (expect 403)
- [ ] Verify an Admin cannot promote a Member to Admin (expect 403)
- [ ] Verify a workspace Admin can still modify any role
- [ ] Verify non-role updates (sort_order, view_props) still work for Members/Guests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced role authorization checks for project member management to enforce stricter permission controls across role modifications.
  * Improved error handling with updated response codes for unauthorized role modification attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->