### PR TITLE
feat(api): expose project pages in the public REST API

### DIFF
--- a/apps/api/plane/api/serializers/__init__.py
+++ b/apps/api/plane/api/serializers/__init__.py
@@ -64,3 +64,4 @@ from .asset import (
 from .invite import WorkspaceInviteSerializer
 from .member import ProjectMemberSerializer
 from .sticky import StickySerializer
+from .page import PageSerializer

--- a/apps/api/plane/api/serializers/page.py
+++ b/apps/api/plane/api/serializers/page.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+# Module imports
+from .base import BaseSerializer
+from plane.db.models import Page, ProjectPage, Project
+
+
+class PageSerializer(BaseSerializer):
+    """
+    Serializer for project pages.
+
+    Handles creation of a Page along with its ProjectPage join row so the
+    public API can create, list, retrieve and update pages scoped to a
+    project. Labels and revisions are not exposed in the MVP serializer.
+    """
+
+    class Meta:
+        model = Page
+        fields = [
+            "id",
+            "name",
+            "description_html",
+            "description_json",
+            "owned_by",
+            "access",
+            "color",
+            "parent",
+            "is_locked",
+            "archived_at",
+            "view_props",
+            "logo_props",
+            "sort_order",
+            "external_id",
+            "external_source",
+            "workspace",
+            "created_at",
+            "updated_at",
+            "created_by",
+            "updated_by",
+        ]
+        read_only_fields = [
+            "id",
+            "owned_by",
+            "workspace",
+            "created_at",
+            "updated_at",
+            "created_by",
+            "updated_by",
+        ]
+
+    def create(self, validated_data):
+        project_id = self.context["project_id"]
+        owned_by_id = self.context["owned_by_id"]
+
+        project = Project.objects.get(pk=project_id)
+
+        page = Page.objects.create(
+            **validated_data,
+            owned_by_id=owned_by_id,
+            workspace_id=project.workspace_id,
+        )
+
+        ProjectPage.objects.create(
+            workspace_id=page.workspace_id,
+            project_id=project_id,
+            page_id=page.id,
+            created_by_id=page.created_by_id,
+            updated_by_id=page.updated_by_id,
+        )
+
+        return page

--- a/apps/api/plane/api/serializers/page.py
+++ b/apps/api/plane/api/serializers/page.py
@@ -2,6 +2,13 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # See the LICENSE file for details.
 
+# Django imports
+from django.db import transaction
+from django.shortcuts import get_object_or_404
+
+# Third party imports
+from rest_framework import serializers
+
 # Module imports
 from .base import BaseSerializer
 from plane.db.models import Page, ProjectPage, Project
@@ -50,11 +57,26 @@ class PageSerializer(BaseSerializer):
             "updated_by",
         ]
 
+    def validate_parent(self, value):
+        if value is None:
+            return value
+        project_id = self.context.get("project_id")
+        if project_id and not ProjectPage.objects.filter(
+            page_id=value.id,
+            project_id=project_id,
+            deleted_at__isnull=True,
+        ).exists():
+            raise serializers.ValidationError(
+                "Parent page must belong to the same project."
+            )
+        return value
+
+    @transaction.atomic
     def create(self, validated_data):
         project_id = self.context["project_id"]
         owned_by_id = self.context["owned_by_id"]
 
