### PR TITLE
fix: correct workspace admin permission validation in project member updates

### DIFF
--- a/apps/api/plane/app/views/project/member.py
+++ b/apps/api/plane/app/views/project/member.py
@@ -206,7 +206,6 @@ class ProjectMemberViewSet(BaseViewSet):
     def partial_update(self, request, slug, project_id, pk):
         project_member = ProjectMember.objects.get(pk=pk, workspace__slug=slug, project_id=project_id, is_active=True)
 
-
         # Fetch the target's workspace role (used to cap the new project role)
         target_workspace_role = WorkspaceMember.objects.get(
             workspace__slug=slug, member=project_member.member, is_active=True
@@ -217,20 +216,8 @@ class ProjectMemberViewSet(BaseViewSet):
         ).role
         is_workspace_admin = requester_workspace_role == ROLE.ADMIN.value
 
-        # Fetch the workspace role of the project member
-        target_workspace_role = WorkspaceMember.objects.get(
-            workspace__slug=slug, member=project_member.member, is_active=True
-        ).role
-
-        # Fetch the workspace role of the requesting user for permission checks
-        requesting_workspace_role = WorkspaceMember.objects.get(
-            workspace__slug=slug, member=request.user, is_active=True
-        ).role
-        is_requesting_workspace_admin = requesting_workspace_role == ROLE.ADMIN.value
-         
-
         # Check if the user is not editing their own role if they are not an admin
-        if request.user.id == project_member.member_id and not is_requesting_workspace_admin:
+        if request.user.id == project_member.member_id and not is_workspace_admin:
             return Response(
                 {"error": "You cannot update your own role"},
                 status=status.HTTP_400_BAD_REQUEST,
@@ -243,8 +230,14 @@ class ProjectMemberViewSet(BaseViewSet):
             is_active=True,
         )
 
-
         if "role" in request.data:
+            # Only Admins can modify roles
+            if requested_project_member.role < ROLE.ADMIN.value and not is_workspace_admin:
+                return Response(
+                    {"error": "You do not have permission to update roles"},
+                    status=status.HTTP_403_FORBIDDEN,
+                )
+
             # Cannot modify a member whose role is equal to or higher than your own
             if project_member.role >= requested_project_member.role and not is_workspace_admin:
                 return Response(
@@ -267,23 +260,6 @@ class ProjectMemberViewSet(BaseViewSet):
                     {"error": "You cannot add a user with role higher than the workspace role"},
                     status=status.HTTP_400_BAD_REQUEST,
                 )
