### PR TITLE
feat: add cover image support for work items in kanban and detail views

### DIFF
--- a/apps/web/core/components/issues/issue-detail/cover-image.tsx
+++ b/apps/web/core/components/issues/issue-detail/cover-image.tsx
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2023-present Plane Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { useState } from "react";
+import { observer } from "mobx-react";
+import { useParams } from "next/navigation";
+import type { TIssueServiceType } from "@plane/types";
+import { EIssueServiceType } from "@plane/types";
+import { useIssueCoverImage } from "@/hooks/use-issue-cover-image";
+
+interface IssueDetailCoverImageProps {
+  issueId: string;
+  projectId: string | null;
+  attachmentCount: number;
+  isEpic?: boolean;
+}
+
+export const IssueDetailCoverImage = observer(function IssueDetailCoverImage(props: IssueDetailCoverImageProps) {
+  const { issueId, projectId, attachmentCount, isEpic = false } = props;
+  const { workspaceSlug } = useParams();
+  const [imageLoadError, setImageLoadError] = useState(false);
+
+  const serviceType: TIssueServiceType = isEpic ? EIssueServiceType.EPICS : EIssueServiceType.ISSUES;
+  const { coverImageUrl, isLoading } = useIssueCoverImage(
+    workspaceSlug?.toString(),
+    projectId,
+    issueId,
+    attachmentCount,
+    serviceType
+  );
+
+  if (isLoading) {
+    return (
+      <div className="-mx-8 -mt-5 mb-4 h-60 w-[calc(100%+4rem)] animate-pulse bg-layer-1" />
+    );
+  }
+
+  if (!coverImageUrl || imageLoadError) {
+    return null;
+  }
+
+  return (
+    <div className="-mx-8 -mt-5 mb-4 h-60 w-[calc(100%+4rem)] overflow-hidden">
+      <img
+        src={coverImageUrl}
+        alt="Cover"
+        className="h-full w-full object-cover"
+        onError={() => setImageLoadError(true)}
+        loading="lazy"
+      />
+    </div>
+  );
+});

--- a/apps/web/core/components/issues/issue-layouts/kanban/block.tsx
+++ b/apps/web/core/components/issues/issue-layouts/kanban/block.tsx
@@ -38,6 +38,7 @@ import { IssueStats } from "@/plane-web/components/issues/issue-layouts/issue-st
 import type { TRenderQuickActions } from "../list/list-view-types";
 import { IssueProperties } from "../properties/all-properties";
 import { WithDisplayPropertiesHOC } from "../properties/with-display-properties-HOC";
