### PR TITLE
feat: add "Completed at" date filter for work items (#8923)

### DIFF
--- a/apps/api/plane/utils/filters/filterset.py
+++ b/apps/api/plane/utils/filters/filterset.py
@@ -164,6 +164,7 @@ class IssueFilterSet(BaseFilterSet):
             "target_date": ["exact", "range"],
             "created_at": ["exact", "range"],
             "updated_at": ["exact", "range"],
+            "completed_at": ["exact", "range"],
             "is_draft": ["exact"],
             "priority": ["exact", "in"],
         }

--- a/apps/web/ce/hooks/work-item-filters/use-work-item-filters-config.tsx
+++ b/apps/web/ce/hooks/work-item-filters/use-work-item-filters-config.tsx
@@ -36,6 +36,7 @@ import type {
 import { Avatar } from "@plane/ui";
 import {
   getAssigneeFilterConfig,
+  getCompletedAtFilterConfig,
   getCreatedAtFilterConfig,
   getCreatedByFilterConfig,
   getCycleFilterConfig,
@@ -349,6 +350,17 @@ export const useWorkItemFiltersConfig = (props: TUseWorkItemFiltersConfigProps):
     [operatorConfigs]
   );
 
+  // completed at filter config
+  const completedAtFilterConfig = useMemo(
+    () =>
+      getCompletedAtFilterConfig<TWorkItemFilterProperty>("completed_at")({
+        isEnabled: true,
+        filterIcon: CalendarLayoutIcon,
+        ...operatorConfigs,
+      }),
+    [operatorConfigs]
+  );
+
   // project filter config
   const projectFilterConfig = useMemo(
     () =>
@@ -378,6 +390,7 @@ export const useWorkItemFiltersConfig = (props: TUseWorkItemFiltersConfigProps):
       targetDateFilterConfig,
       createdAtFilterConfig,
       updatedAtFilterConfig,
+      completedAtFilterConfig,
       createdByFilterConfig,
       subscriberFilterConfig,
     ],
@@ -397,6 +410,7 @@ export const useWorkItemFiltersConfig = (props: TUseWorkItemFiltersConfigProps):
       target_date: targetDateFilterConfig,
       created_at: createdAtFilterConfig,
       updated_at: updatedAtFilterConfig,
+      completed_at: completedAtFilterConfig,
     },
     isFilterEnabled,
     members: members ?? [],

