### PR TITLE
fix: exclude soft-deleted profile assignees

### DIFF
--- a/apps/api/plane/app/views/workspace/user.py
+++ b/apps/api/plane/app/views/workspace/user.py
@@ -286,6 +286,14 @@ class WorkspaceUserProfileEndpoint(BaseAPIView):
         )
         projects = []
         if requesting_workspace_member.role >= 15:
+            visible_project_issue_filter = Q(
+                project_issue__archived_at__isnull=True,
+                project_issue__is_draft=False,
+            )
+            active_project_assignment_filter = Q(
+                project_issue__issue_assignee__assignee_id=user_id,
+                project_issue__issue_assignee__deleted_at__isnull=True,
+            )
             projects = (
                 Project.objects.filter(
                     workspace__slug=slug,
@@ -296,47 +304,44 @@ class WorkspaceUserProfileEndpoint(BaseAPIView):
                 .annotate(
                     created_issues=Count(
                         "project_issue",
-                        filter=Q(
+                        filter=visible_project_issue_filter
+                        & Q(
                             project_issue__created_by_id=user_id,
-                            project_issue__archived_at__isnull=True,
-                            project_issue__is_draft=False,
                         ),
+                        distinct=True,
                     )
                 )
                 .annotate(
                     assigned_issues=Count(
                         "project_issue",
-                        filter=Q(
-                            project_issue__assignees__in=[user_id],
-                            project_issue__archived_at__isnull=True,
-                            project_issue__is_draft=False,
-                        ),
+                        filter=visible_project_issue_filter & active_project_assignment_filter,
+                        distinct=True,
                     )
                 )
                 .annotate(
                     completed_issues=Count(
                         "project_issue",
-                        filter=Q(
+                        filter=visible_project_issue_filter
+                        & active_project_assignment_filter
+                        & Q(
                             project_issue__completed_at__isnull=False,
-                            project_issue__assignees__in=[user_id],
-                            project_issue__archived_at__isnull=True,
-                            project_issue__is_draft=False,
                         ),
+                        distinct=True,
                     )
                 )
                 .annotate(
                     pending_issues=Count(
                         "project_issue",
-                        filter=Q(
+                        filter=visible_project_issue_filter
+                        & active_project_assignment_filter
+                        & Q(
                             project_issue__state__group__in=[
                                 "backlog",
                                 "unstarted",
                                 "started",
                             ],
-                            project_issue__assignees__in=[user_id],
-                            project_issue__archived_at__isnull=True,
-                            project_issue__is_draft=False,
                         ),
+                        distinct=True,
                     )
                 )
                 .values(

--- a/apps/api/plane/tests/contract/app/test_workspace_user_profile_app.py
+++ b/apps/api/plane/tests/contract/app/test_workspace_user_profile_app.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+import pytest
+from django.urls import reverse
+from django.utils import timezone
+
+from plane.db.models import Issue, IssueAssignee, ProjectMember, WorkspaceMember
+from plane.tests.factories import ProjectFactory, UserFactory, WorkspaceFactory
+
+
+@pytest.mark.django_db
+@pytest.mark.contract
+def test_workspace_user_profile_excludes_soft_deleted_assignments_from_project_counts(session_client, create_user):
+    workspace = WorkspaceFactory(owner=create_user)
+    WorkspaceMember.objects.create(workspace=workspace, member=create_user, role=20)
+
+    profiled_user = UserFactory()
+    WorkspaceMember.objects.create(workspace=workspace, member=profiled_user, role=15)
+
+    project = ProjectFactory(
+        workspace=workspace,
+        created_by=create_user,
+        updated_by=create_user,
+        identifier="PRJ",
+    )
+    ProjectMember.objects.create(project=project, member=create_user, role=20)
+    ProjectMember.objects.create(project=project, member=profiled_user, role=15)
+
+    active_issue = Issue.objects.create(
+        project=project,
+        name="Active assignment",
+        created_by=create_user,
+        updated_by=create_user,
+    )
+    IssueAssignee.objects.create(
+        project=project,
+        issue=active_issue,
+        assignee=profiled_user,
+        created_by=create_user,
+        updated_by=create_user,
+    )
+
+    for index in range(2):
+        stale_issue = Issue.objects.create(
+            project=project,
+            name=f"Closed assignment {index}",
+            completed_at=timezone.now(),
+            created_by=create_user,
+            updated_by=create_user,
+        )
+        IssueAssignee.all_objects.create(
+            project=project,
+            issue=stale_issue,
+            assignee=profiled_user,
+            deleted_at=timezone.now(),
+            created_by=create_user,
+            updated_by=create_user,
+        )
+
+    url = reverse(
+        "workspace-user-profile-page",
+        kwargs={"slug": workspace.slug, "user_id": profiled_user.id},
+    )
+
+    response = session_client.get(url)
+
+    assert response.status_code == 200
+    assert len(response.data["project_data"]) == 1
+    assert response.data["project_data"][0]["assigned_issues"] == 1
+    assert response.data["project_data"][0]["completed_issues"] == 0
+    assert response.data["project_data"][0]["pending_issues"] == 0

--- a/apps/api/plane/tests/contract/app/test_workspace_user_profile_app.py
+++ b/apps/api/plane/tests/contract/app/test_workspace_user_profile_app.py
@@ -70,4 +70,4 @@ def test_workspace_user_profile_excludes_soft_deleted_assignments_from_project_c
     assert len(response.data["project_data"]) == 1
     assert response.data["project_data"][0]["assigned_issues"] == 1
     assert response.data["project_data"][0]["completed_issues"] == 0
-    assert response.data["project_data"][0]["pending_issues"] == 0
+    assert response.data["project_data"][0]["created_issues"] == 0


### PR DESCRIPTION
## Summary

Fixes a profile-count mismatch where the project sidebar on a user profile could include stale soft-deleted assignee relations.

Closes #8868.

## Problem

`WorkspaceUserProfileEndpoint` was aggregating project counts with `project_issue__assignees__in=[user_id]`.
That could still count historical `IssueAssignee` rows after the assignment had been soft-deleted, causing the sidebar/project breakdown to drift from the overview cards and assigned work-item list.

## Minimal reproduction

1. Create a user and assign them to 3 work items in the same project.
2. Remove the user from 2 of those work items so the corresponding `IssueAssignee` rows are soft-deleted.
3. Open the user profile overview and assigned tab.
4. Observe the mismatch:
   - overview cards show `1` assigned work item
   - project sidebar breakdown still shows `3`

## Fix

- count assigned-related aggregates via active `IssueAssignee` rows
- require `project_issue__issue_assignee__deleted_at__isnull=True`
- use `distinct=True` on the profile project aggregations to avoid overcounting
- add regression coverage for one active assignment plus two soft-deleted historical assignments

## Verification

- `python3 -m py_compile apps/api/plane/app/views/workspace/user.py apps/api/plane/tests/contract/app/test_workspace_user_profile_app.py`
- `git diff --check`

I did not run the full Django test suite locally because this environment did not have the upstream repo's full database/runtime test setup bootstrapped.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected workspace user profile project counts to exclude archived projects and soft-deleted task assignments, and to avoid duplicate counting so issue counters are accurate.
* **Tests**
  * Added a contract test validating that project issue counters only reflect active (non-deleted, non-archived) assignments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->