### PR TITLE
fix: handle error message for special characters in Identifier of Project

### DIFF
--- a/apps/web/ce/components/projects/create/root.tsx
+++ b/apps/web/ce/components/projects/create/root.tsx
@@ -110,7 +110,7 @@ export const CreateProjectForm = observer(function CreateProjectForm(props: TCre
         if (setToFavorite) {
           handleAddToFavorites(res.id);
         }
-        handleNextStep(res.id);
+        return handleNextStep(res.id);
       })
       .catch((err) => {
         try {
@@ -119,8 +119,9 @@ export const CreateProjectForm = observer(function CreateProjectForm(props: TCre
 
           const nameError = errorData.name?.includes("PROJECT_NAME_ALREADY_EXIST");
           const identifierError = errorData?.identifier?.includes("PROJECT_IDENTIFIER_ALREADY_EXIST");
+          const nameSpecialCharError = errorData?.name?.includes("PROJECT_NAME_CANNOT_CONTAIN_SPECIAL_CHARACTERS");
 
-          if (nameError || identifierError) {
+          if (nameError || identifierError || nameSpecialCharError) {
             if (nameError) {
               setToast({
                 type: TOAST_TYPE.ERROR,
@@ -134,6 +135,14 @@ export const CreateProjectForm = observer(function CreateProjectForm(props: TCre
                 type: TOAST_TYPE.ERROR,
                 title: t("toast.error"),
                 message: t("project_identifier_already_taken"),
+              });
+            }
+
+            if (nameSpecialCharError) {
+              setToast({
+                type: TOAST_TYPE.ERROR,
+                title: t("toast.error"),
+                message: t("project_name_cannot_contain_special_characters"),
               });
             }
           } else {

--- a/apps/web/core/components/project/form.tsx
+++ b/apps/web/core/components/project/form.tsx
@@ -105,8 +105,9 @@ export function ProjectDetailsForm(props: IProjectDetailsForm) {
 
           const nameError = errorData.name?.includes("PROJECT_NAME_ALREADY_EXIST");
           const identifierError = errorData?.identifier?.includes("PROJECT_IDENTIFIER_ALREADY_EXIST");
+          const nameSpecialCharError = errorData?.name?.includes("PROJECT_NAME_CANNOT_CONTAIN_SPECIAL_CHARACTERS");
 
-          if (nameError || identifierError) {
+          if (nameError || identifierError || nameSpecialCharError) {
             if (nameError) {
               setToast({
                 type: TOAST_TYPE.ERROR,
@@ -120,6 +121,14 @@ export function ProjectDetailsForm(props: IProjectDetailsForm) {
                 type: TOAST_TYPE.ERROR,
                 title: t("toast.error"),
                 message: t("project_identifier_already_taken"),
+              });
+            }
+
+            if (nameSpecialCharError) {
+              setToast({
+                type: TOAST_TYPE.ERROR,
+                title: t("toast.error"),
+                message: t("project_name_cannot_contain_special_characters"),
               });
             }
           } else {


### PR DESCRIPTION
### Description
**Root Cause:**
In February 2026, PR #8529 added a `validate_name()` method in the Django serializer (`apps/api/plane/app/serializers/project.py`) that raises a `PROJECT_NAME_CANNOT_CONTAIN_SPECIAL_CHARACTERS` validation error when a project name matches the forbidden characters pattern defined in `apps/api/plane/db/models/project.py`:
```python
FORBIDDEN_IDENTIFIER_CHARS_PATTERN = r"^.*[&+,:;$^}{*=?@#|'<>.()%!-].*$"
```
The API returns this error code in the response, which reaches the frontend through the project service. However, the onSubmit catch block in apps/web/ce/components/projects/create/root.tsx only handled PROJECT_NAME_ALREADY_EXIST and PROJECT_IDENTIFIER_ALREADY_EXIST — the new error code was never handled, causing it to silently fall into the generic "Something went wrong" toast with no actionable feedback for the user.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->
**Before:**
Generic "Something went wrong" toast shown when creating a project with special characters in the name.
<img width="1470" height="802" alt="Screenshot 2026-05-08 at 5 19 10 PM" src="https://github.com/user-attachments/assets/7675a588-1c41-4c79-82e7-b47794ab9193" />
**After:**
Specific and actionable error message "Project name cannot contain special characters." is now shown.
<img width="1470" height="803" alt="Screenshot 2026-05-12 at 9 54 20 PM" src="https://github.com/user-attachments/assets/8ca6d6a7-8341-44e5-be41-b86fd14fde1b" />

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->
1. Create a project with special characters in the name (e.g. `Project + TEST #`) → now shows "Project name cannot contain special characters." ✅
2. Create a project with a duplicate name → still shows "Project name already taken" ✅
3. Create a project with a duplicate identifier → still shows "Project identifier already taken" ✅
4. Create a valid project → creates successfully ✅

### References
<!-- Link related issues if there are any -->
Closes #8969 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Project creation flow now reliably advances to the next step after a successful create.
  * Validation errors for project names containing special characters now show a clear, specific message instead of a generic collision error.
  * The update form also surfaces the same dedicated validation message to ensure consistent feedback when editing project names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->