### PR TITLE
fix: use polyfilled requestIdleCallback in render-if-visible HOC

### DIFF
--- a/apps/web/core/components/core/render-if-visible-HOC.tsx
+++ b/apps/web/core/components/core/render-if-visible-HOC.tsx
@@ -7,6 +7,7 @@
 import type { ReactNode, MutableRefObject } from "react";
 import React, { useState, useRef, useEffect } from "react";
 import { cn } from "@plane/utils";
+import { safeRequestIdleCallback } from "@/lib/polyfills";
 
 type Props = {
   defaultHeight?: string;
@@ -47,12 +48,13 @@ function RenderIfVisible(props: Props) {
 
   // Set visibility with intersection observer
   useEffect(() => {
-    if (intersectionRef.current) {
+    const node = intersectionRef.current;
+    if (node) {
       const observer = new IntersectionObserver(
         (entries) => {
           //DO no remove comments for future
-          if (typeof window !== undefined && window.requestIdleCallback && useIdletime) {
-            window.requestIdleCallback(() => setShouldVisible(entries[entries.length - 1].isIntersecting), {
+          if (useIdletime) {
+            safeRequestIdleCallback(() => setShouldVisible(entries[entries.length - 1].isIntersecting), {
               timeout: 300,
             });
           } else {
@@ -64,20 +66,17 @@ function RenderIfVisible(props: Props) {
           rootMargin: `${verticalOffset}% ${horizontalOffset}% ${verticalOffset}% ${horizontalOffset}%`,
         }
       );
-      observer.observe(intersectionRef.current);
+      observer.observe(node);
       return () => {
-        if (intersectionRef.current) {
-          // eslint-disable-next-line react-hooks/exhaustive-deps
-          observer.unobserve(intersectionRef.current);
-        }
+        observer.unobserve(node);
       };
     }
-  }, [intersectionRef, children, root, verticalOffset, horizontalOffset]);
+  }, [intersectionRef, children, root, verticalOffset, horizontalOffset, useIdletime]);
 
   //Set height after render
   useEffect(() => {
     if (intersectionRef.current && isVisible && shouldRecordHeights) {
-      window.requestIdleCallback(() => {
+      safeRequestIdleCallback(() => {
         if (intersectionRef.current) placeholderHeight.current = `${intersectionRef.current.offsetHeight}px`;
       });
     }

--- a/apps/web/core/components/core/render-if-visible-HOC.tsx
+++ b/apps/web/core/components/core/render-if-visible-HOC.tsx
@@ -7,7 +7,7 @@
 import type { ReactNode, MutableRefObject } from "react";
 import React, { useState, useRef, useEffect } from "react";
 import { cn } from "@plane/utils";
-import { safeRequestIdleCallback } from "@/lib/polyfills";
+import { safeCancelIdleCallback, safeRequestIdleCallback } from "@/lib/polyfills";
 
 type Props = {
   defaultHeight?: string;
@@ -50,11 +50,13 @@ function RenderIfVisible(props: Props) {
   useEffect(() => {
     const node = intersectionRef.current;
     if (node) {
+      let idleHandle: number | undefined;
       const observer = new IntersectionObserver(
         (entries) => {
           //DO no remove comments for future
           if (useIdletime) {
-            safeRequestIdleCallback(() => setShouldVisible(entries[entries.length - 1].isIntersecting), {
+            if (idleHandle !== undefined) safeCancelIdleCallback(idleHandle);
+            idleHandle = safeRequestIdleCallback(() => setShouldVisible(entries[entries.length - 1].isIntersecting), {
               timeout: 300,
             });
           } else {
@@ -69,6 +71,7 @@ function RenderIfVisible(props: Props) {
       observer.observe(node);
       return () => {
         observer.unobserve(node);
+        if (idleHandle !== undefined) safeCancelIdleCallback(idleHandle);
       };
     }
   }, [intersectionRef, children, root, verticalOffset, horizontalOffset, useIdletime]);

--- a/apps/web/core/lib/polyfills/index.ts
+++ b/apps/web/core/lib/polyfills/index.ts
@@ -27,4 +27,31 @@ if (typeof window !== "undefined" && window) {
     };
 }
 
-export {};
+// Defensive wrappers for use at call sites that may run before the side-effect
+// above is applied (e.g., lazy-loaded chunks like gantt-layout-loader that can
+// execute before app/provider.tsx finishes evaluating).
+export const safeRequestIdleCallback: typeof window.requestIdleCallback = (cb, options) => {
+  if (typeof window !== "undefined" && window.requestIdleCallback) {
+    return window.requestIdleCallback(cb, options);
+  }
+  const start = Date.now();
+  // setTimeout's return type is `number | NodeJS.Timeout` depending on the resolved
+  // typings; in a browser context (the only path that reaches this fallback) it is
+  // always `number`. Cast to satisfy the DOM-shaped IdleCallbackHandle return.
+  return setTimeout(
+    () =>
+      cb({
+        didTimeout: false,
+        timeRemaining: () => Math.max(0, 50 - (Date.now() - start)),
+      }),
+    1
+  ) as unknown as number;
+};
+
+export const safeCancelIdleCallback: typeof window.cancelIdleCallback = (id) => {
+  if (typeof window !== "undefined" && window.cancelIdleCallback) {
+    window.cancelIdleCallback(id);
+    return;
+  }
+  clearTimeout(id);
+};


### PR DESCRIPTION
## Description

When opening any project view in Safari, the entire UI crashes with:

> TypeError: window.requestIdleCallback is not a function — gantt-layout-loader-Bameferh.js:1:5524

The polyfill added in #5689 only takes effect when `apps/web/app/provider.tsx`
finishes evaluating. However, lazy-loaded chunks (like `gantt-layout-loader`,
which `RenderIfVisible` is part of) can execute before the provider tree
finishes hydrating. Their direct calls to `window.requestIdleCallback` then
crash on Safari, which is the only major browser without native support
for this API ([caniuse](https://caniuse.com/requestidlecallback)).

This PR fixes the issue by adding two defensive wrappers
(`safeRequestIdleCallback`, `safeCancelIdleCallback`) to the polyfills module
and using them at the only remaining unguarded call site:
`render-if-visible-HOC.tsx`.

### Changes

1. **`apps/web/core/lib/polyfills/index.ts`** — adds wrapper exports while
   preserving the existing side-effect for backward compatibility with any
   code that still depends on `window.requestIdleCallback` being
   monkey-patched.

2. **`apps/web/core/components/core/render-if-visible-HOC.tsx`** — replaces
   both `window.requestIdleCallback` call sites with the new wrapper. Also
   cleans up a small typo at line 54 where the original guard
   `typeof window !== undefined` was missing the quotes around `"undefined"`
   (effectively a no-op check, always truthy).

### Note on behavior change

At the line-54 call site, removing the `&& window.requestIdleCallback`
short-circuit changes Safari behavior from "fall through to synchronous"
to "async via setTimeout fallback". This matches the intent of
`useIdletime: true` (defer the work) and is consistent with the side-effect
polyfill already applied in `app/provider.tsx` for the rest of the tree.

### Incidental hardening

While editing the HOC, two preexisting react-hooks warnings became
blocking under `--deny-warnings`. Both are legitimate fixes that align
with making `RenderIfVisible` more robust:

- Capture `intersectionRef.current` in a local variable inside the
  `useEffect` so the cleanup function uses the captured node rather
  than re-reading the (possibly mutated) ref.
- Add the missing `useIdletime` to the `useEffect` dependency array
  so the observer is reconfigured when the prop changes (it was
  silently sticking to the first render's value).

The previous `// eslint-disable-next-line react-hooks/exhaustive-deps`
directive is removed since the underlying warning is now resolved.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots and Media (if applicable)

Before — Safari opening any project view:

```
TypeError: window.requestIdleCallback is not a function
   at gantt-layout-loader-Bameferh.js:1:5524
   ↳ "Looks like something went wrong" error boundary
   ↳ React minified errors #418 (hydration mismatch)
   ↳ React minified errors #423 (hydration recovery)
```

After: Safari renders all views (List, Kanban, Spreadsheet, Gantt) without crashing.

## Test Scenarios

- [x] Safari (macOS): open `/{workspace}/projects/{project_id}/issues/` → kanban renders, all views switchable, no console errors related to `requestIdleCallback`.
- [x] Chrome / Firefox / Edge: no regression — `window.requestIdleCallback` is used natively (the wrapper short-circuits to `window.requestIdleCallback(cb, options)`).
- [x] Bundle output verified — `gantt-layout-loader-*.js` no longer contains unguarded `window.requestIdleCallback(...)` calls.
- [x] `pnpm check:types --filter=web...` — passes (21/21 tasks).
- [x] `pnpm check:lint --filter=web` — 0 errors. The fix reduces the preexisting warnings on the modified file from 4 to 2.
- [x] `pnpm check:format --filter=web` — passes.
- [x] `pnpm build --filter=web...` — passes (11/11 tasks).

No new tests added; the affected HOC has no existing test coverage in
this repo, and PR #5689 (which originally added the polyfill) followed the
same precedent. Adding test infrastructure for this HOC would be a useful
follow-up.

## References

Closes #8904
Closes #8871
Related to #5689 (the original polyfill PR — this completes its intent for lazy-loaded chunks)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility of visibility detection across browsers to reduce missed or delayed content rendering.
  * More robust deferred measurement and task scheduling with better cleanup to prevent occasional layout glitches and stray background tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->