### PR TITLE
[GIT-175] fix: completed_at updation logic for work items

### DIFF
--- a/apps/api/plane/db/models/issue.py
+++ b/apps/api/plane/db/models/issue.py
@@ -244,7 +244,7 @@ class Issue(ChangeTrackerMixin, ProjectBaseModel):
         if not self._state.adding and not self.has_changed("state_id"):
             return kwargs
 
-        if self.state.group == "completed":
+        if self.state.group == StateGroup.COMPLETED.value:
             self.completed_at = timezone.now()
         else:
             self.completed_at = None

--- a/apps/api/plane/db/models/issue.py
+++ b/apps/api/plane/db/models/issue.py
@@ -18,12 +18,11 @@ from django import apps
 # Module imports
 from plane.utils.html_processor import strip_tags
 from plane.utils.path_validator import sanitize_filename
-from plane.db.mixins import SoftDeletionManager
+from plane.db.mixins import SoftDeletionManager, ChangeTrackerMixin
 from plane.utils.exception_logger import log_exception
 from .project import ProjectBaseModel
 from plane.utils.uuid import convert_uuid_to_integer
 from .description import Description
-from plane.db.mixins import ChangeTrackerMixin
 from .state import StateGroup
 
 
@@ -102,7 +101,9 @@ class IssueManager(SoftDeletionManager):
         )
 
 
-class Issue(ProjectBaseModel):
+class Issue(ChangeTrackerMixin, ProjectBaseModel):
+    TRACKED_FIELDS = ["state_id"]
+
     PRIORITY_CHOICES = (
         ("urgent", "Urgent"),
         ("high", "High"),
@@ -177,30 +178,8 @@ class Issue(ProjectBaseModel):
         ordering = ("-created_at",)
 
     def save(self, *args, **kwargs):
-        if self.state is None:
-            try:
-                from plane.db.models import State
-
-                default_state = State.objects.filter(
-                    ~models.Q(is_triage=True), project=self.project, default=True
-                ).first()
-                if default_state is None:
-                    random_state = State.objects.filter(~models.Q(is_triage=True), project=self.project).first()
-                    self.state = random_state
-                else:
-                    self.state = default_state
-            except ImportError:
-                pass
-        else:
-            try:
-                from plane.db.models import State
-
-                if self.state.group == "completed":
-                    self.completed_at = timezone.now()
-                else:
-                    self.completed_at = None
-            except ImportError:
-                pass
+        self._ensure_default_state()
+        kwargs = self._sync_completed_at(kwargs)
 
         if self._state.adding:
             with transaction.atomic():
@@ -245,6 +224,35 @@ class Issue(ProjectBaseModel):
     def __str__(self):
         """Return name of the issue"""
         return f"{self.name} <{self.project.name}>"
+
+    def _ensure_default_state(self):
+        """Assign a default state when none is set."""
+        if self.state is not None:
+            return
+        try:
+            from plane.db.models import State
+
+            default_state = State.objects.filter(~models.Q(is_triage=True), project=self.project, default=True).first()
+            self.state = default_state or State.objects.filter(~models.Q(is_triage=True), project=self.project).first()
+        except ImportError:
+            pass
+
+    def _sync_completed_at(self, kwargs):
+        """Update completed_at when state changes. Returns kwargs."""
+        if not self.state:
+            return kwargs
+        if not self._state.adding and not self.has_changed("state_id"):
+            return kwargs
+
+        if self.state.group == "completed":
+            self.completed_at = timezone.now()
+        else:
+            self.completed_at = None
+
+        update_fields = kwargs.get("update_fields")
+        if update_fields is not None:
+            kwargs["update_fields"] = list(set(update_fields) | {"completed_at"})
+        return kwargs
 
 
 class IssueBlocker(ProjectBaseModel):

--- a/apps/api/plane/db/models/issue.py
+++ b/apps/api/plane/db/models/issue.py
@@ -234,8 +234,8 @@ class Issue(ChangeTrackerMixin, ProjectBaseModel):
 
             default_state = State.objects.filter(~models.Q(is_triage=True), project=self.project, default=True).first()
             self.state = default_state or State.objects.filter(~models.Q(is_triage=True), project=self.project).first()
-        except ImportError:
-            pass
+        except ImportError as e:
+            log_exception(e)
 
     def _sync_completed_at(self, kwargs):
         """Update completed_at when state changes. Returns kwargs."""


### PR DESCRIPTION
This pull request refactors how the `Issue` model in `issue.py` handles state management and tracking of changes. The main improvements include extracting logic for assigning default states and updating the `completed_at` field into dedicated helper methods, and enabling change tracking for the `state_id` field. These changes improve code clarity, maintainability, and ensure that state transitions are tracked more reliably.

**State management and tracking improvements:**

* The `Issue` model now inherits from `ChangeTrackerMixin` and explicitly tracks changes to the `state_id` field, enabling more robust detection of state changes.
* The logic for assigning a default state and updating the `completed_at` field has been refactored into two private methods: `_ensure_default_state` and `_sync_completed_at`, improving code organization and readability. [[1]](diffhunk://#diff-adbdfb6bfb361d843bba9d9148eb2dabb7aa949e4e49f21d4f3aa325e75d8215L180-R182) [[2]](diffhunk://#diff-adbdfb6bfb361d843bba9d9148eb2dabb7aa949e4e49f21d4f3aa325e75d8215R228-R256)
* The `save` method in `Issue` now delegates state assignment and `completed_at` synchronization to these new helper methods, ensuring consistent behavior and reducing code duplication.

**Code organization:**

* The import of `ChangeTrackerMixin` has been moved to the main import statement for consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Added change-tracking for issue state to centralize and standardize state handling and completion logic.
* **Bug Fixes**
  * Default issue state is now assigned more reliably when missing.
  * Issue completion timestamp now sets or clears correctly when state transitions to/from a completed state.
  * Import errors during state resolution are now logged instead of being silently ignored.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/makeplane/plane/pull/9044)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->