### PR TITLE
[INFRA-346] chore: remove artifacts.plane.so references from community deployments

### DIFF
--- a/deployments/aio/community/Dockerfile
+++ b/deployments/aio/community/Dockerfile
@@ -6,12 +6,12 @@ FROM --platform=$BUILDPLATFORM tonistiigi/binfmt AS binfmt
 # **************************************************
 FROM node:22-alpine AS node
 
-FROM artifacts.plane.so/makeplane/plane-frontend:${PLANE_VERSION} AS web-img
-FROM artifacts.plane.so/makeplane/plane-backend:${PLANE_VERSION} AS backend-img
-FROM artifacts.plane.so/makeplane/plane-space:${PLANE_VERSION} AS space-img
-FROM artifacts.plane.so/makeplane/plane-admin:${PLANE_VERSION} AS admin-img
-FROM artifacts.plane.so/makeplane/plane-live:${PLANE_VERSION} AS live-img
-FROM artifacts.plane.so/makeplane/plane-proxy:${PLANE_VERSION} AS proxy-img
+FROM makeplane/plane-frontend:${PLANE_VERSION} AS web-img
+FROM makeplane/plane-backend:${PLANE_VERSION} AS backend-img
+FROM makeplane/plane-space:${PLANE_VERSION} AS space-img
+FROM makeplane/plane-admin:${PLANE_VERSION} AS admin-img
+FROM makeplane/plane-live:${PLANE_VERSION} AS live-img
+FROM makeplane/plane-proxy:${PLANE_VERSION} AS proxy-img
 
 # **************************************************
 #  STAGE 1: Runner

--- a/deployments/aio/community/README.md
+++ b/deployments/aio/community/README.md
@@ -59,7 +59,7 @@ docker run --name plane-aio --rm -it \
     -e AWS_ACCESS_KEY_ID=your-access-key \
     -e AWS_SECRET_ACCESS_KEY=your-secret-key \
     -e AWS_S3_BUCKET_NAME=your-bucket \
-    artifacts.plane.so/makeplane/plane-aio-community:latest
+    makeplane/plane-aio-community:latest
 ```
 
 ### Example with IP Address
@@ -78,7 +78,7 @@ docker run --name myaio --rm -it \
     -e AWS_S3_BUCKET_NAME=plane-app \
     -e AWS_S3_ENDPOINT_URL=http://${MYIP}:19000 \
     -e FILE_SIZE_LIMIT=10485760 \
-    artifacts.plane.so/makeplane/plane-aio-community:latest
+    makeplane/plane-aio-community:latest
 ```
 
 ## Configuration Options

--- a/deployments/cli/community/docker-compose.yml
+++ b/deployments/cli/community/docker-compose.yml
@@ -61,7 +61,7 @@ x-app-env: &app-env
 
 services:
   web:
-    image: artifacts.plane.so/makeplane/plane-frontend:${APP_RELEASE:-stable}
+    image: makeplane/plane-frontend:${APP_RELEASE:-stable}
     deploy:
       replicas: ${WEB_REPLICAS:-1}
       restart_policy:
@@ -71,7 +71,7 @@ services:
       - worker
 
   space:
-    image: artifacts.plane.so/makeplane/plane-space:${APP_RELEASE:-stable}
+    image: makeplane/plane-space:${APP_RELEASE:-stable}
     deploy:
       replicas: ${SPACE_REPLICAS:-1}
       restart_policy:
@@ -82,7 +82,7 @@ services:
       - web
 
   admin:
-    image: artifacts.plane.so/makeplane/plane-admin:${APP_RELEASE:-stable}
+    image: makeplane/plane-admin:${APP_RELEASE:-stable}
     deploy:
       replicas: ${ADMIN_REPLICAS:-1}
       restart_policy:
@@ -92,7 +92,7 @@ services:
       - web
 
   live:
-    image: artifacts.plane.so/makeplane/plane-live:${APP_RELEASE:-stable}
+    image: makeplane/plane-live:${APP_RELEASE:-stable}
     environment:
       <<: [*live-env, *redis-env]
     deploy:
@@ -104,7 +104,7 @@ services:
       - web
 
   api:
-    image: artifacts.plane.so/makeplane/plane-backend:${APP_RELEASE:-stable}
+    image: makeplane/plane-backend:${APP_RELEASE:-stable}
     command: ./bin/docker-entrypoint-api.sh
     deploy:
       replicas: ${API_REPLICAS:-1}
