### PR TITLE
fix(web): add requestIdleCallback fallback for Safari/iOS

### DIFF
--- a/apps/web/core/components/core/render-if-visible-HOC.tsx
+++ b/apps/web/core/components/core/render-if-visible-HOC.tsx
@@ -23,6 +23,14 @@ type Props = {
   forceRender?: boolean;
 };
 
+const runIdleTask = (callback: () => void) => {
+  if (typeof window !== "undefined" && typeof window.requestIdleCallback === "function") {
+    window.requestIdleCallback(callback, { timeout: 300 });
+    return;
+  }
+  globalThis.setTimeout(callback, 0);
+};
+
 function RenderIfVisible(props: Props) {
   const {
     defaultHeight = "300px",
@@ -47,14 +55,13 @@ function RenderIfVisible(props: Props) {
 
   // Set visibility with intersection observer
   useEffect(() => {
-    if (intersectionRef.current) {
+    const target = intersectionRef.current;
+    if (target) {
       const observer = new IntersectionObserver(
         (entries) => {
           //DO no remove comments for future
-          if (typeof window !== undefined && window.requestIdleCallback && useIdletime) {
-            window.requestIdleCallback(() => setShouldVisible(entries[entries.length - 1].isIntersecting), {
-              timeout: 300,
-            });
+          if (typeof window !== "undefined" && useIdletime) {
+            runIdleTask(() => setShouldVisible(entries[entries.length - 1].isIntersecting));
           } else {
             setShouldVisible(entries[entries.length - 1].isIntersecting);
           }
@@ -64,20 +71,17 @@ function RenderIfVisible(props: Props) {
           rootMargin: `${verticalOffset}% ${horizontalOffset}% ${verticalOffset}% ${horizontalOffset}%`,
         }
       );
-      observer.observe(intersectionRef.current);
+      observer.observe(target);
       return () => {
-        if (intersectionRef.current) {
-          // eslint-disable-next-line react-hooks/exhaustive-deps
-          observer.unobserve(intersectionRef.current);
-        }
+        observer.unobserve(target);
       };
     }
-  }, [intersectionRef, children, root, verticalOffset, horizontalOffset]);
+  }, [intersectionRef, root, verticalOffset, horizontalOffset, useIdletime]);
 
   //Set height after render
   useEffect(() => {
     if (intersectionRef.current && isVisible && shouldRecordHeights) {
-      window.requestIdleCallback(() => {
+      runIdleTask(() => {
         if (intersectionRef.current) placeholderHeight.current = `${intersectionRef.current.offsetHeight}px`;
       });
     }

--- a/apps/web/core/components/core/render-if-visible-HOC.tsx
+++ b/apps/web/core/components/core/render-if-visible-HOC.tsx
@@ -7,6 +7,7 @@
 import type { ReactNode, MutableRefObject } from "react";
 import React, { useState, useRef, useEffect } from "react";
 import { cn } from "@plane/utils";
+import { runIdleTask } from "@/lib/idle-task";
 
 type Props = {
   defaultHeight?: string;
@@ -19,16 +20,8 @@ type Props = {
   placeholderChildren?: ReactNode;
   defaultValue?: boolean;
   shouldRecordHeights?: boolean;
-  useIdletime?: boolean;
+  useIdleTime?: boolean;
   forceRender?: boolean;
-};
-
-const runIdleTask = (callback: () => void) => {
-  if (typeof window !== "undefined" && typeof window.requestIdleCallback === "function") {
-    window.requestIdleCallback(callback, { timeout: 300 });
-    return;
-  }
-  globalThis.setTimeout(callback, 0);
 };
 
 function RenderIfVisible(props: Props) {
@@ -44,12 +37,14 @@ function RenderIfVisible(props: Props) {
     //placeholder children
     placeholderChildren = null, //placeholder children
     defaultValue = false,
-    useIdletime = false,
+    useIdleTime = false,
     forceRender = false,
   } = props;
   const [shouldVisible, setShouldVisible] = useState<boolean>(defaultValue);
   const placeholderHeight = useRef<string>(defaultHeight);
   const intersectionRef = useRef<HTMLElement | null>(null);
+  const visibilityIdleTaskRef = useRef<ReturnType<typeof runIdleTask> | null>(null);
+  const heightIdleTaskRef = useRef<ReturnType<typeof runIdleTask> | null>(null);
 
   const isVisible = shouldVisible || forceRender;
 
@@ -60,8 +55,11 @@ function RenderIfVisible(props: Props) {
       const observer = new IntersectionObserver(
         (entries) => {
           //DO no remove comments for future
-          if (typeof window !== "undefined" && useIdletime) {
-            runIdleTask(() => setShouldVisible(entries[entries.length - 1].isIntersecting));
+          if (typeof window !== "undefined" && useIdleTime) {
+            visibilityIdleTaskRef.current?.cancel();
+            visibilityIdleTaskRef.current = runIdleTask(() =>
+              setShouldVisible(entries[entries.length - 1].isIntersecting)
+            );
           } else {
             setShouldVisible(entries[entries.length - 1].isIntersecting);
           }
@@ -73,18 +71,25 @@ function RenderIfVisible(props: Props) {
       );
       observer.observe(target);
       return () => {
+        visibilityIdleTaskRef.current?.cancel();
+        visibilityIdleTaskRef.current = null;
         observer.unobserve(target);
       };
     }
-  }, [intersectionRef, root, verticalOffset, horizontalOffset, useIdletime]);
+  }, [intersectionRef, root, verticalOffset, horizontalOffset, useIdleTime]);
 
   //Set height after render
   useEffect(() => {
     if (intersectionRef.current && isVisible && shouldRecordHeights) {
-      runIdleTask(() => {
+      heightIdleTaskRef.current?.cancel();
+      heightIdleTaskRef.current = runIdleTask(() => {
         if (intersectionRef.current) placeholderHeight.current = `${intersectionRef.current.offsetHeight}px`;
       });
     }
+    return () => {
+      heightIdleTaskRef.current?.cancel();
+      heightIdleTaskRef.current = null;
+    };
   }, [isVisible, intersectionRef, shouldRecordHeights]);
 
   const child = isVisible ? <>{children}</> : placeholderChildren;

--- a/apps/web/core/components/issues/issue-layouts/kanban/default.tsx
+++ b/apps/web/core/components/issues/issue-layouts/kanban/default.tsx
@@ -204,7 +204,7 @@ export const KanBan = observer(function KanBan(props: IKanBan) {
                     />
                   }
                   defaultValue={groupIndex < 5 && subGroupIndex < 2}
-                  useIdletime
+                  useIdleTime
                 >
                   <KanbanGroup
                     groupId={subList.id}

--- a/apps/web/core/lib/idle-task.ts
+++ b/apps/web/core/lib/idle-task.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2023-present Plane Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+export type IdleTaskHandle = {
+  cancel: () => void;
+};
+
+/**
+ * Schedule lightweight work for idle time and return a cancel handle.
+ * Falls back to setTimeout when requestIdleCallback is unavailable.
+ */
+export const runIdleTask = (callback: () => void): IdleTaskHandle => {
+  if (typeof window !== "undefined" && typeof window.requestIdleCallback === "function") {
+    const idleId = window.requestIdleCallback(callback, { timeout: 300 });
+    return {
+      cancel: () => window.cancelIdleCallback(idleId),
+    };
+  }
+
+  const timeoutId = window.setTimeout(callback, 0);
+  return {
+    cancel: () => window.clearTimeout(timeoutId),
+  };
+};


### PR DESCRIPTION
## Summary
Fixes a runtime crash on Safari/iOS where `window.requestIdleCallback` is not available.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [x] Breaking change
- [x] Documentation update

## Problem
On iPhone Safari, opening a project issues page can crash with:
`TypeError: window.requestIdleCallback is not a function`.

The crash happens in `RenderIfVisible` and can break project/issue views.

## Changes
- Added a small `runIdleTask` helper:
  - uses `window.requestIdleCallback` when available
  - falls back to `globalThis.setTimeout(..., 0)` otherwise
- Replaced direct `window.requestIdleCallback` calls with `runIdleTask`
- Fixed browser check to `typeof window !== "undefined"`
- Updated `IntersectionObserver` cleanup to unobserve a stable `target` reference
- Removed `children` from the observer effect dependency list to avoid unnecessary observer recreation

## Test scenarios
1. Open project issues page in iPhone Safari/iOS -> no crash, page renders normally.
2. Open the same page in Chrome/Firefox -> behavior unchanged.
3. Trigger scrolling/visibility updates -> lazy render behavior still works.

## Screenshots / media
N/A (runtime compatibility fix).

## Why this is safe
- No behavior change for browsers that support `requestIdleCallback`
- Graceful fallback for unsupported browsers
- Keeps lazy rendering logic intact while preventing runtime failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved idle-time scheduling to reduce UI jank and provide smoother visibility updates for conditionally rendered content.
  * More efficient height measurements to prevent layout thrashing and improve scroll/column stability.

* **Bug Fixes**
  * Fixed intermittent visibility and measurement timing in board/column views so items render more reliably.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/makeplane/plane/pull/9094?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->