### PR TITLE
fix: dispatch() error handler returns exc instead of response

### DIFF
--- a/apps/api/plane/api/views/base.py
+++ b/apps/api/plane/api/views/base.py
@@ -123,7 +123,7 @@ class BaseAPIView(TimezoneMixin, GenericAPIView, ReadReplicaControlMixin, BasePa
             return response
         except Exception as exc:
             response = self.handle_exception(exc)
-            return exc
+            return response
 
     def finalize_response(self, request, response, *args, **kwargs):
         # Call super to get the default response

--- a/apps/api/plane/app/views/base.py
+++ b/apps/api/plane/app/views/base.py
@@ -120,7 +120,7 @@ class BaseViewSet(TimezoneMixin, ReadReplicaControlMixin, ModelViewSet, BasePagi
             return response
         except Exception as exc:
             response = self.handle_exception(exc)
-            return exc
+            return response
 
     @property
     def workspace_slug(self):
@@ -215,7 +215,7 @@ class BaseAPIView(TimezoneMixin, ReadReplicaControlMixin, APIView, BasePaginator
 
         except Exception as exc:
             response = self.handle_exception(exc)
-            return exc
+            return response
 
     @property
     def workspace_slug(self):

--- a/apps/api/plane/license/api/views/base.py
+++ b/apps/api/plane/license/api/views/base.py
@@ -106,7 +106,7 @@ class BaseAPIView(TimezoneMixin, APIView, BasePaginator):
 
         except Exception as exc:
             response = self.handle_exception(exc)
-            return exc
+            return response
 
     @property
     def fields(self):

--- a/apps/api/plane/space/views/base.py
+++ b/apps/api/plane/space/views/base.py
@@ -114,7 +114,7 @@ class BaseViewSet(TimezoneMixin, ModelViewSet, BasePaginator):
             return response
         except Exception as exc:
             response = self.handle_exception(exc)
-            return exc
+            return response
 
     @property
     def workspace_slug(self):
@@ -197,7 +197,7 @@ class BaseAPIView(TimezoneMixin, APIView, BasePaginator):
 
         except Exception as exc:
             response = self.handle_exception(exc)
-            return exc
+            return response
 
     @property
     def workspace_slug(self):


### PR DESCRIPTION
### Description

Fixes #8932

In all four base view files, `dispatch()` calls `self.handle_exception(exc)` to build a proper HTTP response but then returns the raw Python exception object (`exc`) instead of the `response` variable it just built.

```python
# Before (wrong)
except Exception as exc:
    response = self.handle_exception(exc)
    return exc

# After (correct)
except Exception as exc:
    response = self.handle_exception(exc)
    return response
```

Six lines changed across four files — nothing else.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Test Scenarios

1. Hit a non-existent resource endpoint — should return `{"error": "The required object does not exist."}` with status 404
2. Send invalid data to a write endpoint — should return `{"error": "Please provide valid detail"}` with status 400
3. Confirm normal (non-error) responses are unaffected

### References

Closes #8932

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed exception handling across API modules to ensure error responses are properly formatted as HTTP responses with appropriate status codes and error messages, rather than returning raw exception objects.
  * Improves consistency and reliability of error handling across all API endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->