+import { KanbanIssueCoverImage } from "./cover-image";
 
 interface IssueBlockProps {
   issueId: string;
@@ -275,7 +276,7 @@ export const KanbanIssueBlock = observer(function KanbanIssueBlock(props: IssueB
           href={workItemLink}
           ref={cardRef}
           className={cn(
-            "block w-full rounded-lg border border-subtle bg-layer-2 p-3 text-13 shadow-raised-100 outline-[0.5px] outline-transparent transition-all hover:border-strong hover:shadow-raised-200",
+            "block w-full rounded-lg border border-subtle bg-layer-2 overflow-hidden text-13 shadow-raised-100 outline-[0.5px] outline-transparent transition-all hover:border-strong hover:shadow-raised-200",
             { "hover:cursor-pointer": isDragAllowed },
             { "border border-accent-strong hover:border-accent-strong": getIsIssuePeeked(issue.id) },
             { "z-[100] bg-layer-1": isCurrentBlockDragging }
@@ -283,24 +284,32 @@ export const KanbanIssueBlock = observer(function KanbanIssueBlock(props: IssueB
           onClick={() => handleIssuePeekOverview(issue)}
           disabled={!!issue?.tempId}
         >
-          <RenderIfVisible
-            classNames="space-y-2"
-            root={scrollableContainerRef}
-            defaultHeight="100px"
-            horizontalOffset={100}
-            verticalOffset={200}
-            defaultValue={shouldRenderByDefault}
-          >
-            <KanbanIssueDetailsBlock
-              cardRef={cardRef}
-              issue={issue}
-              displayProperties={displayProperties}
-              updateIssue={updateIssue}
-              quickActions={quickActions}
-              isReadOnly={!canEditIssueProperties}
-              isEpic={isEpic}
-            />
-          </RenderIfVisible>
+          <KanbanIssueCoverImage
+            issueId={issue.id}
+            projectId={issue.project_id}
+            attachmentCount={issue.attachment_count}
+            isEpic={isEpic}
+          />
+          <div className="p-3">
+            <RenderIfVisible
+              classNames="space-y-2"
+              root={scrollableContainerRef}
+              defaultHeight="100px"
+              horizontalOffset={100}
+              verticalOffset={200}
+              defaultValue={shouldRenderByDefault}
+            >
+              <KanbanIssueDetailsBlock
+                cardRef={cardRef}
+                issue={issue}
+                displayProperties={displayProperties}
+                updateIssue={updateIssue}
+                quickActions={quickActions}
+                isReadOnly={!canEditIssueProperties}
+                isEpic={isEpic}
+              />
+            </RenderIfVisible>
+          </div>
         </ControlLink>
       </div>
     </>

--- a/apps/web/core/components/issues/issue-layouts/kanban/cover-image.tsx
+++ b/apps/web/core/components/issues/issue-layouts/kanban/cover-image.tsx
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2023-present Plane Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { useState } from "react";
+import { observer } from "mobx-react";
+import { useParams } from "next/navigation";
+import type { TIssueServiceType } from "@plane/types";
+import { EIssueServiceType } from "@plane/types";
+import { useIssueCoverImage } from "@/hooks/use-issue-cover-image";
+
+interface KanbanIssueCoverImageProps {
+  issueId: string;
+  projectId: string | null;
+  attachmentCount: number;
+  isEpic?: boolean;
+}
+
+export const KanbanIssueCoverImage = observer(function KanbanIssueCoverImage(props: KanbanIssueCoverImageProps) {
+  const { issueId, projectId, attachmentCount, isEpic = false } = props;
+  const { workspaceSlug } = useParams();
+  const [imageLoadError, setImageLoadError] = useState(false);
+
+  const serviceType: TIssueServiceType = isEpic ? EIssueServiceType.EPICS : EIssueServiceType.ISSUES;
+  const { coverImageUrl, isLoading } = useIssueCoverImage(
+    workspaceSlug?.toString(),
+    projectId,
+    issueId,
+    attachmentCount,
+    serviceType
+  );
+
+  if (isLoading) {
+    return (
+      <div style={{ position: 'relative', height: '128px', width: '100%', backgroundColor: '#f0f0f0' }} className="animate-pulse" />
+    );
+  }
+
+  if (!coverImageUrl || imageLoadError) {
+    return null;
+  }
+
+  return (
+    <div style={{ position: 'relative', height: '128px', width: '100%', overflow: 'hidden' }}>
+      <img
+        src={coverImageUrl}
+        alt="Cover"
+        style={{ height: '100%', width: '100%', objectFit: 'cover' }}
+        onError={() => setImageLoadError(true)}
+        loading="lazy"
+      />
+    </div>
+  );
+});

--- a/apps/web/core/components/issues/peek-overview/issue-detail.tsx
+++ b/apps/web/core/components/issues/peek-overview/issue-detail.tsx
@@ -30,6 +30,7 @@ import { useDebouncedDuplicateIssues } from "@/plane-web/hooks/use-debounced-dup
 import { WorkItemVersionService } from "@/services/issue";
 // local components
 import type { TIssueOperations } from "../issue-detail";
+import { IssueDetailCoverImage } from "../issue-detail/cover-image";
 import { IssueParentDetail } from "../issue-detail/parent";
 import { IssueReaction } from "../issue-detail/reactions";
 import { IssueTitleInput } from "../title-input";
@@ -97,16 +98,22 @@ export const PeekOverviewIssueDetails = observer(function PeekOverviewIssueDetai
       : undefined;
 
   return (
-    <div className="space-y-2">
-      {issue.parent_id && (
-        <IssueParentDetail
-          workspaceSlug={workspaceSlug}
-          projectId={issue.project_id}
-          issueId={issueId}
-          issue={issue}
-          issueOperations={issueOperations}
-        />
-      )}
+    <>
+      <IssueDetailCoverImage
+        issueId={issueId}
+        projectId={issue.project_id}
+        attachmentCount={issue.attachment_count}
+      />
+      <div className="space-y-2">
+        {issue.parent_id && (
+          <IssueParentDetail
+            workspaceSlug={workspaceSlug}
+            projectId={issue.project_id}
+            issueId={issueId}
+            issue={issue}
+            issueOperations={issueOperations}
+          />
+        )}
       <div className="flex items-center justify-between gap-2">
         <IssueTypeSwitcher issueId={issueId} disabled={isArchived || disabled} />
         {duplicateIssues?.length > 0 && (
@@ -193,5 +200,6 @@ export const PeekOverviewIssueDetails = observer(function PeekOverviewIssueDetai
         )}
       </div>
     </div>
+    </>
   );
 });

--- a/apps/web/core/hooks/use-issue-cover-image.ts
+++ b/apps/web/core/hooks/use-issue-cover-image.ts
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2023-present Plane Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { useEffect, useState } from "react";
+import type { TIssueAttachment, TIssueServiceType } from "@plane/types";
+import { EIssueServiceType } from "@plane/types";
+import { getFileURL } from "@plane/utils";
+import { IssueAttachmentService } from "@/services/issue";
+
+const COVER_IMAGE_NAMES = ["cover-image.jpg", "cover-image.jpeg", "cover-image.png", "cover-image.webp", "cover.jpg", "cover.jpeg", "cover.png", "cover.webp"];
+
+export const useIssueCoverImage = (
+  workspaceSlug: string | undefined,
+  projectId: string | null | undefined,
+  issueId: string,
+  attachmentCount: number,
+  serviceType: TIssueServiceType = EIssueServiceType.ISSUES
+) => {
+  const [coverImageUrl, setCoverImageUrl] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    if (!workspaceSlug || !projectId || !issueId || attachmentCount === 0) {
+      setCoverImageUrl(null);
+      return;
+    }
+
+    let isMounted = true;
+    const attachmentService = new IssueAttachmentService(serviceType);
+
+    const fetchCoverImage = async () => {
+      setIsLoading(true);
+      try {
+        const attachments = await attachmentService.getIssueAttachments(workspaceSlug, projectId, issueId);
+
+        if (!isMounted) return;
+
+        // Find attachment with cover image name
+        const coverAttachment = attachments.find((attachment: TIssueAttachment) => {
+          const fileName = attachment.attributes.name.toLowerCase();
+          return COVER_IMAGE_NAMES.some(coverName => fileName === coverName);
+        });
+
+        if (coverAttachment) {
+          const fileUrl = getFileURL(coverAttachment.asset_url);
+          setCoverImageUrl(fileUrl ?? null);
+        } else {
+          setCoverImageUrl(null);
+        }
+      } catch (error) {
+        if (isMounted) {
+          console.error("Failed to fetch cover image:", error);
+          setCoverImageUrl(null);
+        }
+      } finally {
+        if (isMounted) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    fetchCoverImage();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [workspaceSlug, projectId, issueId, attachmentCount, serviceType]);
+
+  return { coverImageUrl, isLoading };
+};

--- a/docs/cover-images.md
+++ b/docs/cover-images.md
@@ -1,0 +1,82 @@
+# Cover Images for Work Items
+
+## Overview
+
+Work items now support cover images, similar to Trello cards. When a work item has an attachment with a specific filename, it will be displayed as a cover image at the top of the card in board/kanban view and at the top of the detail view.
+
+## How to Use
+
+1. Open a work item in your project
+2. Go to the Attachments section
+3. Upload an image with one of the following filenames:
+   - `cover-image.jpg`
+   - `cover-image.jpeg`
+   - `cover-image.png`
+   - `cover-image.webp`
+   - `cover.jpg`
+   - `cover.jpeg`
+   - `cover.png`
+   - `cover.webp`
+
+4. The cover image will automatically appear:
+   - At the top of work item cards in board/kanban view (128px height)
+   - At the top of the work item detail/peek overview (240px height)
+
+## Technical Details
+
+### Implementation
+
+The cover image feature consists of four main components:
+
+1. **Hook: `useIssueCoverImage`** (`apps/web/core/hooks/use-issue-cover-image.ts`)
+   - Fetches attachments for an issue when `attachment_count > 0`
+   - Searches for attachments matching cover image filenames
+   - Uses `getFileURL` to construct proper asset URLs
+   - Returns the asset URL for the cover image
+
+2. **Component: `KanbanIssueCoverImage`** (`apps/web/core/components/issues/issue-layouts/kanban/cover-image.tsx`)
+   - Renders the cover image at the top of kanban cards (128px height)
+   - Shows loading state while fetching
+   - Handles image load errors gracefully
+
+3. **Component: `IssueDetailCoverImage`** (`apps/web/core/components/issues/issue-detail/cover-image.tsx`)
+   - Renders the cover image at the top of work item detail views (240px height)
+   - Uses negative margins to extend edge-to-edge
+   - Shows loading state while fetching
+
+4. **Integration:**
+   - `KanbanIssueBlock` - Integrates cover image into kanban cards
+   - `PeekOverviewIssueDetails` - Integrates cover image into detail/peek views
+
+### Styling
+
+- Cover images are displayed with a fixed height of 128px
+- Images use `object-cover` to maintain aspect ratio
+- The image extends edge-to-edge at the top of the card
+- Card uses `overflow-hidden` to clip the image to rounded corners
+- Lazy loading is enabled for performance
+- Uses inline styles for reliable rendering
+
+### Performance Considerations
+
+- Attachments are only fetched when `attachment_count > 0`
+- Images use lazy loading to improve initial page load
+- Error handling prevents broken image rendering
+- Loading state provides visual feedback during fetch
+
+## Supported File Formats
+
+- JPEG (.jpg, .jpeg)
+- PNG (.png)
+- WebP (.webp)
+
+## Future Enhancements
+
+Potential improvements for future iterations:
+
+- Allow users to select any attachment as cover image via UI
+- Support for drag-and-drop cover image setting
+- Image cropping/positioning controls
+- Support for more image formats (GIF, SVG)
+- Cover image preview in attachment list
+- Batch operations to set cover images for multiple work items


### PR DESCRIPTION
Add support for displaying cover images on work items, similar to Trello cards. When a work item has an attachment with a specific filename (e.g., cover-image.jpg, cover.png), it will be displayed as a cover image.

Features:
- Cover images display at the top of kanban cards (128px height)
- Cover images display at the top of work item detail/peek views (240px height)
- Automatic detection of cover images by filename
- Lazy loading for performance
- Graceful error handling when images fail to load
- Support for both issues and epics

Implementation:
- Created useIssueCoverImage hook for fetching and managing cover images
- Added KanbanIssueCoverImage component for kanban card covers
- Added IssueDetailCoverImage component for detail view covers
- Integrated components into existing kanban and detail view layouts
- Added comprehensive documentation

Supported cover image filenames:
- cover-image.jpg, cover-image.jpeg, cover-image.png, cover-image.webp
- cover.jpg, cover.jpeg, cover.png, cover.webp

### Description
<!-- Provide a detailed description of the changes in this PR -->

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
<!-- Link related issues if there are any -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Display cover images on kanban cards and in issue detail and peek views
  * Cover images automatically load from uploaded attachments with designated filenames
  * Includes skeleton loading state while fetching and graceful error handling for missing or failed images
  * Optimized performance with lazy loading

* **Documentation**
  * Added guide for cover images feature including upload instructions and implementation details

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/makeplane/plane/pull/9106?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->