### PR TITLE
fix(stickies): restore full state on failed delete

### DIFF
--- a/apps/web/core/services/sticky.service.ts
+++ b/apps/web/core/services/sticky.service.ts
@@ -43,7 +43,7 @@ export class StickyService extends APIService {
   }
 
   async getSticky(workspaceSlug: string, id: string) {
-    return this.get(`/api/workspaces/${workspaceSlug}/stickies/${id}`)
+    return this.get(`/api/workspaces/${workspaceSlug}/stickies/${id}/`)
       .then((res) => res?.data)
       .catch((err) => {
         throw err?.response?.data;
@@ -59,7 +59,7 @@ export class StickyService extends APIService {
   }
 
   async deleteSticky(workspaceSlug: string, id: string) {
-    return await this.delete(`/api/workspaces/${workspaceSlug}/stickies/${id}`)
+    return await this.delete(`/api/workspaces/${workspaceSlug}/stickies/${id}/`)
       .then((res) => res?.data)
       .catch((err) => {
         throw err?.response?.data;

--- a/apps/web/core/store/sticky/sticky.store.ts
+++ b/apps/web/core/store/sticky/sticky.store.ts
@@ -205,13 +205,16 @@ export class StickyStore implements IStickyStore {
     } catch (error) {
       console.error("Error in updating sticky:", error);
       this.stickies[id] = sticky;
-      throw new Error();
+      throw error;
     }
   };
 
   deleteSticky = async (workspaceSlug: string, id: string) => {
     const sticky = this.stickies[id];
     if (!sticky) return;
+    const previousWorkspaceStickies = [...(this.workspaceStickies[workspaceSlug] || [])];
+    const previousActiveStickyId = this.activeStickyId;
+    const previousRecentStickyId = this.recentStickyId;
     try {
       this.workspaceStickies[workspaceSlug] = this.workspaceStickies[workspaceSlug].filter(
         (stickyId) => stickyId !== id
@@ -220,9 +223,12 @@ export class StickyStore implements IStickyStore {
       delete this.stickies[id];
       this.recentStickyId = this.workspaceStickies[workspaceSlug][0];
       await this.stickyService.deleteSticky(workspaceSlug, id);
-    } catch (e) {
-      console.log(e);
+    } catch (error) {
       this.stickies[id] = sticky;
+      this.workspaceStickies[workspaceSlug] = previousWorkspaceStickies;
+      this.activeStickyId = previousActiveStickyId;
+      this.recentStickyId = previousRecentStickyId;
+      throw error;
     }
   };
 

--- a/apps/web/core/store/sticky/sticky.store.ts
+++ b/apps/web/core/store/sticky/sticky.store.ts
@@ -212,13 +212,12 @@ export class StickyStore implements IStickyStore {
   deleteSticky = async (workspaceSlug: string, id: string) => {
     const sticky = this.stickies[id];
     if (!sticky) return;
-    const previousWorkspaceStickies = [...(this.workspaceStickies[workspaceSlug] || [])];
+    const currentWorkspaceStickies = this.workspaceStickies[workspaceSlug] || [];
+    const previousWorkspaceStickies = [...currentWorkspaceStickies];
     const previousActiveStickyId = this.activeStickyId;
     const previousRecentStickyId = this.recentStickyId;
     try {
-      this.workspaceStickies[workspaceSlug] = this.workspaceStickies[workspaceSlug].filter(
-        (stickyId) => stickyId !== id
-      );
+      this.workspaceStickies[workspaceSlug] = currentWorkspaceStickies.filter((stickyId) => stickyId !== id);
       if (this.activeStickyId === id) this.activeStickyId = undefined;
       delete this.stickies[id];
       this.recentStickyId = this.workspaceStickies[workspaceSlug][0];


### PR DESCRIPTION
When deleting a sticky note fails (e.g. network error), the frontend performs a partial rollback. This leaves
the sticky invisible in the list even though its data still exists in memory. The sticky only reappears after a full page reload.
Additionally, the success toast ("Sticky has been successfully removed") was still shown even when the API call failed, because the store swallowed the error instead of re-throwing it.

I've also added a trailing slash to the `deleteSticky` and `getSticky` API paths to avoid an unneeded 301 redirect

- Add trailing slash to getSticky and deleteSticky API paths, fixing unnecessary 301 redirect
- Snapshot workspaceStickies, activeStickyId, and recentStickyId before optimistic delete so all three are restored if the API call fails
- Re-throw the error so callers show an error toast instead of success

Fixes #9050

### Description
<!-- Provide a detailed description of the changes in this PR -->

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
<!-- Link related issues if there are any -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved sticky deletion reliability: app state now fully restores if a deletion operation fails.
  * Enhanced error handling for sticky updates: original error details are preserved for clearer troubleshooting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/makeplane/plane/pull/9064)

<!-- review_stack_entry_end -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/makeplane/plane/pull/9064)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->