### PR TITLE
fix(api): require token to view workspace invitation (GHSA-gf48-p6jp-cwc4)

### DIFF
--- a/apps/api/plane/app/views/workspace/invite.py
+++ b/apps/api/plane/app/views/workspace/invite.py
@@ -12,6 +12,7 @@ from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.validators import validate_email
 from django.utils import timezone
+from django.utils.crypto import constant_time_compare
 
 # Third party modules
 from rest_framework import status
@@ -236,9 +237,34 @@ class WorkspaceJoinEndpoint(BaseAPIView):
         )
 
     def get(self, request, slug, pk):
-        workspace_invitation = WorkspaceMemberInvite.objects.get(workspace__slug=slug, pk=pk)
+        # Require the invitation token from the email link; without it,
+        # the endpoint would leak invitation details (including the token
+        # itself via the serializer) to any unauthenticated caller.
+        token = request.GET.get("token", "")
+        forbidden_response = Response(
+            {"error": "You do not have permission to access this invitation"},
+            status=status.HTTP_403_FORBIDDEN,
+        )
+        if not token:
+            return forbidden_response
+
+        try:
+            workspace_invitation = WorkspaceMemberInvite.objects.get(
+                workspace__slug=slug, pk=pk
+            )
+        except WorkspaceMemberInvite.DoesNotExist:
+            return forbidden_response
+
+        if not constant_time_compare(workspace_invitation.token, token):
+            return forbidden_response
+
         serializer = WorkSpaceMemberInviteSerializer(workspace_invitation)
-        return Response(serializer.data, status=status.HTTP_200_OK)
+        data = {
+            key: value
+            for key, value in serializer.data.items()
+            if key not in ("token", "invite_link")
+        }
+        return Response(data, status=status.HTTP_200_OK)
 
 
 class UserWorkspaceInvitationsViewSet(BaseViewSet):

--- a/apps/web/app/(all)/workspace-invitations/page.tsx
+++ b/apps/web/app/(all)/workspace-invitations/page.tsx
@@ -39,9 +39,9 @@ function WorkspaceInvitationPage() {
   const { data: currentUser } = useUser();
 
   const { data: invitationDetail, error } = useSWR(
-    invitation_id && slug && WORKSPACE_INVITATION(invitation_id.toString()),
-    invitation_id && slug
-      ? () => workspaceService.getWorkspaceInvitation(slug.toString(), invitation_id.toString())
+    invitation_id && slug && token && WORKSPACE_INVITATION(invitation_id.toString()),
+    invitation_id && slug && token
+      ? () => workspaceService.getWorkspaceInvitation(slug.toString(), invitation_id.toString(), token.toString())
       : null
   );
 
@@ -58,6 +58,7 @@ function WorkspaceInvitationPage() {
         } else {
           router.push("/");
         }
+        return;
       })
       .catch((err: unknown) => console.error(err));
   };
@@ -71,6 +72,7 @@ function WorkspaceInvitationPage() {
       })
       .then(() => {
         router.push("/");
+        return;
       })
       .catch((err: unknown) => console.error(err));
   };

