### PR TITLE
fix: hide Pages nav item from guests with no accessible pages

### DIFF
--- a/apps/web/core/components/workspace/sidebar/project-navigation.tsx
+++ b/apps/web/core/components/workspace/sidebar/project-navigation.tsx
@@ -116,7 +116,7 @@ export const ProjectNavigation = observer(function ProjectNavigation(props: TPro
         name: "Pages",
         href: `/${workspaceSlug}/projects/${projectId}/pages`,
         icon: PageIcon,
-        access: [EUserPermissions.ADMIN, EUserPermissions.MEMBER, EUserPermissions.GUEST],
+        access: [EUserPermissions.ADMIN, EUserPermissions.MEMBER],
         shouldRender: project?.page_view ?? false,
         sortOrder: 5,
       },


### PR DESCRIPTION
### Description

When `guest_view_all_features` is off, the backend restricts guests to only the pages they own. A guest who hasn't created any pages lands on an empty Pages section with no explanation — the nav link is visible but the content area is empty.

Cycles and Modules already exclude `GUEST` from their `access` arrays in `project-navigation.tsx`. This PR does the same for Pages to be consistent and avoid the confusing empty state.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

### Test Scenarios

1. Create a workspace with a guest user (no pages created by the guest)
2. Verify the Pages nav item is no longer visible in the sidebar
3. Verify admin and member users still see Pages

### References

Fixes #9103