### PR TITLE
fix(web): add Safari fallback for requestIdleCallback

### DIFF
--- a/apps/web/app/entry.client.tsx
+++ b/apps/web/app/entry.client.tsx
@@ -8,6 +8,10 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 import { HydratedRouter } from "react-router/dom";
 
+import polyfills from "@/lib/polyfills";
+
+void polyfills;
+
 startTransition(() => {
   hydrateRoot(
     document,

--- a/apps/web/core/lib/idle-task.ts
+++ b/apps/web/core/lib/idle-task.ts
@@ -8,40 +8,38 @@ export type IdleTaskHandle = {
   cancel: () => void;
 };
 
-const requestIdleFallback = (callback: IdleRequestCallback): number => {
+const requestIdleFallback = (callback: IdleRequestCallback, options?: IdleRequestOptions): number => {
   const start = Date.now();
 
-  return window.setTimeout(() => {
+  return globalThis.setTimeout(() => {
     callback({
       didTimeout: false,
       timeRemaining: () => Math.max(0, 50 - (Date.now() - start)),
     });
-  }, 1);
+  }, options?.timeout ?? 1) as unknown as number;
 };
 
 const cancelIdleFallback = (id: number) => {
-  window.clearTimeout(id);
+  globalThis.clearTimeout(id);
 };
 
 export const requestIdle = (callback: IdleRequestCallback, options?: IdleRequestOptions): number => {
-  if (typeof window !== "undefined" && typeof window.requestIdleCallback === "function")
-    return window.requestIdleCallback(callback, options);
+  if (typeof globalThis.requestIdleCallback === "function") return globalThis.requestIdleCallback(callback, options);
 
-  return requestIdleFallback(callback);
+  return requestIdleFallback(callback, options);
 };
 
 export const cancelIdle = (id: number) => {
-  if (typeof window !== "undefined" && typeof window.cancelIdleCallback === "function")
-    return window.cancelIdleCallback(id);
+  if (typeof globalThis.cancelIdleCallback === "function") return globalThis.cancelIdleCallback(id);
 
   return cancelIdleFallback(id);
 };
 
 export const installIdleCallbackPolyfill = () => {
-  if (typeof window === "undefined") return;
+  if (typeof globalThis === "undefined") return;
 
-  window.requestIdleCallback = window.requestIdleCallback ?? requestIdleFallback;
-  window.cancelIdleCallback = window.cancelIdleCallback ?? cancelIdleFallback;
+  globalThis.requestIdleCallback = globalThis.requestIdleCallback ?? requestIdleFallback;
+  globalThis.cancelIdleCallback = globalThis.cancelIdleCallback ?? cancelIdleFallback;
 };
 
 /**

--- a/apps/web/core/lib/idle-task.ts
+++ b/apps/web/core/lib/idle-task.ts
@@ -8,20 +8,49 @@ export type IdleTaskHandle = {
   cancel: () => void;
 };
 
+const requestIdleFallback = (callback: IdleRequestCallback): number => {
+  const start = Date.now();
+
+  return window.setTimeout(() => {
+    callback({
+      didTimeout: false,
+      timeRemaining: () => Math.max(0, 50 - (Date.now() - start)),
+    });
+  }, 1);
+};
+
+const cancelIdleFallback = (id: number) => {
+  window.clearTimeout(id);
+};
+
+export const requestIdle = (callback: IdleRequestCallback, options?: IdleRequestOptions): number => {
+  if (typeof window !== "undefined" && typeof window.requestIdleCallback === "function")
+    return window.requestIdleCallback(callback, options);
+
+  return requestIdleFallback(callback);
+};
+
+export const cancelIdle = (id: number) => {
+  if (typeof window !== "undefined" && typeof window.cancelIdleCallback === "function")
+    return window.cancelIdleCallback(id);
+
+  return cancelIdleFallback(id);
+};
+
+export const installIdleCallbackPolyfill = () => {
+  if (typeof window === "undefined") return;
+
+  window.requestIdleCallback = window.requestIdleCallback ?? requestIdleFallback;
+  window.cancelIdleCallback = window.cancelIdleCallback ?? cancelIdleFallback;
+};
+
 /**
  * Schedule lightweight work for idle time and return a cancel handle.
  * Falls back to setTimeout when requestIdleCallback is unavailable.
  */
-export const runIdleTask = (callback: () => void): IdleTaskHandle => {
-  if (typeof window !== "undefined" && typeof window.requestIdleCallback === "function") {
-    const idleId = window.requestIdleCallback(callback, { timeout: 300 });
-    return {
-      cancel: () => window.cancelIdleCallback(idleId),
-    };
-  }
-
-  const timeoutId = window.setTimeout(callback, 0);
+export const runIdleTask = (callback: IdleRequestCallback): IdleTaskHandle => {
+  const idleId = requestIdle(callback, { timeout: 300 });
   return {
-    cancel: () => window.clearTimeout(timeoutId),
+    cancel: () => cancelIdle(idleId),
   };
 };

--- a/apps/web/core/lib/polyfills/index.ts
+++ b/apps/web/core/lib/polyfills/index.ts
@@ -4,27 +4,8 @@
  * See the LICENSE file for details.
  */
 
-if (typeof window !== "undefined" && window) {
-  // Add request callback polyfill to browser in case it does not exist
-  window.requestIdleCallback =
-    window.requestIdleCallback ??
-    function (cb) {
-      const start = Date.now();
-      return setTimeout(function () {
-        cb({
-          didTimeout: false,
-          timeRemaining: function () {
-            return Math.max(0, 50 - (Date.now() - start));
-          },
-        });
-      }, 1);
-    };
+import { installIdleCallbackPolyfill } from "@/lib/idle-task";
 
-  window.cancelIdleCallback =
-    window.cancelIdleCallback ??
-    function (id) {
-      clearTimeout(id);
-    };
-}
+installIdleCallbackPolyfill();
 
-export {};
+export default true;


### PR DESCRIPTION
### Description

Fixes a Safari/iOS crash caused by unguarded usage of `window.requestIdleCallback` in the project layout/gantt view.

Safari does not currently support `requestIdleCallback` by default, which caused the following runtime error:

`TypeError: window.requestIdleCallback is not a function`

This PR adds a shared compatibility fallback for:

* `requestIdleCallback`
* `cancelIdleCallback`

The polyfill is installed during client startup before React hydration, while preserving native behavior in Chrome and Firefox.

### Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Feature (non-breaking change which adds functionality)
* [ ] Improvement (change that would cause existing functionality to not work as expected)
* [ ] Code refactoring
* [ ] Performance improvements
* [ ] Documentation update

### Screenshots and Media (if applicable)

N/A

### Test Scenarios

* Ran web lint checks successfully
* Verified Safari fallback executes when `requestIdleCallback` is unavailable
* Confirmed no unsafe direct usages remain outside shared compatibility layer

### References

Closes #9134

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved browser compatibility for idle-task scheduling with robust fallbacks so background work runs reliably across browsers and environments.
  * Centralized and simplified startup initialization of compatibility features to make app startup more consistent and maintainable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/makeplane/plane/pull/9137?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->