### PR TITLE
fix: improve close button contrast on onboarding tour modal

### DIFF
--- a/apps/web/ce/components/onboarding/tour/root.tsx
+++ b/apps/web/ce/components/onboarding/tour/root.tsx
@@ -133,7 +133,7 @@ export const TourRoot = observer(function TourRoot(props: TOnboardingTourProps) 
         <div className="relative grid h-3/5 w-4/5 grid-cols-10 overflow-hidden rounded-[10px] bg-surface-1 sm:h-3/4 md:w-1/2 lg:w-3/5">
           <button
             type="button"
-            className="fixed top-[19%] right-[9%] z-10 translate-x-1/2 -translate-y-1/2 cursor-pointer rounded-full border border-strong p-1 sm:top-[11.5%] md:right-[24%] lg:right-[19%]"
+            className="fixed top-[19%] right-[9%] z-10 translate-x-1/2 -translate-y-1/2 cursor-pointer rounded-full border border-strong bg-surface-1 p-1 shadow-md hover:bg-surface-3 sm:top-[11.5%] md:right-[24%] lg:right-[19%]"
             onClick={onComplete}
           >
             <CloseIcon className="border-strong- h-3 w-3 text-primary" />


### PR DESCRIPTION
## Description

This PR fixes the close (X) button contrast issue on the Cycles onboarding modal (tour component).

### Problem
The close button in the top-right corner of the tour modal has no background color, causing it to blend into the header area with `bg-accent-primary`. This makes the button difficult to notice and reduces discoverability.

### Solution
- Added `bg-surface-1` to give the close button a solid background that contrasts against the accent-colored header
- Added `shadow-md` for better visual separation from the content
- Added `hover:bg-surface-3` for a subtle interactive hover state

### Changes
- `apps/web/ce/components/onboarding/tour/root.tsx`: Updated the close button's className

### Before
The close button had only `border border-strong` with no background, blending into the modal header.

### After
The close button now has a visible surface background, shadow for depth, and hover effect.

Closes #9182

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced the close button in the onboarding tour with improved visual styling, including background color, drop shadow, and hover effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->