### PR TITLE
.1502411993651747:eb9da007b1d220051a281116530b04f1_69f606b5dc48703ced6d007a.69f606bfdc48703ced6d007c.69f606bf0b407201bc3fbc0f:Trae CN.T(2026/5/2 22:14:23)

### DIFF
--- a/apps/api/plane/app/urls/issue.py
+++ b/apps/api/plane/app/urls/issue.py
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # See the LICENSE file for details.
 
-from django.urls import path
-
 from plane.app.views import (
     BulkCreateIssueLabelsEndpoint,
     BulkDeleteIssuesEndpoint,
@@ -31,6 +29,8 @@ from plane.app.views import (
     WorkItemDescriptionVersionEndpoint,
     IssueMetaEndpoint,
     IssueDetailIdentifierEndpoint,
+    TransferIssueEndpoint,
+    BulkTransferIssuesEndpoint,
 )
 
 urlpatterns = [
@@ -282,5 +282,15 @@ urlpatterns = [
         "workspaces/<str:slug>/work-items/<str:project_identifier>-<str:issue_identifier>/",
         IssueDetailIdentifierEndpoint.as_view(),
         name="issue-detail-identifier",
+    ),
+    path(
+        "workspaces/<str:slug>/projects/<uuid:project_id>/transfer-issue/",
+        TransferIssueEndpoint.as_view(),
+        name="transfer-issue",
+    ),
+    path(
+        "workspaces/<str:slug>/projects/<uuid:project_id>/bulk-transfer-issues/",
+        BulkTransferIssuesEndpoint.as_view(),
+        name="bulk-transfer-issues",
     ),
 ]

--- a/apps/api/plane/app/views/__init__.py
+++ b/apps/api/plane/app/views/__init__.py
@@ -126,6 +126,8 @@ from .issue.base import (
     IssueBulkUpdateDateEndpoint,
     IssueMetaEndpoint,
     IssueDetailIdentifierEndpoint,
+    TransferIssueEndpoint,
+    BulkTransferIssuesEndpoint,
 )
 
 from .issue.activity import IssueActivityEndpoint

--- a/apps/api/plane/app/views/issue/base.py
+++ b/apps/api/plane/app/views/issue/base.py
@@ -1353,3 +1353,91 @@ class IssueDetailIdentifierEndpoint(BaseAPIView):
         # Serialize the issue
         serializer = IssueDetailSerializer(issue, expand=self.expand)
         return Response(serializer.data, status=status.HTTP_200_OK)
+
+
+class TransferIssueEndpoint(BaseAPIView):
+    @allow_permission([ROLE.ADMIN, ROLE.MEMBER])
+    def post(self, request, slug, project_id):
+        from plane.utils.issue_transfer import transfer_issue
+
+        target_project_id = request.data.get("target_project_id")
+        issue_id = request.data.get("issue_id")
+
+        if not target_project_id:
+            return Response(
+                {"error": "Target project ID is required"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        if not issue_id:
+            return Response(
+                {"error": "Issue ID is required"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        if str(project_id) == str(target_project_id):
+            return Response(
+                {"error": "Source and target projects are the same"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        result = transfer_issue(
+            slug=slug,
+            source_project_id=project_id,
+            target_project_id=target_project_id,
+            issue_id=issue_id,
+            request=request,
+            user_id=request.user.id,
+        )
+
+        if not result.get("success"):
+            return Response(
+                {"error": result.get("error", "Failed to transfer issue")},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        return Response(result, status=status.HTTP_200_OK)
+
+
+class BulkTransferIssuesEndpoint(BaseAPIView):
+    @allow_permission([ROLE.ADMIN, ROLE.MEMBER])
+    def post(self, request, slug, project_id):
+        from plane.utils.issue_transfer import bulk_transfer_issues
+
+        target_project_id = request.data.get("target_project_id")
+        issue_ids = request.data.get("issue_ids", [])
+
+        if not target_project_id:
+            return Response(
+                {"error": "Target project ID is required"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        if not issue_ids or len(issue_ids) == 0:
+            return Response(
+                {"error": "Issue IDs are required"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        if str(project_id) == str(target_project_id):
+            return Response(
+                {"error": "Source and target projects are the same"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        result = bulk_transfer_issues(
+            slug=slug,
+            source_project_id=project_id,
+            target_project_id=target_project_id,
+            issue_ids=issue_ids,
+            request=request,
+            user_id=request.user.id,
+        )
+
+        if len(result.get("errors", [])) > 0:
+            return Response(
+                result,
+                status=status.HTTP_207_MULTI_STATUS,
+            )
+
+        return Response(result, status=status.HTTP_200_OK)

--- a/apps/api/plane/utils/issue_transfer.py
+++ b/apps/api/plane/utils/issue_transfer.py
@@ -1,0 +1,481 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file in details.
+
+# Python imports
+import json
+
+# Django imports
+from django.core.serializers.json import DjangoJSONEncoder
+from django.db import transaction
+from django.db.models import Q
+from django.utils import timezone
+
+# Module imports
+from plane.db.models import (
+    CycleIssue,
+    Issue,
+    IssueActivity,
+    IssueAssignee,
+    IssueBlocker,
+    IssueComment,
+    IssueLabel,
+    IssueLink,
+    IssueMention,
+    IssueReaction,
+    IssueRelation,
+    IssueSequence,
+    IssueSubscriber,
+    IssueVote,
+    Label,
+    ModuleIssue,
+    Project,
+    ProjectMember,
+    State,
+    UserRecentVisit,
+    CommentReaction,
+    FileAsset,
+)
+from plane.bgtasks.issue_activities_task import issue_activity
+from plane.utils.host import base_host
+
+
+def transfer_issue(
+    slug,
+    source_project_id,
+    target_project_id,
+    issue_id,
+    request,
+    user_id,
+):
+    """
+    Transfer an issue from one project to another within the same workspace.
+
+    This function handles:
+    1. State/label mapping by name, using target project default state if no match
+    2. Clearing cycle/module if they don't exist in target project
+    3. Migrating all related data (comments, attachments, sub-issues, relations, activity)
+    4. Updating issue sequence for target project
+
+    Args:
+        slug: Workspace slug
+        source_project_id: Source project ID
+        target_project_id: Target project ID
+        issue_id: Issue ID to transfer
+        request: HTTP request object
+        user_id: User ID performing the transfer
+
+    Returns:
+        dict: Response data with success or error message
+    """
+    try:
+        with transaction.atomic():
+            target_project = Project.objects.filter(
+                workspace__slug=slug,
+                pk=target_project_id,
+                archived_at__isnull=True,
+            ).first()
+
+            if not target_project:
+                return {
+                    "success": False,
+                    "error": "Target project not found",
+                }
+
+            if str(source_project_id) == str(target_project_id):
+                return {
+                    "success": False,
+                    "error": "Source and target projects are the same",
+                }
+
+            issue = Issue.objects.filter(
+                workspace__slug=slug,
+                project_id=source_project_id,
+                pk=issue_id,
+                archived_at__isnull=True,
+            ).first()
+
+            if not issue:
+                return {
+                    "success": False,
+                    "error": "Issue not found in source project",
+                }
+
+            old_project_id = issue.project_id
+            old_state_id = issue.state_id
+
+            source_state = State.objects.filter(
+                workspace__slug=slug,
+                project_id=source_project_id,
+                pk=issue.state_id,
+            ).first()
+
+            new_state = None
+            if source_state:
+                new_state = State.objects.filter(
+                    workspace__slug=slug,
+                    project_id=target_project_id,
+                    name__iexact=source_state.name,
+                ).first()
+
+            if not new_state:
+                new_state = State.objects.filter(
+                    workspace__slug=slug,
+                    project_id=target_project_id,
+                    default=True,
+                ).first()
+
+            if not new_state:
+                new_state = State.objects.filter(
+                    workspace__slug=slug,
+                    project_id=target_project_id,
+                ).first()
+
+            if not new_state:
+                return {
+                    "success": False,
+                    "error": "Target project has no states",
+                }
+
+            source_labels = list(
+                Label.objects.filter(
+                    workspace__slug=slug,
+                    label_issue__issue=issue,
+                    label_issue__deleted_at__isnull=True,
+                )
+            )
+
+            target_label_ids = []
+            for source_label in source_labels:
+                target_label = Label.objects.filter(
+                    workspace__slug=slug,
+                    Q(project_id=target_project_id) | Q(project__isnull=True),
+                    name__iexact=source_label.name,
+                ).first()
+
+                if target_label:
+                    target_label_ids.append(target_label.id)
+
+            source_assignees = list(
+                IssueAssignee.objects.filter(
+                    workspace__slug=slug,
+                    project_id=source_project_id,
+                    issue=issue,
+                    deleted_at__isnull=True,
+                ).values_list("assignee_id", flat=True)
+            )
+
+            target_assignee_ids = []
+            if source_assignees:
+                target_assignee_ids = list(
+                    ProjectMember.objects.filter(
+                        workspace__slug=slug,
+                        project_id=target_project_id,
+                        member_id__in=source_assignees,
+                        is_active=True,
+                        role__gte=15,
+                    ).values_list("member_id", flat=True)
+                )
+
+            CycleIssue.objects.filter(
+                workspace__slug=slug,
+                project_id=source_project_id,
+                issue=issue,
+            ).delete()
+
+            ModuleIssue.objects.filter(
+                workspace__slug=slug,
+                project_id=source_project_id,
+                issue=issue,
+            ).delete()
+
+            issue.project_id = target_project_id
+            issue.state = new_state
+            issue.sort_order = 65535.0
+            issue.updated_at = timezone.now()
+            issue.updated_by_id = user_id
+            issue.save(update_fields=["project_id", "state", "sort_order", "updated_at", "updated_by_id"])
+
+            IssueLabel.objects.filter(
+                workspace__slug=slug,
+                project_id=source_project_id,
+                issue=issue,
+            ).delete()
+
+            if target_label_ids:
+                new_issue_labels = []
+                for label_id in target_label_ids:
+                    if not IssueLabel.objects.filter(
+                        workspace__slug=slug,
+                        project_id=target_project_id,
+                        issue=issue,
+                        label_id=label_id,
+                        deleted_at__isnull=True,
+                    ).exists():
+                        new_issue_labels.append(
+                            IssueLabel(
+                                workspace_id=target_project.workspace_id,
+                                project_id=target_project_id,
+                                issue=issue,
+                                label_id=label_id,
+                                created_by_id=user_id,
+                                updated_by_id=user_id,
+                            )
+                        )
+                if new_issue_labels:
+                    IssueLabel.objects.bulk_create(new_issue_labels, batch_size=100)
+
+            IssueAssignee.objects.filter(
+                workspace__slug=slug,
+                project_id=source_project_id,
+                issue=issue,
+            ).delete()
+
+            if target_assignee_ids:
+                new_issue_assignees = []
+                for assignee_id in target_assignee_ids:
+                    if not IssueAssignee.objects.filter(
+                        workspace__slug=slug,
+                        project_id=target_project_id,
+                        issue=issue,
+                        assignee_id=assignee_id,
+                        deleted_at__isnull=True,
+                    ).exists():
+                        new_issue_assignees.append(
+                            IssueAssignee(
+                                workspace_id=target_project.workspace_id,
+                                project_id=target_project_id,
+                                issue=issue,
+                                assignee_id=assignee_id,
+                                created_by_id=user_id,
+                                updated_by_id=user_id,
+                            )
+                        )
+                if new_issue_assignees:
+                    IssueAssignee.objects.bulk_create(new_issue_assignees, batch_size=100)
+
+            IssueActivity.objects.filter(
+                workspace__slug=slug,
+                project_id=source_project_id,
+                issue=issue,
+            ).update(
+                project_id=target_project_id,
+            )
+
+            IssueComment.objects.filter(
+                workspace__slug=slug,
+                project_id=source_project_id,
+                issue=issue,
+            ).update(
+                project_id=target_project_id,
+            )
+
+            CommentReaction.objects.filter(
+                workspace__slug=slug,
+                project_id=source_project_id,
+                comment__issue=issue,
+            ).update(
+                project_id=target_project_id,
+            )
+
+            IssueLink.objects.filter(
+                workspace__slug=slug,
+                project_id=source_project_id,
+                issue=issue,
+            ).update(
+                project_id=target_project_id,
+            )
+
+            IssueMention.objects.filter(
+                workspace__slug=slug,
+                project_id=source_project_id,
+                issue=issue,
+            ).update(
+                project_id=target_project_id,
+            )
+
+            IssueReaction.objects.filter(
+                workspace__slug=slug,
+                project_id=source_project_id,
+                issue=issue,
+            ).update(
+                project_id=target_project_id,
+            )
+
+            IssueRelation.objects.filter(
+                workspace__slug=slug,
+                project_id=source_project_id,
+                issue=issue,
+            ).update(
+                project_id=target_project_id,
+            )
+
+            IssueRelation.objects.filter(
+                workspace__slug=slug,
+                project_id=source_project_id,
+                related_issue=issue,
+            ).update(
+                project_id=target_project_id,
+            )
+
+            IssueBlocker.objects.filter(
+                workspace__slug=slug,
+                project_id=source_project_id,
+                block=issue,
+            ).update(
+                project_id=target_project_id,
+            )
+
+            IssueBlocker.objects.filter(
+                workspace__slug=slug,
+                project_id=source_project_id,
+                blocked_by=issue,
+            ).update(
+                project_id=target_project_id,
+            )
+
+            IssueSubscriber.objects.filter(
+                workspace__slug=slug,
+                project_id=source_project_id,
+                issue=issue,
+            ).update(
+                project_id=target_project_id,
+            )
+
+            IssueVote.objects.filter(
+                workspace__slug=slug,
+                project_id=source_project_id,
+                issue=issue,
+            ).update(
+                project_id=target_project_id,
+            )
+
+            FileAsset.objects.filter(
+                workspace__slug=slug,
+                project_id=source_project_id,
+                issue_id=issue.id,
+                entity_type=FileAsset.EntityTypeContext.ISSUE_ATTACHMENT,
+            ).update(
+                project_id=target_project_id,
+            )
+
+            child_issues = Issue.issue_objects.filter(
+                workspace__slug=slug,
+                project_id=source_project_id,
+                parent=issue,
+            )
+
+            for child_issue in child_issues:
+                transfer_issue(
+                    slug=slug,
+                    source_project_id=source_project_id,
+                    target_project_id=target_project_id,
+                    issue_id=str(child_issue.id),
+                    request=request,
+                    user_id=user_id,
+                )
+
+            IssueSequence.objects.filter(
+                workspace__slug=slug,
+                project_id=source_project_id,
+                issue=issue,
+            ).update(
+                project_id=target_project_id,
+            )
+
+            UserRecentVisit.objects.filter(
+                workspace__slug=slug,
+                project_id=source_project_id,
+                entity_identifier=str(issue.id),
+                entity_name="issue",
+            ).update(
+                project_id=target_project_id,
+            )
+
+            activity_data = {
+                "issue_id": str(issue.id),
+                "old_project_id": str(old_project_id),
+                "new_project_id": str(target_project_id),
+                "old_state_id": str(old_state_id) if old_state_id else None,
+                "new_state_id": str(new_state.id),
+            }
+
+            issue_activity.delay(
+                type="issue.activity.transferred",
+                requested_data=json.dumps(activity_data, cls=DjangoJSONEncoder),
+                actor_id=str(user_id),
+                issue_id=str(issue.id),
+                project_id=str(target_project_id),
+                current_instance=None,
+                epoch=int(timezone.now().timestamp()),
+                notification=True,
+                origin=base_host(request=request, is_app=True),
+            )
+
+            return {
+                "success": True,
+                "issue_id": str(issue.id),
+                "source_project_id": str(source_project_id),
+                "target_project_id": str(target_project_id),
+            }
+
+    except Exception as e:
+        return {
+            "success": False,
+            "error": str(e),
+        }
+
+
+def bulk_transfer_issues(
+    slug,
+    source_project_id,
+    target_project_id,
+    issue_ids,
+    request,
+    user_id,
+):
+    """
+    Transfer multiple issues from one project to another.
+
+    Args:
+        slug: Workspace slug
+        source_project_id: Source project ID
+        target_project_id: Target project ID
+        issue_ids: List of issue IDs to transfer
+        request: HTTP request object
+        user_id: User ID performing the transfer
+
+    Returns:
+        dict: Response data with success count and error details
+    """
+    results = []
+    success_count = 0
+    errors = []
+
+    for issue_id in issue_ids:
+        result = transfer_issue(
+            slug=slug,
+            source_project_id=source_project_id,
+            target_project_id=target_project_id,
+            issue_id=issue_id,
+            request=request,
+            user_id=user_id,
+        )
+        results.append(result)
+        if result.get("success"):
+            success_count += 1
+        else:
+            errors.append(
+                {
+                    "issue_id": issue_id,
+                    "error": result.get("error", "Unknown error"),
+                }
+            )
+
+    return {
+        "success": success_count == len(issue_ids),
+        "total": len(issue_ids),
+        "success_count": success_count,
+        "errors": errors,
+        "results": results,
+    }

--- a/apps/api/plane/utils/issue_transfer.py
+++ b/apps/api/plane/utils/issue_transfer.py
@@ -40,6 +40,50 @@ from plane.bgtasks.issue_activities_task import issue_activity
 from plane.utils.host import base_host
 
 
+def check_user_project_permission(slug, project_id, user_id, required_role=15):
+    """
+    Check if a user has the required permission for a project.
+
+    Args:
+        slug: Workspace slug
+        project_id: Project ID
+        user_id: User ID
+        required_role: Minimum required role (default: 15 = MEMBER)
+
+    Returns:
+        bool: True if user has permission, False otherwise
+    """
+    from plane.db.models import WorkspaceMember
+
+    project_member = ProjectMember.objects.filter(
+        workspace__slug=slug,
+        project_id=project_id,
+        member_id=user_id,
+        role__gte=required_role,
+        is_active=True,
+    ).exists()
+
+    if project_member:
+        return True
+
+    workspace_admin = (
+        ProjectMember.objects.filter(
+            workspace__slug=slug,
+            project_id=project_id,
+            member_id=user_id,
+            is_active=True,
+        ).exists()
+        and WorkspaceMember.objects.filter(
+            workspace__slug=slug,
+            member_id=user_id,
+            role=20,
+            is_active=True,
+        ).exists()
+    )
+
+    return workspace_admin
+
+
 def transfer_issue(
     slug,
     source_project_id,
@@ -70,6 +114,12 @@ def transfer_issue(
     """
     try:
         with transaction.atomic():
+            if not check_user_project_permission(slug, target_project_id, user_id):
+                return {
+                    "success": False,
+                    "error": "You do not have permission to transfer issues to the target project",
+                }
+
             target_project = Project.objects.filter(
                 workspace__slug=slug,
                 pk=target_project_id,
@@ -450,6 +500,7 @@ def bulk_transfer_issues(
     """
     results = []
     success_count = 0
+    transferred_issues = []
     errors = []
 
     for issue_id in issue_ids:
@@ -464,6 +515,7 @@ def bulk_transfer_issues(
         results.append(result)
         if result.get("success"):
             success_count += 1
+            transferred_issues.append(result.get("issue_id", issue_id))
         else:
             errors.append(
                 {
@@ -476,6 +528,8 @@ def bulk_transfer_issues(
         "success": success_count == len(issue_ids),
         "total": len(issue_ids),
         "success_count": success_count,
+        "transferred_count": success_count,
+        "transferred_issues": transferred_issues,
         "errors": errors,
         "results": results,
     }

--- a/apps/web/core/components/issues/issue-detail/root.tsx
+++ b/apps/web/core/components/issues/issue-detail/root.tsx
@@ -33,6 +33,12 @@ export type TIssueOperations = {
   remove: (workspaceSlug: string, projectId: string, issueId: string) => Promise<void>;
   archive?: (workspaceSlug: string, projectId: string, issueId: string) => Promise<void>;
   restore?: (workspaceSlug: string, projectId: string, issueId: string) => Promise<void>;
+  transfer?: (
+    workspaceSlug: string,
+    sourceProjectId: string,
+    targetProjectId: string,
+    data: { issue_ids: string[] }
+  ) => Promise<void>;
   addCycleToIssue?: (workspaceSlug: string, projectId: string, cycleId: string, issueId: string) => Promise<void>;
   addIssueToCycle?: (workspaceSlug: string, projectId: string, cycleId: string, issueIds: string[]) => Promise<void>;
   removeIssueFromCycle?: (workspaceSlug: string, projectId: string, cycleId: string, issueId: string) => Promise<void>;
@@ -70,6 +76,7 @@ export const IssueDetailRoot = observer(function IssueDetailRoot(props: TIssueDe
     updateIssue,
     removeIssue,
     archiveIssue,
+    transferIssue,
     addCycleToIssue,
     addIssueToCycle,
     removeIssueFromCycle,
@@ -126,6 +133,18 @@ export const IssueDetailRoot = observer(function IssueDetailRoot(props: TIssueDe
           await archiveIssue(workspaceSlug, projectId, issueId);
         } catch (error) {
           console.log("Error in archiving issue:", error);
+        }
+      },
+      transfer: async (
+        workspaceSlug: string,
+        sourceProjectId: string,
+        targetProjectId: string,
+        data: { issue_ids: string[] }
+      ) => {
+        try {
+          await transferIssue(workspaceSlug, sourceProjectId, targetProjectId, data);
+        } catch (error) {
+          console.log("Error in transferring issue:", error);
         }
       },
       addCycleToIssue: async (workspaceSlug: string, projectId: string, cycleId: string, issueId: string) => {
@@ -205,6 +224,7 @@ export const IssueDetailRoot = observer(function IssueDetailRoot(props: TIssueDe
       updateIssue,
       removeIssue,
       archiveIssue,
+      transferIssue,
       removeArchivedIssue,
       addIssueToCycle,
       addCycleToIssue,

--- a/apps/web/core/components/issues/issue-layouts/quick-action-dropdowns/all-issue.tsx
+++ b/apps/web/core/components/issues/issue-layouts/quick-action-dropdowns/all-issue.tsx
@@ -143,6 +143,7 @@ export const AllIssueQuickActions = observer(function AllIssueQuickActions(props
           handleClose={() => setTransferToProjectModal(false)}
           issueIds={[issue.id]}
           sourceProjectId={issue.project_id}
+          storeType={EIssuesStoreType.GLOBAL}
         />
       )}
 

--- a/apps/web/core/components/issues/issue-layouts/quick-action-dropdowns/all-issue.tsx
+++ b/apps/web/core/components/issues/issue-layouts/quick-action-dropdowns/all-issue.tsx
@@ -23,6 +23,7 @@ import { DuplicateWorkItemModal } from "@/plane-web/components/issues/issue-layo
 import { ArchiveIssueModal } from "../../archive-issue-modal";
 import { DeleteIssueModal } from "../../delete-issue-modal";
 import { CreateUpdateIssueModal } from "../../issue-modal/modal";
+import { TransferIssueToProjectModal } from "../../transfer-issue-to-project-modal";
 import type { IQuickActionProps } from "../list/list-view-types";
 import type { MenuItemFactoryProps } from "./helper";
 import { useAllIssueMenuItems } from "./helper";
@@ -45,6 +46,7 @@ export const AllIssueQuickActions = observer(function AllIssueQuickActions(props
   const [deleteIssueModal, setDeleteIssueModal] = useState(false);
   const [archiveIssueModal, setArchiveIssueModal] = useState(false);
   const [duplicateWorkItemModal, setDuplicateWorkItemModal] = useState(false);
+  const [transferToProjectModal, setTransferToProjectModal] = useState(false);
   // router
   const { workspaceSlug } = useParams();
   const { getStateById } = useProjectState();
@@ -81,6 +83,7 @@ export const AllIssueQuickActions = observer(function AllIssueQuickActions(props
     setDeleteIssueModal,
     setArchiveIssueModal,
     setDuplicateWorkItemModal,
+    setTransferToProjectModal,
     handleDelete,
     handleUpdate,
     handleArchive,
@@ -132,6 +135,14 @@ export const AllIssueQuickActions = observer(function AllIssueQuickActions(props
           onClose={() => setDuplicateWorkItemModal(false)}
           workspaceSlug={workspaceSlug.toString()}
           projectId={issue.project_id}
+        />
+      )}
+      {issue.project_id && workspaceSlug && (
+        <TransferIssueToProjectModal
+          isOpen={transferToProjectModal}
+          handleClose={() => setTransferToProjectModal(false)}
+          issueIds={[issue.id]}
+          sourceProjectId={issue.project_id}
         />
       )}
 

--- a/apps/web/core/components/issues/issue-layouts/quick-action-dropdowns/cycle-issue.tsx
+++ b/apps/web/core/components/issues/issue-layouts/quick-action-dropdowns/cycle-issue.tsx
@@ -156,6 +156,7 @@ export const CycleIssueQuickActions = observer(function CycleIssueQuickActions(p
           handleClose={() => setTransferToProjectModal(false)}
           issueIds={[issue.id]}
           sourceProjectId={issue.project_id}
+          storeType={EIssuesStoreType.CYCLE}
         />
       )}
 

--- a/apps/web/core/components/issues/issue-layouts/quick-action-dropdowns/cycle-issue.tsx
+++ b/apps/web/core/components/issues/issue-layouts/quick-action-dropdowns/cycle-issue.tsx
@@ -26,6 +26,7 @@ import { DuplicateWorkItemModal } from "@/plane-web/components/issues/issue-layo
 import { ArchiveIssueModal } from "../../archive-issue-modal";
 import { DeleteIssueModal } from "../../delete-issue-modal";
 import { CreateUpdateIssueModal } from "../../issue-modal/modal";
+import { TransferIssueToProjectModal } from "../../transfer-issue-to-project-modal";
 import type { IQuickActionProps } from "../list/list-view-types";
 import type { MenuItemFactoryProps } from "./helper";
 import { useCycleIssueMenuItems } from "./helper";
@@ -49,6 +50,7 @@ export const CycleIssueQuickActions = observer(function CycleIssueQuickActions(p
   const [deleteIssueModal, setDeleteIssueModal] = useState(false);
   const [archiveIssueModal, setArchiveIssueModal] = useState(false);
   const [duplicateWorkItemModal, setDuplicateWorkItemModal] = useState(false);
+  const [transferToProjectModal, setTransferToProjectModal] = useState(false);
   // router
   const { workspaceSlug, cycleId } = useParams();
   const { issuesFilter } = useIssues(EIssuesStoreType.CYCLE);
@@ -91,6 +93,7 @@ export const CycleIssueQuickActions = observer(function CycleIssueQuickActions(p
     setDeleteIssueModal,
     setArchiveIssueModal,
     setDuplicateWorkItemModal,
+    setTransferToProjectModal,
     handleRemoveFromView,
     cycleId: cycleId?.toString(),
     handleDelete,
@@ -145,6 +148,14 @@ export const CycleIssueQuickActions = observer(function CycleIssueQuickActions(p
           onClose={() => setDuplicateWorkItemModal(false)}
           workspaceSlug={workspaceSlug.toString()}
           projectId={issue.project_id}
+        />
+      )}
+      {issue.project_id && workspaceSlug && (
+        <TransferIssueToProjectModal
+          isOpen={transferToProjectModal}
+          handleClose={() => setTransferToProjectModal(false)}
+          issueIds={[issue.id]}
+          sourceProjectId={issue.project_id}
         />
       )}
 

--- a/apps/web/core/components/issues/issue-layouts/quick-action-dropdowns/helper.tsx
+++ b/apps/web/core/components/issues/issue-layouts/quick-action-dropdowns/helper.tsx
@@ -5,7 +5,7 @@
  */
 
 import { useMemo } from "react";
-import { XCircle, ArchiveRestoreIcon } from "lucide-react";
+import { XCircle, ArchiveRestoreIcon, MoveRight } from "lucide-react";
 // plane imports
 import { useTranslation } from "@plane/i18n";
 import { LinkIcon, CopyIcon, NewTabIcon, EditIcon, ArchiveIcon, TrashIcon } from "@plane/propel/icons";
@@ -68,6 +68,7 @@ export interface MenuItemFactoryProps {
   setDeleteIssueModal: (open: boolean) => void;
   setArchiveIssueModal?: (open: boolean) => void;
   setDuplicateWorkItemModal?: (open: boolean) => void;
+  setTransferToProjectModal?: (open: boolean) => void;
   handleRemoveFromView?: () => void;
   handleRestore?: () => Promise<void>;
   // External handlers
@@ -251,6 +252,14 @@ export const useMenuItemFactory = (props: MenuItemFactoryProps) => {
     shouldRender: isDeletingAllowed,
   });
 
+  const createTransferToProjectMenuItem = (): TContextMenuItem => ({
+    key: "transfer-to-project",
+    title: "Move to project",
+    icon: MoveRight,
+    action: () => handleOptionalAction(props.setTransferToProjectModal, "Move to project", true),
+    shouldRender: isEditingAllowed && (issueTypeDetail?.is_active ?? true),
+  });
+
   return {
     ...actionHandlers,
     createEditMenuItem,
@@ -262,6 +271,7 @@ export const useMenuItemFactory = (props: MenuItemFactoryProps) => {
     createArchiveMenuItem,
     createRestoreMenuItem,
     createDeleteMenuItem,
+    createTransferToProjectMenuItem,
   };
 };
 
@@ -275,6 +285,7 @@ export const useProjectIssueMenuItems = (props: MenuItemFactoryProps): TContextM
       factory.createCopyMenuItem(),
       factory.createOpenInNewTabMenuItem(),
       factory.createCopyLinkMenuItem(),
+      factory.createTransferToProjectMenuItem(),
       factory.createArchiveMenuItem(),
       factory.createDeleteMenuItem(),
     ],
@@ -289,6 +300,7 @@ export const useWorkItemDetailMenuItems = (props: MenuItemFactoryProps): TContex
     () => [
       factory.createCopyMenuItem(props.workspaceSlug),
       factory.createOpenInNewTabMenuItem(),
+      factory.createTransferToProjectMenuItem(),
       factory.createArchiveMenuItem(),
       factory.createRestoreMenuItem(),
       factory.createDeleteMenuItem(),
@@ -306,6 +318,7 @@ export const useAllIssueMenuItems = (props: MenuItemFactoryProps): TContextMenuI
       factory.createCopyMenuItem(),
       factory.createOpenInNewTabMenuItem(),
       factory.createCopyLinkMenuItem(),
+      factory.createTransferToProjectMenuItem(),
       factory.createArchiveMenuItem(),
       factory.createDeleteMenuItem(),
     ],
@@ -331,6 +344,7 @@ export const useCycleIssueMenuItems = (props: MenuItemFactoryProps): TContextMen
       factory.createOpenInNewTabMenuItem(),
       factory.createCopyLinkMenuItem(),
       factory.createRemoveFromCycleMenuItem(),
+      factory.createTransferToProjectMenuItem(),
       factory.createArchiveMenuItem(),
       factory.createDeleteMenuItem(),
     ],
@@ -356,6 +370,7 @@ export const useModuleIssueMenuItems = (props: MenuItemFactoryProps): TContextMe
       factory.createOpenInNewTabMenuItem(),
       factory.createCopyLinkMenuItem(),
       factory.createRemoveFromModuleMenuItem(),
+      factory.createTransferToProjectMenuItem(),
       factory.createArchiveMenuItem(),
       factory.createDeleteMenuItem(),
     ],

--- a/apps/web/core/components/issues/issue-layouts/quick-action-dropdowns/issue-detail.tsx
+++ b/apps/web/core/components/issues/issue-layouts/quick-action-dropdowns/issue-detail.tsx
@@ -26,6 +26,7 @@ import { DuplicateWorkItemModal } from "@/plane-web/components/issues/issue-layo
 import { ArchiveIssueModal } from "../../archive-issue-modal";
 import { DeleteIssueModal } from "../../delete-issue-modal";
 import { CreateUpdateIssueModal } from "../../issue-modal/modal";
+import { TransferIssueToProjectModal } from "../../transfer-issue-to-project-modal";
 import type { IQuickActionProps } from "../list/list-view-types";
 import type { MenuItemFactoryProps } from "./helper";
 import { useWorkItemDetailMenuItems } from "./helper";
@@ -36,6 +37,7 @@ type TWorkItemDetailQuickActionProps = IQuickActionProps & {
   toggleDeleteIssueModal?: (value: boolean) => void;
   toggleDuplicateIssueModal?: (value: boolean) => void;
   toggleArchiveIssueModal?: (value: boolean) => void;
+  toggleTransferIssueModal?: (value: boolean) => void;
   isPeekMode?: boolean;
 };
 
@@ -56,6 +58,7 @@ export const WorkItemDetailQuickActions = observer(function WorkItemDetailQuickA
     toggleDeleteIssueModal,
     toggleDuplicateIssueModal,
     toggleArchiveIssueModal,
+    toggleTransferIssueModal,
     isPeekMode = false,
   } = props;
   // router
@@ -66,6 +69,7 @@ export const WorkItemDetailQuickActions = observer(function WorkItemDetailQuickA
   const [deleteIssueModal, setDeleteIssueModal] = useState(false);
   const [archiveIssueModal, setArchiveIssueModal] = useState(false);
   const [duplicateWorkItemModal, setDuplicateWorkItemModal] = useState(false);
+  const [transferToProjectModal, setTransferToProjectModal] = useState(false);
   // store hooks
   const { allowPermissions } = useUserPermissions();
   const { issuesFilter } = useIssues(EIssuesStoreType.PROJECT);
@@ -121,6 +125,11 @@ export const WorkItemDetailQuickActions = observer(function WorkItemDetailQuickA
     if (toggleArchiveIssueModal) toggleArchiveIssueModal(true);
   };
 
+  const customTransferAction = async () => {
+    setTransferToProjectModal(true);
+    if (toggleTransferIssueModal) toggleTransferIssueModal(true);
+  };
+
   const customRestoreAction = async () => {
     if (handleRestore) await handleRestore();
   };
@@ -141,6 +150,7 @@ export const WorkItemDetailQuickActions = observer(function WorkItemDetailQuickA
     setDeleteIssueModal: customDeleteAction,
     setArchiveIssueModal: customArchiveAction,
     setDuplicateWorkItemModal: customDuplicateAction,
+    setTransferToProjectModal: customTransferAction,
     handleDelete: customDeleteAction,
     handleUpdate,
     handleArchive: customArchiveAction,
@@ -234,6 +244,17 @@ export const WorkItemDetailQuickActions = observer(function WorkItemDetailQuickA
           }}
           workspaceSlug={workspaceSlug.toString()}
           projectId={issue.project_id}
+        />
+      )}
+      {issue.project_id && workspaceSlug && (
+        <TransferIssueToProjectModal
+          isOpen={transferToProjectModal}
+          handleClose={() => {
+            setTransferToProjectModal(false);
+            if (toggleTransferIssueModal) toggleTransferIssueModal(false);
+          }}
+          issueIds={[issue.id]}
+          sourceProjectId={issue.project_id}
         />
       )}
 

--- a/apps/web/core/components/issues/issue-layouts/quick-action-dropdowns/issue-detail.tsx
+++ b/apps/web/core/components/issues/issue-layouts/quick-action-dropdowns/issue-detail.tsx
@@ -255,6 +255,7 @@ export const WorkItemDetailQuickActions = observer(function WorkItemDetailQuickA
           }}
           issueIds={[issue.id]}
           sourceProjectId={issue.project_id}
+          storeType={EIssuesStoreType.PROJECT}
         />
       )}
 

--- a/apps/web/core/components/issues/issue-layouts/quick-action-dropdowns/module-issue.tsx
+++ b/apps/web/core/components/issues/issue-layouts/quick-action-dropdowns/module-issue.tsx
@@ -155,6 +155,7 @@ export const ModuleIssueQuickActions = observer(function ModuleIssueQuickActions
           handleClose={() => setTransferToProjectModal(false)}
           issueIds={[issue.id]}
           sourceProjectId={issue.project_id}
+          storeType={EIssuesStoreType.MODULE}
         />
       )}
 

--- a/apps/web/core/components/issues/issue-layouts/quick-action-dropdowns/module-issue.tsx
+++ b/apps/web/core/components/issues/issue-layouts/quick-action-dropdowns/module-issue.tsx
@@ -25,6 +25,7 @@ import { DuplicateWorkItemModal } from "@/plane-web/components/issues/issue-layo
 import { ArchiveIssueModal } from "../../archive-issue-modal";
 import { DeleteIssueModal } from "../../delete-issue-modal";
 import { CreateUpdateIssueModal } from "../../issue-modal/modal";
+import { TransferIssueToProjectModal } from "../../transfer-issue-to-project-modal";
 import type { IQuickActionProps } from "../list/list-view-types";
 import type { MenuItemFactoryProps } from "./helper";
 import { useModuleIssueMenuItems } from "./helper";
@@ -48,6 +49,7 @@ export const ModuleIssueQuickActions = observer(function ModuleIssueQuickActions
   const [deleteIssueModal, setDeleteIssueModal] = useState(false);
   const [archiveIssueModal, setArchiveIssueModal] = useState(false);
   const [duplicateWorkItemModal, setDuplicateWorkItemModal] = useState(false);
+  const [transferToProjectModal, setTransferToProjectModal] = useState(false);
   // router
   const { workspaceSlug, moduleId } = useParams();
   // store hooks
@@ -91,6 +93,7 @@ export const ModuleIssueQuickActions = observer(function ModuleIssueQuickActions
     setDeleteIssueModal,
     setArchiveIssueModal,
     setDuplicateWorkItemModal,
+    setTransferToProjectModal,
     handleRemoveFromView,
     moduleId: moduleId?.toString(),
     handleDelete,
@@ -144,6 +147,14 @@ export const ModuleIssueQuickActions = observer(function ModuleIssueQuickActions
           onClose={() => setDuplicateWorkItemModal(false)}
           workspaceSlug={workspaceSlug.toString()}
           projectId={issue.project_id}
+        />
+      )}
+      {issue.project_id && workspaceSlug && (
+        <TransferIssueToProjectModal
+          isOpen={transferToProjectModal}
+          handleClose={() => setTransferToProjectModal(false)}
+          issueIds={[issue.id]}
+          sourceProjectId={issue.project_id}
         />
       )}
 

--- a/apps/web/core/components/issues/issue-layouts/quick-action-dropdowns/project-issue.tsx
+++ b/apps/web/core/components/issues/issue-layouts/quick-action-dropdowns/project-issue.tsx
@@ -157,6 +157,7 @@ export const ProjectIssueQuickActions = observer(function ProjectIssueQuickActio
           handleClose={() => setTransferToProjectModal(false)}
           issueIds={[issue.id]}
           sourceProjectId={issue.project_id}
+          storeType={EIssuesStoreType.PROJECT}
         />
       )}
 

--- a/apps/web/core/components/issues/issue-layouts/quick-action-dropdowns/project-issue.tsx
+++ b/apps/web/core/components/issues/issue-layouts/quick-action-dropdowns/project-issue.tsx
@@ -25,6 +25,7 @@ import { DuplicateWorkItemModal } from "@/plane-web/components/issues/issue-layo
 import { ArchiveIssueModal } from "../../archive-issue-modal";
 import { DeleteIssueModal } from "../../delete-issue-modal";
 import { CreateUpdateIssueModal } from "../../issue-modal/modal";
+import { TransferIssueToProjectModal } from "../../transfer-issue-to-project-modal";
 import type { IQuickActionProps } from "../list/list-view-types";
 import type { MenuItemFactoryProps } from "./helper";
 import { useProjectIssueMenuItems } from "./helper";
@@ -49,6 +50,7 @@ export const ProjectIssueQuickActions = observer(function ProjectIssueQuickActio
   const [deleteIssueModal, setDeleteIssueModal] = useState(false);
   const [archiveIssueModal, setArchiveIssueModal] = useState(false);
   const [duplicateWorkItemModal, setDuplicateWorkItemModal] = useState(false);
+  const [transferToProjectModal, setTransferToProjectModal] = useState(false);
   // store hooks
   const { allowPermissions } = useUserPermissions();
   const { issuesFilter } = useIssues(EIssuesStoreType.PROJECT);
@@ -94,6 +96,7 @@ export const ProjectIssueQuickActions = observer(function ProjectIssueQuickActio
     setDeleteIssueModal,
     setArchiveIssueModal,
     setDuplicateWorkItemModal,
+    setTransferToProjectModal,
     handleDelete,
     handleUpdate,
     handleArchive,
@@ -146,6 +149,14 @@ export const ProjectIssueQuickActions = observer(function ProjectIssueQuickActio
           onClose={() => setDuplicateWorkItemModal(false)}
           workspaceSlug={workspaceSlug.toString()}
           projectId={issue.project_id}
+        />
+      )}
+      {issue.project_id && workspaceSlug && (
+        <TransferIssueToProjectModal
+          isOpen={transferToProjectModal}
+          handleClose={() => setTransferToProjectModal(false)}
+          issueIds={[issue.id]}
+          sourceProjectId={issue.project_id}
         />
       )}
 

--- a/apps/web/core/components/issues/transfer-issue-to-project-modal.tsx
+++ b/apps/web/core/components/issues/transfer-issue-to-project-modal.tsx
@@ -1,0 +1,160 @@
+/**
+ * Copyright (c) 2023-present Plane Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { useState } from "react";
+import { observer } from "mobx-react";
+import { useParams } from "next/navigation";
+import { AlertCircle, Search, MoveRight } from "lucide-react";
+import { SearchIcon, ProjectIcon, CloseIcon } from "@plane/propel/icons";
+import { TOAST_TYPE, setPromiseToast, setToast } from "@plane/propel/toast";
+import { EIssuesStoreType } from "@plane/types";
+import { EModalPosition, EModalWidth, ModalCore } from "@plane/ui";
+import { useIssues } from "@/hooks/store/use-issues";
+import { useProject } from "@/hooks/store/use-project";
+
+type Props = {
+  isOpen: boolean;
+  handleClose: () => void;
+  issueIds: string[];
+  sourceProjectId: string;
+  onSuccess?: () => void;
+};
+
+export const TransferIssueToProjectModal = observer(function TransferIssueToProjectModal(props: Props) {
+  const { isOpen, handleClose, issueIds, sourceProjectId, onSuccess } = props;
+  const [query, setQuery] = useState("");
+
+  const { workspaceSlug } = useParams();
+  const { joinedProjectIds, getProjectById } = useProject();
+  const { issues } = useIssues(EIssuesStoreType.PROJECT);
+
+  const availableProjectIds = joinedProjectIds?.filter((id) => id !== sourceProjectId) ?? [];
+
+  const filteredOptions = availableProjectIds.filter((projectId) => {
+    const projectDetails = getProjectById(projectId);
+    if (!projectDetails) return false;
+    return query === "" || projectDetails.name?.toLowerCase().includes(query?.toLowerCase());
+  });
+
+  const handleTransfer = async (targetProjectId: string) => {
+    if (!workspaceSlug || !sourceProjectId || issueIds.length === 0) return;
+
+    const targetProject = getProjectById(targetProjectId);
+    const isMultiple = issueIds.length > 1;
+
+    const transferPromise = isMultiple
+      ? issues.bulkTransferIssues(
+          workspaceSlug.toString(),
+          sourceProjectId,
+          targetProjectId,
+          issueIds
+        )
+      : issues.transferIssue(
+          workspaceSlug.toString(),
+          sourceProjectId,
+          targetProjectId,
+          issueIds[0]
+        );
+
+    setPromiseToast(transferPromise, {
+      loading: isMultiple
+        ? `Moving ${issueIds.length} work items to ${targetProject?.name}...`
+        : `Moving work item to ${targetProject?.name}...`,
+      success: {
+        title: "Success!",
+        message: () =>
+          isMultiple
+            ? `${issueIds.length} work items moved to ${targetProject?.name} successfully`
+            : `Work item moved to ${targetProject?.name} successfully`,
+      },
+      error: {
+        title: "Error!",
+        message: () =>
+          isMultiple
+            ? `Unable to move work items to ${targetProject?.name}. Please try again.`
+            : `Unable to move work item to ${targetProject?.name}. Please try again.`,
+      },
+    });
+
+    try {
+      const response = await transferPromise;
+      if (response.success) {
+        handleClose();
+        onSuccess?.();
+      }
+    } catch (error) {
+      console.error("Error transferring issues:", error);
+    }
+  };
+
+  return (
+    <ModalCore isOpen={isOpen} handleClose={handleClose} position={EModalPosition.TOP} width={EModalWidth.XXL}>
+      <div className="flex flex-col gap-4 py-5">
+        <div className="flex items-center justify-between px-5">
+          <div className="flex items-center gap-1">
+            <MoveRight className="w-5 fill-primary" />
+            <h4 className="text-18 font-medium text-primary">
+              Move {issueIds.length > 1 ? `${issueIds.length} work items` : "work item"} to project
+            </h4>
+          </div>
+          <button onClick={handleClose}>
+            <CloseIcon className="h-4 w-4" />
+          </button>
+        </div>
+        <div className="flex items-center gap-2 border-b border-subtle px-5 pb-3">
+          <SearchIcon className="h-4 w-4 text-secondary" />
+          <input
+            className="text-13 outline-none"
+            placeholder="Search for a project..."
+            onChange={(e) => setQuery(e.target.value)}
+            value={query}
+          />
+        </div>
+        <div className="flex w-full flex-col items-start gap-2 px-5">
+          {availableProjectIds.length > 0 ? (
+            filteredOptions.length > 0 ? (
+              filteredOptions.map((projectId) => {
+                const projectDetails = getProjectById(projectId);
+
+                if (!projectDetails) return null;
+
+                return (
+                  <button
+                    key={projectId}
+                    className="flex w-full items-center gap-4 rounded-sm px-4 py-3 text-13 text-secondary hover:bg-surface-2"
+                    onClick={() => handleTransfer(projectId)}
+                  >
+                    <ProjectIcon className="h-5 w-5" />
+                    <div className="flex w-full justify-between truncate">
+                      <span className="truncate">{projectDetails.name}</span>
+                      {projectDetails.identifier && (
+                        <span className="flex flex-shrink-0 items-center rounded-full bg-layer-1 px-2 capitalize">
+                          {projectDetails.identifier}
+                        </span>
+                      )}
+                    </div>
+                  </button>
+                );
+              })
+            ) : (
+              <div className="flex w-full items-center justify-center gap-4 p-5 text-13">
+                <AlertCircle className="h-3.5 w-3.5 text-secondary" />
+                <span className="text-center text-secondary">No matching projects found.</span>
+              </div>
+            )
+          ) : (
+            <div className="flex w-full items-center justify-center gap-4 p-5 text-13">
+              <AlertCircle className="h-3.5 w-3.5 text-secondary" />
+              <span className="text-center text-secondary">
+                You don't have access to any other projects to move work items to.
+              </span>
+            </div>
+          )}
+        </div>
+      </div>
+    </ModalCore>
+  );
+});

--- a/apps/web/core/components/issues/transfer-issue-to-project-modal.tsx
+++ b/apps/web/core/components/issues/transfer-issue-to-project-modal.tsx
@@ -20,16 +20,17 @@ type Props = {
   handleClose: () => void;
   issueIds: string[];
   sourceProjectId: string;
+  storeType?: EIssuesStoreType;
   onSuccess?: () => void;
 };
 
 export const TransferIssueToProjectModal = observer(function TransferIssueToProjectModal(props: Props) {
-  const { isOpen, handleClose, issueIds, sourceProjectId, onSuccess } = props;
+  const { isOpen, handleClose, issueIds, sourceProjectId, storeType = EIssuesStoreType.PROJECT, onSuccess } = props;
   const [query, setQuery] = useState("");
 
   const { workspaceSlug } = useParams();
   const { joinedProjectIds, getProjectById } = useProject();
-  const { issues } = useIssues(EIssuesStoreType.PROJECT);
+  const { issues } = useIssues(storeType);
 
   const availableProjectIds = joinedProjectIds?.filter((id) => id !== sourceProjectId) ?? [];
 

--- a/apps/web/core/services/issue/issue.service.ts
+++ b/apps/web/core/services/issue/issue.service.ts
@@ -374,6 +374,46 @@ export class IssueService extends APIService {
       });
   }
 
+  async transferIssue(
+    workspaceSlug: string,
+    projectId: string,
+    data: {
+      target_project_id: string;
+      issue_id: string;
+    }
+  ): Promise<{
+    success: boolean;
+    issue_id: string;
+    source_project_id: string;
+    target_project_id: string;
+  }> {
+    return this.post(`/api/workspaces/${workspaceSlug}/projects/${projectId}/transfer-issue/`, data)
+      .then(async (response) => response?.data)
+      .catch((error) => {
+        throw error?.response?.data;
+      });
+  }
+
+  async bulkTransferIssues(
+    workspaceSlug: string,
+    projectId: string,
+    data: {
+      target_project_id: string;
+      issue_ids: string[];
+    }
+  ): Promise<{
+    success: boolean;
+    transferred_count: number;
+    transferred_issues: string[];
+    errors: { issue_id: string; error: string }[];
+  }> {
+    return this.post(`/api/workspaces/${workspaceSlug}/projects/${projectId}/bulk-transfer-issues/`, data)
+      .then(async (response) => response?.data)
+      .catch((error) => {
+        throw error?.response?.data;
+      });
+  }
+
   // issue subscriptions
   async getIssueNotificationSubscriptionStatus(
     workspaceSlug: string,

--- a/apps/web/core/store/issue/helpers/base-issues.store.ts
+++ b/apps/web/core/store/issue/helpers/base-issues.store.ts
@@ -799,6 +799,12 @@ export abstract class BaseIssuesStore implements IBaseIssuesStore {
         this.removeIssueFromList(issueId);
         this.rootIssueStore.issues.removeIssue(issueId);
       });
+
+      try {
+        await this.issueService.retrieve(workspaceSlug, targetProjectId, issueId);
+      } catch (e) {
+        console.warn("Failed to fetch transferred issue details:", e);
+      }
     }
 
     return response;
@@ -832,6 +838,12 @@ export abstract class BaseIssuesStore implements IBaseIssuesStore {
           this.rootIssueStore.issues.removeIssue(issueId);
         });
       });
+
+      try {
+        await this.issueService.retrieveIssues(workspaceSlug, targetProjectId, transferredIssues);
+      } catch (e) {
+        console.warn("Failed to fetch transferred issues details:", e);
+      }
     }
 
     return response;

--- a/apps/web/core/store/issue/helpers/base-issues.store.ts
+++ b/apps/web/core/store/issue/helpers/base-issues.store.ts
@@ -110,6 +110,29 @@ export interface IBaseIssuesStore {
     removeModuleIds: string[]
   ): Promise<void>;
   updateIssueDates(workspaceSlug: string, updates: IBlockUpdateDependencyData[], projectId?: string): Promise<void>;
+
+  transferIssue: (
+    workspaceSlug: string,
+    sourceProjectId: string,
+    targetProjectId: string,
+    issueId: string
+  ) => Promise<{
+    success: boolean;
+    issue_id: string;
+    source_project_id: string;
+    target_project_id: string;
+  }>;
+  bulkTransferIssues: (
+    workspaceSlug: string,
+    sourceProjectId: string,
+    targetProjectId: string,
+    issueIds: string[]
+  ) => Promise<{
+    success: boolean;
+    transferred_count: number;
+    transferred_issues: string[];
+    errors: { issue_id: string; error: string }[];
+  }>;
 }
 
 // This constant maps the group by keys to the respective issue property that the key relies on
@@ -750,6 +773,68 @@ export abstract class BaseIssuesStore implements IBaseIssuesStore {
         this.updateIssueList(issueDetails, issueBeforeUpdate);
       });
     });
+  };
+
+  /**
+   * @description transfer a single issue to another project
+   * @param workspaceSlug
+   * @param sourceProjectId
+   * @param targetProjectId
+   * @param issueId
+   */
+  transferIssue = async (
+    workspaceSlug: string,
+    sourceProjectId: string,
+    targetProjectId: string,
+    issueId: string
+  ) => {
+    const response = await this.issueService.transferIssue(workspaceSlug, sourceProjectId, {
+      target_project_id: targetProjectId,
+      issue_id: issueId,
+    });
+
+    if (response.success) {
+      this.fetchParentStats(workspaceSlug, sourceProjectId);
+      runInAction(() => {
+        this.removeIssueFromList(issueId);
+        this.rootIssueStore.issues.removeIssue(issueId);
+      });
+    }
+
+    return response;
+  };
+
+  /**
+   * @description transfer multiple issues to another project
+   * @param workspaceSlug
+   * @param sourceProjectId
+   * @param targetProjectId
+   * @param issueIds
+   */
+  bulkTransferIssues = async (
+    workspaceSlug: string,
+    sourceProjectId: string,
+    targetProjectId: string,
+    issueIds: string[]
+  ) => {
+    const response = await this.issueService.bulkTransferIssues(workspaceSlug, sourceProjectId, {
+      target_project_id: targetProjectId,
+      issue_ids: issueIds,
+    });
+
+    const transferredIssues = response.transferred_issues || [];
+
+    if (transferredIssues.length > 0) {
+      this.fetchParentStats(workspaceSlug, sourceProjectId);
+      runInAction(() => {
+        transferredIssues.forEach((issueId) => {
+          this.removeIssueFromList(issueId);
+          this.rootIssueStore.issues.removeIssue(issueId);
+        });
+      });
+    }
+
+    return response;
   };
 
   async updateIssueDates(

--- a/apps/web/core/store/issue/helpers/base-issues.store.ts
+++ b/apps/web/core/store/issue/helpers/base-issues.store.ts
@@ -776,6 +776,50 @@ export abstract class BaseIssuesStore implements IBaseIssuesStore {
   };
 
   /**
+   * @description Helper method to remove an issue from all relevant stores
+   * This ensures that when an issue is transferred, it's removed from all views that might contain it
+   * @param issueId
+   */
+  removeIssueFromAllRelevantStores = (issueId: string) => {
+    runInAction(() => {
+      this.removeIssueFromList(issueId);
+      this.rootIssueStore.issues.removeIssue(issueId);
+
+      if (this.rootIssueStore.projectIssues) {
+        this.rootIssueStore.projectIssues.removeIssueFromList(issueId);
+      }
+      if (this.rootIssueStore.cycleIssues) {
+        this.rootIssueStore.cycleIssues.removeIssueFromList(issueId);
+      }
+      if (this.rootIssueStore.moduleIssues) {
+        this.rootIssueStore.moduleIssues.removeIssueFromList(issueId);
+      }
+      if (this.rootIssueStore.workspaceIssues) {
+        this.rootIssueStore.workspaceIssues.removeIssueFromList(issueId);
+      }
+      if (this.rootIssueStore.profileIssues) {
+        this.rootIssueStore.profileIssues.removeIssueFromList(issueId);
+      }
+      if (this.rootIssueStore.projectViewIssues) {
+        this.rootIssueStore.projectViewIssues.removeIssueFromList(issueId);
+      }
+      if (this.rootIssueStore.archivedIssues) {
+        this.rootIssueStore.archivedIssues.removeIssueFromList(issueId);
+      }
+    });
+  };
+
+  /**
+   * @description Helper method to add fetched issues to the global issue map
+   * @param issues
+   */
+  addFetchedIssuesToStore = (issues: TIssue[]) => {
+    runInAction(() => {
+      this.rootIssueStore.issues.addIssue(issues);
+    });
+  };
+
+  /**
    * @description transfer a single issue to another project
    * @param workspaceSlug
    * @param sourceProjectId
@@ -795,13 +839,13 @@ export abstract class BaseIssuesStore implements IBaseIssuesStore {
 
     if (response.success) {
       this.fetchParentStats(workspaceSlug, sourceProjectId);
-      runInAction(() => {
-        this.removeIssueFromList(issueId);
-        this.rootIssueStore.issues.removeIssue(issueId);
-      });
+      this.removeIssueFromAllRelevantStores(issueId);
 
       try {
-        await this.issueService.retrieve(workspaceSlug, targetProjectId, issueId);
+        const transferredIssue = await this.issueService.retrieve(workspaceSlug, targetProjectId, issueId);
+        if (transferredIssue) {
+          this.addFetchedIssuesToStore([transferredIssue]);
+        }
       } catch (e) {
         console.warn("Failed to fetch transferred issue details:", e);
       }
@@ -834,13 +878,19 @@ export abstract class BaseIssuesStore implements IBaseIssuesStore {
       this.fetchParentStats(workspaceSlug, sourceProjectId);
       runInAction(() => {
         transferredIssues.forEach((issueId) => {
-          this.removeIssueFromList(issueId);
-          this.rootIssueStore.issues.removeIssue(issueId);
+          this.removeIssueFromAllRelevantStores(issueId);
         });
       });
 
       try {
-        await this.issueService.retrieveIssues(workspaceSlug, targetProjectId, transferredIssues);
+        const transferredIssuesDetails = await this.issueService.retrieveIssues(
+          workspaceSlug,
+          targetProjectId,
+          transferredIssues
+        );
+        if (transferredIssuesDetails && transferredIssuesDetails.length > 0) {
+          this.addFetchedIssuesToStore(transferredIssuesDetails);
+        }
       } catch (e) {
         console.warn("Failed to fetch transferred issues details:", e);
       }

--- a/apps/web/core/store/issue/issue-details/issue.store.ts
+++ b/apps/web/core/store/issue/issue-details/issue.store.ts
@@ -20,6 +20,12 @@ export interface IIssueStoreActions {
   updateIssue: (workspaceSlug: string, projectId: string, issueId: string, data: Partial<TIssue>) => Promise<void>;
   removeIssue: (workspaceSlug: string, projectId: string, issueId: string) => Promise<void>;
   archiveIssue: (workspaceSlug: string, projectId: string, issueId: string) => Promise<void>;
+  transferIssue: (
+    workspaceSlug: string,
+    sourceProjectId: string,
+    targetProjectId: string,
+    data: { issue_ids: string[] }
+  ) => Promise<void>;
   addCycleToIssue: (workspaceSlug: string, projectId: string, cycleId: string, issueId: string) => Promise<void>;
   addIssueToCycle: (workspaceSlug: string, projectId: string, cycleId: string, issueIds: string[]) => Promise<void>;
   removeIssueFromCycle: (workspaceSlug: string, projectId: string, cycleId: string, issueId: string) => Promise<void>;
@@ -204,6 +210,19 @@ export class IssueStore implements IIssueStore {
         ? this.rootIssueDetailStore.rootIssueStore.projectEpics
         : this.rootIssueDetailStore.rootIssueStore.projectIssues;
     currentStore.archiveIssue(workspaceSlug, projectId, issueId);
+  };
+
+  transferIssue = async (
+    workspaceSlug: string,
+    sourceProjectId: string,
+    targetProjectId: string,
+    data: { issue_ids: string[] }
+  ) => {
+    const currentStore =
+      this.serviceType === EIssueServiceType.EPICS
+        ? this.rootIssueDetailStore.rootIssueStore.projectEpics
+        : this.rootIssueDetailStore.rootIssueStore.projectIssues;
+    await currentStore.transferIssue(workspaceSlug, sourceProjectId, targetProjectId, data);
   };
 
   addCycleToIssue = async (workspaceSlug: string, projectId: string, cycleId: string, issueId: string) => {

--- a/apps/web/core/store/issue/issue-details/root.store.ts
+++ b/apps/web/core/store/issue/issue-details/root.store.ts
@@ -280,6 +280,12 @@ export abstract class IssueDetail implements IIssueDetail {
     this.issue.removeIssue(workspaceSlug, projectId, issueId);
   archiveIssue = async (workspaceSlug: string, projectId: string, issueId: string) =>
     this.issue.archiveIssue(workspaceSlug, projectId, issueId);
+  transferIssue = async (
+    workspaceSlug: string,
+    sourceProjectId: string,
+    targetProjectId: string,
+    data: { issue_ids: string[] }
+  ) => this.issue.transferIssue(workspaceSlug, sourceProjectId, targetProjectId, data);
   addCycleToIssue = async (workspaceSlug: string, projectId: string, cycleId: string, issueId: string) =>
     this.issue.addCycleToIssue(workspaceSlug, projectId, cycleId, issueId);
   addIssueToCycle = async (workspaceSlug: string, projectId: string, cycleId: string, issueIds: string[]) =>


### PR DESCRIPTION
本轮继续修复跨项目移动issue后的前端状态同步：TransferIssueToProjectModal支持传入storeType，各入口按project/cycle/module/global传递对应store；迁移成功后从多个相关issue store中移除旧issue，并重新获取目标项目中的issue详情写入全局issue map，减少源视图残留。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now transfer individual or multiple issues to different projects within the same workspace
  * New "Transfer to project" quick-action option available across all issue views
  * Dedicated transfer modal enables easy selection of target projects
  * Issue states, labels, and related data are automatically mapped during transfer

<!-- end of auto-generated comment: release notes by coderabbit.ai -->