--- a/apps/web/core/store/issue/helpers/base-issues-utils.ts
+++ b/apps/web/core/store/issue/helpers/base-issues-utils.ts
@@ -192,13 +192,13 @@ export const getIssueIds = (issues: TIssue[]) => issues.map((issue) => issue?.id
 /**
  * Checks if an issue meets the date filter criteria
  * @param issue The issue to check
- * @param filterKey The date field to check ('start_date' or 'target_date')
+ * @param filterKey The date field to check ('start_date', 'target_date', or 'completed_at')
  * @param dateFilters Array of date filter strings
  * @returns boolean indicating if the issue meets the date criteria
  */
 export const checkIssueDateFilter = (
   issue: TIssue,
-  filterKey: "start_date" | "target_date",
+  filterKey: "start_date" | "target_date" | "completed_at",
   dateFilters: string[]
 ): boolean => {
   if (!dateFilters || dateFilters.length === 0) return true;
@@ -254,7 +254,7 @@ export const getFilteredWorkItems = (workItems: TIssue[], filters: IIssueFilterO
     // Check all filter conditions (AND operation between different filters)
     activeFilters.every(([filterKey, filterValues]) => {
       // Handle date filters separately
-      if (filterKey === "start_date" || filterKey === "target_date") {
+      if (filterKey === "start_date" || filterKey === "target_date" || filterKey === "completed_at") {
         return checkIssueDateFilter(workItem, filterKey, filterValues as string[]);
       }
       // Handle regular filters

--- a/packages/constants/src/issue/filter.ts
+++ b/packages/constants/src/issue/filter.ts
@@ -111,7 +111,7 @@ export type TIssueFiltersToDisplayByPageType = {
 
 export const ISSUE_DISPLAY_FILTERS_BY_PAGE: TIssueFiltersToDisplayByPageType = {
   profile_issues: {
-    filters: ["priority", "state_group", "label_id", "start_date", "target_date"],
+    filters: ["priority", "state_group", "label_id", "start_date", "target_date", "completed_at"],
     layoutOptions: {
       list: {
         display_properties: ISSUE_DISPLAY_PROPERTIES_KEYS,
@@ -151,6 +151,7 @@ export const ISSUE_DISPLAY_FILTERS_BY_PAGE: TIssueFiltersToDisplayByPageType = {
       "label_id",
       "start_date",
       "target_date",
+      "completed_at",
     ],
     layoutOptions: {
       list: {
@@ -178,6 +179,7 @@ export const ISSUE_DISPLAY_FILTERS_BY_PAGE: TIssueFiltersToDisplayByPageType = {
       "project_id",
       "start_date",
       "target_date",
+      "completed_at",
     ],
     layoutOptions: {
       spreadsheet: {
@@ -216,6 +218,7 @@ export const ISSUE_DISPLAY_FILTERS_BY_PAGE: TIssueFiltersToDisplayByPageType = {
       "label_id",
       "start_date",
       "target_date",
+      "completed_at",
     ],
     layoutOptions: {
       list: {

--- a/packages/types/src/view-props.ts
+++ b/packages/types/src/view-props.ts
@@ -109,6 +109,7 @@ export const WORK_ITEM_FILTER_PROPERTY_KEYS = [
   "project_id",
   "created_at",
   "updated_at",
+  "completed_at",
 ] as const;
 export type TWorkItemFilterProperty = (typeof WORK_ITEM_FILTER_PROPERTY_KEYS)[number];
 
@@ -143,6 +144,7 @@ export interface IIssueFilterOptions {
   state_group?: string[] | null;
   subscriber?: string[] | null;
   target_date?: string[] | null;
+  completed_at?: string[] | null;
   issue_type?: string[] | null;
 }
 

--- a/packages/utils/src/work-item-filters/configs/filters/date.ts
+++ b/packages/utils/src/work-item-filters/configs/filters/date.ts
@@ -83,3 +83,21 @@ export const getUpdatedAtFilterConfig =
       allowMultipleFilters: true,
       supportedOperatorConfigsMap: getSupportedDateOperators(params),
     });
+
+/**
+ * Get the completed at filter config
+ * @template K - The filter key
+ * @param key - The filter key to use
+ * @returns A function that takes parameters and returns the completed at filter config
+ */
+export const getCompletedAtFilterConfig =
+  <P extends TFilterProperty>(key: P): TCreateFilterConfig<P, TCreateDateFilterParams> =>
+  (params: TCreateDateFilterParams) =>
+    createFilterConfig<P>({
+      id: key,
+      label: "Completed at",
+      ...params,
+      icon: params.filterIcon,
+      allowMultipleFilters: true,
+      supportedOperatorConfigsMap: getSupportedDateOperators(params),
+    });


### PR DESCRIPTION
### Description

Adds a new "Completed at" date filter for work items, allowing users to filter by when a work item was completed.

Currently, users can filter on `Due date`, `Created at`, `Updated at`, and `Start date`, but not on `Completed at` — even though `completed_at` is an existing attribute on work items. This makes it difficult to see what was actually completed at certain points in time, since `Updated at` can change if a completed item is edited.

**Changes:**

- Added `"completed_at"` to `WORK_ITEM_FILTER_PROPERTY_KEYS` in `@plane/types` so the rich filter adapter recognizes it as a valid filter property
- Added `getCompletedAtFilterConfig` factory function in `@plane/utils` (following the same pattern as `getCreatedAtFilterConfig` / `getUpdatedAtFilterConfig`)
- Registered the `completed_at` filter config in the `useWorkItemFiltersConfig` hook (`apps/web/ce`)
- Added `"completed_at"` to all relevant page filter lists in `ISSUE_DISPLAY_FILTERS_BY_PAGE` (`profile_issues`, `archived_issues`, `my_issues`, `issues`)
- Extended client-side date filtering in `checkIssueDateFilter` and `getFilteredWorkItems` to handle `completed_at`

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Test Scenarios

1. Navigate to any project's work items view and open the filter dropdown — "Completed at" should appear as a filter option
2. Apply a "Completed at > after [date]" filter — only work items completed after that date should be shown
3. Apply a "Completed at > before [date]" filter — only work items completed before that date should be shown
4. Apply a date range filter on "Completed at" — only work items completed within the range should be shown
5. Verify the filter works across all views: project issues, my issues, archived issues, profile issues
6. Verify the filter persists when switching between layouts (list, kanban, spreadsheet, etc.)
7. Verify incomplete work items (where `completed_at` is null) are correctly excluded when a "Completed at" filter is active

### References

Closes #8923



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Completed at" date filter: filter work items and issues by completion date across issues, my issues, archived items, and profile pages.
  * Completion-date filtering supports exact and range queries for more precise results.
* **Types & Compatibility**
  * Filter inputs and UI now accept completion-date values for consistent behavior across the app and API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->