### PR TITLE
fix(storage): support AWS_S3_ADDRESSING_STYLE env var for S3 virtual/path addressing

### DIFF
--- a/apps/api/plane/settings/storage.py
+++ b/apps/api/plane/settings/storage.py
@@ -8,6 +8,7 @@ import uuid
 
 # Third party imports
 import boto3
+from botocore.config import Config
 from botocore.exceptions import ClientError
 from urllib.parse import quote
 
@@ -36,6 +37,21 @@ class S3Storage(S3Boto3Storage):
         # Use the SIGNED_URL_EXPIRATION environment variable for the expiration time (default: 3600 seconds)
         self.signed_url_expiration = int(os.environ.get("SIGNED_URL_EXPIRATION", "3600"))
 
+        # S3 addressing style: 'auto', 'virtual', or 'path' (default: 'auto')
+        # virtual = virtual-hosted style (e.g., https://bucket.s3.amazonaws.com)
+        # path = path style (e.g., https://s3.amazonaws.com/bucket)
+        # auto = let botocore decide based on bucket name
+        addressing_style = os.environ.get("AWS_S3_ADDRESSING_STYLE", "auto").lower()
+
+        # Create boto3 Config with addressing style if explicitly set
+        if addressing_style in ("virtual", "path"):
+            boto_config = Config(
+                signature_version="s3v4",
+                s3={"addressing_style": addressing_style},
+            )
+        else:
+            boto_config = Config(signature_version="s3v4")
+
         if os.environ.get("USE_MINIO") == "1":
             # Determine protocol based on environment variable
             if os.environ.get("MINIO_ENDPOINT_SSL") == "1":
@@ -49,7 +65,7 @@ class S3Storage(S3Boto3Storage):
                 aws_secret_access_key=self.aws_secret_access_key,
                 region_name=self.aws_region,
                 endpoint_url=(f"{endpoint_protocol}://{request.get_host()}" if request else self.aws_s3_endpoint_url),
-                config=boto3.session.Config(signature_version="s3v4"),
+                config=boto_config,
             )
         else:
             # Create an S3 client
@@ -59,7 +75,7 @@ class S3Storage(S3Boto3Storage):
                 aws_secret_access_key=self.aws_secret_access_key,
                 region_name=self.aws_region,
                 endpoint_url=self.aws_s3_endpoint_url,
-                config=boto3.session.Config(signature_version="s3v4"),
+                config=boto_config,
             )
 
     def generate_presigned_post(self, object_name, file_type, file_size, expiration=None):

--- a/apps/api/plane/settings/storage.py
+++ b/apps/api/plane/settings/storage.py
@@ -41,7 +41,7 @@ class S3Storage(S3Boto3Storage):
         # virtual = virtual-hosted style (e.g., https://bucket.s3.amazonaws.com)
         # path = path style (e.g., https://s3.amazonaws.com/bucket)
         # auto = let botocore decide based on bucket name
-        addressing_style = os.environ.get("AWS_S3_ADDRESSING_STYLE", "auto").lower()
+        addressing_style = os.environ.get("AWS_S3_ADDRESSING_STYLE", "auto").strip().lower()
 
         # Create boto3 Config with addressing style if explicitly set
         if addressing_style in ("virtual", "path"):

--- a/apps/api/plane/tests/unit/settings/test_storage.py
+++ b/apps/api/plane/tests/unit/settings/test_storage.py
@@ -204,3 +204,97 @@ class TestS3StorageSignedURLExpiration:
         mock_s3_client.generate_presigned_url.assert_called_once()
         call_kwargs = mock_s3_client.generate_presigned_url.call_args[1]
         assert call_kwargs["ExpiresIn"] == 120
