### PR TITLE
fix: add logger_task to CELERY_IMPORTS so process_logs is registered in worker

### DIFF
--- a/apps/api/plane/settings/common.py
+++ b/apps/api/plane/settings/common.py
@@ -305,6 +305,8 @@ CELERY_IMPORTS = (
     # issue version tasks
     "plane.bgtasks.issue_version_sync",
     "plane.bgtasks.issue_description_version_sync",
+    # API activity logging
+    "plane.bgtasks.logger_task",
 )
 
 FILE_SIZE_LIMIT = int(os.environ.get("FILE_SIZE_LIMIT", 5242880))


### PR DESCRIPTION
Fixes #8928

## What

Adds `plane.bgtasks.logger_task` to `CELERY_IMPORTS` in `plane/settings/common.py`.

## Why

`logger_task.py` was introduced in #8245 with a `@shared_task` decorator, but was never added to `CELERY_IMPORTS`. The Celery worker only imports modules listed there, so `process_logs` is never registered. Every API request queues this task (via `APITokenLogMiddleware`) and the worker discards it with:

```
KeyError: 'plane.bgtasks.logger_task.process_logs'
```

This silently breaks API activity logging and floods worker logs with errors.

## Change

```diff
 CELERY_IMPORTS = (
     ...
     # issue version tasks
     "plane.bgtasks.issue_version_sync",
     "plane.bgtasks.issue_description_version_sync",
+    # API activity logging
+    "plane.bgtasks.logger_task",
 )
```

One line added. No other changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Registered a new background task module with the task scheduler to enable logging functionality in background operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->