### PR TITLE
allowing spaces in display name

### DIFF
--- a/packages/utils/src/validation.ts
+++ b/packages/utils/src/validation.ts
@@ -31,7 +31,7 @@ export const PERSON_NAME_REGEX = /^[\p{L}\s'-]+$/u;
  * Use case: International usernames like "josé_123", "李明.dev", "müller-2024"
  * Blocks: Spaces and injection-risk characters
  */
-export const DISPLAY_NAME_REGEX = /^[\p{L}\p{N}_.-]+$/u;
+export const DISPLAY_NAME_REGEX = /^[\p{L}\p{N}_. -]+$/u;
 
 /**
  * Company/Organization Name Pattern (for company_name, workspace names)
@@ -107,7 +107,7 @@ export const validateDisplayName = (displayName: string): boolean | string => {
   }
 
   if (!DISPLAY_NAME_REGEX.test(displayName)) {
-    return "Display name can only contain letters, numbers, periods, hyphens, and underscores";
+    return "Display name can only contain letters, numbers, spaces, periods, hyphens, and underscores";
   }
 
   return true;


### PR DESCRIPTION
### Description
Fixes the issue #9112
We were not allowed to enter spaces in display name, changed the regex so we can now.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<img width="1512" height="982" alt="Screenshot 2026-05-24 at 3 22 33 AM" src="https://github.com/user-attachments/assets/bd597565-45d2-4a14-ae19-e995439504da" />


### Test Scenarios 
- Tried Entering Spaces - It worked
- Tried Entering other characters like * / ( $ - it stopped and gave warning. 

### References
(https://github.com/makeplane/plane/issues/9112)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Display names and usernames can now include space characters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/makeplane/plane/pull/9121?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->