### PR TITLE
fix(services): added plain-text MIME type fallback for consistent file detection

### DIFF
--- a/packages/services/src/file/helper.ts
+++ b/packages/services/src/file/helper.ts
@@ -81,6 +81,18 @@ const detectMimeTypeFromSignature = async (file: File): Promise<string> => {
   }
 };
 
+const PLAIN_TEXT_MIME_MAP: Record<string, string> = {
+  md: "text/markdown",
+  markdown: "text/markdown",
+  txt: "text/plain",
+  csv: "text/csv",
+  json: "application/json",
+  css: "text/css",
+  js: "text/javascript",
+  sql: "application/x-sql",
+  xml: "text/xml",
+};
+
 /**
  * @description Validate and detect the MIME type of a file using signature detection
  * Also performs basic security checks on filename
@@ -103,8 +115,14 @@ const validateAndDetectFileType = async (file: File): Promise<string> => {
     console.warn("Error detecting file type from signature:", _error);
   }
 
-  // fallback for unknown files
-  return "";
+  // Fallback 1: Static extension lookup for whitelisted plain-text files
+  const extension = file.name.split(".").pop()?.toLowerCase() || "";
+  if (extension in PLAIN_TEXT_MIME_MAP) {
+    return PLAIN_TEXT_MIME_MAP[extension];
+  }
+
+  // Fallback 2: Generic browser/OS fallback
+  return file.type || "";
 };
 
 /**

--- a/packages/services/src/file/helper.ts
+++ b/packages/services/src/file/helper.ts
@@ -117,7 +117,7 @@ const validateAndDetectFileType = async (file: File): Promise<string> => {
 
   // Fallback 1: Static extension lookup for whitelisted plain-text files
   const extension = file.name.split(".").pop()?.toLowerCase() || "";
-  if (extension in PLAIN_TEXT_MIME_MAP) {
+  if (Object.hasOwn(PLAIN_TEXT_MIME_MAP, extension)) {
     return PLAIN_TEXT_MIME_MAP[extension];
   }
 


### PR DESCRIPTION
### Description
 Plain Text file like markdown, csv and json cannot be recoginzed with detectMimeTypeFromSignature function based on binary magic numbers and hence earlier an empty string was getting passed to backend and file upload was failing previously . I added plain-text MIME type fallback for consistent file detection in case of plain text files.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<img width="1758" height="890" alt="image" src="https://github.com/user-attachments/assets/ad7eed2c-5903-441a-a58a-98f37a3f9156" />

### Test Scenarios 

### References
Related Issue: #8565  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file type detection for plain-text uploads (e.g., markdown, txt, csv, json, css, js, sql, xml). When signature-based detection fails, the system now checks a trusted extension-to-MIME mapping and otherwise uses the OS/browser-provided type, resulting in more reliable MIME identification during file uploads.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/makeplane/plane/pull/9102?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->