### PR TITLE
fix: add is_server parameter to S3Storage.__init__

### DIFF
--- a/apps/api/plane/settings/storage.py
+++ b/apps/api/plane/settings/storage.py
@@ -22,7 +22,7 @@ class S3Storage(S3Boto3Storage):
 
     """S3 storage class to generate presigned URLs for S3 objects"""
 
-    def __init__(self, request=None):
+    def __init__(self, request=None, is_server=False):
         # Get the AWS credentials and bucket name from the environment
         self.aws_access_key_id = os.environ.get("AWS_ACCESS_KEY_ID")
         # Use the AWS_SECRET_ACCESS_KEY environment variable for the secret key
@@ -48,7 +48,7 @@ class S3Storage(S3Boto3Storage):
                 aws_access_key_id=self.aws_access_key_id,
                 aws_secret_access_key=self.aws_secret_access_key,
                 region_name=self.aws_region,
-                endpoint_url=(f"{endpoint_protocol}://{request.get_host()}" if request else self.aws_s3_endpoint_url),
+                endpoint_url=(f"{endpoint_protocol}://{request.get_host()}" if request and not is_server else self.aws_s3_endpoint_url),
                 config=boto3.session.Config(signature_version="s3v4"),
             )
         else:


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->

asset.py calls S3Storage(request=request, is_server=True) in three places (lines 337, 441, 565), but S3Storage.__init__ in plane/settings/storage.py only accepts request=None — the is_server parameter was never added.

This causes a TypeError: S3Storage.__init__() got an unexpected keyword argument 'is_server' on every request that hits those asset endpoints, resulting in HTTP 500 errors for all asset operations (upload slot creation, presigned URL generation, attachment downloads) when USE_MINIO=1.

The fix adds is_server=False to __init__ and updates the endpoint_url condition so server-side calls use AWS_S3_ENDPOINT_URL instead of deriving the host from the HTTP request object.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [X] Bug fix (non-breaking change which fixes an issue)

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->
N/A

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

- Reproduced the TypeError on Plane 1.3.1 with USE_MINIO=1 / RustFS or Minio storage by hitting GET /api/v1/workspaces/{slug}/assets/{id}/
- Applied the patch to a running pod and confirmed asset upload and download endpoints return 200
- Verified that client-side presigned URL generation (where request is provided and is_server=False) still derives the endpoint from the request host as before

### References
<!-- Link related issues if there are any -->
Fixes #8680

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced S3/MinIO storage configuration handling to support improved endpoint URL resolution for server-side operations, increasing flexibility in storage setup configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/makeplane/plane/pull/9114?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->