### PR TITLE
chore(ci): suppress CodeQL file coverage deprecation warning

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,7 +17,7 @@ jobs:
       security-events: write
 
     env:
-      CODEQL_ACTION_FILE_COVERAGE_ON_PRS: false
+      CODEQL_ACTION_FILE_COVERAGE_ON_PRS: "false"
 
     strategy:
       fail-fast: false

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,6 +16,9 @@ jobs:
       contents: read
       security-events: write
 
+    env:
+      CODEQL_ACTION_FILE_COVERAGE_ON_PRS: false
+
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary
- Adds `CODEQL_ACTION_FILE_COVERAGE_ON_PRS: false` env var to the CodeQL workflow to explicitly opt into the new default behavior where file coverage computation is skipped on PRs for improved analysis performance.
- Resolves the deprecation warning: *"Starting April 2026, the CodeQL Action will skip computing file coverage information on pull requests."*

## Test plan
- [ ] Verify the CodeQL action runs without the file coverage warning on a PR trigger

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Disabled CodeQL file coverage reporting for pull requests.
  * This change reduces noise from per-file coverage reports on PRs while retaining other security scanning and analysis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->