### PR TITLE
fix(api): use requester's workspace role in project member role updates (GHSA-x63v-p7wc-47x4)

### DIFF
--- a/apps/api/plane/app/views/project/member.py
+++ b/apps/api/plane/app/views/project/member.py
@@ -206,11 +206,15 @@ class ProjectMemberViewSet(BaseViewSet):
     def partial_update(self, request, slug, project_id, pk):
         project_member = ProjectMember.objects.get(pk=pk, workspace__slug=slug, project_id=project_id, is_active=True)
 
-        # Fetch the workspace role of the project member
-        workspace_role = WorkspaceMember.objects.get(
+        # Fetch the target's workspace role (used to cap the new project role)
+        target_workspace_role = WorkspaceMember.objects.get(
             workspace__slug=slug, member=project_member.member, is_active=True
         ).role
-        is_workspace_admin = workspace_role == ROLE.ADMIN.value
+        # Fetch the requester's workspace role to decide if they may bypass project-role checks
+        requester_workspace_role = WorkspaceMember.objects.get(
+            workspace__slug=slug, member=request.user, is_active=True
+        ).role
+        is_workspace_admin = requester_workspace_role == ROLE.ADMIN.value
 
         # Check if the user is not editing their own role if they are not an admin
         if request.user.id == project_member.member_id and not is_workspace_admin:
@@ -251,7 +255,7 @@ class ProjectMemberViewSet(BaseViewSet):
                 )
 
             # Cannot assign a role higher than the target's workspace role
-            if workspace_role in [5] and new_role in [15, 20]:
+            if target_workspace_role in [5] and new_role in [15, 20]:
                 return Response(
                     {"error": "You cannot add a user with role higher than the workspace role"},
                     status=status.HTTP_400_BAD_REQUEST,


### PR DESCRIPTION
## Summary

- `ProjectMemberViewSet.partial_update` derived `is_workspace_admin` from the **target** member's workspace role, not the **requester's**. When the target happened to be a workspace admin, all three project-role guards (lines 231 / 238 / 247) were bypassed regardless of who made the request — letting a non-admin requester re-role a workspace admin's project membership.
- This patch computes `is_workspace_admin` from the requester (`request.user`) and renames the target lookup to `target_workspace_role`, which is still used to cap `new_role` against the target's workspace role.
- Related to [GHSA-x63v-p7wc-47x4](https://github.com/makeplane/plane/security/advisories/GHSA-x63v-p7wc-47x4) — the original PoC (Member promotes Guest → Member) was already blocked by [#8833](https://github.com/makeplane/plane/pull/8833) (GHSA-494h-3rcq-5g3c). This fix closes a latent edge case in the same authorization block surfaced while verifying the advisory.

## Trace check

| Scenario | Before | After |
|---|---|---|
| Member attacker → Guest target, payload `{"role": 15}` (advisory PoC) | 403 | 403 ✓ |
| Member attacker → workspace-admin target who is Project Guest, payload `{"role": 20}` | **passes (bug)** | 403 ✓ |
| Workspace admin (Project Member) updates someone's project role | passes | passes ✓ |
| Project Member self-edits own role | 400 | 400 ✓ |

## Test plan

- [ ] Manual: as Project Member, attempt `PATCH /workspaces/{slug}/projects/{id}/members/{pk}/` against a target whose workspace role is Admin — confirm 403.
- [ ] Manual: as Workspace Admin (with project Member role), confirm role updates still succeed.
- [ ] Manual: confirm self-role-update still blocked for non-WS-admins.
- [ ] CI checks pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved member role management by ensuring role updates are validated against the correct user permissions. Member role assignments now properly enforce role hierarchy constraints based on the requester's authorization level rather than the target member's current role.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->