### PR TITLE
fix(api): drop duplicate {bucket}/{key} conditions from presigned-POST policy

### DIFF
--- a/apps/api/plane/settings/storage.py
+++ b/apps/api/plane/settings/storage.py
@@ -79,11 +79,13 @@ class S3Storage(S3Boto3Storage):
             {"Content-Type": file_type},
         ]
 
-        # Add condition for the object name (key)
+        # For prefix uploads (`${filename}` placeholder) we still need a
+        # `starts-with` condition; boto3 cannot derive that from `Key=`.
+        # For exact-key uploads, `Key=<value>` below also makes boto3 add
+        # `"key": <value>` to the returned `fields[]` automatically — no
+        # manual injection needed.
         if object_name.startswith("${filename}"):
             conditions.append(["starts-with", "$key", object_name[: -len("${filename}")]])
-        else:
-            fields["key"] = object_name
 
         # Generate the presigned POST URL
         try:

--- a/apps/api/plane/settings/storage.py
+++ b/apps/api/plane/settings/storage.py
@@ -68,24 +68,18 @@ class S3Storage(S3Boto3Storage):
             expiration = self.signed_url_expiration
         fields = {"Content-Type": file_type}
 
-        # boto3.generate_presigned_post auto-injects {"bucket": ...} and
-        # {"key": ...} conditions when Bucket=/Key= are passed below; do NOT
-        # also add them by hand here. AWS S3 silently accepts the resulting
-        # over-sized policy, but stricter S3-compatible backends enforce a
-        # hard cap on the `policy` form field (some as low as 1024 bytes)
-        # and reject the upload with `MaxMessageLengthExceeded`.
+        # boto3.generate_presigned_post derives every key-related condition
+        # itself: it injects {"bucket": ...}, {"key": <value>}, and (when
+        # `Key` ends with the literal "${filename}" placeholder) the
+        # corresponding ["starts-with", "$key", <prefix>] entry. Do NOT add
+        # any of them by hand here — AWS S3 silently accepts the resulting
+        # duplicates, but stricter S3-compatible backends enforce a hard
+        # cap on the `policy` form field (some as low as 1024 bytes) and
+        # reject the upload with `MaxMessageLengthExceeded`.
         conditions = [
             ["content-length-range", 1, file_size],
             {"Content-Type": file_type},
         ]
-
-        # For prefix uploads (`${filename}` placeholder) we still need a
-        # `starts-with` condition; boto3 cannot derive that from `Key=`.
-        # For exact-key uploads, `Key=<value>` below also makes boto3 add
-        # `"key": <value>` to the returned `fields[]` automatically — no
-        # manual injection needed.
-        if object_name.startswith("${filename}"):
-            conditions.append(["starts-with", "$key", object_name[: -len("${filename}")]])
 
         # Generate the presigned POST URL
         try:

--- a/apps/api/plane/settings/storage.py
+++ b/apps/api/plane/settings/storage.py
@@ -68,8 +68,13 @@ class S3Storage(S3Boto3Storage):
             expiration = self.signed_url_expiration
         fields = {"Content-Type": file_type}
 
+        # boto3.generate_presigned_post auto-injects {"bucket": ...} and
+        # {"key": ...} conditions when Bucket=/Key= are passed below; do NOT
+        # also add them by hand here. AWS S3 silently accepts the resulting
+        # over-sized policy, but stricter S3-compatible backends enforce a
+        # hard cap on the `policy` form field (some as low as 1024 bytes)
+        # and reject the upload with `MaxMessageLengthExceeded`.
         conditions = [
-            {"bucket": self.aws_storage_bucket_name},
             ["content-length-range", 1, file_size],
             {"Content-Type": file_type},
         ]
@@ -79,7 +84,6 @@ class S3Storage(S3Boto3Storage):
             conditions.append(["starts-with", "$key", object_name[: -len("${filename}")]])
         else:
             fields["key"] = object_name
-            conditions.append({"key": object_name})
 
         # Generate the presigned POST URL
         try:

--- a/apps/api/plane/tests/unit/settings/test_storage.py
+++ b/apps/api/plane/tests/unit/settings/test_storage.py
@@ -127,6 +127,47 @@ class TestS3StorageSignedURLExpiration:
         clear=True,
     )
     @patch("plane.settings.storage.boto3")
+    def test_generate_presigned_post_does_not_duplicate_bucket_or_key(self, mock_boto3):
+        """boto3 auto-injects {bucket}/{key} when Bucket=/Key= are passed.
+
+        Adding them again by hand pads the policy by ~80 bytes — a no-op on
+        AWS S3, but enough to overflow stricter S3-compatible backends that
+        cap the `policy` field at 1024 bytes and reject the upload with
+        `MaxMessageLengthExceeded`.
+
+        This is the regression test for that fix.
+        """
+        mock_s3_client = Mock()
+        mock_s3_client.generate_presigned_post.return_value = {
+            "url": "https://test-url.com",
+            "fields": {},
+        }
+        mock_boto3.client.return_value = mock_s3_client
+        storage = S3Storage()
+
+        storage.generate_presigned_post("test-object", "image/png", 1024)
+
+        kw = mock_s3_client.generate_presigned_post.call_args[1]
+        # Bucket+Key must be passed as named args (boto3 derives conditions from them).
+        assert kw["Bucket"] == "test-bucket"
+        assert kw["Key"] == "test-object"
+        # Conditions must NOT contain hand-rolled {"bucket": ...} or {"key": ...}.
+        for cond in kw["Conditions"]:
+            if isinstance(cond, dict):
+                assert "bucket" not in cond, f"hand-rolled bucket condition: {cond}"
+                assert "key" not in cond, f"hand-rolled key condition: {cond}"
+
+    @patch.dict(
+        os.environ,
+        {
+            "AWS_ACCESS_KEY_ID": "test-key",
+            "AWS_SECRET_ACCESS_KEY": "test-secret",
+            "AWS_S3_BUCKET_NAME": "test-bucket",
+            "AWS_REGION": "us-east-1",
+        },
+        clear=True,
+    )
+    @patch("plane.settings.storage.boto3")
     def test_generate_presigned_url_uses_default_expiration(self, mock_boto3):
         """Test that generate_presigned_url uses the configured default expiration"""
         # Mock the boto3 client and its response

