### PR TITLE
[GIT-213] fix: return HTTP response from dispatch() exception handler

### DIFF
--- a/apps/api/plane/api/views/base.py
+++ b/apps/api/plane/api/views/base.py
@@ -110,7 +110,7 @@ class BaseAPIView(TimezoneMixin, GenericAPIView, ReadReplicaControlMixin, BasePa
             return response
         except Exception as exc:
             response = self.handle_exception(exc)
-            return exc
+            return response
 
     def finalize_response(self, request, response, *args, **kwargs):
         # Call super to get the default response

--- a/apps/api/plane/app/views/base.py
+++ b/apps/api/plane/app/views/base.py
@@ -120,7 +120,7 @@ class BaseViewSet(TimezoneMixin, ReadReplicaControlMixin, ModelViewSet, BasePagi
             return response
         except Exception as exc:
             response = self.handle_exception(exc)
-            return exc
+            return response
 
     @property
     def workspace_slug(self):
@@ -215,7 +215,7 @@ class BaseAPIView(TimezoneMixin, ReadReplicaControlMixin, APIView, BasePaginator
 
         except Exception as exc:
             response = self.handle_exception(exc)
-            return exc
+            return response
 
     @property
     def workspace_slug(self):

--- a/apps/api/plane/license/api/views/base.py
+++ b/apps/api/plane/license/api/views/base.py
@@ -106,7 +106,7 @@ class BaseAPIView(TimezoneMixin, APIView, BasePaginator):
 
         except Exception as exc:
             response = self.handle_exception(exc)
-            return exc
+            return response
 
     @property
     def fields(self):

--- a/apps/api/plane/space/views/base.py
+++ b/apps/api/plane/space/views/base.py
@@ -114,7 +114,7 @@ class BaseViewSet(TimezoneMixin, ModelViewSet, BasePaginator):
             return response
         except Exception as exc:
             response = self.handle_exception(exc)
-            return exc
+            return response
 
     @property
     def workspace_slug(self):
@@ -197,7 +197,7 @@ class BaseAPIView(TimezoneMixin, APIView, BasePaginator):
 
         except Exception as exc:
             response = self.handle_exception(exc)
-            return exc
+            return response
 
     @property
     def workspace_slug(self):

--- a/apps/api/plane/tests/unit/views/__init__.py
+++ b/apps/api/plane/tests/unit/views/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.

--- a/apps/api/plane/tests/unit/views/test_base_dispatch.py
+++ b/apps/api/plane/tests/unit/views/test_base_dispatch.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""
+Regression tests for the ``dispatch()`` exception handling on the shared
+``BaseAPIView`` / ``BaseViewSet`` classes.
+
+When ``super().dispatch()`` raises an unhandled exception, ``dispatch()`` must
+return the HTTP ``Response`` produced by ``handle_exception()`` -- not the raw
+exception object. Returning the exception causes Django's response pipeline to
+fail with ``TypeError: 'Exception' object is not a valid HTTP response``.
+
+See: https://github.com/makeplane/plane/issues/9157
+"""
+
+import pytest
+from unittest.mock import patch
+
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework.test import APIRequestFactory
+
+from plane.api.views.base import BaseAPIView as ApiBaseAPIView, BaseViewSet as ApiBaseViewSet
+from plane.app.views.base import BaseAPIView as AppBaseAPIView, BaseViewSet as AppBaseViewSet
+from plane.license.api.views.base import BaseAPIView as LicenseBaseAPIView
+from plane.space.views.base import BaseAPIView as SpaceBaseAPIView, BaseViewSet as SpaceBaseViewSet
+
+
+# Every shared base view that wraps ``super().dispatch()`` in a try/except.
+VIEW_CLASSES = [
+    ApiBaseAPIView,
+    ApiBaseViewSet,
+    AppBaseAPIView,
+    AppBaseViewSet,
+    LicenseBaseAPIView,
+    SpaceBaseAPIView,
+    SpaceBaseViewSet,
+]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "view_class",
+    VIEW_CLASSES,
+    ids=lambda c: f"{c.__module__}.{c.__name__}",
+)
+def test_dispatch_returns_response_when_super_dispatch_raises(view_class):
+    """dispatch() must return handle_exception()'s Response, not the exception."""
+    request = APIRequestFactory().get("/api/test/")
+    view = view_class()
+
+    sentinel = Response(
+        {"error": "Something went wrong please try again later"},
+        status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+    )
+
+    with (
+        patch("rest_framework.views.APIView.dispatch", side_effect=RuntimeError("boom")),
+        patch.object(view_class, "handle_exception", return_value=sentinel) as mock_handle,
+    ):
+        result = view.dispatch(request)
+
+    mock_handle.assert_called_once()
+    assert isinstance(result, Response), (
+        f"{view_class.__module__}.{view_class.__name__}.dispatch() returned "
+        f"{type(result).__name__} instead of an HTTP Response"
+    )
+    assert result is sentinel


### PR DESCRIPTION
### Description

When an API request triggered an unhandled exception, the shared view bases caught it, built the proper error `Response` via `handle_exception()`, but then **returned the raw exception object instead of the response**:

```python
except Exception as exc:
    response = self.handle_exception(exc)
    return exc          # ← should be `return response`
```

Django's response pipeline then failed with `TypeError: 'Exception' object is not a valid HTTP response`, so clients received a malformed 500 with no structured body instead of a clean JSON error.

The same copy-pasted defect existed in **six `dispatch()` methods across four files**, so this PR fixes all of them — not only the one reported in the issue — so the crash cannot surface from the external API, app, space, or license surfaces:

- `apps/api/plane/api/views/base.py` — `BaseAPIView`
- `apps/api/plane/app/views/base.py` — `BaseViewSet`, `BaseAPIView`
- `apps/api/plane/license/api/views/base.py` — `BaseAPIView`
- `apps/api/plane/space/views/base.py` — `BaseViewSet`, `BaseAPIView`

(`api.BaseViewSet` already returned `response` correctly, which confirmed the intended fix.)

A parametrized regression test covers every affected base class and asserts that, when `super().dispatch()` raises, `dispatch()` returns an HTTP `Response` rather than the exception.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots here -->

### Test Scenarios

- Added `apps/api/plane/tests/unit/views/test_base_dispatch.py`: parametrized over all six affected base classes plus `api.BaseViewSet` as a control; asserts `dispatch()` returns a `rest_framework.response.Response` (not the exception) when `super().dispatch()` raises. Verified RED (6 failures) before the fix and GREEN (7 passing) after.
- Full API suite via `docker compose -f docker-compose-test.yml up --build --abort-on-container-exit --exit-code-from api-tests`: **236 passed** (exit code 0), including DB-backed contract/model/serializer tests.
- `ruff check` passes on all changed files.
- Manual: trigger any API endpoint that raises an unhandled exception and confirm the client receives a structured `{"error": ...}` JSON body with a 500 status instead of a crashed response pipeline.

### References

- Closes #9157
- Plane work item: GIT-213

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed exception handling in API request dispatching so callers receive consistent, formatted error responses (HTTP payloads/statuses) instead of raw exception objects.

* **Tests**
  * Added regression tests to verify exception handling behavior across multiple API view implementations.

* **Chores**
  * Added license header to a test package file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->