### PR TITLE
fix: prevent ORM field injection via segment parameter in analytics (GHSA-93x3-ghh7-72j3)

### DIFF
--- a/apps/api/plane/app/views/analytic/base.py
+++ b/apps/api/plane/app/views/analytic/base.py
@@ -29,7 +29,7 @@ from plane.db.models import (
     Module,
 )
 
-from plane.utils.analytics_plot import build_graph_plot
+from plane.utils.analytics_plot import build_graph_plot, VALID_ANALYTICS_FIELDS, VALID_YAXIS
 from plane.utils.issue_filters import issue_filters
 from plane.app.permissions import allow_permission, ROLE
 
@@ -41,32 +41,15 @@ class AnalyticsEndpoint(BaseAPIView):
         y_axis = request.GET.get("y_axis", False)
         segment = request.GET.get("segment", False)
 
-        valid_xaxis_segment = [
-            "state_id",
-            "state__group",
-            "labels__id",
-            "assignees__id",
-            "estimate_point__value",
-            "issue_cycle__cycle_id",
-            "issue_module__module_id",
-            "priority",
-            "start_date",
-            "target_date",
-            "created_at",
-            "completed_at",
-        ]
-
-        valid_yaxis = ["issue_count", "estimate"]
-
         # Check for x-axis and y-axis as thery are required parameters
