### PR TITLE
[WEB-7181] fix: empty comment quick-actions menu in work item activity

### DIFF
--- a/apps/web/core/components/comments/quick-actions.tsx
+++ b/apps/web/core/components/comments/quick-actions.tsx
@@ -78,10 +78,12 @@ export const CommentQuickActions = observer(function CommentQuickActions(props: 
           icon: TrashIcon,
           shouldRender: canDelete,
         },
-      ];
+      ].filter((item) => item.shouldRender !== false);
     },
     [t, setEditMode, canEdit, showCopyLinkOption, activityOperations, comment, showAccessSpecifier, canDelete]
   );
+
+  if (MENU_ITEMS.length === 0) return null;
 
   return (
     <CustomMenu customButton={<IconButton icon={MoreHorizontal} variant="ghost" size="sm" />} closeOnSelect>

--- a/apps/web/core/components/comments/quick-actions.tsx
+++ b/apps/web/core/components/comments/quick-actions.tsx
@@ -87,38 +87,34 @@ export const CommentQuickActions = observer(function CommentQuickActions(props: 
 
   return (
     <CustomMenu customButton={<IconButton icon={MoreHorizontal} variant="ghost" size="sm" />} closeOnSelect>
-      {MENU_ITEMS.map((item) => {
-        if (item.shouldRender === false) return null;
-
-        return (
-          <CustomMenu.MenuItem
-            key={item.key}
-            onClick={() => item.action()}
-            className={cn(
-              "flex items-center gap-2",
-              {
-                "text-placeholder": item.disabled,
-              },
-              item.className
+      {MENU_ITEMS.map((item) => (
+        <CustomMenu.MenuItem
+          key={item.key}
+          onClick={() => item.action()}
+          className={cn(
+            "flex items-center gap-2",
+            {
+              "text-placeholder": item.disabled,
+            },
+            item.className
+          )}
+          disabled={item.disabled}
+        >
+          {item.icon && <item.icon className={cn("size-3 shrink-0", item.iconClassName)} />}
+          <div>
+            <h5>{item.title}</h5>
+            {item.description && (
+              <p
+                className={cn("whitespace-pre-line text-tertiary", {
+                  "text-placeholder": item.disabled,
+                })}
+              >
+                {item.description}
+              </p>
             )}
-            disabled={item.disabled}
-          >
-            {item.icon && <item.icon className={cn("size-3 shrink-0", item.iconClassName)} />}
-            <div>
-              <h5>{item.title}</h5>
-              {item.description && (
-                <p
-                  className={cn("whitespace-pre-line text-tertiary", {
-                    "text-placeholder": item.disabled,
-                  })}
-                >
-                  {item.description}
-                </p>
-              )}
-            </div>
-          </CustomMenu.MenuItem>
-        );
-      })}
+          </div>
+        </CustomMenu.MenuItem>
+      ))}
     </CustomMenu>
   );
 });


### PR DESCRIPTION
### Description
This PR fixes the comment quick-actions menu so the menu is not shown at all when no actions are available.
This avoids rendering empty/invalid menu content in cases where all actions are unavailable.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

### Screenshots and Media (if applicable)


### Test Scenarios 


### References


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * The comments quick actions menu now automatically hides inapplicable options, showing only actions relevant to the current context.
  * If no actions apply, the quick actions menu does not render, reducing visual clutter and improving reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->