### PR TITLE
fix: correct real IP header in nginx configs

### DIFF
--- a/apps/admin/nginx/nginx.conf
+++ b/apps/admin/nginx/nginx.conf
@@ -11,7 +11,7 @@ http {
 
   set_real_ip_from        0.0.0.0/0;
   real_ip_recursive       on;
-  real_ip_header          X-Forward-For;
+  real_ip_header          X-Forwarded-For;
   limit_req_zone          $binary_remote_addr zone=mylimit:10m rate=10r/s;
 
   access_log /dev/stdout;

--- a/apps/space/nginx/nginx.conf
+++ b/apps/space/nginx/nginx.conf
@@ -11,7 +11,7 @@ http {
 
   set_real_ip_from        0.0.0.0/0;
   real_ip_recursive       on;
-  real_ip_header          X-Forward-For;
+  real_ip_header          X-Forwarded-For;
   limit_req_zone          $binary_remote_addr zone=mylimit:10m rate=10r/s;
 
   access_log /dev/stdout;

--- a/apps/web/nginx/nginx.conf
+++ b/apps/web/nginx/nginx.conf
@@ -11,7 +11,7 @@ http {
 
   set_real_ip_from        0.0.0.0/0;
   real_ip_recursive       on;
-  real_ip_header          X-Forward-For;
+  real_ip_header          X-Forwarded-For;
   limit_req_zone          $binary_remote_addr zone=mylimit:10m rate=10r/s;
 
   access_log /dev/stdout;


### PR DESCRIPTION
## Summary

Fixes a typo in the nginx `real_ip_header` directive across the web, admin, and space nginx configs.

## Changes

- Replaces `X-Forward-For` with the standard `X-Forwarded-For` header.
- Updates nginx configs for:
  - `apps/web`
  - `apps/admin`
  - `apps/space`

## Why

`X-Forward-For` is not a standard HTTP header. Using `X-Forwarded-For` allows nginx to resolve the real client IP correctly when Plane is deployed behind a proxy or load balancer.

## Related Issue

Closes #8934

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Corrected Nginx real client IP header detection configuration across admin, space, and web services to properly identify client addresses when recursive IP resolution is enabled. This change improves the accuracy of rate limiting enforcement, access logging, and IP-based security policies that depend on correct client identification across all applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->