### PR TITLE
refactor(api): source API_KEY_RATE_LIMIT from settings, drop service token throttle

### DIFF
--- a/apps/api/plane/api/rate_limit.py
+++ b/apps/api/plane/api/rate_limit.py
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # See the LICENSE file for details.
 
-# python imports
-import os
+# Django imports
+from django.conf import settings
 
 # Third party imports
 from rest_framework.throttling import SimpleRateThrottle
@@ -11,48 +11,7 @@ from rest_framework.throttling import SimpleRateThrottle
 
 class ApiKeyRateThrottle(SimpleRateThrottle):
     scope = "api_key"
-    rate = os.environ.get("API_KEY_RATE_LIMIT", "60/minute")
-
-    def get_cache_key(self, request, view):
-        # Retrieve the API key from the request header
-        api_key = request.headers.get("X-Api-Key")
-        if not api_key:
-            return None  # Allow the request if there's no API key
-
-        # Use the API key as part of the cache key
-        return f"{self.scope}:{api_key}"
-
-    def allow_request(self, request, view):
-        allowed = super().allow_request(request, view)
-
-        if allowed:
-            now = self.timer()
-            # Calculate the remaining limit and reset time
-            history = self.cache.get(self.key, [])
-
-            # Remove old histories
-            while history and history[-1] <= now - self.duration:
-                history.pop()
-
-            # Calculate the requests
-            num_requests = len(history)
-
-            # Check available requests
-            available = self.num_requests - num_requests
-
-            # Unix timestamp for when the rate limit will reset
-            reset_time = int(now + self.duration)
-
-            # Add headers
-            request.META["X-RateLimit-Remaining"] = max(0, available)
-            request.META["X-RateLimit-Reset"] = reset_time
-
-        return allowed
-
-
-class ServiceTokenRateThrottle(SimpleRateThrottle):
-    scope = "service_token"
-    rate = "300/minute"
+    rate = settings.API_KEY_RATE_LIMIT
 
     def get_cache_key(self, request, view):
         # Retrieve the API key from the request header

--- a/apps/api/plane/api/views/base.py
+++ b/apps/api/plane/api/views/base.py
@@ -22,9 +22,8 @@ from rest_framework.exceptions import APIException
 from rest_framework.generics import GenericAPIView
 
 # Module imports
-from plane.db.models.api import APIToken
 from plane.api.middleware.api_authentication import APIKeyAuthentication
-from plane.api.rate_limit import ApiKeyRateThrottle, ServiceTokenRateThrottle
+from plane.api.rate_limit import ApiKeyRateThrottle
 from plane.utils.exception_logger import log_exception
 from plane.utils.paginator import BasePaginator
 from plane.utils.core.mixins import ReadReplicaControlMixin
@@ -60,19 +59,7 @@ class BaseAPIView(TimezoneMixin, GenericAPIView, ReadReplicaControlMixin, BasePa
         return queryset
 
     def get_throttles(self):
-        throttle_classes = []
-        api_key = self.request.headers.get("X-Api-Key")
-
-        if api_key:
-            service_token = APIToken.objects.filter(token=api_key, is_service=True).first()
-
-            if service_token:
-                throttle_classes.append(ServiceTokenRateThrottle())
-                return throttle_classes
-
-        throttle_classes.append(ApiKeyRateThrottle())
-
-        return throttle_classes
+        return [ApiKeyRateThrottle()]
 
     def handle_exception(self, exc):
         """

--- a/apps/api/plane/settings/common.py
+++ b/apps/api/plane/settings/common.py
@@ -132,6 +132,9 @@ REST_FRAMEWORK = {
     "SCHEMA_COERCE_PATH_PK": False,
 }
 
+# API key throttle rate (DRF SimpleRateThrottle format, e.g. "60/minute")
+API_KEY_RATE_LIMIT = os.environ.get("API_KEY_RATE_LIMIT", "60/minute")
+
 # Django Auth Backend
 AUTHENTICATION_BACKENDS = ("django.contrib.auth.backends.ModelBackend",)  # default
 


### PR DESCRIPTION
### Description

Two small cleanups in the API throttling layer:

- **`API_KEY_RATE_LIMIT` now flows through Django settings.** Added `API_KEY_RATE_LIMIT` to `plane/settings/common.py` (defaults to `60/minute`, overridable via env). `ApiKeyRateThrottle` reads `settings.API_KEY_RATE_LIMIT` via `django.conf.settings` instead of calling `os.environ.get` directly. Behavior is unchanged — the same env var and default still apply, but the read path is now consistent with the rest of the project.
- **Removed `ServiceTokenRateThrottle`.** Service tokens are no longer used, so the dedicated `300/minute` throttle class and the conditional branch in `BaseAPIView.get_throttles` that looked up `APIToken(is_service=True)` per request are gone. All API key requests now go through `ApiKeyRateThrottle`. This also removes an extra DB query on every API request.

The existing env wiring in `deployments/aio/community/*` and `deployments/cli/community/*` already exports `API_KEY_RATE_LIMIT` — no deployment changes needed.

### Type of Change

- [x] Code refactoring
- [x] Improvement (removes per-request DB lookup for service-token throttle)

### Screenshots and Media (if applicable)

<!-- N/A — backend-only change with no user-facing UI -->

### Test Scenarios

- Hit any `/api/v1/...` endpoint with `X-Api-Key` set to a regular API token; verify the `X-RateLimit-Remaining` / `X-RateLimit-Reset` response headers appear and counters tick down with each request.
- Send more than 60 requests/minute with the same API key and verify the 61st gets HTTP 429.
- Override `API_KEY_RATE_LIMIT=10/minute` in the API container env and confirm the throttle picks up the new limit after restart.
- Confirm requests using what used to be a service token (`is_service=True`) are now subject to the same `60/minute` (or env-configured) limit as regular API keys — no separate 300/minute bucket.

### References

- Removes `ServiceTokenRateThrottle` and `is_service`-based throttle dispatch in `apps/api/plane/api/views/base.py`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified API rate limiting to use centralized configuration settings
  * API key rate limit now configured via settings instead of environment variables (default: 60/minute)
  * Removed service token-based rate limiting

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/makeplane/plane/pull/9161?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->