-        project = Project.objects.get(pk=project_id)
+        project = get_object_or_404(Project, pk=project_id)
 
         page = Page.objects.create(
             **validated_data,

--- a/apps/api/plane/api/urls/__init__.py
+++ b/apps/api/plane/api/urls/__init__.py
@@ -14,6 +14,7 @@ from .user import urlpatterns as user_patterns
 from .work_item import urlpatterns as work_item_patterns
 from .invite import urlpatterns as invite_patterns
 from .sticky import urlpatterns as sticky_patterns
+from .page import urlpatterns as page_patterns
 
 urlpatterns = [
     *asset_patterns,
@@ -28,4 +29,5 @@ urlpatterns = [
     *work_item_patterns,
     *invite_patterns,
     *sticky_patterns,
+    *page_patterns,
 ]

--- a/apps/api/plane/api/urls/page.py
+++ b/apps/api/plane/api/urls/page.py
@@ -24,7 +24,7 @@ urlpatterns = [
     path(
         "workspaces/<str:slug>/projects/<uuid:project_id>/pages/<uuid:page_id>/",
         ProjectPageDetailAPIEndpoint.as_view(http_method_names=["get", "patch", "delete"]),
-        name="project-pages",
+        name="project-pages-detail",
     ),
     # Summary
     path(

--- a/apps/api/plane/api/urls/page.py
+++ b/apps/api/plane/api/urls/page.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+from django.urls import path
+
+from plane.api.views import (
+    ProjectPageListCreateAPIEndpoint,
+    ProjectPageDetailAPIEndpoint,
+    ProjectPageArchiveAPIEndpoint,
+    ProjectPageLockAPIEndpoint,
+    ProjectPageAccessAPIEndpoint,
+    ProjectPageDuplicateAPIEndpoint,
+    ProjectPageSummaryAPIEndpoint,
+)
+
+urlpatterns = [
+    # CRUD
+    path(
+        "workspaces/<str:slug>/projects/<uuid:project_id>/pages/",
+        ProjectPageListCreateAPIEndpoint.as_view(http_method_names=["get", "post"]),
+        name="project-pages",
+    ),
+    path(
+        "workspaces/<str:slug>/projects/<uuid:project_id>/pages/<uuid:page_id>/",
+        ProjectPageDetailAPIEndpoint.as_view(http_method_names=["get", "patch", "delete"]),
+        name="project-pages",
+    ),
+    # Summary
+    path(
+        "workspaces/<str:slug>/projects/<uuid:project_id>/pages-summary/",
+        ProjectPageSummaryAPIEndpoint.as_view(http_method_names=["get"]),
+        name="project-pages-summary",
+    ),
+    # Archive / unarchive
+    path(
+        "workspaces/<str:slug>/projects/<uuid:project_id>/pages/<uuid:page_id>/archive/",
+        ProjectPageArchiveAPIEndpoint.as_view(http_method_names=["post", "delete"]),
+        name="project-page-archive-unarchive",
+    ),
+    path(
+        "workspaces/<str:slug>/projects/<uuid:project_id>/archived-pages/",
+        ProjectPageArchiveAPIEndpoint.as_view(http_method_names=["get"]),
+        name="project-archived-pages",
+    ),
+    # Lock / unlock
+    path(
+        "workspaces/<str:slug>/projects/<uuid:project_id>/pages/<uuid:page_id>/lock/",
+        ProjectPageLockAPIEndpoint.as_view(http_method_names=["post", "delete"]),
+        name="project-pages-lock-unlock",
+    ),
+    # Access toggle
+    path(
+        "workspaces/<str:slug>/projects/<uuid:project_id>/pages/<uuid:page_id>/access/",
+        ProjectPageAccessAPIEndpoint.as_view(http_method_names=["post"]),
+        name="project-pages-access",
+    ),
+    # Duplicate
+    path(
+        "workspaces/<str:slug>/projects/<uuid:project_id>/pages/<uuid:page_id>/duplicate/",
+        ProjectPageDuplicateAPIEndpoint.as_view(http_method_names=["post"]),
+        name="project-pages-duplicate",
+    ),
+]

--- a/apps/api/plane/api/views/__init__.py
+++ b/apps/api/plane/api/views/__init__.py
@@ -63,3 +63,13 @@ from .user import UserEndpoint
 from .invite import WorkspaceInvitationsViewset
 
 from .sticky import StickyViewSet
+
+from .page import (
+    ProjectPageListCreateAPIEndpoint,
+    ProjectPageDetailAPIEndpoint,
+    ProjectPageArchiveAPIEndpoint,
+    ProjectPageLockAPIEndpoint,
+    ProjectPageAccessAPIEndpoint,
+    ProjectPageDuplicateAPIEndpoint,
+    ProjectPageSummaryAPIEndpoint,
+)

--- a/apps/api/plane/api/views/page.py
+++ b/apps/api/plane/api/views/page.py
@@ -1,0 +1,410 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+# Django imports
+from django.db import connection
+from django.db.models import Case, Count, IntegerField, Q, When
+from django.utils import timezone
+
+# Third party imports
+from rest_framework import status
+from rest_framework.response import Response
+
+# Module imports
+from plane.api.serializers import PageSerializer
+from plane.app.permissions import ProjectEntityPermission
+from plane.db.models import Page, ProjectPage
+from .base import BaseAPIView
+
+
+def _archive_page_and_descendants(page_id, archived_at):
+    """Recursively archive (or unarchive) a page and all its sub-pages."""
+    sql = """
+    WITH RECURSIVE descendants AS (
+        SELECT id FROM pages WHERE id = %s
+        UNION ALL
+        SELECT pages.id FROM pages, descendants WHERE pages.parent_id = descendants.id
+    )
+    UPDATE pages SET archived_at = %s WHERE id IN (SELECT id FROM descendants);
+    """
+    with connection.cursor() as cursor:
+        cursor.execute(sql, [page_id, archived_at])
+
+
+class ProjectPageListCreateAPIEndpoint(BaseAPIView):
+    """List and create project pages via the public API."""
+
+    serializer_class = PageSerializer
+    model = Page
+    permission_classes = [ProjectEntityPermission]
+    use_read_replica = True
+
+    def get_queryset(self):
+        return (
+            Page.objects.filter(workspace__slug=self.kwargs.get("slug"))
+            .filter(projects__id=self.kwargs.get("project_id"))
+            .filter(project_pages__deleted_at__isnull=True)
+            .filter(
+                projects__project_projectmember__member=self.request.user,
+                projects__project_projectmember__is_active=True,
+            )
+            .select_related("workspace")
+            .select_related("owned_by")
+            .order_by(self.kwargs.get("order_by", "-created_at"))
+            .distinct()
+        )
+
+    def get(self, request, slug, project_id):
+        return self.paginate(
+            request=request,
+            queryset=self.get_queryset().filter(archived_at__isnull=True),
+            on_results=lambda pages: PageSerializer(
+                pages, many=True, fields=self.fields, expand=self.expand
+            ).data,
+        )
+
+    def post(self, request, slug, project_id):
+        if (
+            request.data.get("external_id")
+            and request.data.get("external_source")
+            and Page.objects.filter(
+                workspace__slug=slug,
+                projects__id=project_id,
+                external_source=request.data.get("external_source"),
+                external_id=request.data.get("external_id"),
+            ).exists()
+        ):
+            page = Page.objects.filter(
+                workspace__slug=slug,
+                projects__id=project_id,
+                external_source=request.data.get("external_source"),
+                external_id=request.data.get("external_id"),
+            ).first()
+            return Response(
+                {
+                    "error": "Page with the same external id and external source already exists",
+                    "id": str(page.id),
+                },
+                status=status.HTTP_409_CONFLICT,
+            )
+
+        serializer = PageSerializer(
+            data=request.data,
+            context={
+                "project_id": project_id,
+                "owned_by_id": request.user.id,
+            },
+        )
+        if serializer.is_valid():
+            serializer.save()
+            page = self.get_queryset().get(pk=serializer.instance.id)
+            return Response(
+                PageSerializer(page).data,
+                status=status.HTTP_201_CREATED,
+            )
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+
+class ProjectPageDetailAPIEndpoint(BaseAPIView):
+    """Retrieve, update and delete a project page via the public API."""
+
+    serializer_class = PageSerializer
+    model = Page
+    permission_classes = [ProjectEntityPermission]
+    use_read_replica = True
+
+    def get_queryset(self):
+        return (
+            Page.objects.filter(workspace__slug=self.kwargs.get("slug"))
+            .filter(projects__id=self.kwargs.get("project_id"))
+            .filter(project_pages__deleted_at__isnull=True)
+            .filter(
+                projects__project_projectmember__member=self.request.user,
+                projects__project_projectmember__is_active=True,
+            )
+            .select_related("workspace")
+            .select_related("owned_by")
+            .distinct()
+        )
+
+    def get(self, request, slug, project_id, page_id):
+        page = self.get_queryset().get(pk=page_id)
+        serializer = PageSerializer(page, fields=self.fields, expand=self.expand)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+    def patch(self, request, slug, project_id, page_id):
+        page = self.get_queryset().get(pk=page_id)
+
+        if page.is_locked:
+            return Response(
+                {"error": "Page is locked"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        if (
+            page.access != request.data.get("access", page.access)
+            and page.owned_by_id != request.user.id
+        ):
+            return Response(
+                {"error": "Access cannot be updated since this page is owned by someone else"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        serializer = PageSerializer(page, data=request.data, partial=True)
+        if serializer.is_valid():
+            if (
+                request.data.get("external_id")
+                and (page.external_id != request.data.get("external_id"))
+                and Page.objects.filter(
+                    workspace__slug=slug,
+                    projects__id=project_id,
+                    external_source=request.data.get("external_source", page.external_source),
+                    external_id=request.data.get("external_id"),
+                ).exists()
+            ):
+                return Response(
+                    {
+                        "error": "Page with the same external id and external source already exists",
+                        "id": str(page.id),
+                    },
+                    status=status.HTTP_409_CONFLICT,
+                )
+            serializer.save()
+            return Response(serializer.data, status=status.HTTP_200_OK)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    def delete(self, request, slug, project_id, page_id):
+        page = Page.objects.get(
+            pk=page_id,
+            workspace__slug=slug,
+            projects__id=project_id,
+            project_pages__deleted_at__isnull=True,
+        )
+
+        if page.owned_by_id != request.user.id:
+            return Response(
+                {"error": "Only the page owner can delete the page"},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
+        ProjectPage.objects.filter(
+            page_id=page.id,
+            project_id=project_id,
+            workspace__slug=slug,
+        ).delete()
+        page.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+class ProjectPageArchiveAPIEndpoint(BaseAPIView):
+    """Archive, unarchive and list archived project pages via the public API."""
+
+    serializer_class = PageSerializer
+    model = Page
+    permission_classes = [ProjectEntityPermission]
+    use_read_replica = True
+
+    def get_queryset(self):
+        return (
+            Page.objects.filter(workspace__slug=self.kwargs.get("slug"))
+            .filter(projects__id=self.kwargs.get("project_id"))
+            .filter(project_pages__deleted_at__isnull=True)
+            .filter(
+                projects__project_projectmember__member=self.request.user,
+                projects__project_projectmember__is_active=True,
+            )
+            .filter(archived_at__isnull=False)
+            .select_related("workspace")
+            .select_related("owned_by")
+            .order_by("-archived_at")
+            .distinct()
+        )
+
+    def get(self, request, slug, project_id):
+        return self.paginate(
+            request=request,
+            queryset=self.get_queryset(),
+            on_results=lambda pages: PageSerializer(
+                pages, many=True, fields=self.fields, expand=self.expand
+            ).data,
+        )
+
+    def post(self, request, slug, project_id, page_id):
+        page = Page.objects.get(
+            pk=page_id,
+            workspace__slug=slug,
+            projects__id=project_id,
+            project_pages__deleted_at__isnull=True,
+        )
+        if page.archived_at is not None:
+            return Response(
+                {"error": "Page is already archived"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        now = timezone.now()
+        _archive_page_and_descendants(page_id, now)
+        return Response({"archived_at": str(now)}, status=status.HTTP_200_OK)
+
+    def delete(self, request, slug, project_id, page_id):
+        page = Page.objects.get(
+            pk=page_id,
+            workspace__slug=slug,
+            projects__id=project_id,
+            project_pages__deleted_at__isnull=True,
+        )
+        # if parent is still archived, detach to avoid resurrecting under archived parent
+        if page.parent_id and page.parent.archived_at:
+            page.parent = None
+            page.save(update_fields=["parent"])
+        _archive_page_and_descendants(page_id, None)
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+class ProjectPageLockAPIEndpoint(BaseAPIView):
+    """Lock and unlock a project page via the public API."""
+
+    permission_classes = [ProjectEntityPermission]
+
+    def post(self, request, slug, project_id, page_id):
+        page = Page.objects.get(
+            pk=page_id,
+            workspace__slug=slug,
+            projects__id=project_id,
+            project_pages__deleted_at__isnull=True,
+        )
+        page.is_locked = True
+        page.save(update_fields=["is_locked"])
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+    def delete(self, request, slug, project_id, page_id):
+        page = Page.objects.get(
+            pk=page_id,
+            workspace__slug=slug,
+            projects__id=project_id,
+            project_pages__deleted_at__isnull=True,
+        )
+        page.is_locked = False
+        page.save(update_fields=["is_locked"])
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+class ProjectPageAccessAPIEndpoint(BaseAPIView):
+    """Toggle access (public/private) on a project page via the public API."""
+
+    permission_classes = [ProjectEntityPermission]
+
+    def post(self, request, slug, project_id, page_id):
+        page = Page.objects.get(
+            pk=page_id,
+            workspace__slug=slug,
+            projects__id=project_id,
+            project_pages__deleted_at__isnull=True,
+        )
+        access = request.data.get("access")
+        if access is None:
+            return Response(
+                {"error": "'access' is required (0=public, 1=private)"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        try:
+            access = int(access)
+        except (TypeError, ValueError):
+            return Response(
+                {"error": "'access' must be an integer (0=public, 1=private)"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        if access not in (Page.PUBLIC_ACCESS, Page.PRIVATE_ACCESS):
+            return Response(
+                {"error": "'access' must be 0 (public) or 1 (private)"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        if page.access != access and page.owned_by_id != request.user.id:
+            return Response(
+                {"error": "Only the page owner can change access"},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+        page.access = access
+        page.save(update_fields=["access"])
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+class ProjectPageDuplicateAPIEndpoint(BaseAPIView):
+    """Duplicate a project page via the public API."""
+
+    permission_classes = [ProjectEntityPermission]
+
+    def post(self, request, slug, project_id, page_id):
+        page = Page.objects.get(
+            pk=page_id,
+            workspace__slug=slug,
+            projects__id=project_id,
+            project_pages__deleted_at__isnull=True,
+        )
+        if page.access == Page.PRIVATE_ACCESS and page.owned_by_id != request.user.id:
+            return Response({"error": "Permission denied"}, status=status.HTTP_403_FORBIDDEN)
+
+        project_ids = list(
+            ProjectPage.objects.filter(page_id=page.id).values_list("project_id", flat=True)
+        )
+
+        page.pk = None
+        page.name = f"{page.name} (Copy)"
+        page.description_binary = None
+        page.owned_by = request.user
+        page.created_by = request.user
+        page.updated_by = request.user
+        page.archived_at = None
+        page.save()
+
+        for pid in project_ids:
+            ProjectPage.objects.create(
+                workspace_id=page.workspace_id,
+                project_id=pid,
+                page_id=page.id,
+                created_by_id=page.created_by_id,
+                updated_by_id=page.updated_by_id,
+            )
+
+        return Response(PageSerializer(page).data, status=status.HTTP_201_CREATED)
+
+
+class ProjectPageSummaryAPIEndpoint(BaseAPIView):
+    """Aggregate page counts (public, private, archived) for a project."""
+
+    permission_classes = [ProjectEntityPermission]
+    use_read_replica = True
+
+    def get(self, request, slug, project_id):
+        queryset = (
+            Page.objects.filter(workspace__slug=slug)
+            .filter(projects__id=project_id)
+            .filter(project_pages__deleted_at__isnull=True)
+            .filter(
+                projects__project_projectmember__member=request.user,
+                projects__project_projectmember__is_active=True,
+            )
+            .filter(Q(owned_by=request.user) | Q(access=Page.PUBLIC_ACCESS))
+            .distinct()
+        )
+        stats = queryset.aggregate(
+            public_pages=Count(
+                Case(
+                    When(access=Page.PUBLIC_ACCESS, archived_at__isnull=True, then=1),
+                    output_field=IntegerField(),
+                )
+            ),
+            private_pages=Count(
+                Case(
+                    When(access=Page.PRIVATE_ACCESS, archived_at__isnull=True, then=1),
+                    output_field=IntegerField(),
+                )
+            ),
+            archived_pages=Count(
+                Case(
+                    When(archived_at__isnull=False, then=1),
+                    output_field=IntegerField(),
+                )
+            ),
+        )
+        return Response(stats, status=status.HTTP_200_OK)

--- a/apps/api/plane/api/views/page.py
+++ b/apps/api/plane/api/views/page.py
@@ -3,8 +3,9 @@
 # See the LICENSE file for details.
 
 # Django imports
-from django.db import connection
-from django.db.models import Case, Count, IntegerField, Q, When
+from django.db import connection, transaction
+from django.db.models import Count, Q
+from django.shortcuts import get_object_or_404
 from django.utils import timezone
 
 # Third party imports
@@ -18,18 +19,43 @@ from plane.db.models import Page, ProjectPage
 from .base import BaseAPIView
 
 
-def _archive_page_and_descendants(page_id, archived_at):
-    """Recursively archive (or unarchive) a page and all its sub-pages."""
+# Order keys accepted on list endpoints — anything else falls back to default.
+ALLOWED_ORDER_BY = {
+    "created_at", "-created_at",
+    "updated_at", "-updated_at",
+    "name", "-name",
+    "sort_order", "-sort_order",
+}
+
+
+def _safe_order_by(request, default="-created_at"):
+    requested = request.query_params.get("order_by")
+    return requested if requested in ALLOWED_ORDER_BY else default
+
+
+def _archive_page_and_descendants(page_id, project_id, archived_at):
+    """
+    Archive (or unarchive) a page and its descendants, scoped to a single
+    project so the recursion can never cross workspace/project boundaries.
+    Soft-deleted ProjectPage rows are excluded.
+    """
     sql = """
     WITH RECURSIVE descendants AS (
-        SELECT id FROM pages WHERE id = %s
+        SELECT p.id
+        FROM pages p
+        INNER JOIN project_pages pp ON pp.page_id = p.id
+        WHERE p.id = %s AND pp.project_id = %s AND pp.deleted_at IS NULL
         UNION ALL
-        SELECT pages.id FROM pages, descendants WHERE pages.parent_id = descendants.id
+        SELECT child.id
+        FROM pages child
+        INNER JOIN project_pages pp ON pp.page_id = child.id
+        INNER JOIN descendants d ON child.parent_id = d.id
+        WHERE pp.project_id = %s AND pp.deleted_at IS NULL
     )
     UPDATE pages SET archived_at = %s WHERE id IN (SELECT id FROM descendants);
     """
     with connection.cursor() as cursor:
-        cursor.execute(sql, [page_id, archived_at])
+        cursor.execute(sql, [page_id, project_id, project_id, archived_at])
 
 
 class ProjectPageListCreateAPIEndpoint(BaseAPIView):
@@ -51,7 +77,7 @@ class ProjectPageListCreateAPIEndpoint(BaseAPIView):
             )
             .select_related("workspace")
             .select_related("owned_by")
-            .order_by(self.kwargs.get("order_by", "-created_at"))
+            .order_by(_safe_order_by(self.request))
             .distinct()
         )
 
@@ -129,12 +155,12 @@ class ProjectPageDetailAPIEndpoint(BaseAPIView):
         )
 
     def get(self, request, slug, project_id, page_id):
-        page = self.get_queryset().get(pk=page_id)
+        page = get_object_or_404(self.get_queryset(), pk=page_id)
         serializer = PageSerializer(page, fields=self.fields, expand=self.expand)
         return Response(serializer.data, status=status.HTTP_200_OK)
 
     def patch(self, request, slug, project_id, page_id):
-        page = self.get_queryset().get(pk=page_id)
+        page = get_object_or_404(self.get_queryset(), pk=page_id)
 
         if page.is_locked:
             return Response(
@@ -175,7 +201,8 @@ class ProjectPageDetailAPIEndpoint(BaseAPIView):
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
     def delete(self, request, slug, project_id, page_id):
-        page = Page.objects.get(
+        page = get_object_or_404(
+            Page,
             pk=page_id,
             workspace__slug=slug,
             projects__id=project_id,
@@ -188,12 +215,13 @@ class ProjectPageDetailAPIEndpoint(BaseAPIView):
                 status=status.HTTP_403_FORBIDDEN,
             )
 
-        ProjectPage.objects.filter(
-            page_id=page.id,
-            project_id=project_id,
-            workspace__slug=slug,
-        ).delete()
-        page.delete()
+        with transaction.atomic():
+            ProjectPage.objects.filter(
+                page_id=page.id,
+                project_id=project_id,
+                workspace__slug=slug,
+            ).delete()
+            page.delete()
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 
@@ -231,7 +259,8 @@ class ProjectPageArchiveAPIEndpoint(BaseAPIView):
         )
 
     def post(self, request, slug, project_id, page_id):
-        page = Page.objects.get(
+        page = get_object_or_404(
+            Page,
             pk=page_id,
             workspace__slug=slug,
             projects__id=project_id,
@@ -243,11 +272,12 @@ class ProjectPageArchiveAPIEndpoint(BaseAPIView):
                 status=status.HTTP_400_BAD_REQUEST,
             )
         now = timezone.now()
-        _archive_page_and_descendants(page_id, now)
+        _archive_page_and_descendants(page_id, project_id, now)
         return Response({"archived_at": str(now)}, status=status.HTTP_200_OK)
 
     def delete(self, request, slug, project_id, page_id):
-        page = Page.objects.get(
+        page = get_object_or_404(
+            Page,
             pk=page_id,
             workspace__slug=slug,
             projects__id=project_id,
@@ -257,7 +287,7 @@ class ProjectPageArchiveAPIEndpoint(BaseAPIView):
         if page.parent_id and page.parent.archived_at:
             page.parent = None
             page.save(update_fields=["parent"])
-        _archive_page_and_descendants(page_id, None)
+        _archive_page_and_descendants(page_id, project_id, None)
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 
@@ -267,7 +297,8 @@ class ProjectPageLockAPIEndpoint(BaseAPIView):
     permission_classes = [ProjectEntityPermission]
 
     def post(self, request, slug, project_id, page_id):
-        page = Page.objects.get(
+        page = get_object_or_404(
+            Page,
             pk=page_id,
             workspace__slug=slug,
             projects__id=project_id,
@@ -278,7 +309,8 @@ class ProjectPageLockAPIEndpoint(BaseAPIView):
         return Response(status=status.HTTP_204_NO_CONTENT)
 
     def delete(self, request, slug, project_id, page_id):
-        page = Page.objects.get(
+        page = get_object_or_404(
+            Page,
             pk=page_id,
             workspace__slug=slug,
             projects__id=project_id,
@@ -295,7 +327,8 @@ class ProjectPageAccessAPIEndpoint(BaseAPIView):
     permission_classes = [ProjectEntityPermission]
 
     def post(self, request, slug, project_id, page_id):
-        page = Page.objects.get(
+        page = get_object_or_404(
+            Page,
             pk=page_id,
             workspace__slug=slug,
             projects__id=project_id,
@@ -335,7 +368,8 @@ class ProjectPageDuplicateAPIEndpoint(BaseAPIView):
     permission_classes = [ProjectEntityPermission]
 
     def post(self, request, slug, project_id, page_id):
-        page = Page.objects.get(
+        page = get_object_or_404(
+            Page,
             pk=page_id,
             workspace__slug=slug,
             projects__id=project_id,
@@ -344,23 +378,23 @@ class ProjectPageDuplicateAPIEndpoint(BaseAPIView):
         if page.access == Page.PRIVATE_ACCESS and page.owned_by_id != request.user.id:
             return Response({"error": "Permission denied"}, status=status.HTTP_403_FORBIDDEN)
 
-        project_ids = list(
-            ProjectPage.objects.filter(page_id=page.id).values_list("project_id", flat=True)
-        )
+        # The duplicate is linked only to the project the request targeted; the
+        # caller's permission was validated against that single project. Linking
+        # to other projects the source page belongs to would bypass per-project
+        # membership checks.
+        with transaction.atomic():
+            page.pk = None
+            page.name = f"{page.name} (Copy)"
+            page.description_binary = None
+            page.owned_by = request.user
+            page.created_by = request.user
+            page.updated_by = request.user
+            page.archived_at = None
+            page.save()
 
-        page.pk = None
-        page.name = f"{page.name} (Copy)"
-        page.description_binary = None
-        page.owned_by = request.user
-        page.created_by = request.user
-        page.updated_by = request.user
-        page.archived_at = None
-        page.save()
-
-        for pid in project_ids:
             ProjectPage.objects.create(
                 workspace_id=page.workspace_id,
-                project_id=pid,
+                project_id=project_id,
                 page_id=page.id,
                 created_by_id=page.created_by_id,
                 updated_by_id=page.updated_by_id,
@@ -387,24 +421,24 @@ class ProjectPageSummaryAPIEndpoint(BaseAPIView):
             .filter(Q(owned_by=request.user) | Q(access=Page.PUBLIC_ACCESS))
             .distinct()
         )
+        # Use Count("id", distinct=True, filter=...) — the queryset has multiple
+        # JOINs (projects, project members) so each Page row is duplicated; a
+        # plain Count(Case(...)) would scale with project membership.
         stats = queryset.aggregate(
             public_pages=Count(
-                Case(
-                    When(access=Page.PUBLIC_ACCESS, archived_at__isnull=True, then=1),
-                    output_field=IntegerField(),
-                )
+                "id",
+                distinct=True,
+                filter=Q(access=Page.PUBLIC_ACCESS, archived_at__isnull=True),
             ),
             private_pages=Count(
-                Case(
-                    When(access=Page.PRIVATE_ACCESS, archived_at__isnull=True, then=1),
-                    output_field=IntegerField(),
-                )
+                "id",
+                distinct=True,
+                filter=Q(access=Page.PRIVATE_ACCESS, archived_at__isnull=True),
             ),
             archived_pages=Count(
-                Case(
-                    When(archived_at__isnull=False, then=1),
-                    output_field=IntegerField(),
-                )
+                "id",
+                distinct=True,
+                filter=Q(archived_at__isnull=False),
             ),
         )
         return Response(stats, status=status.HTTP_200_OK)


### PR DESCRIPTION
### Description

Exposes Pages in the public REST API namespace (`/api/v1/...`) so external clients — integrations, MCP servers, automation scripts — can manage pages with an `X-API-Key`, instead of being limited to the session-authenticated app API (`/api/...`).

The Page model, ProjectPage join, queries and permission classes already exist; this PR only adds the public-API surface (URLs, views, serializer) and wires it into the existing aggregator. Mirrors the conventions used by `cycle` and `state` (`BaseAPIView`, `APIKeyAuthentication`, `ProjectEntityPermission`, pagination, `external_id` idempotency).

Closes the gap raised in #7319.

### Routes added

All project-scoped, prefixed with `/api/v1/workspaces/<slug>/projects/<project_id>/`:

| Method | Path | Action |
|---|---|---|
| GET / POST | `pages/` | list / create |
| GET / PATCH / DELETE | `pages/<page_id>/` | retrieve / update / delete |
| GET | `pages-summary/` | aggregated counts |
| GET | `archived-pages/` | list archived |
| POST / DELETE | `pages/<page_id>/archive/` | archive / unarchive (recursive on descendants) |
| POST / DELETE | `pages/<page_id>/lock/` | lock / unlock |
| POST | `pages/<page_id>/access/` | toggle public (0) / private (1) |
| POST | `pages/<page_id>/duplicate/` | duplicate |

Out of scope for this PR (can land as follow-ups): per-user favorite endpoint (UX-only), description binary endpoint and page versions (collaborative-editor specific).

### Type of Change

- [x] Feature (non-breaking change which adds functionality)

### Test Scenarios

Smoke-tested against `docker-compose-local.yml` on v1.3.0 + this patch. All routes verified end-to-end with `curl` using a Plane API key:

- CRUD: `200/201/204` on list, create, retrieve, patch, delete
- `external_id` + `external_source` duplicate → `409 Conflict` with existing id
- `lock` → `204` then `PATCH` → `400 {"error":"Page is locked"}` then `unlock` → `204` then `PATCH` → `200`
- `access` accepts `0`/`1`, rejects others with `400`, owner-only enforcement
- `archive` → `200 {archived_at}`, double-archive → `400`, list `pages/` excludes it, list `archived-pages/` includes it, `unarchive` → `204`
- `duplicate` returns the new page with `name = "<original> (Copy)"` and a fresh `id`
- `summary` returns `{public_pages, private_pages, archived_pages}` consistent with create/archive/access flow

### References

- Refs #7319 (Add API Endpoints for Creating and Editing Pages)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a comprehensive project pages API: create, list, update, delete pages; archive/unarchive (recursive); lock/unlock; toggle public/private access; duplicate pages; and view per-project page summaries (public/private/archived counts).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->