### PR TITLE
[WEB-6813] fix: module not associated when accepting intake work items

### DIFF
--- a/apps/web/core/components/issues/issue-modal/base.tsx
+++ b/apps/web/core/components/issues/issue-modal/base.tsx
@@ -267,11 +267,13 @@ export const CreateUpdateIssueModalBase = observer(function CreateUpdateIssueMod
     // - cycle_id is the same as the current cycle id
     if (!("cycle_id" in payload) || isEqual(data?.cycle_id, payload.cycle_id)) return;
 
+    const slug = workspaceSlug.toString();
+
     // Removing the cycle
     const currentCycleId = data?.cycle_id;
     if (currentCycleId && payload.cycle_id === null) {
-      await issues.removeIssueFromCycle(workspaceSlug, data.project_id, currentCycleId, data.id);
-      fetchCycleDetails(workspaceSlug, data.project_id, currentCycleId).catch((error) => {
+      await issues.removeIssueFromCycle(slug, data.project_id, currentCycleId, data.id);
+      fetchCycleDetails(slug, data.project_id, currentCycleId).catch((error) => {
         console.error(error);
       });
     }
@@ -309,7 +311,13 @@ export const CreateUpdateIssueModalBase = observer(function CreateUpdateIssueMod
     }
     // update modules if there are modules to add or remove
     if (modulesToAdd.length > 0 || modulesToRemove.length > 0) {
-      await issues.changeModulesInIssue(workspaceSlug, data.project_id, data.id, modulesToAdd, modulesToRemove);
+      await issues.changeModulesInIssue(
+        workspaceSlug.toString(),
+        data.project_id,
+        data.id,
+        modulesToAdd,
+        modulesToRemove
+      );
     }
   };
 
@@ -320,20 +328,17 @@ export const CreateUpdateIssueModalBase = observer(function CreateUpdateIssueMod
       if (isDraft) await draftIssues.updateIssue(workspaceSlug.toString(), data.id, payload);
       else if (updateIssue) await updateIssue(payload.project_id, data.id, payload);
 
-      await Promise.all([
-        // handle cycle change
-        handleCycleChange(data, payload),
-        // handle module change
-        handleModuleChange(data, payload),
-        // handle other property values
-        handleCreateUpdatePropertyValues({
-          issueId: data.id,
-          issueTypeId: payload.type_id,
-          projectId: payload.project_id,
-          workspaceSlug: workspaceSlug?.toString(),
-          isDraft: isDraft,
-        }),
-      ]);
+      // Run cycle, module, and property changes sequentially to avoid
+      // optimistic store writes from racing against each other.
+      await handleCycleChange(data, payload);
+      await handleModuleChange(data, payload);
+      await handleCreateUpdatePropertyValues({
+        issueId: data.id,
+        issueTypeId: payload.type_id,
+        projectId: payload.project_id,
+        workspaceSlug: workspaceSlug?.toString(),
+        isDraft: isDraft,
+      });
 
       setToast({
         type: TOAST_TYPE.SUCCESS,


### PR DESCRIPTION
## Description
  - Fixes a bug where selecting a module in the intake acceptance modal
    had no effect — the module was never associated with the work item.
  - Root cause: the inline module guard `data.module_ids && payload.module_ids`
    required both to be truthy. Intake items always have `null` module_ids
    (no modules yet), so the entire block was skipped.
   - Code refactoring 

## Type of Change
  - [x] Bug fix
  - [x] Code refactoring

## Test Scenarios 
  - [ ] Accept intake item → select a module → verify module is associated
  - [ ] Accept intake item → no module selected → verify no errors
  - [ ] Accept intake item → select a cycle → verify cycle is associated
  - [ ] Accept intake item → select both module and cycle → verify both associated
  - [ ] Accept intake item → select multiple modules → verify all associated
  - [ ] Edit existing work item → change module → verify add/remove works
  - [ ] Edit existing work item → remove module → verify removal works
  - [ ] Edit existing work item → change cycle → verify cycle switch works
  - [ ] Edit existing work item → remove cycle → verify removal works
  - [ ] Accept intake item with labels/assignees already set → verify preserved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Reduced unnecessary backend calls when changing issue cycles or modules, improving update responsiveness.

* **Refactor**
  * Reorganized issue update logic into clearer, targeted handlers for cycle and module changes, simplifying the update flow and making property updates more reliable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->