### PR TITLE
fix: IDOR in IssueBulkUpdateDateEndpoint (GHSA-4q54-h4x9-m329)

### DIFF
--- a/apps/api/plane/app/views/issue/base.py
+++ b/apps/api/plane/app/views/issue/base.py
@@ -1118,7 +1118,7 @@ class IssueBulkUpdateDateEndpoint(BaseAPIView):
         epoch = int(timezone.now().timestamp())
 
         # Fetch all relevant issues in a single query
-        issues = list(Issue.objects.filter(id__in=issue_ids))
+        issues = list(Issue.objects.filter(id__in=issue_ids, workspace__slug=slug, project_id=project_id))
         issues_dict = {str(issue.id): issue for issue in issues}
         issues_to_update = []
 


### PR DESCRIPTION
## Summary

- Fixes an IDOR vulnerability in `IssueBulkUpdateDateEndpoint` where the issue query was not scoped to the current workspace and project
- An authenticated user with ADMIN or MEMBER role in **any** project could modify `start_date` and `target_date` of issues in **any other** workspace/project across the entire instance
- Scoped the `Issue.objects.filter()` query to include `workspace__slug` and `project_id`, consistent with all other issue endpoints

## Security Details

- **Advisory:** GHSA-4q54-h4x9-m329
- **CWE:** CWE-639 (Authorization Bypass Through User-Controlled Key)
- **CVSS:** 6.5 (Medium)
- **File:** `apps/api/plane/app/views/issue/base.py`

## Root Cause

The query at line 1121 used `Issue.objects.filter(id__in=issue_ids)` without constraining by `workspace__slug=slug` and `project_id=project_id`. This allowed cross-workspace/cross-project issue date modification.

## Fix

```diff
- issues = list(Issue.objects.filter(id__in=issue_ids))
+ issues = list(Issue.objects.filter(id__in=issue_ids, workspace__slug=slug, project_id=project_id))
```

## Test plan

- [ ] Verify bulk date updates still work for issues within the user's own project
- [ ] Verify that attempting to update issues from another project/workspace results in those issues being silently skipped (not found by the scoped query)
- [ ] Verify that the endpoint returns 200 with no modifications when all provided issue IDs belong to other projects

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed bulk date updates for issues to correctly scope to the specified workspace and project, preventing unintended updates to issues outside the current scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->