### PR TITLE
fix: enforce workspace membership on V2 asset endpoints

### DIFF
--- a/apps/api/plane/app/views/asset/v2.py
+++ b/apps/api/plane/app/views/asset/v2.py
@@ -18,7 +18,7 @@ from rest_framework.permissions import AllowAny
 
 # Module imports
 from ..base import BaseAPIView
-from plane.db.models import FileAsset, Workspace, Project, User
+from plane.db.models import FileAsset, Workspace, Project, User, WorkspaceMember
 from plane.settings.storage import S3Storage
 from plane.app.permissions import allow_permission, ROLE
 from plane.utils.cache import invalidate_cache_directly
@@ -311,6 +311,7 @@ class WorkspaceFileAssetEndpoint(BaseAPIView):
         else:
             return
 
+    @allow_permission([ROLE.ADMIN, ROLE.MEMBER, ROLE.GUEST], level="WORKSPACE")
     def post(self, request, slug):
         name = request.data.get("name")
         type = request.data.get("type", "image/jpeg")
@@ -376,6 +377,7 @@ class WorkspaceFileAssetEndpoint(BaseAPIView):
             status=status.HTTP_200_OK,
         )
 
+    @allow_permission([ROLE.ADMIN, ROLE.MEMBER, ROLE.GUEST], level="WORKSPACE")
     def patch(self, request, slug, asset_id):
         # get the asset id
         asset = FileAsset.objects.get(id=asset_id, workspace__slug=slug)
@@ -397,6 +399,7 @@ class WorkspaceFileAssetEndpoint(BaseAPIView):
         asset.save(update_fields=["is_uploaded", "attributes"])
         return Response(status=status.HTTP_204_NO_CONTENT)
 
+    @allow_permission([ROLE.ADMIN, ROLE.MEMBER, ROLE.GUEST], level="WORKSPACE")
     def delete(self, request, slug, asset_id):
         asset = FileAsset.objects.get(id=asset_id, workspace__slug=slug)
         asset.is_deleted = True
@@ -406,6 +409,7 @@ class WorkspaceFileAssetEndpoint(BaseAPIView):
         asset.save(update_fields=["is_deleted", "deleted_at"])
         return Response(status=status.HTTP_204_NO_CONTENT)
 
+    @allow_permission([ROLE.ADMIN, ROLE.MEMBER, ROLE.GUEST], level="WORKSPACE")
     def get(self, request, slug, asset_id):
         # get the asset id
         asset = FileAsset.objects.get(id=asset_id, workspace__slug=slug)
@@ -752,7 +756,16 @@ class DuplicateAssetEndpoint(BaseAPIView):
                 return Response({"error": "Project not found"}, status=status.HTTP_404_NOT_FOUND)
 
         storage = S3Storage(request=request)
-        original_asset = FileAsset.objects.filter(id=asset_id, is_uploaded=True).first()
+        # Scope the source asset lookup to workspaces the caller is a member of
+        user_workspace_ids = WorkspaceMember.objects.filter(
+            member=request.user,
+            is_active=True,
+        ).values_list("workspace_id", flat=True)
+        original_asset = FileAsset.objects.filter(
+            id=asset_id,
+            is_uploaded=True,
+            workspace_id__in=user_workspace_ids,
+        ).first()
 
         if not original_asset:
             return Response({"error": "Asset not found"}, status=status.HTTP_404_NOT_FOUND)


### PR DESCRIPTION
## Summary
- **Adds `@allow_permission` workspace membership checks** to all four methods (`post`, `get`, `patch`, `delete`) on `WorkspaceFileAssetEndpoint`, which previously only required authentication — allowing any logged-in user to read, create, modify, and delete assets in any workspace by slug.
- **Scopes the source asset lookup in `DuplicateAssetEndpoint`** to workspaces where the caller is an active member, preventing cross-workspace asset duplication via UUID.

Ref: GHSA-qw87-v5w3-6vxx

## Test plan
- [ ] Verify a workspace member can still create, read, patch, and delete assets in their own workspace
- [ ] Verify a non-member gets 403 when attempting any operation on another workspace's assets via `/api/assets/v2/workspaces/<slug>/`
- [ ] Verify `DuplicateAssetEndpoint` returns 404 when the source asset belongs to a workspace the caller is not a member of
- [ ] Verify duplication still works when the caller is a member of both the source and destination workspaces

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted asset duplication to authorized workspace members, preventing unauthorized users from duplicating assets across workspaces.
  * Enhanced access control on file asset operations, ensuring only users with appropriate workspace-level permissions can perform actions like uploading, editing, and deleting files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->