### PR TITLE
fix(aio): use JSON array double quotes in VOLUME instruction

### DIFF
--- a/deployments/aio/community/Dockerfile
+++ b/deployments/aio/community/Dockerfile
@@ -59,7 +59,7 @@ RUN mkdir -p /app/logs/access && \
     mkdir -p /app/data && \
     chmod +x /app/start.sh
 
-VOLUME ['/app/data', '/app/logs']
+VOLUME ["/app/data", "/app/logs"]
 
 EXPOSE 80 443
 


### PR DESCRIPTION
### Description

`deployments/aio/community/Dockerfile` declared the `VOLUME` instruction with single quotes:

```dockerfile
VOLUME ['/app/data', '/app/logs']
```

Docker's JSON (exec) form requires double quotes. With single quotes the line is parsed as the shell form and the bracket/comma tokens become literal anonymous-volume paths (`[/app/data,` and `/app/logs]`).

Docker Engine tolerated these non-absolute anonymous volume paths at container create time until Engine 29.5.0, which now rejects them with:

```
invalid mount config for type "volume": invalid mount path: '[/app/data,' mount path must be absolute
```

This breaks `docker compose up -d --force-recreate` and any recreation of the `plane-aio-community` container on Docker ≥ 29.5.0, making the AIO instance non-upgradeable.

This PR switches to the valid JSON array form:

```dockerfile
VOLUME ["/app/data", "/app/logs"]
```

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)

N/A — one-line Dockerfile change.

### Test Scenarios

- `docker history` on an image built from the fixed Dockerfile shows `VOLUME ["/app/data" "/app/logs"]` and `.Config.Volumes` = `{"/app/data":{}, "/app/logs":{}}` (absolute paths).
- `docker create` / `docker compose up -d --force-recreate` succeed on Docker Engine 29.5.0 (previously failed with `mount path must be absolute`).

### References

Fixes #9098

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image configuration formatting for storage volume declarations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/makeplane/plane/pull/9099?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->