@@ -120,7 +120,7 @@ services:
       - plane-mq
 
   worker:
-    image: artifacts.plane.so/makeplane/plane-backend:${APP_RELEASE:-stable}
+    image: makeplane/plane-backend:${APP_RELEASE:-stable}
     command: ./bin/docker-entrypoint-worker.sh
     deploy:
       replicas: ${WORKER_REPLICAS:-1}
@@ -137,7 +137,7 @@ services:
       - plane-mq
 
   beat-worker:
-    image: artifacts.plane.so/makeplane/plane-backend:${APP_RELEASE:-stable}
+    image: makeplane/plane-backend:${APP_RELEASE:-stable}
     command: ./bin/docker-entrypoint-beat.sh
     deploy:
       replicas: ${BEAT_WORKER_REPLICAS:-1}
@@ -154,7 +154,7 @@ services:
       - plane-mq
 
   migrator:
-    image: artifacts.plane.so/makeplane/plane-backend:${APP_RELEASE:-stable}
+    image: makeplane/plane-backend:${APP_RELEASE:-stable}
     command: ./bin/docker-entrypoint-migrator.sh
     deploy:
       replicas: 1
@@ -216,7 +216,7 @@ services:
 
   # Comment this if you already have a reverse proxy running
   proxy:
-    image: artifacts.plane.so/makeplane/plane-proxy:${APP_RELEASE:-stable}
+    image: makeplane/plane-proxy:${APP_RELEASE:-stable}
     deploy:
       replicas: 1
       restart_policy:

--- a/deployments/cli/community/install.sh
+++ b/deployments/cli/community/install.sh
@@ -5,7 +5,7 @@ SCRIPT_DIR=$PWD
 SERVICE_FOLDER=plane-app
 PLANE_INSTALL_DIR=$PWD/$SERVICE_FOLDER
 export APP_RELEASE=stable
-export DOCKERHUB_USER=artifacts.plane.so/makeplane
+export DOCKERHUB_USER=makeplane
 export PULL_POLICY=${PULL_POLICY:-if_not_present}
 export GH_REPO=makeplane/plane
 export RELEASE_DOWNLOAD_URL="https://github.com/$GH_REPO/releases/download"
@@ -690,7 +690,7 @@ if [ -f "$DOCKER_ENV_PATH" ]; then
     CUSTOM_BUILD=$(getEnvValue "CUSTOM_BUILD" "$DOCKER_ENV_PATH")
 
     if [ -z "$DOCKERHUB_USER" ]; then
-        DOCKERHUB_USER=artifacts.plane.so/makeplane
+        DOCKERHUB_USER=makeplane
         updateEnvFile "DOCKERHUB_USER" "$DOCKERHUB_USER" "$DOCKER_ENV_PATH"
     fi
 

--- a/deployments/swarm/community/swarm.sh
+++ b/deployments/swarm/community/swarm.sh
@@ -5,7 +5,7 @@ SERVICE_FOLDER=plane-app
 SCRIPT_DIR=$PWD
 PLANE_INSTALL_DIR=$PWD/$SERVICE_FOLDER
 export APP_RELEASE="stable"
-export DOCKERHUB_USER=artifacts.plane.so/makeplane
+export DOCKERHUB_USER=makeplane
 
 export GH_REPO=makeplane/plane
 export RELEASE_DOWNLOAD_URL="https://github.com/$GH_REPO/releases/download"
@@ -595,7 +595,7 @@ if [ -f "$DOCKER_ENV_PATH" ]; then
     APP_RELEASE=$(getEnvValue "APP_RELEASE" "$DOCKER_ENV_PATH")
 
     if [ -z "$DOCKERHUB_USER" ]; then
-        DOCKERHUB_USER=artifacts.plane.so/makeplane
+        DOCKERHUB_USER=makeplane
         updateEnvFile "DOCKERHUB_USER" "$DOCKERHUB_USER" "$DOCKER_ENV_PATH"
     fi
 


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
This pull request updates all references to Plane container images in the community deployment files, switching from the old `artifacts.plane.so/makeplane` registry to the standard Docker Hub `makeplane` namespace. This change simplifies image pulls and aligns with the new image hosting location. The update affects Dockerfiles, Docker Compose files, shell scripts, and documentation.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [X] Bug fix (non-breaking change which fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated deployment examples and instructions for Docker image references.

* **Chores**
  * Updated Docker image registry references across all community deployment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->