--- a/apps/api/plane/tests/unit/settings/test_storage.py
+++ b/apps/api/plane/tests/unit/settings/test_storage.py
@@ -156,6 +156,9 @@ class TestS3StorageSignedURLExpiration:
             if isinstance(cond, dict):
                 assert "bucket" not in cond, f"hand-rolled bucket condition: {cond}"
                 assert "key" not in cond, f"hand-rolled key condition: {cond}"
+        # Fields must NOT contain a hand-rolled `key` either (boto3 derives
+        # it from Key= and adds it to the returned form fields itself).
+        assert "key" not in kw["Fields"], f"hand-rolled key field: {kw['Fields']}"
 
     @patch.dict(
         os.environ,

--- a/apps/api/plane/tests/unit/settings/test_storage.py
+++ b/apps/api/plane/tests/unit/settings/test_storage.py
@@ -171,6 +171,45 @@ class TestS3StorageSignedURLExpiration:
         clear=True,
     )
     @patch("plane.settings.storage.boto3")
+    def test_generate_presigned_post_no_manual_starts_with_for_filename_placeholder(
+        self, mock_boto3
+    ):
+        """Boto3 derives ["starts-with", "$key", <prefix>] itself when Key
+        ends with the literal "${filename}". The wrapper must not add it
+        again, or the policy carries duplicate starts-with entries.
+        """
+        mock_s3_client = Mock()
+        mock_s3_client.generate_presigned_post.return_value = {
+            "url": "https://test-url.com",
+            "fields": {},
+        }
+        mock_boto3.client.return_value = mock_s3_client
+        storage = S3Storage()
+
+        storage.generate_presigned_post("uploads/${filename}", "image/png", 1024)
+
+        kw = mock_s3_client.generate_presigned_post.call_args[1]
+        # Key is forwarded as-is; boto3 will see the placeholder and inject
+        # the starts-with condition itself.
+        assert kw["Key"] == "uploads/${filename}"
+        # Conditions must NOT contain a hand-rolled starts-with.
+        for cond in kw["Conditions"]:
+            if isinstance(cond, list) and cond and cond[0] == "starts-with":
+                raise AssertionError(
+                    f"hand-rolled starts-with leaked into Conditions: {cond}"
+                )
+
+    @patch.dict(
+        os.environ,
+        {
+            "AWS_ACCESS_KEY_ID": "test-key",
+            "AWS_SECRET_ACCESS_KEY": "test-secret",
+            "AWS_S3_BUCKET_NAME": "test-bucket",
+            "AWS_REGION": "us-east-1",
+        },
+        clear=True,
+    )
+    @patch("plane.settings.storage.boto3")
     def test_generate_presigned_url_uses_default_expiration(self, mock_boto3):
         """Test that generate_presigned_url uses the configured default expiration"""
         # Mock the boto3 client and its response


### PR DESCRIPTION
## Description                                                                                                                                                                                                                                         

  `boto3.generate_presigned_post()` automatically adds `{"bucket": ...}` and
  `{"key": ...}` conditions to the generated policy whenever `Bucket=` and
  `Key=` are passed as named arguments — see the [boto3 docs][1].
  `S3Storage.generate_presigned_post` adds them again by hand in
  `conditions=`, so the policy carries each condition twice and is ~80 bytes
  larger than it needs to be.

  AWS S3 silently accepts the over-sized policy. Some S3-compatible backends
  do not — at least one mainstream vendor enforces a hard cap of **1024
  bytes** on the `policy` form field and rejects the upload with HTTP 400:

  ```xml
  <Error>
    <Code>MaxMessageLengthExceeded</Code>
    <Attribute>policy</Attribute>
    <MaxSizeAllowed>1024</MaxSizeAllowed>
    <ProposedSize>1160</ProposedSize>
  </Error>
```
  The duplication makes attachment upload completely broken on those
  backends.

  After this fix, the resulting policy drops from ~1160 to ~564 bytes for a
  typical attachment, well under every documented per-backend limit.
  Behaviour on AWS S3 is unchanged (boto3 still injects the same conditions
  on its own).

  Type of Change

  - Bug fix (non-breaking change which fixes an issue)

  Test Scenarios

  - New unit test test_generate_presigned_post_does_not_duplicate_bucket_or_key
  asserts that Conditions= no longer contains hand-rolled
  {"bucket": ...} / {"key": ...} entries.
  - Manually verified end-to-end against a self-hosted Plane backed by an
  S3-compatible storage that previously rejected uploads with
  MaxMessageLengthExceeded: file attachments now upload successfully.
  - AWS S3 behaviour spot-checked via boto3==1.34.96: produced policy still
  contains the required bucket/key conditions (boto3 injects them) and
  presigned uploads succeed.

  References

  None — no prior issue. Bug discovered while running self-hosted Plane on
  an S3-compatible storage with strict policy size limits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Presigned POST generation no longer duplicates bucket/key constraints or manually adds filename "starts-with" conditions, preventing oversized policies and upload failures on strict S3-compatible backends.

* **Tests**
  * Added unit tests to verify presigned POSTs omit duplicate bucket/key entries and do not manually inject filename-placeholder conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->