--- a/apps/web/core/components/account/auth-forms/auth-header.tsx
+++ b/apps/web/core/components/account/auth-forms/auth-header.tsx
@@ -19,6 +19,7 @@ import { WorkspaceService } from "@/services/workspace.service";
 type TAuthHeader = {
   workspaceSlug: string | undefined;
   invitationId: string | undefined;
+  invitationToken: string | undefined;
   invitationEmail: string | undefined;
   authMode: EAuthModes;
   currentAuthStep: EAuthSteps;
@@ -58,13 +59,17 @@ const Titles = {
 const workSpaceService = new WorkspaceService();
 
 export const AuthHeader = observer(function AuthHeader(props: TAuthHeader) {
-  const { workspaceSlug, invitationId, invitationEmail, authMode, currentAuthStep } = props;
+  const { workspaceSlug, invitationId, invitationToken, invitationEmail, authMode, currentAuthStep } = props;
   // plane imports
   const { t } = useTranslation();
 
   const { data: invitation, isLoading } = useSWR(
-    workspaceSlug && invitationId ? `WORKSPACE_INVITATION_${workspaceSlug}_${invitationId}` : null,
-    async () => workspaceSlug && invitationId && workSpaceService.getWorkspaceInvitation(workspaceSlug, invitationId),
+    workspaceSlug && invitationId && invitationToken ? `WORKSPACE_INVITATION_${workspaceSlug}_${invitationId}` : null,
+    async () =>
+      workspaceSlug &&
+      invitationId &&
+      invitationToken &&
+      workSpaceService.getWorkspaceInvitation(workspaceSlug, invitationId, invitationToken),
     {
       revalidateOnFocus: false,
       shouldRetryOnError: false,
@@ -74,11 +79,11 @@ export const AuthHeader = observer(function AuthHeader(props: TAuthHeader) {
   const getHeaderSubHeader = (
     step: EAuthSteps,
     mode: EAuthModes,
-    invitation: IWorkspaceMemberInvitation | undefined,
+    inviteData: IWorkspaceMemberInvitation | undefined,
     email: string | undefined
   ) => {
-    if (invitation && email && invitation.email === email && invitation.workspace) {
-      const workspace = invitation.workspace;
+    if (inviteData && email && inviteData.email === email && inviteData.workspace) {
+      const workspace = inviteData.workspace;
       return {
         header: (
           <div className="relative inline-flex items-center gap-2">

--- a/apps/web/core/components/account/auth-forms/auth-root.tsx
+++ b/apps/web/core/components/account/auth-forms/auth-root.tsx
@@ -37,6 +37,7 @@ export const AuthRoot = observer(function AuthRoot(props: TAuthRoot) {
   // query params
   const emailParam = searchParams.get("email");
   const invitation_id = searchParams.get("invitation_id");
+  const invitation_token = searchParams.get("token");
   const workspaceSlug = searchParams.get("slug");
   const error_code = searchParams.get("error_code");
   // props
@@ -121,6 +122,7 @@ export const AuthRoot = observer(function AuthRoot(props: TAuthRoot) {
       <AuthHeader
         workspaceSlug={workspaceSlug?.toString() || undefined}
         invitationId={invitation_id?.toString() || undefined}
+        invitationToken={invitation_token?.toString() || undefined}
         invitationEmail={email || undefined}
         authMode={authMode}
         currentAuthStep={authStep}
@@ -137,10 +139,10 @@ export const AuthRoot = observer(function AuthRoot(props: TAuthRoot) {
           authStep={authStep}
           authMode={authMode}
           email={email}
-          setEmail={(email) => setEmail(email)}
-          setAuthMode={(authMode) => setAuthMode(authMode)}
-          setAuthStep={(authStep) => setAuthStep(authStep)}
-          setErrorInfo={(errorInfo) => setErrorInfo(errorInfo)}
+          setEmail={(value) => setEmail(value)}
+          setAuthMode={(value) => setAuthMode(value)}
+          setAuthStep={(value) => setAuthStep(value)}
+          setErrorInfo={(value) => setErrorInfo(value)}
           currentAuthMode={currentAuthMode}
         />
       )}

--- a/apps/web/core/services/workspace.service.ts
+++ b/apps/web/core/services/workspace.service.ts
@@ -169,8 +169,15 @@ export class WorkspaceService extends APIService {
       });
   }
 
-  async getWorkspaceInvitation(workspaceSlug: string, invitationId: string): Promise<IWorkspaceMemberInvitation> {
-    return this.get(`/api/workspaces/${workspaceSlug}/invitations/${invitationId}/join/`, { headers: {} })
+  async getWorkspaceInvitation(
+    workspaceSlug: string,
+    invitationId: string,
+    token: string
+  ): Promise<IWorkspaceMemberInvitation> {
+    return this.get(`/api/workspaces/${workspaceSlug}/invitations/${invitationId}/join/`, {
+      headers: {},
+      params: { token },
+    })
       .then((response) => response?.data)
       .catch((error) => {
         throw error?.response?.data;


### PR DESCRIPTION
## Summary

Closes the unauthenticated invitation token leak reported in [GHSA-gf48-p6jp-cwc4](https://github.com/makeplane/plane/security/advisories/GHSA-gf48-p6jp-cwc4).

`GET /api/workspaces/<slug>/invitations/<pk>/join/` was registered with `permission_classes = [AllowAny]` and serialized `WorkspaceMemberInvite` with `fields = "__all__"`, exposing the secret invitation `token` (plus an `invite_link` containing it) to any caller who could guess a workspace slug + invitation id. An attacker could iterate through invitation IDs and accept invites intended for other users.

### Backend (`apps/api/plane/app/views/workspace/invite.py`)
- `WorkspaceJoinEndpoint.get` now requires the `?token=` from the email link, compared in constant time. Missing/mismatched/non-existent invites all return a uniform `403` so existence cannot be probed.
- `token` and `invite_link` are stripped from the response as defense in depth, even for verified callers — they already have the token, so we don't echo it back.
- `POST` behavior is unchanged.

### Frontend
- `WorkspaceService.getWorkspaceInvitation(slug, id, token)` now requires a token and forwards it as a query param.
- `/workspace-invitations` page passes the token it already extracts from the URL.
- `AuthRoot` reads `token` from the search params and threads it into `AuthHeader` as `invitationToken`. When absent, `AuthHeader` simply skips the invitation-context SWR call — pages without proof of access shouldn't render invitation data anyway.
- A few pre-existing lint warnings in the touched files (`no-shadow`, `always-return`) were tidied up so the security commit could pass `lint-staged` without bypass.

## Test plan

- [ ] Unauthenticated `GET /api/workspaces/<slug>/invitations/<pk>/join/` without `?token=` returns 403 and no invitation data.
- [ ] Same endpoint with a wrong token returns 403.
- [ ] Same endpoint with the correct token returns the invitation **without** `token` or `invite_link` in the body.
- [ ] Clicking an emailed invite link still loads the `/workspace-invitations` page and lets the invitee accept/reject.
- [ ] Sign-in/sign-up via an invite link still shows the "Join {workspace}" header (token is now propagated through `AuthRoot` → `AuthHeader`).
- [ ] Visiting `/sign-in` without invite params still works (no SWR call fires).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced workspace invitation security with required token verification for all invitation access requests
  * Prevented accidental exposure of sensitive invitation data in API responses
  * Strengthened protection against timing-based validation attacks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->