### PR TITLE
fix: prevent IME composition Enter from triggering submit actions

### DIFF
--- a/apps/web/core/components/comments/card/edit-form.tsx
+++ b/apps/web/core/components/comments/card/edit-form.tsx
@@ -77,6 +77,8 @@ export const CommentCardEditForm = observer(function CommentCardEditForm(props: 
     <form className="flex flex-col gap-2">
       <div
         onKeyDown={(e) => {
+          // Prevent IME composition Enter from triggering submit
+          if (e.nativeEvent.isComposing || e.keyCode === 229) return;
           if (e.key === "Enter" && !e.shiftKey && !e.ctrlKey && !e.metaKey && !isEmpty) handleSubmit(onEnter)(e);
         }}
       >

--- a/apps/web/core/components/comments/comment-create.tsx
+++ b/apps/web/core/components/comments/comment-create.tsx
@@ -94,6 +94,8 @@ export const CommentCreate = observer(function CommentCreate(props: TCommentCrea
     <div
       className={cn("sticky bottom-0 z-[4] bg-surface-1 sm:static")}
       onKeyDown={(e) => {
+        // Prevent IME composition Enter from triggering submit
+        if (e.nativeEvent.isComposing || e.keyCode === 229) return;
         if (
           e.key === "Enter" &&
           !e.shiftKey &&

--- a/apps/web/core/components/core/modals/gpt-assistant-popover.tsx
+++ b/apps/web/core/components/core/modals/gpt-assistant-popover.tsx
@@ -153,6 +153,8 @@ export function GptAssistantPopover(props: Props) {
 
   useEffect(() => {
     const handleEnterKeyPress = (event: KeyboardEvent) => {
+      // Prevent IME composition Enter from triggering submit
+      if (event.isComposing || event.keyCode === 229) return;
       if (event.key === "Enter" && !event.shiftKey) {
         event.preventDefault();
         handleSubmit(handleAIResponse)();

--- a/packages/editor/src/core/components/links/link-edit-view.tsx
+++ b/packages/editor/src/core/components/links/link-edit-view.tsx
@@ -123,6 +123,8 @@ export function LinkEditView({ viewProps }: LinkEditViewProps) {
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
+      // Prevent IME composition Enter from triggering submit
+      if (e.nativeEvent.isComposing || e.keyCode === 229) return;
       if (e.key === "Enter") {
         e.stopPropagation();
         if (applyChanges()) {

--- a/packages/editor/src/core/components/menus/bubble-menu/link-selector.tsx
+++ b/packages/editor/src/core/components/menus/bubble-menu/link-selector.tsx
@@ -84,6 +84,8 @@ export function BubbleMenuLinkSelector(props: Props) {
             defaultValue={editor.getAttributes("link").href || ""}
             onKeyDown={(e) => {
               setError(false);
+              // Prevent IME composition Enter from triggering submit
+              if (e.nativeEvent.isComposing || e.keyCode === 229) return;
               if (e.key === "Enter") {
                 e.preventDefault();
                 handleLinkSubmit();


### PR DESCRIPTION
## Description

Fix IME (Input Method Editor) composition conflict with Enter key
in comment inputs and other text fields.

When using CJK input methods (Chinese Zhuyin/Bopomofo, Japanese IME,
Korean IME), pressing Enter to confirm character selection
unintentionally triggers form submission. On macOS, pressing Enter
during IME composition still fires a `keydown` event, and existing
handlers did not check for active composition state.

### Changes (5 files)

**Comment inputs** (improved upon PR #8425 by @LinEvil):
- `comment-create.tsx` — added `isComposing` + `keyCode === 229` guard
- `edit-form.tsx` — same

**Other CJK text input areas** (new):
- `gpt-assistant-popover.tsx` — AI assistant prompt input
- `link-edit-view.tsx` — link text editing in editor
- `link-selector.tsx` — link selector in editor

### Note on EnterKeyExtension (ProseMirror plugin)

During investigation, CodeRabbit flagged in PR #8425 that the
Tiptap `EnterKeyExtension` could be a second pathway for
Enter-triggered submission. After deeper analysis, I found that
ProseMirror's core already guards against this — its
`editHandlers.keydown` calls `inOrNearComposition(view, event)`
which checks `view.composing` and includes a 500ms grace period
for Safari's `compositionend` timing. This means
`addKeyboardShortcuts` in Tiptap extensions are never invoked
during IME composition in the first place, so no fix is needed
at that layer.

### Guard pattern

```typescript
// React layer (SyntheticEvent)
if (e.nativeEvent.isComposing || e.keyCode === 229) return;
```

`keyCode === 229` is a fallback for browsers where
`compositionend` fires before `keydown`, causing `isComposing`
to already be `false` on the final confirmation Enter.

### Relationship to existing PRs

- **PR #7084** (merged) — Fixed labels and dropdowns
- **PR #8425** (open, by @LinEvil) — Fixed comment React layer.
  This PR builds on @LinEvil's work with `keyCode === 229`
  fallback and extends coverage to additional input areas.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Scenarios

- [x] CJK IME (Chinese Zhuyin, Japanese) — Enter during
      composition confirms character, does NOT submit
- [x] English input — Enter submits normally
- [x] Shift+Enter — Creates new line, unaffected
- [x] macOS + Chrome

## References

Closes #5485
Related: #7022, #7084, #8425

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed Enter key behavior during IME (Input Method Editor) composition in comment creation/editing, AI assistant popover, and link editor components to prevent accidental form submissions when typing in CJK languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->