### PR TITLE
fix(api): pass project_lead_id (not User instance) when creating ProjectMember

### DIFF
--- a/apps/api/plane/api/serializers/project.py
+++ b/apps/api/plane/api/serializers/project.py
@@ -114,13 +114,20 @@ class ProjectCreateSerializer(BaseSerializer):
         if project_identifier is not None and re.match(Project.FORBIDDEN_IDENTIFIER_CHARS_PATTERN, project_identifier):
             raise serializers.ValidationError("Project identifier cannot contain special characters.")
 
-        if data.get("project_lead", None) is not None:
-            # Check if the project lead is a member of the workspace
-            if not WorkspaceMember.objects.filter(
+        project_lead = data.get("project_lead")
+        if (
+            project_lead
+            and not WorkspaceMember.objects.filter(
                 workspace_id=self.context["workspace_id"],
-                member_id=data.get("project_lead"),
-            ).exists():
-                raise serializers.ValidationError("Project lead should be a user in the workspace")
+                member=project_lead,
+                is_active=True,
+            ).exists()
+        ):
+            # Field-shaped error so DRF surfaces it under the specific key
+            # rather than as non_field_errors. Also requires the membership
+            # to be active so that revoked / removed members can't slip
+            # through and trigger the FK error downstream.
+            raise serializers.ValidationError({"project_lead": "The provided user is not a member of this workspace."})
 
         if data.get("default_assignee", None) is not None:
             # Check if the default assignee is a member of the workspace

--- a/apps/api/plane/api/views/project.py
+++ b/apps/api/plane/api/views/project.py
@@ -300,10 +300,17 @@ class ProjectListCreateAPIEndpoint(BaseAPIView):
                     {"name": "The project name is already taken"},
                     status=status.HTTP_409_CONFLICT,
                 )
