### PR TITLE
fix: strip control characters from sanitized filenames

### DIFF
--- a/apps/api/plane/utils/path_validator.py
+++ b/apps/api/plane/utils/path_validator.py
@@ -15,8 +15,8 @@ def sanitize_filename(filename):
     """
     Sanitize a filename to prevent path traversal attacks.
 
-    Strips directory components, path traversal sequences, and null bytes
-    from user-supplied filenames used in upload paths and S3 object keys.
+    Strips directory components, path traversal sequences, and control
+    characters from user-supplied filenames used in upload paths and S3 object keys.
 
     Returns None for empty/missing input so callers can still validate
     that a filename was provided.
@@ -24,8 +24,8 @@ def sanitize_filename(filename):
     if not filename or not isinstance(filename, str):
         return None
 
-    # Strip null bytes
-    filename = filename.replace("\x00", "")
+    # Strip ASCII control characters (0-31 and 127), including null bytes
+    filename = "".join(char for char in filename if not (ord(char) < 32 or ord(char) == 127))
 
     # Normalize backslashes so os.path.basename handles Windows-style paths on POSIX
     filename = filename.replace("\\", "/")


### PR DESCRIPTION
Prevent tab, newline, and other ASCII control characters from appearing in S3 object keys generated from user-provided upload filenames.

Fixes #9127

### Description
Prevent tab, newline and other ASCII Keys char in the s3 object pr regarding security standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced filename sanitization in file uploads to handle a broader range of control characters, improving compatibility with storage systems.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/makeplane/plane/pull/9151?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->