### PR TITLE
fix: support /god-mode route without trailing slash (#9068)

### DIFF
--- a/apps/admin/react-router.config.ts
+++ b/apps/admin/react-router.config.ts
@@ -1,8 +1,7 @@
 import type { Config } from "@react-router/dev/config";
+import { normalizeBasePath } from "@plane/utils";
 
-const rawBasePath = process.env.VITE_ADMIN_BASE_PATH ?? "";
-
-const basePath = rawBasePath === "/" || rawBasePath === "" ? "/" : rawBasePath.replace(/\/+$/, "");
+const basePath = normalizeBasePath(process.env.VITE_ADMIN_BASE_PATH ?? "");
 
 export default {
   appDirectory: "app",

--- a/apps/admin/react-router.config.ts
+++ b/apps/admin/react-router.config.ts
@@ -1,7 +1,8 @@
 import type { Config } from "@react-router/dev/config";
-import { joinUrlPath } from "@plane/utils";
 
-const basePath = joinUrlPath(process.env.VITE_ADMIN_BASE_PATH ?? "", "/") ?? "/";
+const rawBasePath = process.env.VITE_ADMIN_BASE_PATH ?? "";
+
+const basePath = rawBasePath === "/" || rawBasePath === "" ? "/" : rawBasePath.replace(/\/+$/, "");
 
 export default {
   appDirectory: "app",

--- a/apps/admin/vite.config.ts
+++ b/apps/admin/vite.config.ts
@@ -3,7 +3,6 @@ import * as dotenv from "dotenv";
 import { reactRouter } from "@react-router/dev/vite";
 import { defineConfig } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
-import { joinUrlPath } from "@plane/utils";
 
 dotenv.config({ path: path.resolve(__dirname, ".env") });
 
@@ -15,7 +14,9 @@ const viteEnv = Object.keys(process.env)
     return a;
   }, {});
 
-const basePath = joinUrlPath(process.env.VITE_ADMIN_BASE_PATH ?? "", "/") ?? "/";
+const rawBasePath = process.env.VITE_ADMIN_BASE_PATH ?? "";
+
+const basePath = rawBasePath === "/" || rawBasePath === "" ? "/" : rawBasePath.replace(/\/+$/, "");
 
 export default defineConfig(() => ({
   base: basePath,

--- a/apps/admin/vite.config.ts
+++ b/apps/admin/vite.config.ts
@@ -3,6 +3,7 @@ import * as dotenv from "dotenv";
 import { reactRouter } from "@react-router/dev/vite";
 import { defineConfig } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
+import { normalizeBasePath } from "@plane/utils";
 
 dotenv.config({ path: path.resolve(__dirname, ".env") });
 
@@ -14,9 +15,7 @@ const viteEnv = Object.keys(process.env)
     return a;
   }, {});
 
-const rawBasePath = process.env.VITE_ADMIN_BASE_PATH ?? "";
-
-const basePath = rawBasePath === "/" || rawBasePath === "" ? "/" : rawBasePath.replace(/\/+$/, "");
+const basePath = normalizeBasePath(process.env.VITE_ADMIN_BASE_PATH ?? "");
 
 export default defineConfig(() => ({
   base: basePath,

--- a/packages/utils/src/string.ts
+++ b/packages/utils/src/string.ts
@@ -432,6 +432,22 @@ export const joinUrlPath = (...segments: string[]): string => {
   }
 };
 
+/**
+ * @description Normalizes a base path by:
+ * - converting empty or slash-only values to "/"
+ * - collapsing duplicate slashes
+ * - removing trailing slashes except for root
+ * - ensuring the path starts with a leading slash
+ *
+ * @param {string} rawBasePath - Raw base path to normalize
+ * @returns {string} Normalized base path
+ *
+ * @example
+ * normalizeBasePath("") // returns "/"
+ * normalizeBasePath("/") // returns "/"
+ * normalizeBasePath("///api//v1/") // returns "/api/v1"
+ * normalizeBasePath("api/v1") // returns "/api/v1"
+ */
 export const normalizeBasePath = (rawBasePath: string): string => {
   const trimmed = rawBasePath.trim();
 

--- a/packages/utils/src/string.ts
+++ b/packages/utils/src/string.ts
@@ -56,7 +56,7 @@ export const truncateText = (str: string, length: number) => {
 export const createSimilarString = (str: string) => {
   const shuffled = str
     .split("")
-    .sort(() => Math.random() - 0.5)
+    .toSorted(() => Math.random() - 0.5)
     .join("");
 
   return shuffled;
@@ -153,7 +153,7 @@ export const checkEmailValidity = (email: string): boolean => {
   if (!email) return false;
 
   const isEmailValid =
-    /^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/.test(
+    /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/.test(
       email
     );
 
@@ -236,7 +236,7 @@ export const isCommentEmpty = (comment: Content | undefined): boolean => {
 
   // Handle JSONContent[] (array)
   if (Array.isArray(comment)) {
-    return comment.length === 0 || comment.every(isJSONContentEmpty);
+    return comment.every(isJSONContentEmpty);
   }
 
   // Handle JSONContent (object)
@@ -430,4 +430,22 @@ export const joinUrlPath = (...segments: string[]): string => {
     const pathParts = joined.split("/").filter((part) => part !== "");
     return pathParts.length > 0 ? `/${pathParts.join("/")}` : "";
   }
+};
+
+export const normalizeBasePath = (rawBasePath: string): string => {
+  const trimmed = rawBasePath.trim();
+
+  // Empty or slash-only paths become root
+  if (trimmed === "" || /^\/+$/.test(trimmed)) {
+    return "/";
+  }
+
+  // Collapse multiple slashes
+  const normalized = trimmed.replace(/\/{2,}/g, "/");
+
+  // Remove trailing slashes except root
+  const withoutTrailingSlashes = normalized.replace(/\/+$/, "");
+
+  // Ensure leading slash
+  return withoutTrailingSlashes.startsWith("/") ? withoutTrailingSlashes : `/${withoutTrailingSlashes}`;
 };


### PR DESCRIPTION
Closes #9068

## Summary

Fixes an issue where accessing `/god-mode` without a trailing slash caused the admin app to render a blank/loading page.

## Root Cause

The admin router basename and Vite base path were configured with a trailing slash (`/god-mode/`), causing React Router to fail matching requests to `/god-mode`.

## Changes

* Normalized the admin base path configuration to consistently remove trailing slashes for:

  * React Router basename
  * Vite base config

## Testing

Verified that:

* `/god-mode` renders correctly
* `/god-mode/` renders correctly
* both routes behave consistently without router basename errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved base-path normalization for admin build and routing to produce more consistent URLs and avoid edge-case path issues.
* **Bug Fixes**
  * Tightened email validation and simplified comment-empty detection for more reliable input handling.
* **Style / Minor Improvements**
  * Made string shuffling non-mutating to improve safety.
* **New Features**
  * Added a utility for normalizing base paths across the app.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/makeplane/plane/pull/9070)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->