### PR TITLE
.1502411993651747:8e9923a802edaea9bd8229dbabb9500e_69f5e617dc48703ced6cf949.69f5e61adc48703ced6cf94b.69f5e61a0b407201bc3fbc0d:Trae CN.T(2026/5/2 19:55:06)

### DIFF
--- a/apps/api/plane/app/urls/issue.py
+++ b/apps/api/plane/app/urls/issue.py
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # See the LICENSE file for details.
 
-from django.urls import path
-
 from plane.app.views import (
     BulkCreateIssueLabelsEndpoint,
     BulkDeleteIssuesEndpoint,
@@ -31,6 +29,8 @@ from plane.app.views import (
     WorkItemDescriptionVersionEndpoint,
     IssueMetaEndpoint,
     IssueDetailIdentifierEndpoint,
+    TransferIssueEndpoint,
+    BulkTransferIssuesEndpoint,
 )
 
 urlpatterns = [
@@ -282,5 +282,15 @@ urlpatterns = [
         "workspaces/<str:slug>/work-items/<str:project_identifier>-<str:issue_identifier>/",
         IssueDetailIdentifierEndpoint.as_view(),
         name="issue-detail-identifier",
+    ),
+    path(
+        "workspaces/<str:slug>/projects/<uuid:project_id>/transfer-issue/",
+        TransferIssueEndpoint.as_view(),
+        name="transfer-issue",
+    ),
+    path(
+        "workspaces/<str:slug>/projects/<uuid:project_id>/bulk-transfer-issues/",
+        BulkTransferIssuesEndpoint.as_view(),
+        name="bulk-transfer-issues",
     ),
 ]

--- a/apps/api/plane/app/views/__init__.py
+++ b/apps/api/plane/app/views/__init__.py
@@ -126,6 +126,8 @@ from .issue.base import (
     IssueBulkUpdateDateEndpoint,
     IssueMetaEndpoint,
     IssueDetailIdentifierEndpoint,
+    TransferIssueEndpoint,
+    BulkTransferIssuesEndpoint,
 )
 
 from .issue.activity import IssueActivityEndpoint

--- a/apps/api/plane/app/views/issue/base.py
+++ b/apps/api/plane/app/views/issue/base.py
@@ -1353,3 +1353,91 @@ class IssueDetailIdentifierEndpoint(BaseAPIView):
         # Serialize the issue
         serializer = IssueDetailSerializer(issue, expand=self.expand)
         return Response(serializer.data, status=status.HTTP_200_OK)
+
+
+class TransferIssueEndpoint(BaseAPIView):
+    @allow_permission([ROLE.ADMIN, ROLE.MEMBER])
+    def post(self, request, slug, project_id):
+        from plane.utils.issue_transfer import transfer_issue
+
+        target_project_id = request.data.get("target_project_id")
+        issue_id = request.data.get("issue_id")
+
+        if not target_project_id:
+            return Response(
+                {"error": "Target project ID is required"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        if not issue_id:
+            return Response(
+                {"error": "Issue ID is required"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        if str(project_id) == str(target_project_id):
+            return Response(
+                {"error": "Source and target projects are the same"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        result = transfer_issue(
+            slug=slug,
+            source_project_id=project_id,
+            target_project_id=target_project_id,
+            issue_id=issue_id,
+            request=request,
+            user_id=request.user.id,
+        )
+
+        if not result.get("success"):
+            return Response(
+                {"error": result.get("error", "Failed to transfer issue")},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        return Response(result, status=status.HTTP_200_OK)
+
+
+class BulkTransferIssuesEndpoint(BaseAPIView):
+    @allow_permission([ROLE.ADMIN, ROLE.MEMBER])
+    def post(self, request, slug, project_id):
+        from plane.utils.issue_transfer import bulk_transfer_issues
+
+        target_project_id = request.data.get("target_project_id")
+        issue_ids = request.data.get("issue_ids", [])
+
+        if not target_project_id:
+            return Response(
+                {"error": "Target project ID is required"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        if not issue_ids or len(issue_ids) == 0:
+            return Response(
+                {"error": "Issue IDs are required"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        if str(project_id) == str(target_project_id):
+            return Response(
+                {"error": "Source and target projects are the same"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        result = bulk_transfer_issues(
+            slug=slug,
+            source_project_id=project_id,
+            target_project_id=target_project_id,
+            issue_ids=issue_ids,
+            request=request,
+            user_id=request.user.id,
+        )
+
+        if len(result.get("errors", [])) > 0:
+            return Response(
+                result,
+                status=status.HTTP_207_MULTI_STATUS,
+            )
+
+        return Response(result, status=status.HTTP_200_OK)

--- a/apps/api/plane/utils/issue_transfer.py
+++ b/apps/api/plane/utils/issue_transfer.py
@@ -1,0 +1,481 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file in details.
+
+# Python imports
+import json
+
+# Django imports
+from django.core.serializers.json import DjangoJSONEncoder
+from django.db import transaction
+from django.db.models import Q
+from django.utils import timezone
+
+# Module imports
+from plane.db.models import (
+    CycleIssue,
+    Issue,
+    IssueActivity,
+    IssueAssignee,
+    IssueBlocker,
+    IssueComment,
+    IssueLabel,
+    IssueLink,
+    IssueMention,
+    IssueReaction,
+    IssueRelation,
+    IssueSequence,
+    IssueSubscriber,
+    IssueVote,
+    Label,
+    ModuleIssue,
+    Project,
+    ProjectMember,
+    State,
+    UserRecentVisit,
+    CommentReaction,
+    FileAsset,
+)
+from plane.bgtasks.issue_activities_task import issue_activity
+from plane.utils.host import base_host
+
+
+def transfer_issue(
+    slug,
+    source_project_id,
+    target_project_id,
+    issue_id,
+    request,
+    user_id,
+):
+    """
+    Transfer an issue from one project to another within the same workspace.
+
+    This function handles:
+    1. State/label mapping by name, using target project default state if no match
+    2. Clearing cycle/module if they don't exist in target project
+    3. Migrating all related data (comments, attachments, sub-issues, relations, activity)
+    4. Updating issue sequence for target project
+
+    Args:
+        slug: Workspace slug
+        source_project_id: Source project ID
+        target_project_id: Target project ID
+        issue_id: Issue ID to transfer
+        request: HTTP request object
+        user_id: User ID performing the transfer
+
+    Returns:
+        dict: Response data with success or error message
+    """
+    try:
+        with transaction.atomic():
+            target_project = Project.objects.filter(
+                workspace__slug=slug,
+                pk=target_project_id,
+                archived_at__isnull=True,
+            ).first()
+
+            if not target_project:
+                return {
+                    "success": False,
+                    "error": "Target project not found",
+                }
+
+            if str(source_project_id) == str(target_project_id):
+                return {
+                    "success": False,
+                    "error": "Source and target projects are the same",
+                }
+
+            issue = Issue.objects.filter(
+                workspace__slug=slug,
+                project_id=source_project_id,
+                pk=issue_id,
+                archived_at__isnull=True,
+            ).first()
+
+            if not issue:
+                return {
+                    "success": False,
+                    "error": "Issue not found in source project",
+                }
+
+            old_project_id = issue.project_id
+            old_state_id = issue.state_id
+
+            source_state = State.objects.filter(
+                workspace__slug=slug,
+                project_id=source_project_id,
+                pk=issue.state_id,
+            ).first()
+
+            new_state = None
+            if source_state:
+                new_state = State.objects.filter(
+                    workspace__slug=slug,
+                    project_id=target_project_id,
+                    name__iexact=source_state.name,
+                ).first()
+
+            if not new_state:
+                new_state = State.objects.filter(
+                    workspace__slug=slug,
+                    project_id=target_project_id,
+                    default=True,
+                ).first()
+
+            if not new_state:
+                new_state = State.objects.filter(
+                    workspace__slug=slug,
+                    project_id=target_project_id,
+                ).first()
+
+            if not new_state:
+                return {
+                    "success": False,
+                    "error": "Target project has no states",
+                }
+
+            source_labels = list(
+                Label.objects.filter(
+                    workspace__slug=slug,
+                    label_issue__issue=issue,
+                    label_issue__deleted_at__isnull=True,
+                )
+            )
+
+            target_label_ids = []
+            for source_label in source_labels:
+                target_label = Label.objects.filter(
+                    workspace__slug=slug,
+                    Q(project_id=target_project_id) | Q(project__isnull=True),
+                    name__iexact=source_label.name,
+                ).first()
+
+                if target_label:
+                    target_label_ids.append(target_label.id)
+
+            source_assignees = list(
+                IssueAssignee.objects.filter(
+                    workspace__slug=slug,
+                    project_id=source_project_id,
+                    issue=issue,
+                    deleted_at__isnull=True,
+                ).values_list("assignee_id", flat=True)
+            )
+
+            target_assignee_ids = []
+            if source_assignees:
+                target_assignee_ids = list(
+                    ProjectMember.objects.filter(
+                        workspace__slug=slug,
+                        project_id=target_project_id,
+                        member_id__in=source_assignees,
+                        is_active=True,
+                        role__gte=15,
+                    ).values_list("member_id", flat=True)
+                )
+
+            CycleIssue.objects.filter(
+                workspace__slug=slug,
+                project_id=source_project_id,
+                issue=issue,
+            ).delete()
+
+            ModuleIssue.objects.filter(
+                workspace__slug=slug,
+                project_id=source_project_id,
+                issue=issue,
+            ).delete()
+
+            issue.project_id = target_project_id
+            issue.state = new_state
+            issue.sort_order = 65535.0
+            issue.updated_at = timezone.now()
+            issue.updated_by_id = user_id
+            issue.save(update_fields=["project_id", "state", "sort_order", "updated_at", "updated_by_id"])
+
+            IssueLabel.objects.filter(
+                workspace__slug=slug,
+                project_id=source_project_id,
+                issue=issue,
+            ).delete()
+
+            if target_label_ids:
+                new_issue_labels = []
+                for label_id in target_label_ids:
+                    if not IssueLabel.objects.filter(
+                        workspace__slug=slug,
+                        project_id=target_project_id,
+                        issue=issue,
+                        label_id=label_id,
+                        deleted_at__isnull=True,
+                    ).exists():
+                        new_issue_labels.append(
+                            IssueLabel(
+                                workspace_id=target_project.workspace_id,
+                                project_id=target_project_id,
+                                issue=issue,
+                                label_id=label_id,
+                                created_by_id=user_id,
+                                updated_by_id=user_id,
+                            )
+                        )
+                if new_issue_labels:
+                    IssueLabel.objects.bulk_create(new_issue_labels, batch_size=100)
+
+            IssueAssignee.objects.filter(
+                workspace__slug=slug,
+                project_id=source_project_id,
+                issue=issue,
+            ).delete()
+
+            if target_assignee_ids:
+                new_issue_assignees = []
+                for assignee_id in target_assignee_ids:
+                    if not IssueAssignee.objects.filter(
+                        workspace__slug=slug,
+                        project_id=target_project_id,
+                        issue=issue,
+                        assignee_id=assignee_id,
+                        deleted_at__isnull=True,
+                    ).exists():
+                        new_issue_assignees.append(
+                            IssueAssignee(
+                                workspace_id=target_project.workspace_id,
+                                project_id=target_project_id,
+                                issue=issue,
+                                assignee_id=assignee_id,
+                                created_by_id=user_id,
+                                updated_by_id=user_id,
+                            )
+                        )
+                if new_issue_assignees:
+                    IssueAssignee.objects.bulk_create(new_issue_assignees, batch_size=100)
+
+            IssueActivity.objects.filter(
+                workspace__slug=slug,
+                project_id=source_project_id,
+                issue=issue,
+            ).update(
+                project_id=target_project_id,
+            )
+
+            IssueComment.objects.filter(
+                workspace__slug=slug,
+                project_id=source_project_id,
+                issue=issue,
+            ).update(
+                project_id=target_project_id,
+            )
+
+            CommentReaction.objects.filter(
+                workspace__slug=slug,
+                project_id=source_project_id,
+                comment__issue=issue,
+            ).update(
+                project_id=target_project_id,
+            )
+
+            IssueLink.objects.filter(
+                workspace__slug=slug,
+                project_id=source_project_id,
+                issue=issue,
+            ).update(
+                project_id=target_project_id,
+            )
+
+            IssueMention.objects.filter(
+                workspace__slug=slug,
+                project_id=source_project_id,
+                issue=issue,
+            ).update(
+                project_id=target_project_id,
+            )
+
+            IssueReaction.objects.filter(
+                workspace__slug=slug,
+                project_id=source_project_id,
+                issue=issue,
+            ).update(
+                project_id=target_project_id,
+            )
+
+            IssueRelation.objects.filter(
+                workspace__slug=slug,
+                project_id=source_project_id,
+                issue=issue,
+            ).update(
+                project_id=target_project_id,
+            )
+
+            IssueRelation.objects.filter(
+                workspace__slug=slug,
+                project_id=source_project_id,
+                related_issue=issue,
+            ).update(
+                project_id=target_project_id,
+            )
+
+            IssueBlocker.objects.filter(
+                workspace__slug=slug,
+                project_id=source_project_id,
+                block=issue,
+            ).update(
+                project_id=target_project_id,
+            )
+
+            IssueBlocker.objects.filter(
+                workspace__slug=slug,
+                project_id=source_project_id,
+                blocked_by=issue,
+            ).update(
+                project_id=target_project_id,
+            )
+
+            IssueSubscriber.objects.filter(
+                workspace__slug=slug,
+                project_id=source_project_id,
+                issue=issue,
+            ).update(
+                project_id=target_project_id,
+            )
+
+            IssueVote.objects.filter(
+                workspace__slug=slug,
+                project_id=source_project_id,
+                issue=issue,
+            ).update(
+                project_id=target_project_id,
+            )
+
+            FileAsset.objects.filter(
+                workspace__slug=slug,
+                project_id=source_project_id,
+                issue_id=issue.id,
+                entity_type=FileAsset.EntityTypeContext.ISSUE_ATTACHMENT,
+            ).update(
+                project_id=target_project_id,
+            )
+
+            child_issues = Issue.issue_objects.filter(
+                workspace__slug=slug,
+                project_id=source_project_id,
+                parent=issue,
+            )
+
+            for child_issue in child_issues:
+                transfer_issue(
+                    slug=slug,
+                    source_project_id=source_project_id,
+                    target_project_id=target_project_id,
+                    issue_id=str(child_issue.id),
+                    request=request,
+                    user_id=user_id,
+                )
+
+            IssueSequence.objects.filter(
+                workspace__slug=slug,
+                project_id=source_project_id,
+                issue=issue,
+            ).update(
+                project_id=target_project_id,
+            )
+
+            UserRecentVisit.objects.filter(
+                workspace__slug=slug,
+                project_id=source_project_id,
+                entity_identifier=str(issue.id),
+                entity_name="issue",
+            ).update(
+                project_id=target_project_id,
+            )
+
+            activity_data = {
+                "issue_id": str(issue.id),
+                "old_project_id": str(old_project_id),
+                "new_project_id": str(target_project_id),
+                "old_state_id": str(old_state_id) if old_state_id else None,
+                "new_state_id": str(new_state.id),
+            }
+
+            issue_activity.delay(
+                type="issue.activity.transferred",
+                requested_data=json.dumps(activity_data, cls=DjangoJSONEncoder),
+                actor_id=str(user_id),
+                issue_id=str(issue.id),
+                project_id=str(target_project_id),
+                current_instance=None,
+                epoch=int(timezone.now().timestamp()),
+                notification=True,
+                origin=base_host(request=request, is_app=True),
+            )
+
+            return {
+                "success": True,
+                "issue_id": str(issue.id),
+                "source_project_id": str(source_project_id),
+                "target_project_id": str(target_project_id),
+            }
+
+    except Exception as e:
+        return {
+            "success": False,
+            "error": str(e),
+        }
+
+
+def bulk_transfer_issues(
+    slug,
+    source_project_id,
+    target_project_id,
+    issue_ids,
+    request,
+    user_id,
+):
+    """
+    Transfer multiple issues from one project to another.
+
+    Args:
+        slug: Workspace slug
+        source_project_id: Source project ID
+        target_project_id: Target project ID
+        issue_ids: List of issue IDs to transfer
+        request: HTTP request object
+        user_id: User ID performing the transfer
+
+    Returns:
+        dict: Response data with success count and error details
+    """
+    results = []
+    success_count = 0
+    errors = []
+
+    for issue_id in issue_ids:
+        result = transfer_issue(
+            slug=slug,
+            source_project_id=source_project_id,
+            target_project_id=target_project_id,
+            issue_id=issue_id,
+            request=request,
+            user_id=user_id,
+        )
+        results.append(result)
+        if result.get("success"):
+            success_count += 1
+        else:
+            errors.append(
+                {
+                    "issue_id": issue_id,
+                    "error": result.get("error", "Unknown error"),
+                }
+            )
+
+    return {
+        "success": success_count == len(issue_ids),
+        "total": len(issue_ids),
+        "success_count": success_count,
+        "errors": errors,
+        "results": results,
+    }

--- a/apps/web/core/services/issue/issue.service.ts
+++ b/apps/web/core/services/issue/issue.service.ts
@@ -374,6 +374,46 @@ export class IssueService extends APIService {
       });
   }
 
+  async transferIssue(
+    workspaceSlug: string,
+    projectId: string,
+    data: {
+      target_project_id: string;
+      issue_id: string;
+    }
+  ): Promise<{
+    success: boolean;
+    issue_id: string;
+    source_project_id: string;
+    target_project_id: string;
+  }> {
+    return this.post(`/api/workspaces/${workspaceSlug}/projects/${projectId}/transfer-issue/`, data)
+      .then(async (response) => response?.data)
+      .catch((error) => {
+        throw error?.response?.data;
+      });
+  }
+
+  async bulkTransferIssues(
+    workspaceSlug: string,
+    projectId: string,
+    data: {
+      target_project_id: string;
+      issue_ids: string[];
+    }
+  ): Promise<{
+    success: boolean;
+    transferred_count: number;
+    transferred_issues: string[];
+    errors: { issue_id: string; error: string }[];
+  }> {
+    return this.post(`/api/workspaces/${workspaceSlug}/projects/${projectId}/bulk-transfer-issues/`, data)
+      .then(async (response) => response?.data)
+      .catch((error) => {
+        throw error?.response?.data;
+      });
+  }
+
   // issue subscriptions
   async getIssueNotificationSubscriptionStatus(
     workspaceSlug: string,

--- a/apps/web/core/store/issue/helpers/base-issues.store.ts
+++ b/apps/web/core/store/issue/helpers/base-issues.store.ts
@@ -110,6 +110,29 @@ export interface IBaseIssuesStore {
     removeModuleIds: string[]
   ): Promise<void>;
   updateIssueDates(workspaceSlug: string, updates: IBlockUpdateDependencyData[], projectId?: string): Promise<void>;
+
+  transferIssue: (
+    workspaceSlug: string,
+    sourceProjectId: string,
+    targetProjectId: string,
+    issueId: string
+  ) => Promise<{
+    success: boolean;
+    issue_id: string;
+    source_project_id: string;
+    target_project_id: string;
+  }>;
+  bulkTransferIssues: (
+    workspaceSlug: string,
+    sourceProjectId: string,
+    targetProjectId: string,
+    issueIds: string[]
+  ) => Promise<{
+    success: boolean;
+    transferred_count: number;
+    transferred_issues: string[];
+    errors: { issue_id: string; error: string }[];
+  }>;
 }
 
 // This constant maps the group by keys to the respective issue property that the key relies on
@@ -750,6 +773,68 @@ export abstract class BaseIssuesStore implements IBaseIssuesStore {
         this.updateIssueList(issueDetails, issueBeforeUpdate);
       });
     });
+  };
+
+  /**
+   * @description transfer a single issue to another project
+   * @param workspaceSlug
+   * @param sourceProjectId
+   * @param targetProjectId
+   * @param issueId
+   */
+  transferIssue = async (
+    workspaceSlug: string,
+    sourceProjectId: string,
+    targetProjectId: string,
+    issueId: string
+  ) => {
+    const response = await this.issueService.transferIssue(workspaceSlug, sourceProjectId, {
+      target_project_id: targetProjectId,
+      issue_id: issueId,
+    });
+
+    if (response.success) {
+      this.fetchParentStats(workspaceSlug, sourceProjectId);
+      runInAction(() => {
+        this.removeIssueFromList(issueId);
+        this.rootIssueStore.issues.removeIssue(issueId);
+      });
+    }
+
+    return response;
+  };
+
+  /**
+   * @description transfer multiple issues to another project
+   * @param workspaceSlug
+   * @param sourceProjectId
+   * @param targetProjectId
+   * @param issueIds
+   */
+  bulkTransferIssues = async (
+    workspaceSlug: string,
+    sourceProjectId: string,
+    targetProjectId: string,
+    issueIds: string[]
+  ) => {
+    const response = await this.issueService.bulkTransferIssues(workspaceSlug, sourceProjectId, {
+      target_project_id: targetProjectId,
+      issue_ids: issueIds,
+    });
+
+    const transferredIssues = response.transferred_issues || [];
+
+    if (transferredIssues.length > 0) {
+      this.fetchParentStats(workspaceSlug, sourceProjectId);
+      runInAction(() => {
+        transferredIssues.forEach((issueId) => {
+          this.removeIssueFromList(issueId);
+          this.rootIssueStore.issues.removeIssue(issueId);
+        });
+      });
+    }
+
+    return response;
   };
 
   async updateIssueDates(


### PR DESCRIPTION
新增跨项目移动issue的后端迁移逻辑和API端点，处理state/label映射、cycle/module清空，以及评论、附件、activity、关联记录、订阅者和子issue等关联数据迁移；前端service和issue store新增单个/批量跨项目移动方法。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added issue transfer functionality, enabling users to move individual issues or bulk-transfer multiple issues between projects within the same workspace. Transferred issues automatically map to corresponding states, get reassigned to eligible team members based on target project configuration, and all related data including comments, reactions, links, and attachments are preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->