### PR TITLE
fix: prevent IME enter from submitting issue comments

### DIFF
--- a/apps/web/core/components/comments/card/edit-form.tsx
+++ b/apps/web/core/components/comments/card/edit-form.tsx
@@ -14,6 +14,7 @@ import type { TCommentsOperations, TIssueComment } from "@plane/types";
 import { cn, isCommentEmpty } from "@plane/utils";
 // components
 import { LiteTextEditor } from "@/components/editor/lite-text";
+import { isComposingKeyboardEvent } from "@/helpers/keyboard";
 
 type Props = {
   activityOperations: TCommentsOperations;
@@ -77,6 +78,8 @@ export const CommentCardEditForm = observer(function CommentCardEditForm(props: 
     <form className="flex flex-col gap-2">
       <div
         onKeyDown={(e) => {
+          if (isComposingKeyboardEvent(e.nativeEvent)) return;
+
           if (e.key === "Enter" && !e.shiftKey && !e.ctrlKey && !e.metaKey && !isEmpty) handleSubmit(onEnter)(e);
         }}
       >

--- a/apps/web/core/components/comments/comment-create.tsx
+++ b/apps/web/core/components/comments/comment-create.tsx
@@ -14,6 +14,7 @@ import type { TIssueComment, TCommentsOperations } from "@plane/types";
 import { cn, isCommentEmpty } from "@plane/utils";
 // components
 import { LiteTextEditor } from "@/components/editor/lite-text";
+import { isComposingKeyboardEvent } from "@/helpers/keyboard";
 // hooks
 import { useWorkspace } from "@/hooks/store/use-workspace";
 // services
@@ -94,6 +95,8 @@ export const CommentCreate = observer(function CommentCreate(props: TCommentCrea
     <div
       className={cn("sticky bottom-0 z-[4] bg-surface-1 sm:static")}
       onKeyDown={(e) => {
+        if (isComposingKeyboardEvent(e.nativeEvent)) return;
+
         if (
           e.key === "Enter" &&
           !e.shiftKey &&

--- a/apps/web/core/helpers/keyboard.ts
+++ b/apps/web/core/helpers/keyboard.ts
@@ -1,0 +1,2 @@
+export const isComposingKeyboardEvent = (event: Pick<KeyboardEvent, "isComposing" | "keyCode">) =>
+  event.isComposing || event.keyCode === 229;

--- a/packages/editor/src/core/extensions/enter-key.ts
+++ b/packages/editor/src/core/extensions/enter-key.ts
@@ -15,6 +15,10 @@ export const EnterKeyExtension = (onEnterKeyPress?: () => void) =>
     addKeyboardShortcuts(this) {
       return {
         Enter: () => {
+          if (this.editor.view.composing) {
+            return false;
+          }
+
           const { activeDropbarExtensions } = this.editor.storage.utility;
 
           if (activeDropbarExtensions.length === 0) {


### PR DESCRIPTION
### Description
This PR fixes an issue where pressing `Enter` while composing Chinese text with an IME in issue comments would submit the comment immediately instead of confirming the composition.

Changes included:
- Added IME composition state detection in the comment creation component
- Added IME composition state detection in the comment edit form
- Added composition state checks in the editor `Enter` key extension
- Introduced a shared `isComposingKeyboardEvent` helper for IME keyboard event handling

This ensures that `Enter` confirms the current Chinese input first, and only submits the comment when composition is finished.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
N/A

### Test Scenarios
- Verified issue comment creation no longer submits when pressing `Enter` during Chinese IME composition
- Verified issue comment editing no longer submits when pressing `Enter` during Chinese IME composition
- Verified comment submission still works normally when pressing `Enter` after composition is completed
- Verified existing modifier behavior such as `Shift+Enter` is unaffected

### References
Closes #8913


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where comment submissions could be triggered unintentionally while using input methods with text composition (e.g., IME for Asian languages). The Enter key is now properly ignored during active composition to prevent accidental submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->