### PR TITLE
fix(nginx): correct real_ip_header typo X-Forward-For → X-Forwarded-For

### DIFF
--- a/apps/admin/nginx/nginx.conf
+++ b/apps/admin/nginx/nginx.conf
@@ -11,7 +11,7 @@ http {
 
   set_real_ip_from        0.0.0.0/0;
   real_ip_recursive       on;
-  real_ip_header          X-Forward-For;
+  real_ip_header          X-Forwarded-For;
   limit_req_zone          $binary_remote_addr zone=mylimit:10m rate=10r/s;
 
   access_log /dev/stdout;

--- a/apps/space/nginx/nginx.conf
+++ b/apps/space/nginx/nginx.conf
@@ -11,7 +11,7 @@ http {
 
   set_real_ip_from        0.0.0.0/0;
   real_ip_recursive       on;
-  real_ip_header          X-Forward-For;
+  real_ip_header          X-Forwarded-For;
   limit_req_zone          $binary_remote_addr zone=mylimit:10m rate=10r/s;
 
   access_log /dev/stdout;

--- a/apps/web/nginx/nginx.conf
+++ b/apps/web/nginx/nginx.conf
@@ -11,7 +11,7 @@ http {
 
   set_real_ip_from        0.0.0.0/0;
   real_ip_recursive       on;
-  real_ip_header          X-Forward-For;
+  real_ip_header          X-Forwarded-For;
   limit_req_zone          $binary_remote_addr zone=mylimit:10m rate=10r/s;
 
   access_log /dev/stdout;


### PR DESCRIPTION
### Description

Fixes #8934

All three nginx configs had a typo in the `real_ip_header` directive — `X-Forward-For` instead of the standard `X-Forwarded-For`. `X-Forward-For` is not a real HTTP header, so Nginx silently ignored the directive and never replaced `$remote_addr` with the actual client IP.

**Changes:**

- Fixed `real_ip_header X-Forward-For` → `real_ip_header X-Forwarded-For` in `apps/web/nginx/nginx.conf`
- Fixed `real_ip_header X-Forward-For` → `real_ip_header X-Forwarded-For` in `apps/admin/nginx/nginx.conf`
- Fixed `real_ip_header X-Forward-For` → `real_ip_header X-Forwarded-For` in `apps/space/nginx/nginx.conf`

One character added in 3 files, nothing else.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Test Scenarios

1. Deploy behind a proxy or CDN that sets `X-Forwarded-For`
2. Verify Nginx logs show the real client IP, not the proxy IP
3. Verify rate limiting applies per real client IP, not per proxy

### References

Closes #8934

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated server configurations across admin, space, and web applications to correctly identify real client IP addresses from incoming proxy headers. These changes standardize IP detection behavior across the platform, fixing inconsistencies and ensuring accurate and reliable client identification. All services now consistently process client IP information in a uniform manner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->