### PR TITLE
fix: sanitize filenames in upload paths to prevent path traversal

### DIFF
--- a/apps/api/plane/api/views/asset.py
+++ b/apps/api/plane/api/views/asset.py
@@ -17,6 +17,7 @@ from drf_spectacular.utils import OpenApiExample, OpenApiRequest
 # Module Imports
 from plane.bgtasks.storage_metadata_task import get_asset_object_metadata
 from plane.settings.storage import S3Storage
+from plane.utils.path_validator import sanitize_filename
 from plane.db.models import FileAsset, User, Workspace
 from plane.api.views.base import BaseAPIView
 from plane.api.serializers import (
@@ -114,7 +115,7 @@ class UserAssetEndpoint(BaseAPIView):
         This endpoint generates the necessary credentials for direct S3 upload.
         """
         # get the asset key
-        name = request.data.get("name")
+        name = sanitize_filename(request.data.get("name"))
         type = request.data.get("type", "image/jpeg")
         size = int(request.data.get("size", settings.FILE_SIZE_LIMIT))
         entity_type = request.data.get("entity_type", False)
@@ -287,7 +288,7 @@ class UserServerAssetEndpoint(BaseAPIView):
         necessary credentials for direct S3 upload with server-side authentication.
         """
         # get the asset key
-        name = request.data.get("name")
+        name = sanitize_filename(request.data.get("name"))
         type = request.data.get("type", "image/jpeg")
         size = int(request.data.get("size", settings.FILE_SIZE_LIMIT))
         entity_type = request.data.get("entity_type", False)
@@ -498,7 +499,7 @@ class GenericAssetEndpoint(BaseAPIView):
         Create a presigned URL for uploading generic assets that can be bound to entities like work items.
         Supports various file types and includes external source tracking for integrations.
         """
-        name = request.data.get("name")
+        name = sanitize_filename(request.data.get("name"))
         type = request.data.get("type")
         size = int(request.data.get("size", settings.FILE_SIZE_LIMIT))
         project_id = request.data.get("project_id")

--- a/apps/api/plane/api/views/asset.py
+++ b/apps/api/plane/api/views/asset.py
@@ -115,7 +115,7 @@ class UserAssetEndpoint(BaseAPIView):
         This endpoint generates the necessary credentials for direct S3 upload.
         """
         # get the asset key
-        name = sanitize_filename(request.data.get("name"))
+        name = sanitize_filename(request.data.get("name")) or "unnamed"
         type = request.data.get("type", "image/jpeg")
         size = int(request.data.get("size", settings.FILE_SIZE_LIMIT))
         entity_type = request.data.get("entity_type", False)
@@ -288,7 +288,7 @@ class UserServerAssetEndpoint(BaseAPIView):
         necessary credentials for direct S3 upload with server-side authentication.
         """
         # get the asset key
-        name = sanitize_filename(request.data.get("name"))
+        name = sanitize_filename(request.data.get("name")) or "unnamed"
         type = request.data.get("type", "image/jpeg")
         size = int(request.data.get("size", settings.FILE_SIZE_LIMIT))
         entity_type = request.data.get("entity_type", False)

--- a/apps/api/plane/api/views/issue.py
+++ b/apps/api/plane/api/views/issue.py
@@ -82,6 +82,7 @@ from plane.db.models import (
     Workspace,
 )
 from plane.settings.storage import S3Storage
+from plane.utils.path_validator import sanitize_filename
 from plane.bgtasks.storage_metadata_task import get_asset_object_metadata
 from .base import BaseAPIView
 from plane.utils.host import base_host
@@ -1861,7 +1862,7 @@ class IssueAttachmentListCreateAPIEndpoint(BaseAPIView):
                 status=status.HTTP_403_FORBIDDEN,
             )
 
-        name = request.data.get("name")
+        name = sanitize_filename(request.data.get("name"))
         type = request.data.get("type", False)
         size = request.data.get("size")
         external_id = request.data.get("external_id")

--- a/apps/api/plane/app/views/asset/v2.py
+++ b/apps/api/plane/app/views/asset/v2.py
@@ -22,6 +22,7 @@ from plane.db.models import FileAsset, Workspace, Project, User
 from plane.settings.storage import S3Storage
 from plane.app.permissions import allow_permission, ROLE
 from plane.utils.cache import invalidate_cache_directly
+from plane.utils.path_validator import sanitize_filename
 from plane.bgtasks.storage_metadata_task import get_asset_object_metadata
 from plane.throttles.asset import AssetRateThrottle
 
@@ -108,7 +109,7 @@ class UserAssetsV2Endpoint(BaseAPIView):
 
     def post(self, request):
         # get the asset key
-        name = request.data.get("name")
+        name = sanitize_filename(request.data.get("name"))
         type = request.data.get("type", "image/jpeg")
         size = int(request.data.get("size", settings.FILE_SIZE_LIMIT))
         entity_type = request.data.get("entity_type", False)
@@ -312,7 +313,7 @@ class WorkspaceFileAssetEndpoint(BaseAPIView):
             return
 
     def post(self, request, slug):
-        name = request.data.get("name")
+        name = sanitize_filename(request.data.get("name"))
         type = request.data.get("type", "image/jpeg")
         size = int(request.data.get("size", settings.FILE_SIZE_LIMIT))
         entity_type = request.data.get("entity_type")
@@ -511,7 +512,7 @@ class ProjectAssetEndpoint(BaseAPIView):
 
     @allow_permission([ROLE.ADMIN, ROLE.MEMBER, ROLE.GUEST])
     def post(self, request, slug, project_id):
-        name = request.data.get("name")
+        name = sanitize_filename(request.data.get("name"))
         type = request.data.get("type", "image/jpeg")
         size = int(request.data.get("size", settings.FILE_SIZE_LIMIT))
         entity_type = request.data.get("entity_type", "")
@@ -757,7 +758,7 @@ class DuplicateAssetEndpoint(BaseAPIView):
         if not original_asset:
             return Response({"error": "Asset not found"}, status=status.HTTP_404_NOT_FOUND)
 
-        destination_key = f"{workspace.id}/{uuid.uuid4().hex}-{original_asset.attributes.get('name')}"
+        destination_key = f"{workspace.id}/{uuid.uuid4().hex}-{sanitize_filename(original_asset.attributes.get('name'))}"
         duplicated_asset = FileAsset.objects.create(
             attributes={
                 "name": original_asset.attributes.get("name"),

--- a/apps/api/plane/app/views/asset/v2.py
+++ b/apps/api/plane/app/views/asset/v2.py
@@ -758,7 +758,8 @@ class DuplicateAssetEndpoint(BaseAPIView):
         if not original_asset:
             return Response({"error": "Asset not found"}, status=status.HTTP_404_NOT_FOUND)
 
-        destination_key = f"{workspace.id}/{uuid.uuid4().hex}-{sanitize_filename(original_asset.attributes.get('name')) or 'unnamed'}"
+        sanitized_name = sanitize_filename(original_asset.attributes.get("name")) or "unnamed"
+        destination_key = f"{workspace.id}/{uuid.uuid4().hex}-{sanitized_name}"
         duplicated_asset = FileAsset.objects.create(
             attributes={
                 "name": original_asset.attributes.get("name"),

--- a/apps/api/plane/app/views/asset/v2.py
+++ b/apps/api/plane/app/views/asset/v2.py
@@ -109,7 +109,7 @@ class UserAssetsV2Endpoint(BaseAPIView):
 
     def post(self, request):
         # get the asset key
-        name = sanitize_filename(request.data.get("name"))
+        name = sanitize_filename(request.data.get("name")) or "unnamed"
         type = request.data.get("type", "image/jpeg")
         size = int(request.data.get("size", settings.FILE_SIZE_LIMIT))
         entity_type = request.data.get("entity_type", False)
@@ -313,7 +313,7 @@ class WorkspaceFileAssetEndpoint(BaseAPIView):
             return
 
     def post(self, request, slug):
-        name = sanitize_filename(request.data.get("name"))
+        name = sanitize_filename(request.data.get("name")) or "unnamed"
         type = request.data.get("type", "image/jpeg")
         size = int(request.data.get("size", settings.FILE_SIZE_LIMIT))
         entity_type = request.data.get("entity_type")
@@ -512,7 +512,7 @@ class ProjectAssetEndpoint(BaseAPIView):
 
     @allow_permission([ROLE.ADMIN, ROLE.MEMBER, ROLE.GUEST])
     def post(self, request, slug, project_id):
-        name = sanitize_filename(request.data.get("name"))
+        name = sanitize_filename(request.data.get("name")) or "unnamed"
         type = request.data.get("type", "image/jpeg")
         size = int(request.data.get("size", settings.FILE_SIZE_LIMIT))
         entity_type = request.data.get("entity_type", "")
@@ -758,7 +758,7 @@ class DuplicateAssetEndpoint(BaseAPIView):
         if not original_asset:
             return Response({"error": "Asset not found"}, status=status.HTTP_404_NOT_FOUND)
 
-        destination_key = f"{workspace.id}/{uuid.uuid4().hex}-{sanitize_filename(original_asset.attributes.get('name'))}"
+        destination_key = f"{workspace.id}/{uuid.uuid4().hex}-{sanitize_filename(original_asset.attributes.get('name')) or 'unnamed'}"
         duplicated_asset = FileAsset.objects.create(
             attributes={
                 "name": original_asset.attributes.get("name"),

--- a/apps/api/plane/app/views/issue/attachment.py
+++ b/apps/api/plane/app/views/issue/attachment.py
@@ -24,6 +24,7 @@ from plane.db.models import FileAsset, Workspace
 from plane.bgtasks.issue_activities_task import issue_activity
 from plane.app.permissions import allow_permission, ROLE
 from plane.settings.storage import S3Storage
+from plane.utils.path_validator import sanitize_filename
 from plane.bgtasks.storage_metadata_task import get_asset_object_metadata
 from plane.utils.host import base_host
 
@@ -97,7 +98,7 @@ class IssueAttachmentV2Endpoint(BaseAPIView):
 
     @allow_permission([ROLE.ADMIN, ROLE.MEMBER, ROLE.GUEST])
     def post(self, request, slug, project_id, issue_id):
-        name = request.data.get("name")
+        name = sanitize_filename(request.data.get("name"))
         type = request.data.get("type", False)
         size = int(request.data.get("size", settings.FILE_SIZE_LIMIT))
 

--- a/apps/api/plane/app/views/issue/attachment.py
+++ b/apps/api/plane/app/views/issue/attachment.py
@@ -98,7 +98,7 @@ class IssueAttachmentV2Endpoint(BaseAPIView):
 
     @allow_permission([ROLE.ADMIN, ROLE.MEMBER, ROLE.GUEST])
     def post(self, request, slug, project_id, issue_id):
-        name = sanitize_filename(request.data.get("name"))
+        name = sanitize_filename(request.data.get("name")) or "unnamed"
         type = request.data.get("type", False)
         size = int(request.data.get("size", settings.FILE_SIZE_LIMIT))
 

--- a/apps/api/plane/db/models/asset.py
+++ b/apps/api/plane/db/models/asset.py
@@ -17,7 +17,7 @@ from .base import BaseModel
 
 
 def get_upload_path(instance, filename):
-    filename = sanitize_filename(filename) or "unnamed"
+    filename = sanitize_filename(filename) or uuid4().hex
     if instance.workspace_id is not None:
         return f"{instance.workspace.id}/{uuid4().hex}-{filename}"
     return f"user-{uuid4().hex}-{filename}"

--- a/apps/api/plane/db/models/asset.py
+++ b/apps/api/plane/db/models/asset.py
@@ -11,10 +11,13 @@ from django.core.exceptions import ValidationError
 from django.db import models
 
 # Module import
+from plane.utils.path_validator import sanitize_filename
+
 from .base import BaseModel
 
 
 def get_upload_path(instance, filename):
+    filename = sanitize_filename(filename)
     if instance.workspace_id is not None:
         return f"{instance.workspace.id}/{uuid4().hex}-{filename}"
     return f"user-{uuid4().hex}-{filename}"

--- a/apps/api/plane/db/models/asset.py
+++ b/apps/api/plane/db/models/asset.py
@@ -17,7 +17,7 @@ from .base import BaseModel
 
 
 def get_upload_path(instance, filename):
-    filename = sanitize_filename(filename)
+    filename = sanitize_filename(filename) or "unnamed"
     if instance.workspace_id is not None:
         return f"{instance.workspace.id}/{uuid4().hex}-{filename}"
     return f"user-{uuid4().hex}-{filename}"

--- a/apps/api/plane/db/models/issue.py
+++ b/apps/api/plane/db/models/issue.py
@@ -17,6 +17,7 @@ from django import apps
 
 # Module imports
 from plane.utils.html_processor import strip_tags
+from plane.utils.path_validator import sanitize_filename
 from plane.db.mixins import SoftDeletionManager
 from plane.utils.exception_logger import log_exception
 from .project import ProjectBaseModel
@@ -376,6 +377,7 @@ class IssueLink(ProjectBaseModel):
 
 
 def get_upload_path(instance, filename):
+    filename = sanitize_filename(filename)
     return f"{instance.workspace.id}/{uuid4().hex}-{filename}"
 
 

--- a/apps/api/plane/db/models/issue.py
+++ b/apps/api/plane/db/models/issue.py
@@ -377,7 +377,7 @@ class IssueLink(ProjectBaseModel):
 
 
 def get_upload_path(instance, filename):
-    filename = sanitize_filename(filename) or "unnamed"
+    filename = sanitize_filename(filename) or uuid4().hex
     return f"{instance.workspace.id}/{uuid4().hex}-{filename}"
 
 

--- a/apps/api/plane/db/models/issue.py
+++ b/apps/api/plane/db/models/issue.py
@@ -377,7 +377,7 @@ class IssueLink(ProjectBaseModel):
 
 
 def get_upload_path(instance, filename):
-    filename = sanitize_filename(filename)
+    filename = sanitize_filename(filename) or "unnamed"
     return f"{instance.workspace.id}/{uuid4().hex}-{filename}"
 
 

--- a/apps/api/plane/space/views/asset.py
+++ b/apps/api/plane/space/views/asset.py
@@ -18,6 +18,7 @@ from rest_framework.response import Response
 from plane.bgtasks.storage_metadata_task import get_asset_object_metadata
 from plane.db.models import DeployBoard, FileAsset
 from plane.settings.storage import S3Storage
+from plane.utils.path_validator import sanitize_filename
 
 # Module imports
 from .base import BaseAPIView
@@ -73,7 +74,7 @@ class EntityAssetEndpoint(BaseAPIView):
             return Response({"error": "Project is not published"}, status=status.HTTP_404_NOT_FOUND)
 
         # Get the asset
-        name = request.data.get("name")
+        name = sanitize_filename(request.data.get("name"))
         type = request.data.get("type", "image/jpeg")
         size = int(request.data.get("size", settings.FILE_SIZE_LIMIT))
         entity_type = request.data.get("entity_type", "")

--- a/apps/api/plane/space/views/asset.py
+++ b/apps/api/plane/space/views/asset.py
@@ -74,7 +74,7 @@ class EntityAssetEndpoint(BaseAPIView):
             return Response({"error": "Project is not published"}, status=status.HTTP_404_NOT_FOUND)
 
         # Get the asset
-        name = sanitize_filename(request.data.get("name"))
+        name = sanitize_filename(request.data.get("name")) or "unnamed"
         type = request.data.get("type", "image/jpeg")
         size = int(request.data.get("size", settings.FILE_SIZE_LIMIT))
         entity_type = request.data.get("entity_type", "")

--- a/apps/api/plane/utils/path_validator.py
+++ b/apps/api/plane/utils/path_validator.py
@@ -7,7 +7,40 @@ from django.utils.http import url_has_allowed_host_and_scheme
 from django.conf import settings
 
 # Python imports
+import os
+import re
 from urllib.parse import urlparse
+
+
+def sanitize_filename(filename):
+    """
+    Sanitize a filename to prevent path traversal attacks.
+
+    Strips directory components, path traversal sequences, and null bytes
+    from user-supplied filenames used in upload paths and S3 object keys.
+    """
+    if not filename or not isinstance(filename, str):
+        return "unnamed"
+
+    # Strip null bytes
+    filename = filename.replace("\x00", "")
+
+    # Take only the basename to remove any directory components
+    filename = os.path.basename(filename)
+
+    # Remove any remaining path traversal sequences
+    filename = filename.replace("..", "")
+
+    # Remove leading dots (hidden files)
+    filename = filename.lstrip(".")
+
+    # Strip whitespace
+    filename = filename.strip()
+
+    if not filename:
+        return "unnamed"
+
+    return filename
 
 
 def _contains_suspicious_patterns(path: str) -> bool:

--- a/apps/api/plane/utils/path_validator.py
+++ b/apps/api/plane/utils/path_validator.py
@@ -8,7 +8,6 @@ from django.conf import settings
 
 # Python imports
 import os
-import re
 from urllib.parse import urlparse
 
 
@@ -18,12 +17,18 @@ def sanitize_filename(filename):
 
     Strips directory components, path traversal sequences, and null bytes
     from user-supplied filenames used in upload paths and S3 object keys.
+
+    Returns None for empty/missing input so callers can still validate
+    that a filename was provided.
     """
     if not filename or not isinstance(filename, str):
-        return "unnamed"
+        return None
 
     # Strip null bytes
     filename = filename.replace("\x00", "")
+
+    # Normalize backslashes so os.path.basename handles Windows-style paths on POSIX
+    filename = filename.replace("\\", "/")
 
     # Take only the basename to remove any directory components
     filename = os.path.basename(filename)
@@ -31,14 +36,17 @@ def sanitize_filename(filename):
     # Remove any remaining path traversal sequences
     filename = filename.replace("..", "")
 
+    # Strip whitespace before removing leading dots so " .env" is caught
+    filename = filename.strip()
+
     # Remove leading dots (hidden files)
     filename = filename.lstrip(".")
 
-    # Strip whitespace
+    # Strip any remaining whitespace
     filename = filename.strip()
 
     if not filename:
-        return "unnamed"
+        return None
 
     return filename
 


### PR DESCRIPTION
## Summary

- Adds server-side `sanitize_filename()` utility that strips path traversal sequences (`../`), null bytes, directory components, and leading dots from user-supplied filenames
- Applies sanitization across all file upload endpoints (10 locations) and both `get_upload_path()` model functions
- Addresses GHSA-v57h-5999-w7xp (path traversal in file upload)

## Context

A security advisory reported that user-supplied filenames flow unsanitized into S3 object keys via `asset_key` construction and `get_upload_path()`. While S3 keys are flat strings (no filesystem traversal), this fix adds defense-in-depth against S3 key pollution and protects against risk if the storage backend were ever changed.

**Files changed:**
- `apps/api/plane/utils/path_validator.py` — new `sanitize_filename()` function
- `apps/api/plane/db/models/asset.py` — sanitize in `get_upload_path()`
- `apps/api/plane/db/models/issue.py` — sanitize in `get_upload_path()`
- `apps/api/plane/app/views/asset/v2.py` — sanitize in 3 upload endpoints + duplicate endpoint
- `apps/api/plane/app/views/issue/attachment.py` — sanitize in attachment upload
- `apps/api/plane/api/views/asset.py` — sanitize in 3 API upload endpoints
- `apps/api/plane/api/views/issue.py` — sanitize in issue attachment API
- `apps/api/plane/space/views/asset.py` — sanitize in space entity upload

## Test plan

- [ ] Verify normal file uploads still work (images, attachments)
- [ ] Verify filenames with `../` sequences are stripped to basename
- [ ] Verify null/empty filenames fall back to "unnamed"
- [ ] Verify hidden files (starting with `.`) have leading dots stripped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Filenames for uploaded assets and issue attachments are now sanitized to remove invalid characters, null bytes, and path-traversal sequences.
  * Sanitized names are used when generating storage paths and presigned uploads; empty or invalid names fall back to "unnamed".
  * Duplication now uses sanitized destination names to ensure consistent storage keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->