### PR TITLE
fix: correct X-Forward-For typo to X-Forwarded-For in nginx configs

### DIFF
--- a/apps/admin/nginx/nginx.conf
+++ b/apps/admin/nginx/nginx.conf
@@ -11,7 +11,7 @@ http {
 
   set_real_ip_from        0.0.0.0/0;
   real_ip_recursive       on;
-  real_ip_header          X-Forward-For;
+  real_ip_header          X-Forwarded-For;
   limit_req_zone          $binary_remote_addr zone=mylimit:10m rate=10r/s;
 
   access_log /dev/stdout;

--- a/apps/space/nginx/nginx.conf
+++ b/apps/space/nginx/nginx.conf
@@ -11,7 +11,7 @@ http {
 
   set_real_ip_from        0.0.0.0/0;
   real_ip_recursive       on;
-  real_ip_header          X-Forward-For;
+  real_ip_header          X-Forwarded-For;
   limit_req_zone          $binary_remote_addr zone=mylimit:10m rate=10r/s;
 
   access_log /dev/stdout;

--- a/apps/web/nginx/nginx.conf
+++ b/apps/web/nginx/nginx.conf
@@ -11,7 +11,7 @@ http {
 
   set_real_ip_from        0.0.0.0/0;
   real_ip_recursive       on;
-  real_ip_header          X-Forward-For;
+  real_ip_header          X-Forwarded-For;
   limit_req_zone          $binary_remote_addr zone=mylimit:10m rate=10r/s;
 
   access_log /dev/stdout;


### PR DESCRIPTION
Closes #8934

## What
Corrects the `real_ip_header` directive in `apps/web`, `apps/admin`, and `apps/space` nginx configs from the non-existent `X-Forward-For` header to the standard `X-Forwarded-For`.

## Why
`X-Forward-For` is not a real HTTP header, so nginx never replaces `$remote_addr` with the actual client IP. As a result, `limit_req_zone $binary_remote_addr` rate-limits per-proxy instead of per-client and access logs record the proxy IP. See #8934.

## Notes
- Opened as draft — please review before marking ready.
- Verification: changes are limited to three nginx config files; no app code touched. Did not run nginx locally.