### PR TITLE
fix(api): scope cross-workspace resource lookups to prevent IDOR

### DIFF
--- a/apps/api/plane/app/views/estimate/base.py
+++ b/apps/api/plane/app/views/estimate/base.py
@@ -113,7 +113,7 @@ class BulkEstimatePointEndpoint(BaseViewSet):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        estimate = Estimate.objects.get(pk=estimate_id)
+        estimate = Estimate.objects.get(pk=estimate_id, workspace__slug=slug, project_id=project_id)
 
         if request.data.get("estimate"):
             estimate.name = request.data.get("estimate").get("name", estimate.name)

--- a/apps/api/plane/app/views/project/base.py
+++ b/apps/api/plane/app/views/project/base.py
@@ -332,7 +332,7 @@ class ProjectViewSet(BaseViewSet):
 
         workspace = Workspace.objects.get(slug=slug)
 
-        project = Project.objects.get(pk=pk)
+        project = Project.objects.get(pk=pk, workspace__slug=slug)
         intake_view = request.data.get("inbox_view", project.intake_view)
         current_instance = json.dumps(ProjectSerializer(project).data, cls=DjangoJSONEncoder)
         if project.archived_at:

--- a/apps/api/plane/app/views/workspace/user.py
+++ b/apps/api/plane/app/views/workspace/user.py
@@ -279,11 +279,16 @@ class WorkspaceUserPropertiesEndpoint(BaseAPIView):
 
 class WorkspaceUserProfileEndpoint(BaseAPIView):
     def get(self, request, slug, user_id):
-        user_data = User.objects.get(pk=user_id)
-
         requesting_workspace_member = WorkspaceMember.objects.get(
             workspace__slug=slug, member=request.user, is_active=True
         )
+
+        # Verify the target user is also an active member of this workspace
+        # before exposing their profile data.
+        target_workspace_member = WorkspaceMember.objects.select_related("member").get(
+            workspace__slug=slug, member_id=user_id, is_active=True
+        )
+        user_data = target_workspace_member.member
         projects = []
         if requesting_workspace_member.role >= 15:
             projects = (


### PR DESCRIPTION
## Summary

Three endpoints fetched objects by primary key alone after a workspace-scoped permission check. An authenticated caller could act on resources in other workspaces by supplying a foreign UUID together with their own workspace slug in the URL.

- **`ProjectViewSet.partial_update`** (`apps/api/plane/app/views/project/base.py:335`): A workspace admin could PATCH any project's name, identifier, description, network/visibility, default assignee, etc. across workspaces. Scope the `Project.objects.get(...)` lookup by `workspace__slug=slug`, matching the pattern already used in `destroy` (line 393).
- **`BulkEstimatePointEndpoint.partial_update`** (`apps/api/plane/app/views/estimate/base.py:116`): Any project member could rename or retype estimates in foreign workspaces. Scope the `Estimate.objects.get(...)` lookup by `workspace__slug` and `project_id`, matching `retrieve` (line 104) and `destroy` (line 148).
- **`WorkspaceUserProfileEndpoint.get`** (`apps/api/plane/app/views/workspace/user.py:282`): Any authenticated workspace member could read another user's email, name, avatar, timezone, and join date by UUID, regardless of whether the target user belonged to that workspace. Require the target `user_id` to be an active `WorkspaceMember` of the requested workspace before exposing profile data; fetch the user via the membership row in a single query.

The reported logic flaw in the `partial_update` permission guard (workspace admins bypass the project-admin check) is intentional behavior in this codebase — workspace admins do have project-edit authority. The bug was strictly the unscoped object lookup; once the project fetch is bound to the workspace slug, an admin of workspace A cannot reach into workspace B even if the guard is satisfied.

## Test plan

- [ ] As a workspace-A admin, attempt `PATCH /api/v1/workspaces/workspace-a/projects/{workspace-B-project-uuid}/` with a body changing `name`. Expect 404 (was 200 + mutation).
- [ ] As a workspace-A admin/member, attempt `PATCH /api/v1/workspaces/workspace-a/projects/{workspace-A-project-uuid}/estimates/{workspace-B-estimate-uuid}/`. Expect 404 (was 200 + mutation).
- [ ] As a workspace-A member, attempt `GET /api/v1/workspaces/workspace-a/user-profile/{user-not-in-workspace-A-uuid}/`. Expect 404 (was 200 + PII).
- [ ] Regress the happy paths: in-workspace project edit, in-project estimate edit, and same-workspace user profile fetch all still return 200 with expected payloads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed estimate updates to properly validate workspace and project context, preventing unintended cross-workspace modifications
  * Strengthened project update validation to enforce workspace-level scoping for better isolation
  * Enhanced workspace user profile endpoint to verify active workspace membership before granting access

<!-- end of auto-generated comment: release notes by coderabbit.ai -->