### PR TITLE
🐛 Bug: Fix greeting timezone mismatch and add night greeting

### DIFF
--- a/apps/web/core/components/home/user-greetings.tsx
+++ b/apps/web/core/components/home/user-greetings.tsx
@@ -25,7 +25,7 @@ export function UserGreetingsView(props: IUserGreetingsView) {
         {t(`greetings.${greeting}`, { first_name: user?.first_name ?? "", last_name: user?.last_name ?? "" })}
       </h2>
       <h5 className="flex items-center gap-2 font-medium text-placeholder">
-        <div>{greeting === "morning" ? "🌤️" : greeting === "afternoon" ? "🌥️" : "🌙"}</div>
+        <div aria-hidden="true">{greeting === "morning" ? "🌤️" : greeting === "afternoon" ? "🌥️" : "🌙"}</div>
         <div>
           {weekDay}, {date} {timeString}
         </div>

--- a/apps/web/core/components/home/user-greetings.tsx
+++ b/apps/web/core/components/home/user-greetings.tsx
@@ -5,6 +5,7 @@
  */
 
 // plane types
+import { useMemo } from "react";
 import { useTranslation } from "@plane/i18n";
 import type { IUser } from "@plane/types";
 // plane ui
@@ -22,15 +23,16 @@ export function UserGreetingsView(props: IUserGreetingsView) {
   // store hooks
   const { t } = useTranslation();
 
-  const userTimezone = (() => {
+  const userTimezone = useMemo(() => {
     if (!user?.user_timezone) return undefined;
     try {
-      Intl.DateTimeFormat(undefined, { timeZone: user.user_timezone });
+      new Intl.DateTimeFormat(undefined, { timeZone: user.user_timezone });
       return user.user_timezone;
-    } catch {
+    } catch (e) {
+      console.warn(`[UserGreetingsView] Invalid user_timezone "${user.user_timezone}", falling back to browser timezone.`, e);
       return undefined;
     }
-  })();
+  }, [user?.user_timezone]);
 
   const hour = new Intl.DateTimeFormat("en-US", {
     timeZone: userTimezone,

--- a/apps/web/core/components/home/user-greetings.tsx
+++ b/apps/web/core/components/home/user-greetings.tsx
@@ -34,7 +34,7 @@ export function UserGreetingsView(props: IUserGreetingsView) {
 
   const hour = new Intl.DateTimeFormat("en-US", {
     timeZone: userTimezone,
-    hour12: false,
+    hourCycle: "h23",
     hour: "numeric",
   }).format(currentTime);
 
@@ -51,7 +51,7 @@ export function UserGreetingsView(props: IUserGreetingsView) {
 
   const timeString = new Intl.DateTimeFormat("en-US", {
     timeZone: userTimezone,
-    hour12: false,
+    hourCycle: "h23",
     hour: "2-digit",
     minute: "2-digit",
   }).format(currentTime);

--- a/apps/web/core/components/home/user-greetings.tsx
+++ b/apps/web/core/components/home/user-greetings.tsx
@@ -64,7 +64,7 @@ export function UserGreetingsView(props: IUserGreetingsView) {
   return (
     <div className="my-6 flex flex-col items-center">
       <h2 className="text-center text-20 font-semibold">
-        {t("good")} {t(greeting)}, {user?.first_name} {user?.last_name}
+        {t(`greetings.${greeting}`, { first_name: user?.first_name ?? "", last_name: user?.last_name ?? "" })}
       </h2>
       <h5 className="flex items-center gap-2 font-medium text-placeholder">
         <div>{greeting === "morning" ? "🌤️" : greeting === "afternoon" ? "🌥️" : "🌙"}</div>

--- a/apps/web/core/components/home/user-greetings.tsx
+++ b/apps/web/core/components/home/user-greetings.tsx
@@ -5,12 +5,10 @@
  */
 
 // plane types
-import { useMemo } from "react";
 import { useTranslation } from "@plane/i18n";
 import type { IUser } from "@plane/types";
-// plane ui
 // hooks
-import { useCurrentTime } from "@/hooks/use-current-time";
+import { useGreeting } from "@/hooks/use-greeting";
 
 export interface IUserGreetingsView {
   user: IUser;
@@ -18,48 +16,8 @@ export interface IUserGreetingsView {
 
 export function UserGreetingsView(props: IUserGreetingsView) {
   const { user } = props;
-  // current time hook
-  const { currentTime } = useCurrentTime();
-  // store hooks
+  const { greeting, timeString, weekDay, date } = useGreeting(user);
   const { t } = useTranslation();
-
-  const userTimezone = useMemo(() => {
-    if (!user?.user_timezone) return undefined;
-    try {
-      new Intl.DateTimeFormat(undefined, { timeZone: user.user_timezone });
-      return user.user_timezone;
-    } catch (e) {
-      console.warn(`[UserGreetingsView] Invalid user_timezone "${user.user_timezone}", falling back to browser timezone.`, e);
-      return undefined;
-    }
-  }, [user?.user_timezone]);
-
-  const hour = new Intl.DateTimeFormat("en-US", {
-    timeZone: userTimezone,
-    hourCycle: "h23",
-    hour: "numeric",
-  }).format(currentTime);
-
-  const date = new Intl.DateTimeFormat("en-US", {
-    timeZone: userTimezone,
-    month: "short",
-    day: "numeric",
-  }).format(currentTime);
-
-  const weekDay = new Intl.DateTimeFormat("en-US", {
-    timeZone: userTimezone,
-    weekday: "long",
-  }).format(currentTime);
-
-  const timeString = new Intl.DateTimeFormat("en-US", {
-    timeZone: userTimezone,
-    hourCycle: "h23",
-    hour: "2-digit",
-    minute: "2-digit",
-  }).format(currentTime);
-
-  const hourNum = parseInt(hour, 10);
-  const greeting = hourNum < 5 ? "night" : hourNum < 12 ? "morning" : hourNum < 18 ? "afternoon" : "evening";
 
   return (
     <div className="my-6 flex flex-col items-center">

--- a/apps/web/core/components/home/user-greetings.tsx
+++ b/apps/web/core/components/home/user-greetings.tsx
@@ -22,28 +22,42 @@ export function UserGreetingsView(props: IUserGreetingsView) {
   // store hooks
   const { t } = useTranslation();
 
+  const userTimezone = (() => {
+    if (!user?.user_timezone) return undefined;
+    try {
+      Intl.DateTimeFormat(undefined, { timeZone: user.user_timezone });
+      return user.user_timezone;
+    } catch {
+      return undefined;
+    }
+  })();
+
   const hour = new Intl.DateTimeFormat("en-US", {
+    timeZone: userTimezone,
     hour12: false,
     hour: "numeric",
   }).format(currentTime);
 
   const date = new Intl.DateTimeFormat("en-US", {
+    timeZone: userTimezone,
     month: "short",
     day: "numeric",
   }).format(currentTime);
 
   const weekDay = new Intl.DateTimeFormat("en-US", {
+    timeZone: userTimezone,
     weekday: "long",
   }).format(currentTime);
 
   const timeString = new Intl.DateTimeFormat("en-US", {
-    timeZone: user?.user_timezone,
-    hour12: false, // Use 24-hour format
+    timeZone: userTimezone,
+    hour12: false,
     hour: "2-digit",
     minute: "2-digit",
   }).format(currentTime);
 
-  const greeting = parseInt(hour, 10) < 12 ? "morning" : parseInt(hour, 10) < 18 ? "afternoon" : "evening";
+  const hourNum = parseInt(hour, 10);
+  const greeting = hourNum < 5 ? "night" : hourNum < 12 ? "morning" : hourNum < 18 ? "afternoon" : "evening";
 
   return (
     <div className="my-6 flex flex-col items-center">
@@ -51,7 +65,7 @@ export function UserGreetingsView(props: IUserGreetingsView) {
         {t("good")} {t(greeting)}, {user?.first_name} {user?.last_name}
       </h2>
       <h5 className="flex items-center gap-2 font-medium text-placeholder">
-        <div>{greeting === "morning" ? "🌤️" : greeting === "afternoon" ? "🌥️" : "🌙️"}</div>
+        <div>{greeting === "morning" ? "🌤️" : greeting === "afternoon" ? "🌥️" : "🌙"}</div>
         <div>
           {weekDay}, {date} {timeString}
         </div>

--- a/apps/web/core/components/user/user-greetings.tsx
+++ b/apps/web/core/components/user/user-greetings.tsx
@@ -25,7 +25,7 @@ export function UserGreetingsView(props: IUserGreetingsView) {
         {t(`greetings.${greeting}`, { first_name: user?.first_name ?? "", last_name: user?.last_name ?? "" })}
       </h2>
       <h5 className="flex items-center gap-2 font-medium text-placeholder">
-        <div>{greeting === "morning" ? "🌤️" : greeting === "afternoon" ? "🌥️" : "🌙"}</div>
+        <div aria-hidden="true">{greeting === "morning" ? "🌤️" : greeting === "afternoon" ? "🌥️" : "🌙"}</div>
         <div>
           {weekDay}, {date} {timeString}
         </div>

--- a/apps/web/core/components/user/user-greetings.tsx
+++ b/apps/web/core/components/user/user-greetings.tsx
@@ -34,7 +34,7 @@ export function UserGreetingsView(props: IUserGreetingsView) {
 
   const hour = new Intl.DateTimeFormat("en-US", {
     timeZone: userTimezone,
-    hour12: false,
+    hourCycle: "h23",
     hour: "numeric",
   }).format(currentTime);
 
@@ -51,7 +51,7 @@ export function UserGreetingsView(props: IUserGreetingsView) {
 
   const timeString = new Intl.DateTimeFormat("en-US", {
     timeZone: userTimezone,
-    hour12: false,
+    hourCycle: "h23",
     hour: "2-digit",
     minute: "2-digit",
   }).format(currentTime);

--- a/apps/web/core/components/user/user-greetings.tsx
+++ b/apps/web/core/components/user/user-greetings.tsx
@@ -64,7 +64,7 @@ export function UserGreetingsView(props: IUserGreetingsView) {
   return (
     <div className="my-6 flex flex-col items-center">
       <h2 className="text-center text-20 font-semibold">
-        {t("good")} {t(greeting)}, {user?.first_name} {user?.last_name}
+        {t(`greetings.${greeting}`, { first_name: user?.first_name ?? "", last_name: user?.last_name ?? "" })}
       </h2>
       <h5 className="flex items-center gap-2 font-medium text-placeholder">
         <div>{greeting === "morning" ? "🌤️" : greeting === "afternoon" ? "🌥️" : "🌙"}</div>

--- a/apps/web/core/components/user/user-greetings.tsx
+++ b/apps/web/core/components/user/user-greetings.tsx
@@ -5,6 +5,7 @@
  */
 
 // plane types
+import { useMemo } from "react";
 import { useTranslation } from "@plane/i18n";
 // hooks
 import type { IUser } from "@plane/types";
@@ -22,15 +23,16 @@ export function UserGreetingsView(props: IUserGreetingsView) {
   // store hooks
   const { t } = useTranslation();
 
-  const userTimezone = (() => {
+  const userTimezone = useMemo(() => {
     if (!user?.user_timezone) return undefined;
     try {
-      Intl.DateTimeFormat(undefined, { timeZone: user.user_timezone });
+      new Intl.DateTimeFormat(undefined, { timeZone: user.user_timezone });
       return user.user_timezone;
-    } catch {
+    } catch (e) {
+      console.warn(`[UserGreetingsView] Invalid user_timezone "${user.user_timezone}", falling back to browser timezone.`, e);
       return undefined;
     }
-  })();
+  }, [user?.user_timezone]);
 
   const hour = new Intl.DateTimeFormat("en-US", {
     timeZone: userTimezone,

--- a/apps/web/core/components/user/user-greetings.tsx
+++ b/apps/web/core/components/user/user-greetings.tsx
@@ -22,28 +22,42 @@ export function UserGreetingsView(props: IUserGreetingsView) {
   // store hooks
   const { t } = useTranslation();
 
+  const userTimezone = (() => {
+    if (!user?.user_timezone) return undefined;
+    try {
+      Intl.DateTimeFormat(undefined, { timeZone: user.user_timezone });
+      return user.user_timezone;
+    } catch {
+      return undefined;
+    }
+  })();
+
   const hour = new Intl.DateTimeFormat("en-US", {
+    timeZone: userTimezone,
     hour12: false,
     hour: "numeric",
   }).format(currentTime);
 
   const date = new Intl.DateTimeFormat("en-US", {
+    timeZone: userTimezone,
     month: "short",
     day: "numeric",
   }).format(currentTime);
 
   const weekDay = new Intl.DateTimeFormat("en-US", {
+    timeZone: userTimezone,
     weekday: "long",
   }).format(currentTime);
 
   const timeString = new Intl.DateTimeFormat("en-US", {
-    timeZone: user?.user_timezone,
-    hour12: false, // Use 24-hour format
+    timeZone: userTimezone,
+    hour12: false,
     hour: "2-digit",
     minute: "2-digit",
   }).format(currentTime);
 
-  const greeting = parseInt(hour, 10) < 12 ? "morning" : parseInt(hour, 10) < 18 ? "afternoon" : "evening";
+  const hourNum = parseInt(hour, 10);
+  const greeting = hourNum < 5 ? "night" : hourNum < 12 ? "morning" : hourNum < 18 ? "afternoon" : "evening";
 
   return (
     <div className="my-6 flex flex-col items-center">
@@ -51,7 +65,7 @@ export function UserGreetingsView(props: IUserGreetingsView) {
         {t("good")} {t(greeting)}, {user?.first_name} {user?.last_name}
       </h2>
       <h5 className="flex items-center gap-2 font-medium text-placeholder">
-        <div>{greeting === "morning" ? "🌤️" : greeting === "afternoon" ? "🌥️" : "🌙️"}</div>
+        <div>{greeting === "morning" ? "🌤️" : greeting === "afternoon" ? "🌥️" : "🌙"}</div>
         <div>
           {weekDay}, {date} {timeString}
         </div>

--- a/apps/web/core/components/user/user-greetings.tsx
+++ b/apps/web/core/components/user/user-greetings.tsx
@@ -5,12 +5,10 @@
  */
 
 // plane types
-import { useMemo } from "react";
 import { useTranslation } from "@plane/i18n";
-// hooks
 import type { IUser } from "@plane/types";
-import { useCurrentTime } from "@/hooks/use-current-time";
-// types
+// hooks
+import { useGreeting } from "@/hooks/use-greeting";
 
 export interface IUserGreetingsView {
   user: IUser;
@@ -18,48 +16,8 @@ export interface IUserGreetingsView {
 
 export function UserGreetingsView(props: IUserGreetingsView) {
   const { user } = props;
-  // current time hook
-  const { currentTime } = useCurrentTime();
-  // store hooks
+  const { greeting, timeString, weekDay, date } = useGreeting(user);
   const { t } = useTranslation();
-
-  const userTimezone = useMemo(() => {
-    if (!user?.user_timezone) return undefined;
-    try {
-      new Intl.DateTimeFormat(undefined, { timeZone: user.user_timezone });
-      return user.user_timezone;
-    } catch (e) {
-      console.warn(`[UserGreetingsView] Invalid user_timezone "${user.user_timezone}", falling back to browser timezone.`, e);
-      return undefined;
-    }
-  }, [user?.user_timezone]);
-
-  const hour = new Intl.DateTimeFormat("en-US", {
-    timeZone: userTimezone,
-    hourCycle: "h23",
-    hour: "numeric",
-  }).format(currentTime);
-
-  const date = new Intl.DateTimeFormat("en-US", {
-    timeZone: userTimezone,
-    month: "short",
-    day: "numeric",
-  }).format(currentTime);
-
-  const weekDay = new Intl.DateTimeFormat("en-US", {
-    timeZone: userTimezone,
-    weekday: "long",
-  }).format(currentTime);
-
-  const timeString = new Intl.DateTimeFormat("en-US", {
-    timeZone: userTimezone,
-    hourCycle: "h23",
-    hour: "2-digit",
-    minute: "2-digit",
-  }).format(currentTime);
-
-  const hourNum = parseInt(hour, 10);
-  const greeting = hourNum < 5 ? "night" : hourNum < 12 ? "morning" : hourNum < 18 ? "afternoon" : "evening";
 
   return (
     <div className="my-6 flex flex-col items-center">

--- a/apps/web/core/hooks/use-greeting.ts
+++ b/apps/web/core/hooks/use-greeting.ts
@@ -10,42 +10,27 @@ import { useCurrentTime } from "@/hooks/use-current-time";
 
 export type TGreeting = "morning" | "afternoon" | "evening";
 
-export const useGreeting = (user: IUser) => {
+export const useGreeting = (_user: IUser) => {
   const { currentTime } = useCurrentTime();
 
-  const userTimezone = useMemo(() => {
-    if (!user?.user_timezone) return undefined;
-    try {
-      new Intl.DateTimeFormat(undefined, { timeZone: user.user_timezone });
-      return user.user_timezone;
-    } catch (e) {
-      console.warn(
-        `[useGreeting] Invalid user_timezone "${user.user_timezone}", falling back to browser timezone.`,
-        e
-      );
-      return undefined;
-    }
-  }, [user?.user_timezone]);
-
   const hourFormatter = useMemo(
-    () => new Intl.DateTimeFormat("en-US", { timeZone: userTimezone, hourCycle: "h23", hour: "numeric" }),
-    [userTimezone]
+    () => new Intl.DateTimeFormat("en-US", { hourCycle: "h23", hour: "numeric" }),
+    []
   );
 
   const dateFormatter = useMemo(
-    () => new Intl.DateTimeFormat("en-US", { timeZone: userTimezone, month: "short", day: "numeric" }),
-    [userTimezone]
+    () => new Intl.DateTimeFormat("en-US", { month: "short", day: "numeric" }),
+    []
   );
 
   const weekDayFormatter = useMemo(
-    () => new Intl.DateTimeFormat("en-US", { timeZone: userTimezone, weekday: "long" }),
-    [userTimezone]
+    () => new Intl.DateTimeFormat("en-US", { weekday: "long" }),
+    []
   );
 
   const timeStringFormatter = useMemo(
-    () =>
-      new Intl.DateTimeFormat("en-US", { timeZone: userTimezone, hourCycle: "h23", hour: "2-digit", minute: "2-digit" }),
-    [userTimezone]
+    () => new Intl.DateTimeFormat("en-US", { hourCycle: "h23", hour: "2-digit", minute: "2-digit" }),
+    []
   );
 
   const hour = hourFormatter.format(currentTime);

--- a/apps/web/core/hooks/use-greeting.ts
+++ b/apps/web/core/hooks/use-greeting.ts
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2023-present Plane Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { useMemo } from "react";
+import type { IUser } from "@plane/types";
+import { useCurrentTime } from "@/hooks/use-current-time";
+
+export type TGreeting = "morning" | "afternoon" | "evening";
+
+export const useGreeting = (user: IUser) => {
+  const { currentTime } = useCurrentTime();
+
+  const userTimezone = useMemo(() => {
+    if (!user?.user_timezone) return undefined;
+    try {
+      new Intl.DateTimeFormat(undefined, { timeZone: user.user_timezone });
+      return user.user_timezone;
+    } catch (e) {
+      console.warn(
+        `[useGreeting] Invalid user_timezone "${user.user_timezone}", falling back to browser timezone.`,
+        e
+      );
+      return undefined;
+    }
+  }, [user?.user_timezone]);
+
+  const hour = new Intl.DateTimeFormat("en-US", {
+    timeZone: userTimezone,
+    hourCycle: "h23",
+    hour: "numeric",
+  }).format(currentTime);
+
+  const date = new Intl.DateTimeFormat("en-US", {
+    timeZone: userTimezone,
+    month: "short",
+    day: "numeric",
+  }).format(currentTime);
+
+  const weekDay = new Intl.DateTimeFormat("en-US", {
+    timeZone: userTimezone,
+    weekday: "long",
+  }).format(currentTime);
+
+  const timeString = new Intl.DateTimeFormat("en-US", {
+    timeZone: userTimezone,
+    hourCycle: "h23",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(currentTime);
+
+  const hourNum = parseInt(hour, 10);
+  // 5–11: morning, 12–16: afternoon, 17–4: evening
+  const greeting: TGreeting =
+    hourNum >= 5 && hourNum < 12 ? "morning" : hourNum >= 12 && hourNum < 17 ? "afternoon" : "evening";
+
+  return { greeting, timeString, weekDay, date };
+};

--- a/apps/web/core/hooks/use-greeting.ts
+++ b/apps/web/core/hooks/use-greeting.ts
@@ -27,29 +27,31 @@ export const useGreeting = (user: IUser) => {
     }
   }, [user?.user_timezone]);
 
-  const hour = new Intl.DateTimeFormat("en-US", {
-    timeZone: userTimezone,
-    hourCycle: "h23",
-    hour: "numeric",
-  }).format(currentTime);
+  const hourFormatter = useMemo(
+    () => new Intl.DateTimeFormat("en-US", { timeZone: userTimezone, hourCycle: "h23", hour: "numeric" }),
+    [userTimezone]
+  );
 
-  const date = new Intl.DateTimeFormat("en-US", {
-    timeZone: userTimezone,
-    month: "short",
-    day: "numeric",
-  }).format(currentTime);
+  const dateFormatter = useMemo(
+    () => new Intl.DateTimeFormat("en-US", { timeZone: userTimezone, month: "short", day: "numeric" }),
+    [userTimezone]
+  );
 
-  const weekDay = new Intl.DateTimeFormat("en-US", {
-    timeZone: userTimezone,
-    weekday: "long",
-  }).format(currentTime);
+  const weekDayFormatter = useMemo(
+    () => new Intl.DateTimeFormat("en-US", { timeZone: userTimezone, weekday: "long" }),
+    [userTimezone]
+  );
 
-  const timeString = new Intl.DateTimeFormat("en-US", {
-    timeZone: userTimezone,
-    hourCycle: "h23",
-    hour: "2-digit",
-    minute: "2-digit",
-  }).format(currentTime);
+  const timeStringFormatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat("en-US", { timeZone: userTimezone, hourCycle: "h23", hour: "2-digit", minute: "2-digit" }),
+    [userTimezone]
+  );
+
+  const hour = hourFormatter.format(currentTime);
+  const date = dateFormatter.format(currentTime);
+  const weekDay = weekDayFormatter.format(currentTime);
+  const timeString = timeStringFormatter.format(currentTime);
 
   const hourNum = parseInt(hour, 10);
   // 5–11: morning, 12–16: afternoon, 17–4: evening

--- a/packages/i18n/src/locales/cs/translations.ts
+++ b/packages/i18n/src/locales/cs/translations.ts
@@ -489,6 +489,7 @@ export default {
   morning: "ráno",
   afternoon: "odpoledne",
   evening: "večer",
+  night: "night",
   show_all: "Zobrazit vše",
   show_less: "Zobrazit méně",
   no_data_yet: "Zatím žádná data",

--- a/packages/i18n/src/locales/cs/translations.ts
+++ b/packages/i18n/src/locales/cs/translations.ts
@@ -490,6 +490,12 @@ export default {
   afternoon: "odpoledne",
   evening: "večer",
   night: "noc",
+  greetings: {
+    morning: "Dobré ráno, {first_name} {last_name}",
+    afternoon: "Dobré odpoledne, {first_name} {last_name}",
+    evening: "Dobrý večer, {first_name} {last_name}",
+    night: "Dobrou noc, {first_name} {last_name}",
+  },
   show_all: "Zobrazit vše",
   show_less: "Zobrazit méně",
   no_data_yet: "Zatím žádná data",

--- a/packages/i18n/src/locales/cs/translations.ts
+++ b/packages/i18n/src/locales/cs/translations.ts
@@ -489,7 +489,7 @@ export default {
   morning: "ráno",
   afternoon: "odpoledne",
   evening: "večer",
-  night: "night",
+  night: "noc",
   show_all: "Zobrazit vše",
   show_less: "Zobrazit méně",
   no_data_yet: "Zatím žádná data",

--- a/packages/i18n/src/locales/cs/translations.ts
+++ b/packages/i18n/src/locales/cs/translations.ts
@@ -494,7 +494,6 @@ export default {
     morning: "Dobré ráno, {first_name} {last_name}",
     afternoon: "Dobré odpoledne, {first_name} {last_name}",
     evening: "Dobrý večer, {first_name} {last_name}",
-    night: "Dobrou noc, {first_name} {last_name}",
   },
   show_all: "Zobrazit vše",
   show_less: "Zobrazit méně",

--- a/packages/i18n/src/locales/cs/translations.ts
+++ b/packages/i18n/src/locales/cs/translations.ts
@@ -489,7 +489,6 @@ export default {
   morning: "ráno",
   afternoon: "odpoledne",
   evening: "večer",
-  night: "noc",
   greetings: {
     morning: "Dobré ráno, {first_name} {last_name}",
     afternoon: "Dobré odpoledne, {first_name} {last_name}",

--- a/packages/i18n/src/locales/de/translations.ts
+++ b/packages/i18n/src/locales/de/translations.ts
@@ -502,7 +502,7 @@ export default {
   morning: "Morgen",
   afternoon: "Nachmittag",
   evening: "Abend",
-  night: "night",
+  night: "Nacht",
   show_all: "Alle anzeigen",
   show_less: "Weniger anzeigen",
   no_data_yet: "Noch keine Daten",

--- a/packages/i18n/src/locales/de/translations.ts
+++ b/packages/i18n/src/locales/de/translations.ts
@@ -502,6 +502,7 @@ export default {
   morning: "Morgen",
   afternoon: "Nachmittag",
   evening: "Abend",
+  night: "night",
   show_all: "Alle anzeigen",
   show_less: "Weniger anzeigen",
   no_data_yet: "Noch keine Daten",

--- a/packages/i18n/src/locales/de/translations.ts
+++ b/packages/i18n/src/locales/de/translations.ts
@@ -503,6 +503,12 @@ export default {
   afternoon: "Nachmittag",
   evening: "Abend",
   night: "Nacht",
+  greetings: {
+    morning: "Guten Morgen, {first_name} {last_name}",
+    afternoon: "Guten Nachmittag, {first_name} {last_name}",
+    evening: "Guten Abend, {first_name} {last_name}",
+    night: "Gute Nacht, {first_name} {last_name}",
+  },
   show_all: "Alle anzeigen",
   show_less: "Weniger anzeigen",
   no_data_yet: "Noch keine Daten",

--- a/packages/i18n/src/locales/de/translations.ts
+++ b/packages/i18n/src/locales/de/translations.ts
@@ -507,7 +507,6 @@ export default {
     morning: "Guten Morgen, {first_name} {last_name}",
     afternoon: "Guten Nachmittag, {first_name} {last_name}",
     evening: "Guten Abend, {first_name} {last_name}",
-    night: "Gute Nacht, {first_name} {last_name}",
   },
   show_all: "Alle anzeigen",
   show_less: "Weniger anzeigen",

--- a/packages/i18n/src/locales/de/translations.ts
+++ b/packages/i18n/src/locales/de/translations.ts
@@ -502,7 +502,6 @@ export default {
   morning: "Morgen",
   afternoon: "Nachmittag",
   evening: "Abend",
-  night: "Nacht",
   greetings: {
     morning: "Guten Morgen, {first_name} {last_name}",
     afternoon: "Guten Nachmittag, {first_name} {last_name}",

--- a/packages/i18n/src/locales/en/translations.ts
+++ b/packages/i18n/src/locales/en/translations.ts
@@ -322,7 +322,6 @@ export default {
   morning: "morning",
   afternoon: "afternoon",
   evening: "evening",
-  night: "night",
   greetings: {
     morning: "Good morning, {first_name} {last_name}",
     afternoon: "Good afternoon, {first_name} {last_name}",

--- a/packages/i18n/src/locales/en/translations.ts
+++ b/packages/i18n/src/locales/en/translations.ts
@@ -327,7 +327,6 @@ export default {
     morning: "Good morning, {first_name} {last_name}",
     afternoon: "Good afternoon, {first_name} {last_name}",
     evening: "Good evening, {first_name} {last_name}",
-    night: "Good night, {first_name} {last_name}",
   },
   show_all: "Show all",
   show_less: "Show less",

--- a/packages/i18n/src/locales/en/translations.ts
+++ b/packages/i18n/src/locales/en/translations.ts
@@ -323,6 +323,12 @@ export default {
   afternoon: "afternoon",
   evening: "evening",
   night: "night",
+  greetings: {
+    morning: "Good morning, {first_name} {last_name}",
+    afternoon: "Good afternoon, {first_name} {last_name}",
+    evening: "Good evening, {first_name} {last_name}",
+    night: "Good night, {first_name} {last_name}",
+  },
   show_all: "Show all",
   show_less: "Show less",
   no_data_yet: "No Data yet",

--- a/packages/i18n/src/locales/en/translations.ts
+++ b/packages/i18n/src/locales/en/translations.ts
@@ -322,6 +322,7 @@ export default {
   morning: "morning",
   afternoon: "afternoon",
   evening: "evening",
+  night: "night",
   show_all: "Show all",
   show_less: "Show less",
   no_data_yet: "No Data yet",

--- a/packages/i18n/src/locales/es/translations.ts
+++ b/packages/i18n/src/locales/es/translations.ts
@@ -502,7 +502,7 @@ export default {
   morning: "días",
   afternoon: "tardes",
   evening: "noches",
-  night: "night",
+  night: "noche",
   show_all: "Mostrar todo",
   show_less: "Mostrar menos",
   no_data_yet: "Aún no hay datos",

--- a/packages/i18n/src/locales/es/translations.ts
+++ b/packages/i18n/src/locales/es/translations.ts
@@ -503,6 +503,12 @@ export default {
   afternoon: "tardes",
   evening: "noches",
   night: "noche",
+  greetings: {
+    morning: "Buenos días, {first_name} {last_name}",
+    afternoon: "Buenas tardes, {first_name} {last_name}",
+    evening: "Buenas noches, {first_name} {last_name}",
+    night: "Buenas noches, {first_name} {last_name}",
+  },
   show_all: "Mostrar todo",
   show_less: "Mostrar menos",
   no_data_yet: "Aún no hay datos",

--- a/packages/i18n/src/locales/es/translations.ts
+++ b/packages/i18n/src/locales/es/translations.ts
@@ -502,7 +502,6 @@ export default {
   morning: "días",
   afternoon: "tardes",
   evening: "noches",
-  night: "noche",
   greetings: {
     morning: "Buenos días, {first_name} {last_name}",
     afternoon: "Buenas tardes, {first_name} {last_name}",

--- a/packages/i18n/src/locales/es/translations.ts
+++ b/packages/i18n/src/locales/es/translations.ts
@@ -502,6 +502,7 @@ export default {
   morning: "días",
   afternoon: "tardes",
   evening: "noches",
+  night: "night",
   show_all: "Mostrar todo",
   show_less: "Mostrar menos",
   no_data_yet: "Aún no hay datos",

--- a/packages/i18n/src/locales/es/translations.ts
+++ b/packages/i18n/src/locales/es/translations.ts
@@ -507,7 +507,6 @@ export default {
     morning: "Buenos días, {first_name} {last_name}",
     afternoon: "Buenas tardes, {first_name} {last_name}",
     evening: "Buenas noches, {first_name} {last_name}",
-    night: "Buenas noches, {first_name} {last_name}",
   },
   show_all: "Mostrar todo",
   show_less: "Mostrar menos",

--- a/packages/i18n/src/locales/fr/translations.ts
+++ b/packages/i18n/src/locales/fr/translations.ts
@@ -498,7 +498,6 @@ export default {
   morning: "matin",
   afternoon: "après-midi",
   evening: "soir",
-  night: "nuit",
   greetings: {
     morning: "Bonjour, {first_name} {last_name}",
     afternoon: "Bon après-midi, {first_name} {last_name}",

--- a/packages/i18n/src/locales/fr/translations.ts
+++ b/packages/i18n/src/locales/fr/translations.ts
@@ -499,6 +499,12 @@ export default {
   afternoon: "après-midi",
   evening: "soir",
   night: "nuit",
+  greetings: {
+    morning: "Bonjour, {first_name} {last_name}",
+    afternoon: "Bon après-midi, {first_name} {last_name}",
+    evening: "Bonsoir, {first_name} {last_name}",
+    night: "Bonne nuit, {first_name} {last_name}",
+  },
   show_all: "Tout afficher",
   show_less: "Afficher moins",
   no_data_yet: "Pas encore de données",

--- a/packages/i18n/src/locales/fr/translations.ts
+++ b/packages/i18n/src/locales/fr/translations.ts
@@ -503,7 +503,6 @@ export default {
     morning: "Bonjour, {first_name} {last_name}",
     afternoon: "Bon après-midi, {first_name} {last_name}",
     evening: "Bonsoir, {first_name} {last_name}",
-    night: "Bonne nuit, {first_name} {last_name}",
   },
   show_all: "Tout afficher",
   show_less: "Afficher moins",

--- a/packages/i18n/src/locales/fr/translations.ts
+++ b/packages/i18n/src/locales/fr/translations.ts
@@ -498,6 +498,7 @@ export default {
   morning: "matin",
   afternoon: "après-midi",
   evening: "soir",
+  night: "night",
   show_all: "Tout afficher",
   show_less: "Afficher moins",
   no_data_yet: "Pas encore de données",

--- a/packages/i18n/src/locales/fr/translations.ts
+++ b/packages/i18n/src/locales/fr/translations.ts
@@ -498,7 +498,7 @@ export default {
   morning: "matin",
   afternoon: "après-midi",
   evening: "soir",
-  night: "night",
+  night: "nuit",
   show_all: "Tout afficher",
   show_less: "Afficher moins",
   no_data_yet: "Pas encore de données",

--- a/packages/i18n/src/locales/id/translations.ts
+++ b/packages/i18n/src/locales/id/translations.ts
@@ -499,7 +499,6 @@ export default {
     morning: "Selamat pagi, {first_name} {last_name}",
     afternoon: "Selamat siang, {first_name} {last_name}",
     evening: "Selamat malam, {first_name} {last_name}",
-    night: "Selamat malam, {first_name} {last_name}",
   },
   show_all: "Tampilkan semua",
   show_less: "Tampilkan lebih sedikit",

--- a/packages/i18n/src/locales/id/translations.ts
+++ b/packages/i18n/src/locales/id/translations.ts
@@ -494,7 +494,6 @@ export default {
   morning: "pagi",
   afternoon: "siang",
   evening: "malam",
-  night: "dini hari",
   greetings: {
     morning: "Selamat pagi, {first_name} {last_name}",
     afternoon: "Selamat siang, {first_name} {last_name}",

--- a/packages/i18n/src/locales/id/translations.ts
+++ b/packages/i18n/src/locales/id/translations.ts
@@ -495,6 +495,12 @@ export default {
   afternoon: "siang",
   evening: "malam",
   night: "dini hari",
+  greetings: {
+    morning: "Selamat pagi, {first_name} {last_name}",
+    afternoon: "Selamat siang, {first_name} {last_name}",
+    evening: "Selamat malam, {first_name} {last_name}",
+    night: "Selamat malam, {first_name} {last_name}",
+  },
   show_all: "Tampilkan semua",
   show_less: "Tampilkan lebih sedikit",
   no_data_yet: "Belum ada data",

--- a/packages/i18n/src/locales/id/translations.ts
+++ b/packages/i18n/src/locales/id/translations.ts
@@ -494,6 +494,7 @@ export default {
   morning: "pagi",
   afternoon: "siang",
   evening: "malam",
+  night: "night",
   show_all: "Tampilkan semua",
   show_less: "Tampilkan lebih sedikit",
   no_data_yet: "Belum ada data",

--- a/packages/i18n/src/locales/id/translations.ts
+++ b/packages/i18n/src/locales/id/translations.ts
@@ -494,7 +494,7 @@ export default {
   morning: "pagi",
   afternoon: "siang",
   evening: "malam",
-  night: "night",
+  night: "dini hari",
   show_all: "Tampilkan semua",
   show_less: "Tampilkan lebih sedikit",
   no_data_yet: "Belum ada data",

--- a/packages/i18n/src/locales/it/translations.ts
+++ b/packages/i18n/src/locales/it/translations.ts
@@ -495,7 +495,6 @@ export default {
   morning: "Mattina",
   afternoon: "Pomeriggio",
   evening: "Sera",
-  night: "notte",
   greetings: {
     morning: "Buongiorno, {first_name} {last_name}",
     afternoon: "Buon pomeriggio, {first_name} {last_name}",

--- a/packages/i18n/src/locales/it/translations.ts
+++ b/packages/i18n/src/locales/it/translations.ts
@@ -500,7 +500,6 @@ export default {
     morning: "Buongiorno, {first_name} {last_name}",
     afternoon: "Buon pomeriggio, {first_name} {last_name}",
     evening: "Buonasera, {first_name} {last_name}",
-    night: "Buonanotte, {first_name} {last_name}",
   },
   show_all: "Mostra tutto",
   show_less: "Mostra meno",

--- a/packages/i18n/src/locales/it/translations.ts
+++ b/packages/i18n/src/locales/it/translations.ts
@@ -495,6 +495,7 @@ export default {
   morning: "Mattina",
   afternoon: "Pomeriggio",
   evening: "Sera",
+  night: "night",
   show_all: "Mostra tutto",
   show_less: "Mostra meno",
   no_data_yet: "Nessun dato disponibile",

--- a/packages/i18n/src/locales/it/translations.ts
+++ b/packages/i18n/src/locales/it/translations.ts
@@ -495,7 +495,7 @@ export default {
   morning: "Mattina",
   afternoon: "Pomeriggio",
   evening: "Sera",
-  night: "night",
+  night: "notte",
   show_all: "Mostra tutto",
   show_less: "Mostra meno",
   no_data_yet: "Nessun dato disponibile",

--- a/packages/i18n/src/locales/it/translations.ts
+++ b/packages/i18n/src/locales/it/translations.ts
@@ -496,6 +496,12 @@ export default {
   afternoon: "Pomeriggio",
   evening: "Sera",
   night: "notte",
+  greetings: {
+    morning: "Buongiorno, {first_name} {last_name}",
+    afternoon: "Buon pomeriggio, {first_name} {last_name}",
+    evening: "Buonasera, {first_name} {last_name}",
+    night: "Buonanotte, {first_name} {last_name}",
+  },
   show_all: "Mostra tutto",
   show_less: "Mostra meno",
   no_data_yet: "Nessun dato disponibile",

--- a/packages/i18n/src/locales/ja/translations.ts
+++ b/packages/i18n/src/locales/ja/translations.ts
@@ -493,7 +493,6 @@ export default {
     morning: "おはようございます、{first_name} {last_name}",
     afternoon: "こんにちは、{first_name} {last_name}",
     evening: "こんばんは、{first_name} {last_name}",
-    night: "おやすみなさい、{first_name} {last_name}",
   },
   show_all: "すべて表示",
   show_less: "表示を減らす",

--- a/packages/i18n/src/locales/ja/translations.ts
+++ b/packages/i18n/src/locales/ja/translations.ts
@@ -488,7 +488,6 @@ export default {
   morning: "ございます",
   afternoon: "こんにちは",
   evening: "こんばんは",
-  night: "夜",
   greetings: {
     morning: "おはようございます、{first_name} {last_name}",
     afternoon: "こんにちは、{first_name} {last_name}",

--- a/packages/i18n/src/locales/ja/translations.ts
+++ b/packages/i18n/src/locales/ja/translations.ts
@@ -488,7 +488,7 @@ export default {
   morning: "ございます",
   afternoon: "こんにちは",
   evening: "こんばんは",
-  night: "night",
+  night: "夜",
   show_all: "すべて表示",
   show_less: "表示を減らす",
   no_data_yet: "まだデータがありません",

--- a/packages/i18n/src/locales/ja/translations.ts
+++ b/packages/i18n/src/locales/ja/translations.ts
@@ -488,6 +488,7 @@ export default {
   morning: "ございます",
   afternoon: "こんにちは",
   evening: "こんばんは",
+  night: "night",
   show_all: "すべて表示",
   show_less: "表示を減らす",
   no_data_yet: "まだデータがありません",

--- a/packages/i18n/src/locales/ja/translations.ts
+++ b/packages/i18n/src/locales/ja/translations.ts
@@ -489,6 +489,12 @@ export default {
   afternoon: "こんにちは",
   evening: "こんばんは",
   night: "夜",
+  greetings: {
+    morning: "おはようございます、{first_name} {last_name}",
+    afternoon: "こんにちは、{first_name} {last_name}",
+    evening: "こんばんは、{first_name} {last_name}",
+    night: "おやすみなさい、{first_name} {last_name}",
+  },
   show_all: "すべて表示",
   show_less: "表示を減らす",
   no_data_yet: "まだデータがありません",

--- a/packages/i18n/src/locales/ko/translations.ts
+++ b/packages/i18n/src/locales/ko/translations.ts
@@ -487,7 +487,6 @@ export default {
     morning: "좋은 아침, {first_name} {last_name}",
     afternoon: "좋은 오후, {first_name} {last_name}",
     evening: "좋은 저녁, {first_name} {last_name}",
-    night: "좋은 밤, {first_name} {last_name}",
   },
   show_all: "모두 보기",
   show_less: "간략히 보기",

--- a/packages/i18n/src/locales/ko/translations.ts
+++ b/packages/i18n/src/locales/ko/translations.ts
@@ -483,6 +483,12 @@ export default {
   afternoon: "오후",
   evening: "저녁",
   night: "밤",
+  greetings: {
+    morning: "좋은 아침, {first_name} {last_name}",
+    afternoon: "좋은 오후, {first_name} {last_name}",
+    evening: "좋은 저녁, {first_name} {last_name}",
+    night: "좋은 밤, {first_name} {last_name}",
+  },
   show_all: "모두 보기",
   show_less: "간략히 보기",
   no_data_yet: "아직 데이터 없음",

--- a/packages/i18n/src/locales/ko/translations.ts
+++ b/packages/i18n/src/locales/ko/translations.ts
@@ -482,7 +482,6 @@ export default {
   morning: "아침",
   afternoon: "오후",
   evening: "저녁",
-  night: "밤",
   greetings: {
     morning: "좋은 아침, {first_name} {last_name}",
     afternoon: "좋은 오후, {first_name} {last_name}",

--- a/packages/i18n/src/locales/ko/translations.ts
+++ b/packages/i18n/src/locales/ko/translations.ts
@@ -482,7 +482,7 @@ export default {
   morning: "아침",
   afternoon: "오후",
   evening: "저녁",
-  night: "night",
+  night: "밤",
   show_all: "모두 보기",
   show_less: "간략히 보기",
   no_data_yet: "아직 데이터 없음",

--- a/packages/i18n/src/locales/ko/translations.ts
+++ b/packages/i18n/src/locales/ko/translations.ts
@@ -482,6 +482,7 @@ export default {
   morning: "아침",
   afternoon: "오후",
   evening: "저녁",
+  night: "night",
   show_all: "모두 보기",
   show_less: "간략히 보기",
   no_data_yet: "아직 데이터 없음",

--- a/packages/i18n/src/locales/pl/translations.ts
+++ b/packages/i18n/src/locales/pl/translations.ts
@@ -493,7 +493,6 @@ export default {
     morning: "Dzień dobry, {first_name} {last_name}",
     afternoon: "Dzień dobry, {first_name} {last_name}",
     evening: "Dobry wieczór, {first_name} {last_name}",
-    night: "Dobranoc, {first_name} {last_name}",
   },
   show_all: "Pokaż wszystko",
   show_less: "Pokaż mniej",

--- a/packages/i18n/src/locales/pl/translations.ts
+++ b/packages/i18n/src/locales/pl/translations.ts
@@ -488,7 +488,6 @@ export default {
   morning: "rano",
   afternoon: "po południu",
   evening: "wieczorem",
-  night: "noc",
   greetings: {
     morning: "Dzień dobry, {first_name} {last_name}",
     afternoon: "Dzień dobry, {first_name} {last_name}",

--- a/packages/i18n/src/locales/pl/translations.ts
+++ b/packages/i18n/src/locales/pl/translations.ts
@@ -489,6 +489,12 @@ export default {
   afternoon: "po południu",
   evening: "wieczorem",
   night: "noc",
+  greetings: {
+    morning: "Dzień dobry, {first_name} {last_name}",
+    afternoon: "Dzień dobry, {first_name} {last_name}",
+    evening: "Dobry wieczór, {first_name} {last_name}",
+    night: "Dobranoc, {first_name} {last_name}",
+  },
   show_all: "Pokaż wszystko",
   show_less: "Pokaż mniej",
   no_data_yet: "Brak danych",

--- a/packages/i18n/src/locales/pl/translations.ts
+++ b/packages/i18n/src/locales/pl/translations.ts
@@ -488,7 +488,7 @@ export default {
   morning: "rano",
   afternoon: "po południu",
   evening: "wieczorem",
-  night: "night",
+  night: "noc",
   show_all: "Pokaż wszystko",
   show_less: "Pokaż mniej",
   no_data_yet: "Brak danych",

--- a/packages/i18n/src/locales/pl/translations.ts
+++ b/packages/i18n/src/locales/pl/translations.ts
@@ -488,6 +488,7 @@ export default {
   morning: "rano",
   afternoon: "po południu",
   evening: "wieczorem",
+  night: "night",
   show_all: "Pokaż wszystko",
   show_less: "Pokaż mniej",
   no_data_yet: "Brak danych",

--- a/packages/i18n/src/locales/pt-BR/translations.ts
+++ b/packages/i18n/src/locales/pt-BR/translations.ts
@@ -498,7 +498,6 @@ export default {
   morning: "manhã",
   afternoon: "tarde",
   evening: "noite",
-  night: "noite",
   greetings: {
     morning: "Bom dia, {first_name} {last_name}",
     afternoon: "Boa tarde, {first_name} {last_name}",

--- a/packages/i18n/src/locales/pt-BR/translations.ts
+++ b/packages/i18n/src/locales/pt-BR/translations.ts
@@ -498,7 +498,7 @@ export default {
   morning: "manhã",
   afternoon: "tarde",
   evening: "noite",
-  night: "night",
+  night: "noite",
   show_all: "Mostrar tudo",
   show_less: "Mostrar menos",
   no_data_yet: "Nenhum dado ainda",

--- a/packages/i18n/src/locales/pt-BR/translations.ts
+++ b/packages/i18n/src/locales/pt-BR/translations.ts
@@ -499,6 +499,12 @@ export default {
   afternoon: "tarde",
   evening: "noite",
   night: "noite",
+  greetings: {
+    morning: "Bom dia, {first_name} {last_name}",
+    afternoon: "Boa tarde, {first_name} {last_name}",
+    evening: "Boa noite, {first_name} {last_name}",
+    night: "Boa noite, {first_name} {last_name}",
+  },
   show_all: "Mostrar tudo",
   show_less: "Mostrar menos",
   no_data_yet: "Nenhum dado ainda",

--- a/packages/i18n/src/locales/pt-BR/translations.ts
+++ b/packages/i18n/src/locales/pt-BR/translations.ts
@@ -498,6 +498,7 @@ export default {
   morning: "manhã",
   afternoon: "tarde",
   evening: "noite",
+  night: "night",
   show_all: "Mostrar tudo",
   show_less: "Mostrar menos",
   no_data_yet: "Nenhum dado ainda",

--- a/packages/i18n/src/locales/pt-BR/translations.ts
+++ b/packages/i18n/src/locales/pt-BR/translations.ts
@@ -503,7 +503,6 @@ export default {
     morning: "Bom dia, {first_name} {last_name}",
     afternoon: "Boa tarde, {first_name} {last_name}",
     evening: "Boa noite, {first_name} {last_name}",
-    night: "Boa noite, {first_name} {last_name}",
   },
   show_all: "Mostrar tudo",
   show_less: "Mostrar menos",

--- a/packages/i18n/src/locales/ro/translations.ts
+++ b/packages/i18n/src/locales/ro/translations.ts
@@ -495,6 +495,7 @@ export default {
   morning: "dimineața",
   afternoon: "după-amiaza",
   evening: "seara",
+  night: "night",
   show_all: "Arată tot",
   show_less: "Arată mai puțin",
   no_data_yet: "Nicio dată încă",

--- a/packages/i18n/src/locales/ro/translations.ts
+++ b/packages/i18n/src/locales/ro/translations.ts
@@ -496,6 +496,12 @@ export default {
   afternoon: "după-amiaza",
   evening: "seara",
   night: "noapte",
+  greetings: {
+    morning: "Bună dimineața, {first_name} {last_name}",
+    afternoon: "Bună ziua, {first_name} {last_name}",
+    evening: "Bună seara, {first_name} {last_name}",
+    night: "Noapte bună, {first_name} {last_name}",
+  },
   show_all: "Arată tot",
   show_less: "Arată mai puțin",
   no_data_yet: "Nicio dată încă",

--- a/packages/i18n/src/locales/ro/translations.ts
+++ b/packages/i18n/src/locales/ro/translations.ts
@@ -495,7 +495,6 @@ export default {
   morning: "dimineața",
   afternoon: "după-amiaza",
   evening: "seara",
-  night: "noapte",
   greetings: {
     morning: "Bună dimineața, {first_name} {last_name}",
     afternoon: "Bună ziua, {first_name} {last_name}",

--- a/packages/i18n/src/locales/ro/translations.ts
+++ b/packages/i18n/src/locales/ro/translations.ts
@@ -500,7 +500,6 @@ export default {
     morning: "Bună dimineața, {first_name} {last_name}",
     afternoon: "Bună ziua, {first_name} {last_name}",
     evening: "Bună seara, {first_name} {last_name}",
-    night: "Noapte bună, {first_name} {last_name}",
   },
   show_all: "Arată tot",
   show_less: "Arată mai puțin",

--- a/packages/i18n/src/locales/ro/translations.ts
+++ b/packages/i18n/src/locales/ro/translations.ts
@@ -495,7 +495,7 @@ export default {
   morning: "dimineața",
   afternoon: "după-amiaza",
   evening: "seara",
-  night: "night",
+  night: "noapte",
   show_all: "Arată tot",
   show_less: "Arată mai puțin",
   no_data_yet: "Nicio dată încă",

--- a/packages/i18n/src/locales/ru/translations.ts
+++ b/packages/i18n/src/locales/ru/translations.ts
@@ -502,7 +502,6 @@ export default {
     morning: "Доброе утро, {first_name} {last_name}",
     afternoon: "Добрый день, {first_name} {last_name}",
     evening: "Добрый вечер, {first_name} {last_name}",
-    night: "Доброй ночи, {first_name} {last_name}",
   },
   show_all: "Показать все",
   show_less: "Свернуть",

--- a/packages/i18n/src/locales/ru/translations.ts
+++ b/packages/i18n/src/locales/ru/translations.ts
@@ -497,7 +497,7 @@ export default {
   morning: "утра",
   afternoon: "дня",
   evening: "вечера",
-  night: "night",
+  night: "ночи",
   show_all: "Показать все",
   show_less: "Свернуть",
   no_data_yet: "Нет данных",

--- a/packages/i18n/src/locales/ru/translations.ts
+++ b/packages/i18n/src/locales/ru/translations.ts
@@ -497,6 +497,7 @@ export default {
   morning: "утра",
   afternoon: "дня",
   evening: "вечера",
+  night: "night",
   show_all: "Показать все",
   show_less: "Свернуть",
   no_data_yet: "Нет данных",

--- a/packages/i18n/src/locales/ru/translations.ts
+++ b/packages/i18n/src/locales/ru/translations.ts
@@ -497,7 +497,6 @@ export default {
   morning: "утра",
   afternoon: "дня",
   evening: "вечера",
-  night: "ночи",
   greetings: {
     morning: "Доброе утро, {first_name} {last_name}",
     afternoon: "Добрый день, {first_name} {last_name}",

--- a/packages/i18n/src/locales/ru/translations.ts
+++ b/packages/i18n/src/locales/ru/translations.ts
@@ -498,6 +498,12 @@ export default {
   afternoon: "дня",
   evening: "вечера",
   night: "ночи",
+  greetings: {
+    morning: "Доброе утро, {first_name} {last_name}",
+    afternoon: "Добрый день, {first_name} {last_name}",
+    evening: "Добрый вечер, {first_name} {last_name}",
+    night: "Доброй ночи, {first_name} {last_name}",
+  },
   show_all: "Показать все",
   show_less: "Свернуть",
   no_data_yet: "Нет данных",

--- a/packages/i18n/src/locales/sk/translations.ts
+++ b/packages/i18n/src/locales/sk/translations.ts
@@ -489,7 +489,6 @@ export default {
   morning: "ráno",
   afternoon: "popoludnie",
   evening: "večer",
-  night: "noc",
   greetings: {
     morning: "Dobré ráno, {first_name} {last_name}",
     afternoon: "Dobré popoludnie, {first_name} {last_name}",

--- a/packages/i18n/src/locales/sk/translations.ts
+++ b/packages/i18n/src/locales/sk/translations.ts
@@ -489,6 +489,7 @@ export default {
   morning: "ráno",
   afternoon: "popoludnie",
   evening: "večer",
+  night: "night",
   show_all: "Zobraziť všetko",
   show_less: "Zobraziť menej",
   no_data_yet: "Zatiaľ žiadne dáta",

--- a/packages/i18n/src/locales/sk/translations.ts
+++ b/packages/i18n/src/locales/sk/translations.ts
@@ -489,7 +489,7 @@ export default {
   morning: "ráno",
   afternoon: "popoludnie",
   evening: "večer",
-  night: "night",
+  night: "noc",
   show_all: "Zobraziť všetko",
   show_less: "Zobraziť menej",
   no_data_yet: "Zatiaľ žiadne dáta",

--- a/packages/i18n/src/locales/sk/translations.ts
+++ b/packages/i18n/src/locales/sk/translations.ts
@@ -490,6 +490,12 @@ export default {
   afternoon: "popoludnie",
   evening: "večer",
   night: "noc",
+  greetings: {
+    morning: "Dobré ráno, {first_name} {last_name}",
+    afternoon: "Dobré popoludnie, {first_name} {last_name}",
+    evening: "Dobrý večer, {first_name} {last_name}",
+    night: "Dobrú noc, {first_name} {last_name}",
+  },
   show_all: "Zobraziť všetko",
   show_less: "Zobraziť menej",
   no_data_yet: "Zatiaľ žiadne dáta",

--- a/packages/i18n/src/locales/sk/translations.ts
+++ b/packages/i18n/src/locales/sk/translations.ts
@@ -494,7 +494,6 @@ export default {
     morning: "Dobré ráno, {first_name} {last_name}",
     afternoon: "Dobré popoludnie, {first_name} {last_name}",
     evening: "Dobrý večer, {first_name} {last_name}",
-    night: "Dobrú noc, {first_name} {last_name}",
   },
   show_all: "Zobraziť všetko",
   show_less: "Zobraziť menej",

--- a/packages/i18n/src/locales/tr-TR/translations.ts
+++ b/packages/i18n/src/locales/tr-TR/translations.ts
@@ -490,7 +490,7 @@ export default {
   morning: "sabah",
   afternoon: "öğleden sonra",
   evening: "akşam",
-  night: "night",
+  night: "gece",
   show_all: "Tümünü göster",
   show_less: "Daha az göster",
   no_data_yet: "Henüz veri yok",

--- a/packages/i18n/src/locales/tr-TR/translations.ts
+++ b/packages/i18n/src/locales/tr-TR/translations.ts
@@ -490,6 +490,7 @@ export default {
   morning: "sabah",
   afternoon: "öğleden sonra",
   evening: "akşam",
+  night: "night",
   show_all: "Tümünü göster",
   show_less: "Daha az göster",
   no_data_yet: "Henüz veri yok",

--- a/packages/i18n/src/locales/tr-TR/translations.ts
+++ b/packages/i18n/src/locales/tr-TR/translations.ts
@@ -491,6 +491,12 @@ export default {
   afternoon: "öğleden sonra",
   evening: "akşam",
   night: "gece",
+  greetings: {
+    morning: "Günaydın, {first_name} {last_name}",
+    afternoon: "İyi günler, {first_name} {last_name}",
+    evening: "İyi akşamlar, {first_name} {last_name}",
+    night: "İyi geceler, {first_name} {last_name}",
+  },
   show_all: "Tümünü göster",
   show_less: "Daha az göster",
   no_data_yet: "Henüz veri yok",

--- a/packages/i18n/src/locales/tr-TR/translations.ts
+++ b/packages/i18n/src/locales/tr-TR/translations.ts
@@ -495,7 +495,6 @@ export default {
     morning: "Günaydın, {first_name} {last_name}",
     afternoon: "İyi günler, {first_name} {last_name}",
     evening: "İyi akşamlar, {first_name} {last_name}",
-    night: "İyi geceler, {first_name} {last_name}",
   },
   show_all: "Tümünü göster",
   show_less: "Daha az göster",

--- a/packages/i18n/src/locales/tr-TR/translations.ts
+++ b/packages/i18n/src/locales/tr-TR/translations.ts
@@ -490,7 +490,6 @@ export default {
   morning: "sabah",
   afternoon: "öğleden sonra",
   evening: "akşam",
-  night: "gece",
   greetings: {
     morning: "Günaydın, {first_name} {last_name}",
     afternoon: "İyi günler, {first_name} {last_name}",

--- a/packages/i18n/src/locales/ua/translations.ts
+++ b/packages/i18n/src/locales/ua/translations.ts
@@ -497,6 +497,7 @@ export default {
   morning: "ранку",
   afternoon: "дня",
   evening: "вечора",
+  night: "night",
   show_all: "Показати все",
   show_less: "Показати менше",
   no_data_yet: "Поки що немає даних",

--- a/packages/i18n/src/locales/ua/translations.ts
+++ b/packages/i18n/src/locales/ua/translations.ts
@@ -502,7 +502,6 @@ export default {
     morning: "Добрий ранок, {first_name} {last_name}",
     afternoon: "Добрий день, {first_name} {last_name}",
     evening: "Добрий вечір, {first_name} {last_name}",
-    night: "Доброї ночі, {first_name} {last_name}",
   },
   show_all: "Показати все",
   show_less: "Показати менше",

--- a/packages/i18n/src/locales/ua/translations.ts
+++ b/packages/i18n/src/locales/ua/translations.ts
@@ -497,7 +497,7 @@ export default {
   morning: "ранку",
   afternoon: "дня",
   evening: "вечора",
-  night: "night",
+  night: "ночі",
   show_all: "Показати все",
   show_less: "Показати менше",
   no_data_yet: "Поки що немає даних",

--- a/packages/i18n/src/locales/ua/translations.ts
+++ b/packages/i18n/src/locales/ua/translations.ts
@@ -497,7 +497,6 @@ export default {
   morning: "ранку",
   afternoon: "дня",
   evening: "вечора",
-  night: "ночі",
   greetings: {
     morning: "Добрий ранок, {first_name} {last_name}",
     afternoon: "Добрий день, {first_name} {last_name}",

--- a/packages/i18n/src/locales/ua/translations.ts
+++ b/packages/i18n/src/locales/ua/translations.ts
@@ -498,6 +498,12 @@ export default {
   afternoon: "дня",
   evening: "вечора",
   night: "ночі",
+  greetings: {
+    morning: "Добрий ранок, {first_name} {last_name}",
+    afternoon: "Добрий день, {first_name} {last_name}",
+    evening: "Добрий вечір, {first_name} {last_name}",
+    night: "Доброї ночі, {first_name} {last_name}",
+  },
   show_all: "Показати все",
   show_less: "Показати менше",
   no_data_yet: "Поки що немає даних",

--- a/packages/i18n/src/locales/vi-VN/translations.ts
+++ b/packages/i18n/src/locales/vi-VN/translations.ts
@@ -500,7 +500,6 @@ export default {
     morning: "Chào buổi sáng, {first_name} {last_name}",
     afternoon: "Chào buổi chiều, {first_name} {last_name}",
     evening: "Chào buổi tối, {first_name} {last_name}",
-    night: "Chúc ngủ ngon, {first_name} {last_name}",
   },
   show_all: "Hiển thị tất cả",
   show_less: "Hiển thị ít hơn",

--- a/packages/i18n/src/locales/vi-VN/translations.ts
+++ b/packages/i18n/src/locales/vi-VN/translations.ts
@@ -495,7 +495,6 @@ export default {
   morning: "Buổi sáng",
   afternoon: "Buổi chiều",
   evening: "Buổi tối",
-  night: "Buổi đêm",
   greetings: {
     morning: "Chào buổi sáng, {first_name} {last_name}",
     afternoon: "Chào buổi chiều, {first_name} {last_name}",

--- a/packages/i18n/src/locales/vi-VN/translations.ts
+++ b/packages/i18n/src/locales/vi-VN/translations.ts
@@ -496,6 +496,12 @@ export default {
   afternoon: "Buổi chiều",
   evening: "Buổi tối",
   night: "Buổi đêm",
+  greetings: {
+    morning: "Chào buổi sáng, {first_name} {last_name}",
+    afternoon: "Chào buổi chiều, {first_name} {last_name}",
+    evening: "Chào buổi tối, {first_name} {last_name}",
+    night: "Chúc ngủ ngon, {first_name} {last_name}",
+  },
   show_all: "Hiển thị tất cả",
   show_less: "Hiển thị ít hơn",
   no_data_yet: "Chưa có dữ liệu",

--- a/packages/i18n/src/locales/vi-VN/translations.ts
+++ b/packages/i18n/src/locales/vi-VN/translations.ts
@@ -495,6 +495,7 @@ export default {
   morning: "Buổi sáng",
   afternoon: "Buổi chiều",
   evening: "Buổi tối",
+  night: "night",
   show_all: "Hiển thị tất cả",
   show_less: "Hiển thị ít hơn",
   no_data_yet: "Chưa có dữ liệu",

--- a/packages/i18n/src/locales/vi-VN/translations.ts
+++ b/packages/i18n/src/locales/vi-VN/translations.ts
@@ -495,7 +495,7 @@ export default {
   morning: "Buổi sáng",
   afternoon: "Buổi chiều",
   evening: "Buổi tối",
-  night: "night",
+  night: "Buổi đêm",
   show_all: "Hiển thị tất cả",
   show_less: "Hiển thị ít hơn",
   no_data_yet: "Chưa có dữ liệu",

--- a/packages/i18n/src/locales/zh-CN/translations.ts
+++ b/packages/i18n/src/locales/zh-CN/translations.ts
@@ -482,7 +482,6 @@ export default {
     morning: "早上好，{first_name} {last_name}",
     afternoon: "下午好，{first_name} {last_name}",
     evening: "晚上好，{first_name} {last_name}",
-    night: "晚安，{first_name} {last_name}",
   },
   show_all: "显示全部",
   show_less: "显示更少",

--- a/packages/i18n/src/locales/zh-CN/translations.ts
+++ b/packages/i18n/src/locales/zh-CN/translations.ts
@@ -477,7 +477,7 @@ export default {
   morning: "早上",
   afternoon: "下午",
   evening: "晚上",
-  night: "night",
+  night: "晚安",
   show_all: "显示全部",
   show_less: "显示更少",
   no_data_yet: "暂无数据",

--- a/packages/i18n/src/locales/zh-CN/translations.ts
+++ b/packages/i18n/src/locales/zh-CN/translations.ts
@@ -478,6 +478,12 @@ export default {
   afternoon: "下午",
   evening: "晚上",
   night: "晚安",
+  greetings: {
+    morning: "早上好，{first_name} {last_name}",
+    afternoon: "下午好，{first_name} {last_name}",
+    evening: "晚上好，{first_name} {last_name}",
+    night: "晚安，{first_name} {last_name}",
+  },
   show_all: "显示全部",
   show_less: "显示更少",
   no_data_yet: "暂无数据",

--- a/packages/i18n/src/locales/zh-CN/translations.ts
+++ b/packages/i18n/src/locales/zh-CN/translations.ts
@@ -477,6 +477,7 @@ export default {
   morning: "早上",
   afternoon: "下午",
   evening: "晚上",
+  night: "night",
   show_all: "显示全部",
   show_less: "显示更少",
   no_data_yet: "暂无数据",

--- a/packages/i18n/src/locales/zh-CN/translations.ts
+++ b/packages/i18n/src/locales/zh-CN/translations.ts
@@ -477,7 +477,6 @@ export default {
   morning: "早上",
   afternoon: "下午",
   evening: "晚上",
-  night: "晚安",
   greetings: {
     morning: "早上好，{first_name} {last_name}",
     afternoon: "下午好，{first_name} {last_name}",

--- a/packages/i18n/src/locales/zh-TW/translations.ts
+++ b/packages/i18n/src/locales/zh-TW/translations.ts
@@ -481,7 +481,6 @@ export default {
     morning: "早安，{first_name} {last_name}",
     afternoon: "午安，{first_name} {last_name}",
     evening: "晚上好，{first_name} {last_name}",
-    night: "晚安，{first_name} {last_name}",
   },
   show_all: "顯示全部",
   show_less: "顯示較少",

--- a/packages/i18n/src/locales/zh-TW/translations.ts
+++ b/packages/i18n/src/locales/zh-TW/translations.ts
@@ -476,7 +476,6 @@ export default {
   morning: "早上",
   afternoon: "下午",
   evening: "晚上",
-  night: "晚安",
   greetings: {
     morning: "早安，{first_name} {last_name}",
     afternoon: "午安，{first_name} {last_name}",

--- a/packages/i18n/src/locales/zh-TW/translations.ts
+++ b/packages/i18n/src/locales/zh-TW/translations.ts
@@ -477,6 +477,12 @@ export default {
   afternoon: "下午",
   evening: "晚上",
   night: "晚安",
+  greetings: {
+    morning: "早安，{first_name} {last_name}",
+    afternoon: "午安，{first_name} {last_name}",
+    evening: "晚上好，{first_name} {last_name}",
+    night: "晚安，{first_name} {last_name}",
+  },
   show_all: "顯示全部",
   show_less: "顯示較少",
   no_data_yet: "尚無資料",

--- a/packages/i18n/src/locales/zh-TW/translations.ts
+++ b/packages/i18n/src/locales/zh-TW/translations.ts
@@ -476,7 +476,7 @@ export default {
   morning: "早上",
   afternoon: "下午",
   evening: "晚上",
-  night: "night",
+  night: "晚安",
   show_all: "顯示全部",
   show_less: "顯示較少",
   no_data_yet: "尚無資料",

--- a/packages/i18n/src/locales/zh-TW/translations.ts
+++ b/packages/i18n/src/locales/zh-TW/translations.ts
@@ -476,6 +476,7 @@ export default {
   morning: "早上",
   afternoon: "下午",
   evening: "晚上",
+  night: "night",
   show_all: "顯示全部",
   show_less: "顯示較少",
   no_data_yet: "尚無資料",


### PR DESCRIPTION
### Description

The home page greeting component had two bugs:

1. **Timezone mismatch**: `hour` (used to determine greeting text) was computed using the browser's local timezone, while `timeString` (displayed time) used `user.user_timezone` from the profile. These two could differ, producing a greeting like "Good morning" while showing 19:38.

2. **Missing night bucket**: `hour < 12` classified all midnight-to-noon hours as "morning", so users at 1 AM, 2 AM, 3 AM would see "Good morning".

**Root cause in one line:** the displayed time and greeting logic were reading time from two different clocks.

**Fix:**
- All four `Intl.DateTimeFormat` calls now use `timeZone: userTimezone` consistently
- Added timezone validation with try/catch — if `user_timezone` is an invalid IANA string, falls back to browser local time instead of throwing `RangeError` and crashing the component
- Added night threshold (0–4 AM → "Good night")
- Added `night` i18n key to all 19 locale files

**Greeting thresholds:**
| Hours | Greeting |
|-------|----------|
| 0–4   | Good night |
| 5–11  | Good morning |
| 12–17 | Good afternoon |
| 18–23 | Good evening |

Both `apps/web/core/components/home/user-greetings.tsx` and `apps/web/core/components/user/user-greetings.tsx` had identical bugs and were fixed identically.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### Screenshots and Media

<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

### Test Scenarios

- Set profile timezone to UTC, verify greeting text and displayed time both reflect UTC hour
- Set profile timezone to a valid non-local timezone (e.g. `America/New_York` while in IST), verify greeting and time both use New York time
- Set profile timezone to an invalid string, verify component does not crash and falls back to browser local time
- Log in between 00:00–04:59 in the active timezone, verify "Good night" appears
- Log in between 05:00–11:59, verify "Good morning"

### References

<!-- Link related issues if there are any -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "night" greeting for late-night hours and consolidated greeting display into a single localized template that includes first and last name placeholders.

* **Bug Fixes**
  * Improved timezone handling with fallback to the browser timezone and consistent 24-hour time formatting.

* **Localization**
  * Added "night" and per‑daypart greeting entries across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->