-            # Any other IntegrityError is unexpected — let the catch-all
-            # `Exception` branch below log it and return 500 instead of
-            # falling through to an implicit 200 with no body.
-            raise
+            # Any other IntegrityError is unexpected: log it the same way
+            # the catch-all `except Exception` below would and return the
+            # same generic 500 so the client gets a uniform error shape.
+            # `raise` here would not fall through to a sibling except
+            # clause — it would exit the try/except entirely and bypass
+            # both the logging and the JSON response.
+            log_exception(e)
+            return Response(
+                {"error": "An unexpected error occurred"},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
         except Workspace.DoesNotExist:
             return Response({"error": "Workspace does not exist"}, status=status.HTTP_404_NOT_FOUND)
         except ValidationError:

--- a/apps/api/plane/api/views/project.py
+++ b/apps/api/plane/api/views/project.py
@@ -6,7 +6,7 @@
 import json
 
 # Django imports
-from django.db import IntegrityError
+from django.db import IntegrityError, transaction
 from django.db.models import Exists, F, Func, OuterRef, Prefetch, Q, Subquery, Count
 from django.db.models.functions import Coalesce
 from django.utils import timezone
@@ -38,6 +38,7 @@ from plane.db.models import (
     ProjectPage,
 )
 from plane.bgtasks.webhook_task import model_activity, webhook_activity
+from plane.utils.exception_logger import log_exception
 from .base import BaseAPIView
 from plane.utils.host import base_host
 from plane.api.serializers import (
@@ -223,48 +224,59 @@ class ProjectListCreateAPIEndpoint(BaseAPIView):
             serializer = ProjectCreateSerializer(data={**request.data}, context={"workspace_id": workspace.id})
 
             if serializer.is_valid():
-                serializer.save()
+                with transaction.atomic():
+                    serializer.save()
 
-                # Add the user as Administrator to the project
-                _ = ProjectMember.objects.create(project_id=serializer.instance.id, member=request.user, role=20)
+                    # Add the creator as Administrator of the project.
+                    _ = ProjectMember.objects.create(project_id=serializer.instance.id, member=request.user, role=20)
 
-                if serializer.instance.project_lead is not None and str(serializer.instance.project_lead) != str(
-                    request.user.id
-                ):
-                    ProjectMember.objects.create(
-                        project_id=serializer.instance.id,
-                        member_id=serializer.instance.project_lead,
-                        role=20,
+                    # If a different project_lead was provided, add them as
+                    # Administrator too. Use project_lead_id (the FK column)
+                    # rather than project_lead (the related descriptor, which
+                    # would resolve to a User instance and break UUID coercion
+                    # downstream in ProjectMember.objects.create).
+                    if (
+                        serializer.instance.project_lead_id is not None
+                        and serializer.instance.project_lead_id != request.user.id
+                    ):
+                        ProjectMember.objects.create(
+                            project_id=serializer.instance.id,
+                            member_id=serializer.instance.project_lead_id,
+                            role=20,
+                        )
+
+                    State.objects.bulk_create(
+                        [
+                            State(
+                                name=state["name"],
+                                color=state["color"],
+                                project=serializer.instance,
+                                sequence=state["sequence"],
+                                workspace=serializer.instance.workspace,
+                                group=state["group"],
+                                default=state.get("default", False),
+                                created_by=request.user,
+                            )
+                            for state in DEFAULT_STATES
+                        ]
                     )
 
-                State.objects.bulk_create(
-                    [
-                        State(
-                            name=state["name"],
-                            color=state["color"],
-                            project=serializer.instance,
-                            sequence=state["sequence"],
-                            workspace=serializer.instance.workspace,
-                            group=state["group"],
-                            default=state.get("default", False),
-                            created_by=request.user,
+                    project = self.get_queryset().filter(pk=serializer.instance.id).first()
+
+                    # Defer the activity-log task until the surrounding
+                    # transaction commits, so it never fires on a rolled-back
+                    # creation.
+                    transaction.on_commit(
+                        lambda: model_activity.delay(
+                            model_name="project",
+                            model_id=str(project.id),
+                            requested_data=request.data,
+                            current_instance=None,
+                            actor_id=request.user.id,
+                            slug=slug,
+                            origin=base_host(request=request, is_app=True),
                         )
-                        for state in DEFAULT_STATES
-                    ]
-                )
-
-                project = self.get_queryset().filter(pk=serializer.instance.id).first()
-
-                # Model activity
-                model_activity.delay(
-                    model_name="project",
-                    model_id=str(project.id),
-                    requested_data=request.data,
-                    current_instance=None,
-                    actor_id=request.user.id,
-                    slug=slug,
-                    origin=base_host(request=request, is_app=True),
-                )
+                    )
 
                 serializer = ProjectSerializer(project)
                 return Response(serializer.data, status=status.HTTP_201_CREATED)
@@ -281,6 +293,14 @@ class ProjectListCreateAPIEndpoint(BaseAPIView):
             return Response(
                 {"identifier": "The project identifier is already taken"},
                 status=status.HTTP_409_CONFLICT,
+            )
+        except Exception as e:
+            # Surface unexpected failures in the api logs so future regressions
+            # are debuggable. Keep the public response generic.
+            log_exception(e)
+            return Response(
+                {"error": "Please provide valid detail"},
+                status=status.HTTP_400_BAD_REQUEST,
             )
 
 

--- a/apps/api/plane/api/views/project.py
+++ b/apps/api/plane/api/views/project.py
@@ -4,6 +4,7 @@
 
 # Python imports
 import json
+from functools import partial
 
 # Django imports
 from django.db import IntegrityError, transaction
@@ -265,9 +266,12 @@ class ProjectListCreateAPIEndpoint(BaseAPIView):
 
                     # Defer the activity-log task until the surrounding
                     # transaction commits, so it never fires on a rolled-back
-                    # creation.
+                    # creation. Use functools.partial so the bound arguments
+                    # are captured at scheduling time rather than via a
+                    # late-binding closure.
                     transaction.on_commit(
-                        lambda: model_activity.delay(
+                        partial(
+                            model_activity.delay,
                             model_name="project",
                             model_id=str(project.id),
                             requested_data=request.data,
@@ -287,6 +291,10 @@ class ProjectListCreateAPIEndpoint(BaseAPIView):
                     {"name": "The project name is already taken"},
                     status=status.HTTP_409_CONFLICT,
                 )
+            # Any other IntegrityError is unexpected — let the catch-all
+            # `Exception` branch below log it and return 500 instead of
+            # falling through to an implicit 200 with no body.
+            raise
         except Workspace.DoesNotExist:
             return Response({"error": "Workspace does not exist"}, status=status.HTTP_404_NOT_FOUND)
         except ValidationError:
@@ -295,12 +303,14 @@ class ProjectListCreateAPIEndpoint(BaseAPIView):
                 status=status.HTTP_409_CONFLICT,
             )
         except Exception as e:
-            # Surface unexpected failures in the api logs so future regressions
-            # are debuggable. Keep the public response generic.
+            # Unexpected server-side failure: log the traceback and return a
+            # generic 500 so the client can distinguish it from a 4xx caused
+            # by bad input. Returning 400 here was the anti-pattern that
+            # masked the original ghost-create bug.
             log_exception(e)
             return Response(
-                {"error": "Please provide valid detail"},
-                status=status.HTTP_400_BAD_REQUEST,
+                {"error": "An unexpected error occurred"},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 
 

--- a/apps/api/plane/api/views/project.py
+++ b/apps/api/plane/api/views/project.py
@@ -4,7 +4,6 @@
 
 # Python imports
 import json
-from functools import partial
 
 # Django imports
 from django.db import IntegrityError, transaction
@@ -266,12 +265,21 @@ class ProjectListCreateAPIEndpoint(BaseAPIView):
 
                     # Defer the activity-log task until the surrounding
                     # transaction commits, so it never fires on a rolled-back
-                    # creation. Use functools.partial so the bound arguments
-                    # are captured at scheduling time rather than via a
-                    # late-binding closure.
-                    transaction.on_commit(
-                        partial(
-                            model_activity.delay,
+                    # creation.
+                    # robust=True so broker / dispatch failures are logged
+                    # internally by Django and don't surface as 500 after a
+                    # successful commit (the inverse of the rollback path
+                    # covered by test_model_activity_not_called_on_rollback).
+                    # A nested function (rather than functools.partial) is
+                    # used here because Django's robust on_commit logging
+                    # path reads ``func.__qualname__`` to format the error
+                    # message; ``partial`` objects don't have that dunder
+                    # by default and the workaround is brittle when the
+                    # wrapped callable is a mock. The closure captures
+                    # the locals at construction time and they are never
+                    # rebound, so late-binding is not a hazard here.
+                    def _dispatch_model_activity():
+                        model_activity.delay(
                             model_name="project",
                             model_id=str(project.id),
                             requested_data=request.data,
@@ -280,7 +288,8 @@ class ProjectListCreateAPIEndpoint(BaseAPIView):
                             slug=slug,
                             origin=base_host(request=request, is_app=True),
                         )
-                    )
+
+                    transaction.on_commit(_dispatch_model_activity, robust=True)
 
                 serializer = ProjectSerializer(project)
                 return Response(serializer.data, status=status.HTTP_201_CREATED)

--- a/apps/api/plane/tests/contract/api/test_projects.py
+++ b/apps/api/plane/tests/contract/api/test_projects.py
@@ -1,0 +1,105 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+import pytest
+from rest_framework import status
+
+from plane.db.models import Project, ProjectMember, State, User, WorkspaceMember
+
+
+@pytest.fixture
+def other_workspace_member(db, workspace):
+    """Create another user that is a member of the workspace, distinct from the creator."""
+    from uuid import uuid4
+
+    unique_id = uuid4().hex[:8]
+    other = User.objects.create(
+        email=f"other-{unique_id}@plane.so",
+        username=f"other_user_{unique_id}",
+        first_name="Other",
+        last_name="User",
+    )
+    other.set_password("test-password")
+    other.save()
+    WorkspaceMember.objects.create(workspace=workspace, member=other, role=20)
+    return other
+
+
+@pytest.mark.contract
+class TestProjectListCreateAPIEndpoint:
+    """Contract tests for POST /api/v1/workspaces/{slug}/projects/."""
+
+    def get_url(self, workspace_slug):
+        return f"/api/v1/workspaces/{workspace_slug}/projects/"
+
+    @pytest.mark.django_db
+    def test_create_project_with_lead_as_creator(self, api_key_client, workspace, create_user):
+        """Regression for the ghost-create bug.
+
+        When project_lead points to the creator's own user_id, the endpoint
+        must return 201 and create a fully-populated project (single
+        ProjectMember as admin, default workflow states).
+
+        Before the fix, the endpoint returned 400 "Please provide valid detail"
+        but had already persisted the Project row without states or members,
+        leaving an unusable orphan.
+        """
+        url = self.get_url(workspace.slug)
+        payload = {
+            "name": "Self Lead Project",
+            "identifier": "SL",
+            "project_lead": str(create_user.id),
+        }
+
+        response = api_key_client.post(url, payload, format="json")
+
+        assert response.status_code == status.HTTP_201_CREATED, f"Got {response.status_code}: {response.data!r}"
+        assert Project.objects.count() == 1
+
+        project = Project.objects.first()
+        # Creator is registered as admin (single membership; lead == creator
+        # should not produce a duplicate row).
+        assert ProjectMember.objects.filter(project=project, member=create_user, role=20).count() == 1
+        # Default workflow states must be created.
+        assert State.objects.filter(project=project).count() == 5
+
+    @pytest.mark.django_db
+    def test_create_project_with_lead_as_other_user(
+        self, api_key_client, workspace, create_user, other_workspace_member
+    ):
+        """When project_lead is a different workspace member, both creator
+        and lead become admins of the project."""
+        url = self.get_url(workspace.slug)
+        payload = {
+            "name": "Other Lead Project",
+            "identifier": "OL",
+            "project_lead": str(other_workspace_member.id),
+        }
+
+        response = api_key_client.post(url, payload, format="json")
+
+        assert response.status_code == status.HTTP_201_CREATED, f"Got {response.status_code}: {response.data!r}"
+        project = Project.objects.first()
+
+        # Both creator and other_workspace_member are admins.
+        assert ProjectMember.objects.filter(project=project, member=create_user, role=20).exists()
+        assert ProjectMember.objects.filter(project=project, member=other_workspace_member, role=20).exists()
+        assert State.objects.filter(project=project).count() == 5
+
+    @pytest.mark.django_db
+    def test_create_project_without_lead(self, api_key_client, workspace, create_user):
+        """Baseline regression: omitting project_lead must succeed and the
+        creator becomes the sole admin."""
+        url = self.get_url(workspace.slug)
+        payload = {
+            "name": "Basic Project",
+            "identifier": "BP",
+        }
+
+        response = api_key_client.post(url, payload, format="json")
+
+        assert response.status_code == status.HTTP_201_CREATED, f"Got {response.status_code}: {response.data!r}"
+        project = Project.objects.first()
+        assert ProjectMember.objects.filter(project=project, member=create_user, role=20).count() == 1
+        assert State.objects.filter(project=project).count() == 5

--- a/apps/api/plane/tests/contract/api/test_projects.py
+++ b/apps/api/plane/tests/contract/api/test_projects.py
@@ -182,3 +182,35 @@ class TestProjectListCreateAPIEndpoint:
         # And the deferred Celery task must not have been dispatched —
         # transaction.on_commit() callbacks only fire on a successful commit.
         mocked_activity.delay.assert_not_called()
+
+    @pytest.mark.django_db(transaction=True)
+    def test_response_still_201_when_broker_dispatch_fails(self, api_key_client, workspace, create_user):
+        """If model_activity.delay raises *after* the atomic block has
+        committed (e.g., the Celery broker is down), the project, member
+        rows and states are already persisted — the response must remain
+        201 and the failure must be absorbed by Django's robust=True
+        on_commit handling, not surface as a 500.
+
+        Uses ``transaction=True`` so the surrounding test transaction is
+        actually committed and the ``on_commit`` callback fires (the
+        default ``django_db`` wrapper would suppress it via rollback)."""
+        url = self.get_url(workspace.slug)
+        payload = {
+            "name": "Broker Down",
+            "identifier": "BD",
+            "project_lead": str(create_user.id),
+        }
+
+        with mock.patch("plane.api.views.project.model_activity") as mocked_activity:
+            mocked_activity.delay.side_effect = RuntimeError("broker unavailable")
+            response = api_key_client.post(url, payload, format="json")
+
+        assert response.status_code == status.HTTP_201_CREATED, f"Got {response.status_code}: {response.data!r}"
+        # Project and its scaffolding are persisted (commit happened
+        # before the on_commit callback fired).
+        project = Project.objects.get(id=response.data["id"])
+        assert ProjectMember.objects.filter(project=project).count() == 1
+        assert State.objects.filter(project=project).count() == 5
+        # The dispatch was attempted but its failure was swallowed by
+        # transaction.on_commit(robust=True).
+        mocked_activity.delay.assert_called_once()

--- a/apps/api/plane/tests/contract/api/test_projects.py
+++ b/apps/api/plane/tests/contract/api/test_projects.py
@@ -2,6 +2,9 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # See the LICENSE file for details.
 
+from unittest import mock
+from uuid import uuid4
+
 import pytest
 from rest_framework import status
 
@@ -11,8 +14,6 @@ from plane.db.models import Project, ProjectMember, State, User, WorkspaceMember
 @pytest.fixture
 def other_workspace_member(db, workspace):
     """Create another user that is a member of the workspace, distinct from the creator."""
-    from uuid import uuid4
-
     unique_id = uuid4().hex[:8]
     other = User.objects.create(
         email=f"other-{unique_id}@plane.so",
@@ -24,6 +25,21 @@ def other_workspace_member(db, workspace):
     other.save()
     WorkspaceMember.objects.create(workspace=workspace, member=other, role=20)
     return other
+
+
+@pytest.fixture
+def outsider_user(db):
+    """Create a user that is NOT a member of any workspace under test."""
+    unique_id = uuid4().hex[:8]
+    outsider = User.objects.create(
+        email=f"outsider-{unique_id}@plane.so",
+        username=f"outsider_{unique_id}",
+        first_name="Out",
+        last_name="Sider",
+    )
+    outsider.set_password("test-password")
+    outsider.save()
+    return outsider
 
 
 @pytest.mark.contract
@@ -55,9 +71,10 @@ class TestProjectListCreateAPIEndpoint:
         response = api_key_client.post(url, payload, format="json")
 
         assert response.status_code == status.HTTP_201_CREATED, f"Got {response.status_code}: {response.data!r}"
-        assert Project.objects.count() == 1
 
-        project = Project.objects.first()
+        # Look up the project we just created instead of relying on
+        # ordering-sensitive Project.objects.first().
+        project = Project.objects.get(id=response.data["id"])
         # Creator is registered as admin (single membership; lead == creator
         # should not produce a duplicate row).
         assert ProjectMember.objects.filter(project=project, member=create_user, role=20).count() == 1
@@ -80,7 +97,7 @@ class TestProjectListCreateAPIEndpoint:
         response = api_key_client.post(url, payload, format="json")
 
         assert response.status_code == status.HTTP_201_CREATED, f"Got {response.status_code}: {response.data!r}"
-        project = Project.objects.first()
+        project = Project.objects.get(id=response.data["id"])
 
         # Both creator and other_workspace_member are admins.
         assert ProjectMember.objects.filter(project=project, member=create_user, role=20).exists()
@@ -100,6 +117,68 @@ class TestProjectListCreateAPIEndpoint:
         response = api_key_client.post(url, payload, format="json")
 
         assert response.status_code == status.HTTP_201_CREATED, f"Got {response.status_code}: {response.data!r}"
-        project = Project.objects.first()
+        project = Project.objects.get(id=response.data["id"])
         assert ProjectMember.objects.filter(project=project, member=create_user, role=20).count() == 1
         assert State.objects.filter(project=project).count() == 5
+
+    @pytest.mark.django_db
+    def test_create_project_with_lead_not_in_workspace_returns_400(self, api_key_client, workspace, outsider_user):
+        """When project_lead refers to a user that is NOT a member of the
+        target workspace, the endpoint must reject the request with a 400
+        carrying a field-shaped error and must not persist the Project."""
+        url = self.get_url(workspace.slug)
+        payload = {
+            "name": "Outsider Lead Project",
+            "identifier": "OUT",
+            "project_lead": str(outsider_user.id),
+        }
+
+        response = api_key_client.post(url, payload, format="json")
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, f"Got {response.status_code}: {response.data!r}"
+        assert "project_lead" in response.data, (
+            f"Expected field-shaped error under 'project_lead', got {response.data!r}"
+        )
+        # No project should have been persisted.
+        assert Project.objects.count() == 0
+
+    @pytest.mark.django_db
+    def test_model_activity_not_called_on_rollback(self, api_key_client, workspace, create_user):
+        """If anything inside the transaction.atomic() block raises, the
+        whole creation must roll back (no Project, no ProjectMember, no
+        State) and the deferred model_activity.delay() task must not fire,
+        because it is registered with transaction.on_commit().
+
+        Force the failure inside State.objects.bulk_create — past the point
+        where the original ghost-create bug would have committed a partial
+        Project — and verify the response is 500 with no side effects.
+        """
+        url = self.get_url(workspace.slug)
+        payload = {
+            "name": "Rollback Probe",
+            "identifier": "RB",
+            "project_lead": str(create_user.id),
+        }
+
+        forced_error = RuntimeError("forced failure for rollback test")
+
+        with (
+            mock.patch(
+                "plane.api.views.project.State.objects.bulk_create",
+                side_effect=forced_error,
+            ),
+            mock.patch("plane.api.views.project.model_activity") as mocked_activity,
+        ):
+            response = api_key_client.post(url, payload, format="json")
+
+        assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR, (
+            f"Got {response.status_code}: {response.data!r}"
+        )
+        # Transaction must have rolled back: no Project, no ProjectMember,
+        # no State persisted.
+        assert Project.objects.count() == 0
+        assert ProjectMember.objects.count() == 0
+        assert State.objects.count() == 0
+        # And the deferred Celery task must not have been dispatched —
+        # transaction.on_commit() callbacks only fire on a successful commit.
+        mocked_activity.delay.assert_not_called()


### PR DESCRIPTION
## Description

The public REST API endpoint `POST /api/v1/workspaces/{slug}/projects/`
returned `400 "Please provide valid detail"` whenever the payload
included a `project_lead`, even when the request was otherwise valid.
Worse, the `Project` row had **already been persisted** before the
exception bubbled up, leaving an unusable orphan: no workflow states,
no `ProjectMember` entries, no default cycles.

The bug had three contributing parts in
`apps/api/plane/api/views/project.py:214 (def post)`:

1. **UUID vs User instance.** The endpoint passed
   `serializer.instance.project_lead` (the *related descriptor*, which
   Django resolves to a `User` instance) where a UUID was expected:

   ```python
   ProjectMember.objects.create(
       project_id=serializer.instance.id,
       member_id=serializer.instance.project_lead,  # ← User instance, not UUID
       role=20,
   )
   ```

   Django's `UUIDField.to_python(value=<User>)` then crashed with
   `AttributeError: 'User' object has no attribute 'replace'`. The
   generic exception handler in `BaseAPIView.handle_exception` mapped
   any uncaught exception to `400 "Please provide valid detail"` — a
   misleading response that hid the real failure.

2. **Buggy lead-vs-creator guard.** The guard compared `str(<User>)`
   against `str(<UUID>)`, which never matched (different `__str__`
   outputs), so the buggy branch above was always entered when
   `project_lead` was provided — including the very common case where
   the creator is also the lead.

3. **No transaction wrapping.** There was no `transaction.atomic()`
   around the post-save side effects (member creation, default state
   seeding, queryset re-fetch), so any partial failure left the
   database in an inconsistent state.

## Reproduction (before fix)

```bash
curl -X POST \
  -H "X-API-Key: $PAT" -H "Content-Type: application/json" \
  -d '{"name": "Repro", "identifier": "RP", "project_lead": "<creator-uuid>"}' \
  https://your-plane.example/api/v1/workspaces/<slug>/projects/

# → HTTP 400 {"error": "Please provide valid detail"}
# → Project row exists in db, with 0 states, no ProjectMember.
```

Stack trace (with debug logging temporarily enabled in
`BaseAPIView.handle_exception`):

```
File "/code/plane/api/views/project.py", line 234, in post
    ProjectMember.objects.create(
File ".../django/db/models/query.py", line 660, in create
    obj.save(force_insert=True, using=self.db)
File ".../django/db/models/fields/__init__.py", line 2688, in to_python
    return uuid.UUID(**{input_form: value})
File ".../uuid.py", line 175, in __init__
    hex = hex.replace('urn:', '').replace('uuid:', '')
        ↳ AttributeError: 'User' object has no attribute 'replace'
```

## Changes

### `apps/api/plane/api/views/project.py`

- Use `project_lead_id` (FK column directly) for both the guard
  comparison and `ProjectMember.objects.create(member_id=...)`. No more
  descriptor-resolved `User` instance leaking into a UUID field.
- Compare UUIDs directly (`!= request.user.id`) instead of via
  `str()` of two heterogeneous objects.
- Wrap the post-`is_valid()` block in `with transaction.atomic():` so
  the `Project` + `ProjectMember` + `State.bulk_create` all roll back
  as a unit if any future failure is added in between.
- Defer `model_activity.delay(...)` with `transaction.on_commit(...)`,
  so the activity-log task never fires on a rolled-back creation.
- Add a final `except Exception as e:` branch that calls
  `log_exception(e)` before returning the generic 400 — keeps the
  public response stable but ensures unexpected regressions are
  visible in API logs going forward.

### `apps/api/plane/tests/contract/api/test_projects.py` (new file)

Three contract tests covering the create-project endpoint:

- `test_create_project_with_lead_as_creator` — regression for the bug
  (project_lead == creator).
- `test_create_project_with_lead_as_other_user` — verifies both
  creator and lead become Admins of the project.
- `test_create_project_without_lead` — baseline regression.

The first two FAIL on `preview` HEAD before this fix and PASS after.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Scenarios

- [x] `pytest plane/tests/contract/api/test_projects.py` — 3/3 PASS on
  this branch. Same 3 tests on `preview` HEAD: 2 FAIL (the bug) + 1
  PASS (baseline).
- [x] `ruff check apps/api/plane/api/views/project.py apps/api/plane/tests/contract/api/test_projects.py` — All checks passed.
- [x] `ruff format --check ...` — both files already formatted.
- [x] Manual repro against a live Plane self-hosted (v1.3.0):
  `POST /projects/` with `project_lead = creator_id` →
  before fix: 400 + ghost project (0 states, no member);
  after fix: 201 + complete project (5 default states + creator as
  Admin).

## Note on follow-up

A related data-integrity issue exists where
`ProjectCreateSerializer.create()`
(`apps/api/plane/api/serializers/project.py:135`) does **not** create
a corresponding `ProjectIdentifier` row, while its in-file sibling
`ProjectSerializer.create()` (line 276) and the frontend serializer
`apps/api/plane/app/serializers/project.py:95` both do. This means
projects created via the public API don't register their identifier
in the `project_identifiers` table that tracks workspace-wide
identifier uniqueness. **Out of scope for this PR**; will follow up
separately.

## References

The bug was not previously reported upstream (verified via issue +
PR search for `"Please provide valid detail"`, `"orphaned project"`,
`"states not created"`, `"project create 400"`, `"transaction.atomic"`,
`"create project api"`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Project creation is now fully transactional; partial creations are rolled back, activity dispatch occurs only after commit, and unexpected server errors return a uniform HTTP 500 and are logged. Creator is always an admin; project lead is made admin only when distinct. Default project states are created atomically.

* **Validation**
  * Project lead must reference an active workspace member and returns a field-specific error when invalid.

* **Tests**
  * Added contract tests covering creation, lead-assignment scenarios, validation failures, rollback behavior, exact default-state creation, and post-commit dispatch errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->