### PR TITLE
fix: handle compact JSON in checkLatestRelease()

### DIFF
--- a/deployments/cli/community/install.sh
+++ b/deployments/cli/community/install.sh
@@ -57,7 +57,7 @@ function spinner() {
 
 function checkLatestRelease(){
     echo "Checking for the latest release..." >&2
-    local latest_release=$(curl -sSL https://api.github.com/repos/$GH_REPO/releases/latest |  grep -o '"tag_name": "[^"]*"' | sed 's/"tag_name": "//;s/"//g')
+    local latest_release=$(curl -sSL https://api.github.com/repos/$GH_REPO/releases/latest |  grep -o '"tag_name":[ ]*"[^"]*"' | sed 's/"tag_name":[ ]*"//;s/"//g')
     if [ -z "$latest_release" ]; then
         echo "Failed to check for the latest release. Exiting..." >&2
         exit 1

--- a/deployments/swarm/community/swarm.sh
+++ b/deployments/swarm/community/swarm.sh
@@ -38,7 +38,7 @@ EOF
 
 function checkLatestRelease(){
     echo "Checking for the latest release..." >&2
-    local latest_release=$(curl -s https://api.github.com/repos/$GH_REPO/releases/latest |  grep -o '"tag_name": "[^"]*"' | sed 's/"tag_name": "//;s/"//g')
+    local latest_release=$(curl -s https://api.github.com/repos/$GH_REPO/releases/latest |  grep -o '"tag_name":[ ]*"[^"]*"' | sed 's/"tag_name":[ ]*"//;s/"//g')
     if [ -z "$latest_release" ]; then
         echo "Failed to check for the latest release. Exiting..." >&2
         exit 1


### PR DESCRIPTION
## Summary

Fixes #8775

The `checkLatestRelease()` function uses `grep` to extract `tag_name` from the GitHub API response. The current pattern `'"tag_name": "[^"]*"'` assumes a space after the colon, but the GitHub API sometimes returns compact JSON without spaces (`"tag_name":"v1.2.3"`), causing the grep to match nothing and the script to exit with an error.

## Changes

- Made the space after the colon optional in both `grep` and `sed` patterns using `[ ]*` (zero or more spaces)
- Applied the fix to both `deployments/cli/community/install.sh` and `deployments/swarm/community/swarm.sh`

## Test plan

1. Run `./setup.sh` and select Option 5 (Upgrade)
2. Verify the script correctly parses the latest release tag regardless of JSON formatting