### PR TITLE
fix: normalize OAuth provider config flags

### DIFF
--- a/apps/api/plane/license/api/views/instance.py
+++ b/apps/api/plane/license/api/views/instance.py
@@ -25,6 +25,10 @@ from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_control
 
 
+def _is_config_enabled(value):
+    return str(value).strip().lower() in ("1", "true")
+
+
 class InstanceEndpoint(BaseAPIView):
     def get_permissions(self):
         if self.request.method == "PATCH":
@@ -129,10 +133,10 @@ class InstanceEndpoint(BaseAPIView):
         # Authentication
         data["enable_signup"] = ENABLE_SIGNUP == "1"
         data["is_workspace_creation_disabled"] = DISABLE_WORKSPACE_CREATION == "1"
-        data["is_google_enabled"] = IS_GOOGLE_ENABLED == "1"
-        data["is_github_enabled"] = IS_GITHUB_ENABLED == "1"
-        data["is_gitlab_enabled"] = IS_GITLAB_ENABLED == "1"
-        data["is_gitea_enabled"] = IS_GITEA_ENABLED == "1"
+        data["is_google_enabled"] = _is_config_enabled(IS_GOOGLE_ENABLED)
+        data["is_github_enabled"] = _is_config_enabled(IS_GITHUB_ENABLED)
+        data["is_gitlab_enabled"] = _is_config_enabled(IS_GITLAB_ENABLED)
+        data["is_gitea_enabled"] = _is_config_enabled(IS_GITEA_ENABLED)
         data["is_magic_login_enabled"] = ENABLE_MAGIC_LINK_LOGIN == "1"
         data["is_email_password_enabled"] = ENABLE_EMAIL_PASSWORD == "1"
 


### PR DESCRIPTION
## Description

Fixes the issue where OAuth providers such as Gitea were not rendered on the login page when self-hosted instances used boolean-like config values such as `"true"` instead of `"1"`.

The issue occurred because OAuth provider flags were serialized using strict `"1"` comparisons.

This change normalizes OAuth provider config checks so values like:

* `"1"`
* `"true"`
* `"TRUE"`
* `" true "`

are treated as enabled.

The fix is scoped only to OAuth provider flags:

* Google
* GitHub
* GitLab
* Gitea

Closes #9124

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)

## Test Scenarios

* Verified Python compilation passes
* Verified `"1"` resolves to enabled
* Verified `"true"` resolves to enabled
* Verified `"0"` and `"false"` remain disabled
* Confirmed change is limited to OAuth provider serialization logic

## References

Issue: https://github.com/makeplane/plane/issues/9124

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced configuration parsing for authentication integrations (Google, GitHub, GitLab, Gitea) to recognize multiple input formats when enabling these providers, improving flexibility in instance configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/makeplane/plane/pull/9135?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->