### PR TITLE
fix(web): add requestIdleCallback fallback for Safari/iOS

### DIFF
--- a/apps/web/core/components/core/render-if-visible-HOC.tsx
+++ b/apps/web/core/components/core/render-if-visible-HOC.tsx
@@ -23,6 +23,14 @@ type Props = {
   forceRender?: boolean;
 };
 
+const runIdleTask = (callback: () => void) => {
+  if (typeof window !== "undefined" && typeof window.requestIdleCallback === "function") {
+    window.requestIdleCallback(callback, { timeout: 300 });
+    return;
+  }
+  window.setTimeout(callback, 0);
+};
+
 function RenderIfVisible(props: Props) {
   const {
     defaultHeight = "300px",
@@ -47,14 +55,13 @@ function RenderIfVisible(props: Props) {
 
   // Set visibility with intersection observer
   useEffect(() => {
-    if (intersectionRef.current) {
+    const target = intersectionRef.current;
+    if (target) {
       const observer = new IntersectionObserver(
         (entries) => {
           //DO no remove comments for future
-          if (typeof window !== undefined && window.requestIdleCallback && useIdletime) {
-            window.requestIdleCallback(() => setShouldVisible(entries[entries.length - 1].isIntersecting), {
-              timeout: 300,
-            });
+          if (typeof window !== "undefined" && useIdletime) {
+            runIdleTask(() => setShouldVisible(entries[entries.length - 1].isIntersecting));
           } else {
             setShouldVisible(entries[entries.length - 1].isIntersecting);
           }
@@ -64,20 +71,17 @@ function RenderIfVisible(props: Props) {
           rootMargin: `${verticalOffset}% ${horizontalOffset}% ${verticalOffset}% ${horizontalOffset}%`,
         }
       );
-      observer.observe(intersectionRef.current);
+      observer.observe(target);
       return () => {
-        if (intersectionRef.current) {
-          // eslint-disable-next-line react-hooks/exhaustive-deps
-          observer.unobserve(intersectionRef.current);
-        }
+        observer.unobserve(target);
       };
     }
-  }, [intersectionRef, children, root, verticalOffset, horizontalOffset]);
+  }, [intersectionRef, children, root, verticalOffset, horizontalOffset, useIdletime]);
 
   //Set height after render
   useEffect(() => {
     if (intersectionRef.current && isVisible && shouldRecordHeights) {
-      window.requestIdleCallback(() => {
+      runIdleTask(() => {
         if (intersectionRef.current) placeholderHeight.current = `${intersectionRef.current.offsetHeight}px`;
       });
     }


### PR DESCRIPTION
## Summary
Fixes a runtime crash on Safari/iOS where `window.requestIdleCallback` is not available.

## Problem
On iPhone Safari, opening a project issues page can crash with:
`TypeError: window.requestIdleCallback is not a function`.

The crash happens in `RenderIfVisible` and can break project/issue views.

## Changes
- Added a small `runIdleTask` helper:
  - uses `window.requestIdleCallback` when available
  - falls back to `window.setTimeout(..., 0)` otherwise
- Replaced direct `window.requestIdleCallback` calls with `runIdleTask`
- Fixed browser check to `typeof window !== "undefined"`
- Updated `IntersectionObserver` cleanup to unobserve a stable `target` reference

## Why this is safe
- No behavior change for browsers that support `requestIdleCallback`
- Graceful fallback for unsupported browsers
- Keeps lazy rendering logic intact while preventing runtime failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cross-browser compatibility issue affecting visibility state updates to work reliably across all supported browser platforms

* **Performance**
  * Optimized rendering performance for conditionally displayed elements by improving how idle-time tasks are scheduled and executed, reducing impact during page load and user interactions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/makeplane/plane/pull/9093?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->