### PR TITLE
[INFRA-392] deployments(fix): rename API key rate limit environment variables to DEFAULT_API_RATE_LIMIT

### DIFF
--- a/deployments/aio/community/start.sh
+++ b/deployments/aio/community/start.sh
@@ -149,7 +149,7 @@ update_env_file(){
     update_env_value "FILE_SIZE_LIMIT" "${FILE_SIZE_LIMIT:-5242880}"
     update_env_value "LIVE_SERVER_SECRET_KEY" "${LIVE_SERVER_SECRET_KEY:-htbqvBJAgpm9bzvf3r4urJer0ENReatceh}"
 
-    update_env_value "API_KEY_RATE_LIMIT" "${API_KEY_RATE_LIMIT:-60/minute}"
+    update_env_value "DEFAULT_API_RATE_LIMIT" "${API_KEY_RATE_LIMIT:-60/minute}"
 
     echo "✅ Environment file updated"
     echo ""

--- a/deployments/aio/community/variables.env
+++ b/deployments/aio/community/variables.env
@@ -48,7 +48,6 @@ MINIO_ENDPOINT_SSL=0
 
 # API key rate limit
 DEFAULT_API_RATE_LIMIT=60/minute
-API_KEY_RATE_LIMIT=60/minute
 
 # Live Server Secret Key
 LIVE_SERVER_SECRET_KEY=htbqvBJAgpm9bzvf3r4urJer0ENReatceh

--- a/deployments/aio/community/variables.env
+++ b/deployments/aio/community/variables.env
@@ -48,6 +48,7 @@ MINIO_ENDPOINT_SSL=0
 
 # API key rate limit
 DEFAULT_API_RATE_LIMIT=60/minute
+API_KEY_RATE_LIMIT=60/minute
 
 # Live Server Secret Key
 LIVE_SERVER_SECRET_KEY=htbqvBJAgpm9bzvf3r4urJer0ENReatceh

--- a/deployments/aio/community/variables.env
+++ b/deployments/aio/community/variables.env
@@ -47,7 +47,7 @@ GUNICORN_WORKERS=1
 MINIO_ENDPOINT_SSL=0
 
 # API key rate limit
-API_KEY_RATE_LIMIT=60/minute
+DEFAULT_API_RATE_LIMIT=60/minute
 
 # Live Server Secret Key
 LIVE_SERVER_SECRET_KEY=htbqvBJAgpm9bzvf3r4urJer0ENReatceh

--- a/deployments/cli/community/docker-compose.yml
+++ b/deployments/cli/community/docker-compose.yml
@@ -55,7 +55,7 @@ x-app-env: &app-env
   DATABASE_URL: ${DATABASE_URL:-postgresql://plane:plane@plane-db/plane}
   SECRET_KEY: ${SECRET_KEY:-60gp0byfz2dvffa45cxl20p1scy9xbpf6d8c5y0geejgkyp1b5}
   AMQP_URL: ${AMQP_URL:-amqp://plane:plane@plane-mq:5672/plane}
-  API_KEY_RATE_LIMIT: ${API_KEY_RATE_LIMIT:-60/minute}
+  DEFAULT_API_RATE_LIMIT: ${API_KEY_RATE_LIMIT:-60/minute}
   MINIO_ENDPOINT_SSL: ${MINIO_ENDPOINT_SSL:-0}
   LIVE_SERVER_SECRET_KEY: ${LIVE_SERVER_SECRET_KEY:-2FiJk1U2aiVPEQtzLehYGlTSnTnrs7LW}
   WEBHOOK_ALLOWED_IPS: ${WEBHOOK_ALLOWED_IPS:-}


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->This pull request standardizes the naming of the API key rate limit environment variable across deployment scripts and configuration files. The variable name has been changed from `API_KEY_RATE_LIMIT` to `DEFAULT_API_RATE_LIMIT` to improve clarity and consistency.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [X] Bug fix (non-breaking change which fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized API rate limit configuration across deployments by introducing a default rate-limit setting while preserving the existing per-key limit and the 60 requests/minute default. This aligns environment variables for consistent behavior without changing runtime throttling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/makeplane/plane/pull/9141?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->