### PR TITLE
fix(web): Safari work items crash from requestIdleCallback

### DIFF
--- a/apps/web/app/entry.client.tsx
+++ b/apps/web/app/entry.client.tsx
@@ -4,6 +4,7 @@
  * See the LICENSE file for details.
  */
 
+import "@/lib/polyfills";
 import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 import { HydratedRouter } from "react-router/dom";

--- a/apps/web/core/components/core/render-if-visible-HOC.tsx
+++ b/apps/web/core/components/core/render-if-visible-HOC.tsx
@@ -7,6 +7,7 @@
 import type { ReactNode, MutableRefObject } from "react";
 import React, { useState, useRef, useEffect } from "react";
 import { cn } from "@plane/utils";
+import { scheduleIdleCallback } from "@/lib/polyfills";
 
 type Props = {
   defaultHeight?: string;
@@ -51,8 +52,8 @@ function RenderIfVisible(props: Props) {
       const observer = new IntersectionObserver(
         (entries) => {
           //DO no remove comments for future
-          if (typeof window !== undefined && window.requestIdleCallback && useIdletime) {
-            window.requestIdleCallback(() => setShouldVisible(entries[entries.length - 1].isIntersecting), {
+          if (typeof window !== "undefined" && useIdletime) {
+            scheduleIdleCallback(() => setShouldVisible(entries[entries.length - 1].isIntersecting), {
               timeout: 300,
             });
           } else {
@@ -77,7 +78,7 @@ function RenderIfVisible(props: Props) {
   //Set height after render
   useEffect(() => {
     if (intersectionRef.current && isVisible && shouldRecordHeights) {
-      window.requestIdleCallback(() => {
+      scheduleIdleCallback(() => {
         if (intersectionRef.current) placeholderHeight.current = `${intersectionRef.current.offsetHeight}px`;
       });
     }

--- a/apps/web/core/components/core/render-if-visible-HOC.tsx
+++ b/apps/web/core/components/core/render-if-visible-HOC.tsx
@@ -74,7 +74,7 @@ function RenderIfVisible(props: Props) {
         observer.disconnect();
       };
     }
-  }, [intersectionRef, children, root, verticalOffset, horizontalOffset, useIdletime]);
+  }, [intersectionRef, root, verticalOffset, horizontalOffset, useIdletime]);
 
   //Set height after render
   useEffect(() => {

--- a/apps/web/core/components/core/render-if-visible-HOC.tsx
+++ b/apps/web/core/components/core/render-if-visible-HOC.tsx
@@ -67,13 +67,10 @@ function RenderIfVisible(props: Props) {
       );
       observer.observe(intersectionRef.current);
       return () => {
-        if (intersectionRef.current) {
-          // eslint-disable-next-line react-hooks/exhaustive-deps
-          observer.unobserve(intersectionRef.current);
-        }
+        observer.disconnect();
       };
     }
-  }, [intersectionRef, children, root, verticalOffset, horizontalOffset]);
+  }, [intersectionRef, children, root, verticalOffset, horizontalOffset, useIdletime]);
 
   //Set height after render
   useEffect(() => {

--- a/apps/web/core/components/core/render-if-visible-HOC.tsx
+++ b/apps/web/core/components/core/render-if-visible-HOC.tsx
@@ -24,6 +24,10 @@ type Props = {
   forceRender?: boolean;
 };
 
+/**
+ * Renders children only when the element intersects the viewport (or is forced visible), using a placeholder and
+ * optional height recording to reduce work for long lists.
+ */
 function RenderIfVisible(props: Props) {
   const {
     defaultHeight = "300px",

--- a/apps/web/core/lib/polyfills/index.ts
+++ b/apps/web/core/lib/polyfills/index.ts
@@ -4,8 +4,12 @@
  * See the LICENSE file for details.
  */
 
-if (typeof window !== "undefined" && window) {
-  // Add request callback polyfill to browser in case it does not exist
+/** Installs `window.requestIdleCallback` / `cancelIdleCallback` when missing (e.g. older Safari). Idempotent. */
+function ensureRequestIdleCallbackPolyfilled(): void {
+  if (typeof window === "undefined" || !window) {
+    return;
+  }
+
   window.requestIdleCallback =
     window.requestIdleCallback ??
     function (cb) {
@@ -27,4 +31,15 @@ if (typeof window !== "undefined" && window) {
     };
 }
 
-export {};
+ensureRequestIdleCallbackPolyfilled();
+
+export function scheduleIdleCallback(
+  callback: IdleRequestCallback,
+  options?: IdleRequestOptions,
+): number {
+  ensureRequestIdleCallbackPolyfilled();
+  if (typeof window === "undefined") {
+    return 0;
+  }
+  return window.requestIdleCallback(callback, options);
+}

--- a/apps/web/core/lib/polyfills/index.ts
+++ b/apps/web/core/lib/polyfills/index.ts
@@ -4,7 +4,11 @@
  * See the LICENSE file for details.
  */
 
-/** Installs `window.requestIdleCallback` / `cancelIdleCallback` when missing (e.g. older Safari). Idempotent. */
+/**
+ * Ensures `window.requestIdleCallback` and `window.cancelIdleCallback` exist.
+ * Installs minimal shims when the browser omits them (e.g. older Safari / WebKit).
+ * Safe to call repeatedly; only assigns missing APIs once.
+ */
 function ensureRequestIdleCallbackPolyfilled(): void {
   if (typeof window === "undefined" || !window) {
     return;
@@ -33,6 +37,13 @@ function ensureRequestIdleCallbackPolyfilled(): void {
 
 ensureRequestIdleCallbackPolyfilled();
 
+/**
+ * Schedules work to run when the browser is idle, or after a short delay when idle scheduling is unavailable.
+ *
+ * @param callback - Invoked with an `IdleDeadline`-like object (native or polyfilled).
+ * @param options - Optional `timeout` forwarded to the native API when present.
+ * @returns An idle handle for cancellation, or `0` when `window` is undefined (SSR).
+ */
 export function scheduleIdleCallback(callback: IdleRequestCallback, options?: IdleRequestOptions): number {
   ensureRequestIdleCallbackPolyfilled();
   if (typeof window === "undefined") {

--- a/apps/web/core/lib/polyfills/index.ts
+++ b/apps/web/core/lib/polyfills/index.ts
@@ -33,10 +33,7 @@ function ensureRequestIdleCallbackPolyfilled(): void {
 
 ensureRequestIdleCallbackPolyfilled();
 
-export function scheduleIdleCallback(
-  callback: IdleRequestCallback,
-  options?: IdleRequestOptions,
-): number {
+export function scheduleIdleCallback(callback: IdleRequestCallback, options?: IdleRequestOptions): number {
   ensureRequestIdleCallbackPolyfilled();
   if (typeof window === "undefined") {
     return 0;


### PR DESCRIPTION
### Description
`RenderIfVisible` calls `window.requestIdleCallback` when recording row heights after visible render. Safari (+WebKit) lacks this API.

A polyfill existed in `core/lib/polyfills/index.ts` but was never imported, so the runtime still threw.

### Changes
- Import client polyfills from `entry.client.tsx` before hydration.
- Export `scheduleIdleCallback()` that applies the idle polyfill idempotently and delegates.
- Replace direct `window.requestIdleCallback` usage in `render-if-visible-HOC.tsx` with `scheduleIdleCallback`.
- Fix incorrect `typeof window !== undefined` check (use `"undefined"`).

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [x] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<img width="1723" height="993" alt="image" src="https://github.com/user-attachments/assets/3c43ba24-eed0-4cb3-b85e-8222bcc1d675" />


### Test Scenarios 
- [ ] Open a project Work Items /{WORKSPACE/projects/{PROJECT_ID}/issues/ on Safari (or WebKit without `requestIdleCallback`).
- [ ] Scroll and expand rows; confirm no console error and layout still correct.

### References
<!-- Link related issues if there are any -->
Closes https://github.com/makeplane/plane/issues/8904
Closes https://github.com/makeplane/plane/issues/8871
Related to https://github.com/makeplane/plane/pull/5689 (the original polyfill PR — this completes its intent for lazy-loaded chunks)

Could be duplicate of PR #8937 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Initialize polyfills during client startup to improve browser compatibility.
  * Unify idle-callback scheduling across render paths to defer visibility updates and placeholder measurements, reducing main-thread work and smoothing rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->