-        if not x_axis or not y_axis or x_axis not in valid_xaxis_segment or y_axis not in valid_yaxis:
+        if not x_axis or not y_axis or x_axis not in VALID_ANALYTICS_FIELDS or y_axis not in VALID_YAXIS:
             return Response(
                 {"error": "x-axis and y-axis dimensions are required and the values should be valid"},
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
         # If segment is present it cannot be same as x-axis
-        if segment and (segment not in valid_xaxis_segment or x_axis == segment):
+        if segment and (segment not in VALID_ANALYTICS_FIELDS or x_axis == segment):
             return Response(
                 {"error": "Both segment and x axis cannot be same and segment should be valid"},
                 status=status.HTTP_400_BAD_REQUEST,
@@ -221,6 +204,13 @@ class SavedAnalyticEndpoint(BaseAPIView):
             )
 
         segment = request.GET.get("segment", False)
+
+        if segment and (segment not in VALID_ANALYTICS_FIELDS or x_axis == segment):
+            return Response(
+                {"error": "Both segment and x axis cannot be same and segment should be valid"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
         distribution = build_graph_plot(queryset=queryset, x_axis=x_axis, y_axis=y_axis, segment=segment)
         total_issues = queryset.count()
         return Response(
@@ -236,32 +226,15 @@ class ExportAnalyticsEndpoint(BaseAPIView):
         y_axis = request.data.get("y_axis", False)
         segment = request.data.get("segment", False)
 
-        valid_xaxis_segment = [
-            "state_id",
-            "state__group",
-            "labels__id",
-            "assignees__id",
-            "estimate_point",
-            "issue_cycle__cycle_id",
-            "issue_module__module_id",
-            "priority",
-            "start_date",
-            "target_date",
-            "created_at",
-            "completed_at",
-        ]
-
-        valid_yaxis = ["issue_count", "estimate"]
-
         # Check for x-axis and y-axis as thery are required parameters
-        if not x_axis or not y_axis or x_axis not in valid_xaxis_segment or y_axis not in valid_yaxis:
+        if not x_axis or not y_axis or x_axis not in VALID_ANALYTICS_FIELDS or y_axis not in VALID_YAXIS:
             return Response(
                 {"error": "x-axis and y-axis dimensions are required and the values should be valid"},
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
         # If segment is present it cannot be same as x-axis
-        if segment and (segment not in valid_xaxis_segment or x_axis == segment):
+        if segment and (segment not in VALID_ANALYTICS_FIELDS or x_axis == segment):
             return Response(
                 {"error": "Both segment and x axis cannot be same and segment should be valid"},
                 status=status.HTTP_400_BAD_REQUEST,

--- a/apps/api/plane/app/views/analytic/base.py
+++ b/apps/api/plane/app/views/analytic/base.py
@@ -197,9 +197,9 @@ class SavedAnalyticEndpoint(BaseAPIView):
         x_axis = analytic_view.query_dict.get("x_axis", False)
         y_axis = analytic_view.query_dict.get("y_axis", False)
 
-        if not x_axis or not y_axis:
+        if not x_axis or not y_axis or x_axis not in VALID_ANALYTICS_FIELDS or y_axis not in VALID_YAXIS:
             return Response(
-                {"error": "x-axis and y-axis dimensions are required"},
+                {"error": "x-axis and y-axis dimensions are required and the values should be valid"},
                 status=status.HTTP_400_BAD_REQUEST,
             )
 

--- a/apps/api/plane/bgtasks/analytic_plot_export.py
+++ b/apps/api/plane/bgtasks/analytic_plot_export.py
@@ -20,7 +20,7 @@ from django.db.models.functions import Concat
 # Module imports
 from plane.db.models import Issue
 from plane.license.utils.instance_value import get_email_configuration
-from plane.utils.analytics_plot import build_graph_plot
+from plane.utils.analytics_plot import build_graph_plot, VALID_ANALYTICS_FIELDS, VALID_YAXIS
 from plane.utils.email import generate_plain_text_from_html
 from plane.utils.exception_logger import log_exception
 from plane.utils.issue_filters import issue_filters

--- a/apps/api/plane/bgtasks/analytic_plot_export.py
+++ b/apps/api/plane/bgtasks/analytic_plot_export.py
@@ -20,7 +20,7 @@ from django.db.models.functions import Concat
 # Module imports
 from plane.db.models import Issue
 from plane.license.utils.instance_value import get_email_configuration
-from plane.utils.analytics_plot import build_graph_plot, VALID_ANALYTICS_FIELDS, VALID_YAXIS
+from plane.utils.analytics_plot import build_graph_plot
 from plane.utils.email import generate_plain_text_from_html
 from plane.utils.exception_logger import log_exception
 from plane.utils.issue_filters import issue_filters

--- a/apps/api/plane/utils/analytics_plot.py
+++ b/apps/api/plane/utils/analytics_plot.py
@@ -22,6 +22,23 @@ from django.utils import timezone
 # Module imports
 from plane.db.models import Issue, Project
 
+VALID_ANALYTICS_FIELDS = [
+    "state_id",
+    "state__group",
+    "labels__id",
+    "assignees__id",
+    "estimate_point__value",
+    "issue_cycle__cycle_id",
+    "issue_module__module_id",
+    "priority",
+    "start_date",
+    "target_date",
+    "created_at",
+    "completed_at",
+]
+
+VALID_YAXIS = ["issue_count", "estimate"]
+
 
 def annotate_with_monthly_dimension(queryset, field_name, attribute):
     # Get the year and the months
@@ -34,6 +51,8 @@ def annotate_with_monthly_dimension(queryset, field_name, attribute):
 
 
 def extract_axis(queryset, x_axis):
+    if x_axis not in VALID_ANALYTICS_FIELDS:
+        raise ValueError(f"Invalid x_axis value: {x_axis}")
     # Format the dimension when the axis is in date
     if x_axis in ["created_at", "start_date", "target_date", "completed_at"]:
         queryset = annotate_with_monthly_dimension(queryset, x_axis, "dimension")
@@ -52,6 +71,13 @@ def sort_data(data, temp_axis):
 
 
 def build_graph_plot(queryset, x_axis, y_axis, segment=None):
+    if x_axis not in VALID_ANALYTICS_FIELDS:
+        raise ValueError(f"Invalid x_axis value: {x_axis}")
+    if y_axis not in VALID_YAXIS:
+        raise ValueError(f"Invalid y_axis value: {y_axis}")
+    if segment and segment not in VALID_ANALYTICS_FIELDS:
+        raise ValueError(f"Invalid segment value: {segment}")
+
     # temp x_axis
     temp_axis = x_axis
     # Extract the x_axis and queryset


### PR DESCRIPTION
## Summary
- Fixes ORM field reference injection vulnerability in `SavedAnalyticEndpoint` where the `segment` query parameter was passed directly to Django's `F()` expression without validation, allowing authenticated workspace members to extract arbitrary related model fields (e.g. password hashes, emails, tokens)
- Centralizes analytics field allowlists (`VALID_ANALYTICS_FIELDS`, `VALID_YAXIS`) into `analytics_plot.py` as single source of truth, replacing duplicate inline lists across 3 endpoints
- Adds defense-in-depth validation in `build_graph_plot()` and `extract_axis()` so no current or future caller can pass unsafe field references
- Fixes `ExportAnalyticsEndpoint` allowlist using `estimate_point` instead of `estimate_point__value`

## Security Advisory
https://github.com/makeplane/plane/security/advisories/GHSA-93x3-ghh7-72j3

## Test plan
- [ ] Verify `AnalyticsEndpoint` accepts valid segment values and rejects invalid ones
- [ ] Verify `SavedAnalyticEndpoint` now rejects arbitrary segment values like `workspace__owner__password`
- [ ] Verify `ExportAnalyticsEndpoint` accepts `estimate_point__value` as a valid field
- [ ] Verify `build_graph_plot()` raises `ValueError` for invalid x_axis/y_axis/segment inputs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced analytics parameter validation to prevent invalid data processing across all analytics endpoints.
  * Improved error handling for unsupported dimension and segment values with consistent validation rules.
  * Strengthened validation to ensure data integrity when building analytics reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->