### PR TITLE
feat(i18n): try browser language before English fallback

### DIFF
--- a/packages/i18n/src/store/index.ts
+++ b/packages/i18n/src/store/index.ts
@@ -59,16 +59,16 @@ export class TranslationStore {
       return;
     }
 
-    // Try to detect the user's preferred language from the browser
-    // before falling back to the default.
+    // Try the browser's preferred language. persist=false so future
+    // visits keep re-evaluating navigator.languages.
     const detected = this.detectBrowserLanguage();
     if (detected) {
-      this.setLanguage(detected);
+      this.setLanguage(detected, false);
       return;
     }
 
     // Fallback to default language
-    this.setLanguage(FALLBACK_LANGUAGE);
+    this.setLanguage(FALLBACK_LANGUAGE, false);
   }
 
   /**
@@ -283,10 +283,11 @@ export class TranslationStore {
   }
 
   /**
-   * Sets the current language and updates the translations
+   * Sets the current language and updates the translations.
    * @param lng - The new language
+   * @param persistPreference - If true (default), writes to localStorage. Pass false for session-only application.
    */
-  async setLanguage(lng: TLanguage): Promise<void> {
+  async setLanguage(lng: TLanguage, persistPreference: boolean = true): Promise<void> {
     try {
       if (!this.isValidLanguage(lng)) {
         throw new Error(`Invalid language: ${lng}`);
@@ -298,7 +299,9 @@ export class TranslationStore {
       }
 
       if (typeof window !== "undefined") {
-        localStorage.setItem(LANGUAGE_STORAGE_KEY, lng);
+        if (persistPreference) {
+          localStorage.setItem(LANGUAGE_STORAGE_KEY, lng);
+        }
         document.documentElement.lang = lng;
       }
 

--- a/packages/i18n/src/store/index.ts
+++ b/packages/i18n/src/store/index.ts
@@ -49,7 +49,7 @@ export class TranslationStore {
     this.loadTranslations();
   }
 
-  /** Initializes the language based on the local storage or browser language */
+  /** Initializes the language based on local storage, browser preferences, or the fallback. */
   private initializeLanguage() {
     if (typeof window === "undefined") return;
 
@@ -59,8 +59,42 @@ export class TranslationStore {
       return;
     }
 
+    // Try to detect the user's preferred language from the browser
+    // before falling back to the default.
+    const detected = this.detectBrowserLanguage();
+    if (detected) {
+      this.setLanguage(detected);
+      return;
+    }
+
     // Fallback to default language
     this.setLanguage(FALLBACK_LANGUAGE);
+  }
+
+  /**
+   * Detects the user's preferred language from navigator.languages /
+   * navigator.language. Returns the first supported language code found.
+   * Tries an exact match first (e.g. "pt-BR"), then strips the region
+   * subtag and retries the base language (e.g. "es-AR" -> "es").
+   * Returns null when no candidate matches a supported language.
+   */
+  private detectBrowserLanguage(): TLanguage | null {
+    if (typeof navigator === "undefined") return null;
+
+    const candidates: string[] =
+      navigator.languages && navigator.languages.length > 0
+        ? Array.from(navigator.languages)
+        : navigator.language
+          ? [navigator.language]
+          : [];
+
+    for (const cand of candidates) {
+      if (this.isValidLanguage(cand)) return cand;
+      const base = cand.split("-")[0];
+      if (base !== cand && this.isValidLanguage(base)) return base;
+    }
+
+    return null;
   }
 
   /** Loads the translations for the current language */


### PR DESCRIPTION
### Description

Self-hosted Plane instances currently always boot every user into English on first visit. This PR changes the i18n initialization so that, when no saved `userLanguage` preference exists in `localStorage`, the store consults `navigator.languages` and selects the first supported match before falling back to English.

**Selection priority (new behavior in bold):**

1. `localStorage["userLanguage"]` if it holds a supported code *(unchanged)*
2. **First supported entry in `navigator.languages` (or `navigator.language` as fallback), with regional fallthrough — e.g. `pt-BR` matches exactly, `es-AR` falls through to `es`**
3. `FALLBACK_LANGUAGE` (English) *(unchanged)*

Once a user explicitly picks a language, the choice is persisted to `localStorage` as before and takes precedence on future visits. Behavior for users with an existing saved preference is therefore unchanged.

**Scope of the change**

- Single file: `packages/i18n/src/store/index.ts`
- New private method `detectBrowserLanguage()` (~25 lines)
- One added call site inside `initializeLanguage()`, between the localStorage check and the English fallback
- One docstring updated to reflect the new behavior
- No API changes, no new dependencies, no migrations
- SSR-safe (guards on `typeof navigator === "undefined"`)

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [x] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)

N/A — the change is invisible to anyone who already has a saved language preference, and new visitors simply land in their browser's locale instead of English.

### Test Scenarios

Manually verified the four meaningful cases. The `@plane/i18n` package has no test infrastructure (no jest/vitest in devDependencies, no `test` script), so this PR is code-only; happy to bootstrap a test setup if reviewers want one, but that's arguably a separate concern.

- **Browser `navigator.languages = ["es-AR", "es", "en"]`, no localStorage entry** → loads in Spanish
- **Browser `navigator.languages = ["fr-CA", "fr"]`, no localStorage entry** → loads in French
- **Browser `navigator.languages = ["xx-YY"]` (unsupported), no localStorage entry** → falls through to English
- **localStorage has `userLanguage=ja` already** → loads Japanese, browser preference ignored (unchanged behavior)

### References

No existing open issue matches exactly. Closest tangentially-related is #8581 ("DateTime Format is not taking effect"), about date/time format persistence rather than UI language. Happy to file a tracking issue first if maintainers prefer that workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App now detects and applies the browser's language preferences on startup, with intelligent fallback to related language variants when no exact match is supported.
  * Detected languages are applied for the session (not persisted) by default when derived from the browser.

* **Behavior Change**
  * You can now choose to change the app language without saving the preference; language attribute and in-memory cache still update immediately.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/makeplane/plane/pull/9060)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->