### PR TITLE
fixed issue for muliple tap were nedded to view sub issue.

### DIFF
--- a/apps/web/core/components/issues/issue-layouts/list/block.tsx
+++ b/apps/web/core/components/issues/issue-layouts/list/block.tsx
@@ -143,17 +143,15 @@ export const IssueBlock = observer(function IssueBlock(props: IssueBlockProps) {
 
   const marginLeft = `${spacingLeft}px`;
 
-  const handleToggleExpand = (e: MouseEvent<HTMLButtonElement>) => {
+  const handleToggleExpand = async (e: MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
     e.preventDefault();
     if (nestingLevel >= 3) {
       handleIssuePeekOverview(issue);
     } else {
-      setExpanded((prevState) => {
-        if (!prevState && workspaceSlug && issue && issue.project_id)
-          subIssuesStore.fetchSubIssues(workspaceSlug.toString(), issue.project_id, issue.id);
-        return !prevState;
-      });
+      if (!isExpanded && workspaceSlug && issue.project_id)
+        await subIssuesStore.fetchSubIssues(workspaceSlug.toString(), issue.project_id, issue.id);
+      setExpanded((prevState) => !prevState);
     }
   };
 
@@ -321,11 +319,16 @@ export const IssueBlock = observer(function IssueBlock(props: IssueBlockProps) {
                 isEpic={isEpic}
               />
               <div
+                role="presentation"
                 className={cn("hidden", {
                   "md:flex": isSidebarCollapsed,
                   "lg:flex": !isSidebarCollapsed,
                 })}
                 onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                }}
+                onKeyDown={(e) => {
                   e.preventDefault();
                   e.stopPropagation();
                 }}


### PR DESCRIPTION
### Description
fixes the issue #9124
component was rendering before we were getting data from api, so we have to make it re render or make it asyncronus.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Screenshots and Media (if applicable)

https://github.com/user-attachments/assets/0d9ed65a-3a9e-4752-be97-9370fb506f4b


### Test Scenarios 
did the manual testing for behaviour of opening and closing of sub issues,

### References
#9124

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved responsiveness when expanding nested items by ensuring proper data loading before UI updates.

* **Accessibility**
  * Enhanced keyboard interaction support for actions on expanded items.
  * Improved semantic markup for better screen reader compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/makeplane/plane/pull/9139?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->