-
-        if target_workspace_role in [5] and int(request.data.get("role", project_member.role)) in [15, 20]:
-            return Response(
-                {"error": "You cannot add a user with role higher than the workspace role"},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
-
-        if (
-            "role" in request.data
-            and int(request.data.get("role", project_member.role)) > requested_project_member.role
-            and not is_requesting_workspace_admin
-        ):
-            return Response(
-                {"error": "You cannot update a role that is higher than your own role"},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
-
 
         serializer = ProjectMemberSerializer(project_member, data=request.data, partial=True)
 

--- a/apps/api/plane/app/views/project/member.py
+++ b/apps/api/plane/app/views/project/member.py
@@ -245,13 +245,6 @@ class ProjectMemberViewSet(BaseViewSet):
 
 
         if "role" in request.data:
-            # Only Admins can modify roles
-            if requested_project_member.role < ROLE.ADMIN.value and not is_workspace_admin:
-                return Response(
-                    {"error": "You do not have permission to update roles"},
-                    status=status.HTTP_403_FORBIDDEN,
-                )
-
             # Cannot modify a member whose role is equal to or higher than your own
             if project_member.role >= requested_project_member.role and not is_workspace_admin:
                 return Response(

--- a/apps/api/plane/app/views/project/member.py
+++ b/apps/api/plane/app/views/project/member.py
@@ -206,6 +206,7 @@ class ProjectMemberViewSet(BaseViewSet):
     def partial_update(self, request, slug, project_id, pk):
         project_member = ProjectMember.objects.get(pk=pk, workspace__slug=slug, project_id=project_id, is_active=True)
 
+
         # Fetch the target's workspace role (used to cap the new project role)
         target_workspace_role = WorkspaceMember.objects.get(
             workspace__slug=slug, member=project_member.member, is_active=True
@@ -216,8 +217,20 @@ class ProjectMemberViewSet(BaseViewSet):
         ).role
         is_workspace_admin = requester_workspace_role == ROLE.ADMIN.value
 
+        # Fetch the workspace role of the project member
+        target_workspace_role = WorkspaceMember.objects.get(
+            workspace__slug=slug, member=project_member.member, is_active=True
+        ).role
+
+        # Fetch the workspace role of the requesting user for permission checks
+        requesting_workspace_role = WorkspaceMember.objects.get(
+            workspace__slug=slug, member=request.user, is_active=True
+        ).role
+        is_requesting_workspace_admin = requesting_workspace_role == ROLE.ADMIN.value
+         
+
         # Check if the user is not editing their own role if they are not an admin
-        if request.user.id == project_member.member_id and not is_workspace_admin:
+        if request.user.id == project_member.member_id and not is_requesting_workspace_admin:
             return Response(
                 {"error": "You cannot update your own role"},
                 status=status.HTTP_400_BAD_REQUEST,
@@ -229,6 +242,7 @@ class ProjectMemberViewSet(BaseViewSet):
             member=request.user,
             is_active=True,
         )
+
 
         if "role" in request.data:
             # Only Admins can modify roles
@@ -260,6 +274,23 @@ class ProjectMemberViewSet(BaseViewSet):
                     {"error": "You cannot add a user with role higher than the workspace role"},
                     status=status.HTTP_400_BAD_REQUEST,
                 )
+
+        if target_workspace_role in [5] and int(request.data.get("role", project_member.role)) in [15, 20]:
+            return Response(
+                {"error": "You cannot add a user with role higher than the workspace role"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        if (
+            "role" in request.data
+            and int(request.data.get("role", project_member.role)) > requested_project_member.role
+            and not is_requesting_workspace_admin
+        ):
+            return Response(
+                {"error": "You cannot update a role that is higher than your own role"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
 
         serializer = ProjectMemberSerializer(project_member, data=request.data, partial=True)
 

--- a/apps/api/plane/tests/contract/app/test_project_app.py
+++ b/apps/api/plane/tests/contract/app/test_project_app.py
@@ -15,6 +15,7 @@ from plane.db.models import (
     WorkspaceMember,
     User,
 )
+from plane.app.permissions import ROLE
 
 
 class TestProjectBase:
@@ -241,50 +242,86 @@ class TestProjectMemberAPI:
         """Workspace admins can assign project roles above their own project role."""
         project = Project.objects.create(name="Role Project", identifier="RP", workspace=workspace)
         requesting_project_member = ProjectMember.objects.create(
-            project=project, member=create_user, role=5, is_active=True
+            project=project, member=create_user, role=ROLE.GUEST.value, is_active=True
         )
 
         target_user = User.objects.create_user(email="target@example.com", username="target")
-        WorkspaceMember.objects.create(workspace=workspace, member=target_user, role=15, is_active=True)
+        WorkspaceMember.objects.create(
+            workspace=workspace, member=target_user, role=ROLE.MEMBER.value, is_active=True
+        )
         target_project_member = ProjectMember.objects.create(
-            project=project, member=target_user, role=15, is_active=True
+            project=project, member=target_user, role=ROLE.MEMBER.value, is_active=True
         )
 
         url = self.get_project_member_url(workspace.slug, project.id, target_project_member.id)
-        response = session_client.patch(url, {"role": 20}, format="json")
+        response = session_client.patch(url, {"role": ROLE.ADMIN.value}, format="json")
 
         assert response.status_code == status.HTTP_200_OK
         target_project_member.refresh_from_db()
-        assert target_project_member.role == 20
+        assert target_project_member.role == ROLE.ADMIN.value
 
         requesting_project_member.refresh_from_db()
-        assert requesting_project_member.role == 5
+        assert requesting_project_member.role == ROLE.GUEST.value
 
     @pytest.mark.django_db
-    def test_project_member_cannot_promote_member_above_own_project_role(self, api_client, workspace):
-        """Non-workspace-admin project members cannot assign roles above their own project role."""
+    def test_non_admin_project_member_cannot_promote_member_to_admin(self, api_client, workspace):
+        """Non-admin project members cannot promote project members."""
         project = Project.objects.create(name="Protected Role Project", identifier="PRP", workspace=workspace)
 
         requesting_user = User.objects.create_user(email="requester@example.com", username="requester")
-        WorkspaceMember.objects.create(workspace=workspace, member=requesting_user, role=15, is_active=True)
-        ProjectMember.objects.create(project=project, member=requesting_user, role=15, is_active=True)
+        WorkspaceMember.objects.create(
+            workspace=workspace, member=requesting_user, role=ROLE.MEMBER.value, is_active=True
+        )
+        ProjectMember.objects.create(project=project, member=requesting_user, role=ROLE.MEMBER.value, is_active=True)
 
         target_user = User.objects.create_user(email="member-target@example.com", username="member-target")
-        WorkspaceMember.objects.create(workspace=workspace, member=target_user, role=15, is_active=True)
+        WorkspaceMember.objects.create(
+            workspace=workspace, member=target_user, role=ROLE.MEMBER.value, is_active=True
+        )
         target_project_member = ProjectMember.objects.create(
-            project=project, member=target_user, role=15, is_active=True
+            project=project, member=target_user, role=ROLE.MEMBER.value, is_active=True
         )
 
         api_client.force_authenticate(user=requesting_user)
 
         url = self.get_project_member_url(workspace.slug, project.id, target_project_member.id)
-        response = api_client.patch(url, {"role": 20}, format="json")
+        response = api_client.patch(url, {"role": ROLE.ADMIN.value}, format="json")
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert response.data["error"] == "You cannot update a role that is higher than your own role"
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert response.data["error"] == "You do not have permission to update roles"
 
         target_project_member.refresh_from_db()
-        assert target_project_member.role == 15
+        assert target_project_member.role == ROLE.MEMBER.value
+
+    @pytest.mark.django_db
+    def test_project_member_cannot_promote_lower_project_member(self, api_client, workspace):
+        """Non-admin project members cannot promote lower project members."""
+        project = Project.objects.create(name="No Expansion Project", identifier="NEP", workspace=workspace)
+
+        requesting_user = User.objects.create_user(email="role-member@example.com", username="role-member")
+        WorkspaceMember.objects.create(
+            workspace=workspace, member=requesting_user, role=ROLE.MEMBER.value, is_active=True
+        )
+        ProjectMember.objects.create(project=project, member=requesting_user, role=ROLE.MEMBER.value, is_active=True)
+
+        target_user = User.objects.create_user(email="lower-target@example.com", username="lower-target")
+        WorkspaceMember.objects.create(
+            workspace=workspace, member=target_user, role=ROLE.MEMBER.value, is_active=True
+        )
+        target_project_member = ProjectMember.objects.create(
+            project=project, member=target_user, role=ROLE.GUEST.value, is_active=True
+        )
+
+        api_client.force_authenticate(user=requesting_user)
+
+        url = self.get_project_member_url(workspace.slug, project.id, target_project_member.id)
+        response = api_client.patch(url, {"role": ROLE.MEMBER.value}, format="json")
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert response.data["error"] == "You do not have permission to update roles"
+
+        target_project_member.refresh_from_db()
+        assert target_project_member.role == ROLE.GUEST.value
 
 
 @pytest.mark.contract

--- a/apps/api/plane/tests/contract/app/test_project_app.py
+++ b/apps/api/plane/tests/contract/app/test_project_app.py
@@ -230,6 +230,64 @@ class TestProjectAPIPost(TestProjectBase):
 
 
 @pytest.mark.contract
+class TestProjectMemberAPI:
+    """Test project member role operations"""
+
+    def get_project_member_url(self, workspace_slug: str, project_id: uuid.UUID, pk: uuid.UUID) -> str:
+        return f"/api/workspaces/{workspace_slug}/projects/{project_id}/members/{pk}/"
+
+    @pytest.mark.django_db
+    def test_workspace_admin_can_promote_member_above_project_role(self, session_client, workspace, create_user):
+        """Workspace admins can assign project roles above their own project role."""
+        project = Project.objects.create(name="Role Project", identifier="RP", workspace=workspace)
+        requesting_project_member = ProjectMember.objects.create(
+            project=project, member=create_user, role=5, is_active=True
+        )
+
+        target_user = User.objects.create_user(email="target@example.com", username="target")
+        WorkspaceMember.objects.create(workspace=workspace, member=target_user, role=15, is_active=True)
+        target_project_member = ProjectMember.objects.create(
+            project=project, member=target_user, role=15, is_active=True
+        )
+
+        url = self.get_project_member_url(workspace.slug, project.id, target_project_member.id)
+        response = session_client.patch(url, {"role": 20}, format="json")
+
+        assert response.status_code == status.HTTP_200_OK
+        target_project_member.refresh_from_db()
+        assert target_project_member.role == 20
+
+        requesting_project_member.refresh_from_db()
+        assert requesting_project_member.role == 5
+
+    @pytest.mark.django_db
+    def test_project_member_cannot_promote_member_above_own_project_role(self, api_client, workspace):
+        """Non-workspace-admin project members cannot assign roles above their own project role."""
+        project = Project.objects.create(name="Protected Role Project", identifier="PRP", workspace=workspace)
+
+        requesting_user = User.objects.create_user(email="requester@example.com", username="requester")
+        WorkspaceMember.objects.create(workspace=workspace, member=requesting_user, role=15, is_active=True)
+        ProjectMember.objects.create(project=project, member=requesting_user, role=15, is_active=True)
+
+        target_user = User.objects.create_user(email="member-target@example.com", username="member-target")
+        WorkspaceMember.objects.create(workspace=workspace, member=target_user, role=15, is_active=True)
+        target_project_member = ProjectMember.objects.create(
+            project=project, member=target_user, role=15, is_active=True
+        )
+
+        api_client.force_authenticate(user=requesting_user)
+
+        url = self.get_project_member_url(workspace.slug, project.id, target_project_member.id)
+        response = api_client.patch(url, {"role": 20}, format="json")
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.data["error"] == "You cannot update a role that is higher than your own role"
+
+        target_project_member.refresh_from_db()
+        assert target_project_member.role == 15
+
+
+@pytest.mark.contract
 class TestProjectAPIGet(TestProjectBase):
     """Test project GET operations"""
 


### PR DESCRIPTION
### Description

Fixes issue #9109 where workspace admins could not promote project members to Admin if their own project role was lower.

The backend permission validation in `ProjectMemberViewSet.partial_update` was incorrectly checking the workspace role of the target member being edited instead of the requesting user.

This change updates the validation logic to use the requesting user's workspace role for permission checks.

### Type of Change

* [ ] Bug fix (non-breaking change which fixes an issue)

### Screenshots and Media (if applicable)

N/A

### Test Scenarios

* Verified workspace admins can assign higher project roles even if their own project role is lower.
* Verified non-admin project members still cannot assign roles higher than their own.
* Reviewed backend permission flow for requester vs target role validation.

### References

Fixes #9109

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added contract tests for project member role-update authorization. Tests verify proper access controls for role promotions, ensuring appropriate capabilities for different permission levels while non-admin members receive proper restrictions, and validate database consistency following authorization checks across multiple role promotion scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/makeplane/plane/pull/9119?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->