### PR TITLE
fix: prevent comment submission during IME composition

### DIFF
--- a/apps/web/core/components/comments/card/edit-form.tsx
+++ b/apps/web/core/components/comments/card/edit-form.tsx
@@ -77,7 +77,8 @@ export const CommentCardEditForm = observer(function CommentCardEditForm(props: 
     <form className="flex flex-col gap-2">
       <div
         onKeyDown={(e) => {
-          if (e.key === "Enter" && !e.shiftKey && !e.ctrlKey && !e.metaKey && !isEmpty) handleSubmit(onEnter)(e);
+          if (e.key === "Enter" && !e.nativeEvent.isComposing && !e.shiftKey && !e.ctrlKey && !e.metaKey && !isEmpty)
+            handleSubmit(onEnter)(e);
         }}
       >
         <LiteTextEditor
@@ -90,7 +91,7 @@ export const CommentCardEditForm = observer(function CommentCardEditForm(props: 
           value={null}
           onChange={(_comment_json, comment_html) => setValue("comment_html", comment_html)}
           onEnterKeyPress={(e) => {
-            if (!isEmpty && !isSubmitting) {
+            if (!e.nativeEvent.isComposing && !isEmpty && !isSubmitting) {
               handleSubmit(onEnter)(e);
             }
           }}

--- a/apps/web/core/components/comments/comment-create.tsx
+++ b/apps/web/core/components/comments/comment-create.tsx
@@ -96,6 +96,7 @@ export const CommentCreate = observer(function CommentCreate(props: TCommentCrea
       onKeyDown={(e) => {
         if (
           e.key === "Enter" &&
+          !e.nativeEvent.isComposing &&
           !e.shiftKey &&
           !e.ctrlKey &&
           !e.metaKey &&
@@ -122,7 +123,7 @@ export const CommentCreate = observer(function CommentCreate(props: TCommentCrea
                 workspaceSlug={workspaceSlug}
                 projectId={projectId}
                 onEnterKeyPress={(e) => {
-                  if (!isEmpty && !isSubmitting) {
+                  if (!e.nativeEvent.isComposing && !isEmpty && !isSubmitting) {
                     handleSubmit(onSubmit)(e);
                   }
                 }}


### PR DESCRIPTION
## Summary

Prevents comments from being submitted while an IME composition is in progress.

## Changes

- Checks `e.nativeEvent.isComposing` before submitting a new comment with Enter.
- Checks `e.nativeEvent.isComposing` before submitting an edited comment with Enter.
- Applies the guard to both wrapper `onKeyDown` handlers and `LiteTextEditor` `onEnterKeyPress` handlers.

## Why

When typing Chinese or other IME-based text, pressing Enter can be used to confirm the current composition. Without checking `isComposing`, the comment can be submitted unexpectedly before the user finishes typing.

## Related Issue

Closes #8913

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved comment submission handling to prevent accidental form submission when composing text using Input Method Editors (IME), ensuring text entry completes before submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->