+
+
+@pytest.mark.unit
+class TestS3StorageAddressingStyle:
+    """Test the S3 addressing style configuration via AWS_S3_ADDRESSING_STYLE"""
+
+    @patch.dict(
+        os.environ,
+        {
+            "AWS_ACCESS_KEY_ID": "test-key",
+            "AWS_SECRET_ACCESS_KEY": "test-secret",
+            "AWS_S3_BUCKET_NAME": "test-bucket",
+            "AWS_REGION": "us-east-1",
+            "AWS_S3_ENDPOINT_URL": "https://s3.amazonaws.com",
+            "AWS_S3_ADDRESSING_STYLE": "virtual",
+        },
+        clear=True,
+    )
+    @patch("plane.settings.storage.boto3")
+    def test_virtual_addressing_style(self, mock_boto3):
+        """Test that virtual addressing style is configured via botocore Config"""
+        mock_boto3.client.return_value = Mock()
+
+        storage = S3Storage()
+
+        call_kwargs = mock_boto3.client.call_args[1]
+        assert call_kwargs["config"].s3["addressing_style"] == "virtual"
+
+    @patch.dict(
+        os.environ,
+        {
+            "AWS_ACCESS_KEY_ID": "test-key",
+            "AWS_SECRET_ACCESS_KEY": "test-secret",
+            "AWS_S3_BUCKET_NAME": "test-bucket",
+            "AWS_REGION": "us-east-1",
+            "AWS_S3_ENDPOINT_URL": "https://s3.amazonaws.com",
+            "AWS_S3_ADDRESSING_STYLE": "path",
+        },
+        clear=True,
+    )
+    @patch("plane.settings.storage.boto3")
+    def test_path_addressing_style(self, mock_boto3):
+        """Test that path addressing style is configured via botocore Config"""
+        mock_boto3.client.return_value = Mock()
+
+        storage = S3Storage()
+
+        call_kwargs = mock_boto3.client.call_args[1]
+        assert call_kwargs["config"].s3["addressing_style"] == "path"
+
+    @patch.dict(
+        os.environ,
+        {
+            "AWS_ACCESS_KEY_ID": "test-key",
+            "AWS_SECRET_ACCESS_KEY": "test-secret",
+            "AWS_S3_BUCKET_NAME": "test-bucket",
+            "AWS_REGION": "us-east-1",
+            "AWS_S3_ENDPOINT_URL": "https://s3.amazonaws.com",
+        },
+        clear=True,
+    )
+    @patch("plane.settings.storage.boto3")
+    def test_auto_addressing_style_by_default(self, mock_boto3):
+        """Test that auto addressing style is used by default (no s3 config in botocore Config)"""
+        mock_boto3.client.return_value = Mock()
+
+        storage = S3Storage()
+
+        call_kwargs = mock_boto3.client.call_args[1]
+        # When addressing_style is 'auto' or not set, botocore Config should not have s3 dict
+        assert "s3" not in call_kwargs["config"]._user_provided_options
+
+    @patch.dict(
+        os.environ,
+        {
+            "AWS_ACCESS_KEY_ID": "test-key",
+            "AWS_SECRET_ACCESS_KEY": "test-secret",
+            "AWS_S3_BUCKET_NAME": "test-bucket",
+            "AWS_REGION": "us-east-1",
+            "AWS_S3_ENDPOINT_URL": "https://nyc3.digitaloceanspaces.com",
+            "AWS_S3_ADDRESSING_STYLE": "virtual",
+        },
+        clear=True,
+    )
+    @patch("plane.settings.storage.boto3")
+    def test_virtual_style_with_digitalocean_spaces(self, mock_boto3):
+        """Test virtual addressing style works with DigitalOcean Spaces"""
+        mock_boto3.client.return_value = Mock()
+
+        storage = S3Storage()
+
+        call_kwargs = mock_boto3.client.call_args[1]
+        assert call_kwargs["config"].s3["addressing_style"] == "virtual"
+        assert call_kwargs["endpoint_url"] == "https://nyc3.digitaloceanspaces.com"


### PR DESCRIPTION
### Description
- Some cloud storage service providers have limited compatibility with S3 path-style addressing, while modern providers predominantly use virtual-hosted style addressing. This caused "Error Loading Image" issues when uploading files through S3 storage.
### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update


### Changes made:

- Added AWS_S3_ADDRESSING_STYLE environment variable support (default: auto)
- Supports three modes: auto, virtual, path
- When set to virtual or path, configures botocore's Config(s3={"addressing_style": ...}) to control presigned URL format
- Updated unit tests for the new addressing style configuration

### Usage:
```
# Virtual-hosted style (https://bucket.s3.amazonaws.com/key)
AWS_S3_ADDRESSING_STYLE=virtual

# Path style (https://s3.amazonaws.com/bucket/key)
AWS_S3_ADDRESSING_STYLE=path

# Auto (let botocore decide) - default
AWS_S3_ADDRESSING_STYLE=auto
```

### Notes:

- This PR only modifies the boto3 S3 client in the S3Storage class. Other locations (such as export_task.py, exporter_expired_task.py, etc.) still use the original boto3 client creation method, which can be unified later if needed.
- Impact: This PR uses a compatible approach to modify the code. Not introducing AWS_S3_ADDRESSING_STYLE environment variable will have no impact; existing deployments can upgrade normally.

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->
The issue with image uploads occurs when using S3 with a cloud storage provider that does not support path-style access mode.
<img width="670" height="488" alt="image" src="https://github.com/user-attachments/assets/6f57267d-a350-4b98-83b4-a8f264c8aa1d" />

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->
<img width="1418" height="440" alt="image" src="https://github.com/user-attachments/assets/1e2cf872-e3a7-417a-9661-d9cd1efe6bfd" />
<img width="750" height="734" alt="image" src="https://github.com/user-attachments/assets/9c00a053-1455-4bbf-977b-6f61a9f1273d" />

### References
<!-- Link related issues if there are any -->
- Issue: "Error Loading Image" when uploading files (V1.3.0)
- Root cause: S3 client using path-style addressing incompatible with some cloud providers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable S3 addressing style support (virtual or path) to improve compatibility with different S3-compatible providers.

* **Tests**
  * Added tests covering virtual, path, and default (auto) addressing behaviors, including a case for custom endpoint providers (e.g., DigitalOcean Spaces).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/makeplane/plane/pull/9062)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->