### PR TITLE
fix: handle plain text descriptions in intake API

### DIFF
--- a/apps/api/plane/api/views/intake.py
+++ b/apps/api/plane/api/views/intake.py
@@ -187,7 +187,7 @@ class IntakeIssueListCreateAPIEndpoint(BaseAPIView):
         # create an issue
         issue_data = request.data.get("issue", {})
         description = issue_data.get("description")
-        description_json = issue_data.get("description_json") or {}
+        description_json = issue_data.get("description_json") if "description_json" in issue_data else {}
         if "description_json" not in issue_data and isinstance(description, (dict, list)):
             description_json = description
         description_html = issue_data.get("description_html") or "<p></p>"

--- a/apps/api/plane/api/views/intake.py
+++ b/apps/api/plane/api/views/intake.py
@@ -8,6 +8,7 @@ import json
 # Django imports
 from django.core.serializers.json import DjangoJSONEncoder
 from django.utils import timezone
+from django.utils.html import escape
 from django.db.models import Q, Value, UUIDField
 from django.db.models.functions import Coalesce
 from django.contrib.postgres.aggregates import ArrayAgg
@@ -185,12 +186,18 @@ class IntakeIssueListCreateAPIEndpoint(BaseAPIView):
 
         # create an issue
         issue_data = request.data.get("issue", {})
-        # Accept both "description" and "description_json" keys for the description_json field
-        description_json = issue_data.get("description") or issue_data.get("description_json") or {}
+        description = issue_data.get("description")
+        description_json = issue_data.get("description_json") or {}
+        if "description_json" not in issue_data and isinstance(description, (dict, list)):
+            description_json = description
+        description_html = issue_data.get("description_html") or "<p></p>"
+        if "description_html" not in issue_data and isinstance(description, str) and description:
+            description_html = f"<p>{escape(description)}</p>"
+
         issue = Issue.objects.create(
             name=issue_data.get("name"),
             description_json=description_json,
-            description_html=issue_data.get("description_html", "<p></p>"),
+            description_html=description_html,
             priority=issue_data.get("priority", "none"),
             project_id=project_id,
             state_id=triage_state.id,


### PR DESCRIPTION
### Description
This PR fixes how plain text descriptions are handled when creating intake issues through the API.

Previously, when `issue.description` was provided as a plain string, it could be stored directly in `description_json`, while `description_html` remained as the default empty paragraph (`<p></p>`). As a result, the description was saved but not rendered correctly in the Plane UI.

This change keeps `description_json` for structured descriptions and converts plain string descriptions into escaped HTML when `description_html` is not explicitly provided.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

### Test Scenarios 
Tested intake issue creation through the API using only `name`, `description`, and `priority`.

Example payload:
```json
{
  "issue": {
    "name": "Test via API",
    "description": "Request created through the API",
    "priority": "medium"
  }
}

### References
https://github.com/makeplane/plane/issues/9180

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Plain-text issue descriptions are now safely escaped and wrapped as sanitized HTML.
  * Description fields follow clear precedence: structured JSON is used when present; otherwise plain-text is converted appropriately.
  * Empty or missing HTML descriptions default to a safe empty paragraph to prevent accidental rendering issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->