### PR TITLE
fix(pages): resolve RTL text shaping and layout in PDF export

### DIFF
--- a/apps/live/src/lib/pdf/node-renderers.tsx
+++ b/apps/live/src/lib/pdf/node-renderers.tsx
@@ -104,9 +104,8 @@ export const nodeRenderers: NodeRendererRegistry = {
   paragraph: (node: TipTapNode, children: ReactElement[], ctx: PDFRenderContext): ReactElement => {
     const textAlign = node.attrs?.textAlign as string | null;
     const dir = node.attrs?.dir as string | null | undefined;
-    const isRtl = dir === "rtl";
     // For RTL paragraphs with no explicit alignment, default to right-aligned
-    const effectiveTextAlign = textAlign ?? (isRtl ? "right" : null);
+    const effectiveTextAlign = textAlign ?? (dir === "rtl" ? "right" : null);
     const background = node.attrs?.backgroundColor as string | undefined;
     const alignStyle = getTextAlignStyle(effectiveTextAlign);
     const flexStyle = getFlexAlignStyle(effectiveTextAlign);
@@ -128,9 +127,8 @@ export const nodeRenderers: NodeRendererRegistry = {
     const style = pdfStyles[styleKey] || pdfStyles.heading1;
     const textAlign = node.attrs?.textAlign as string | null;
     const dir = node.attrs?.dir as string | null | undefined;
-    const isRtl = dir === "rtl";
     // For RTL headings with no explicit alignment, default to right-aligned
-    const effectiveTextAlign = textAlign ?? (isRtl ? "right" : null);
+    const effectiveTextAlign = textAlign ?? (dir === "rtl" ? "right" : null);
     const alignStyle = getTextAlignStyle(effectiveTextAlign);
     const flexStyle = getFlexAlignStyle(effectiveTextAlign);
     const rtlStyle = getRtlStyle(dir);

--- a/apps/live/src/lib/pdf/node-renderers.tsx
+++ b/apps/live/src/lib/pdf/node-renderers.tsx
@@ -88,6 +88,11 @@ const getFlexAlignStyle = (textAlign: string | null | undefined): Style => {
   return {};
 };
 
+const getRtlStyle = (dir: string | null | undefined): Style => {
+  if (dir !== "rtl") return {};
+  return { fontFamily: "Vazirmatn" };
+};
+
 export const nodeRenderers: NodeRendererRegistry = {
   doc: (_node: TipTapNode, children: ReactElement[], ctx: PDFRenderContext): ReactElement => (
     <View key={ctx.getKey()}>{children}</View>
@@ -98,16 +103,21 @@ export const nodeRenderers: NodeRendererRegistry = {
 
   paragraph: (node: TipTapNode, children: ReactElement[], ctx: PDFRenderContext): ReactElement => {
     const textAlign = node.attrs?.textAlign as string | null;
+    const dir = node.attrs?.dir as string | null | undefined;
+    const isRtl = dir === "rtl";
+    // For RTL paragraphs with no explicit alignment, default to right-aligned
+    const effectiveTextAlign = textAlign ?? (isRtl ? "right" : null);
     const background = node.attrs?.backgroundColor as string | undefined;
-    const alignStyle = getTextAlignStyle(textAlign);
-    const flexStyle = getFlexAlignStyle(textAlign);
+    const alignStyle = getTextAlignStyle(effectiveTextAlign);
+    const flexStyle = getFlexAlignStyle(effectiveTextAlign);
+    const rtlStyle = getRtlStyle(dir);
     const resolvedBgColor =
       background && background !== "default" ? resolveColorForPdf(background, "background") : null;
     const bgStyle = resolvedBgColor ? { backgroundColor: resolvedBgColor } : {};
 
     return (
       <View key={ctx.getKey()} style={[pdfStyles.paragraphWrapper, flexStyle, bgStyle]}>
-        <Text style={[pdfStyles.paragraph, alignStyle, bgStyle]}>{children}</Text>
+        <Text style={[pdfStyles.paragraph, alignStyle, rtlStyle, bgStyle]}>{children}</Text>
       </View>
     );
   },
@@ -117,12 +127,17 @@ export const nodeRenderers: NodeRendererRegistry = {
     const styleKey = `heading${level}` as keyof typeof pdfStyles;
     const style = pdfStyles[styleKey] || pdfStyles.heading1;
     const textAlign = node.attrs?.textAlign as string | null;
-    const alignStyle = getTextAlignStyle(textAlign);
-    const flexStyle = getFlexAlignStyle(textAlign);
+    const dir = node.attrs?.dir as string | null | undefined;
+    const isRtl = dir === "rtl";
+    // For RTL headings with no explicit alignment, default to right-aligned
+    const effectiveTextAlign = textAlign ?? (isRtl ? "right" : null);
+    const alignStyle = getTextAlignStyle(effectiveTextAlign);
+    const flexStyle = getFlexAlignStyle(effectiveTextAlign);
+    const rtlStyle = getRtlStyle(dir);
 
     return (
       <View key={ctx.getKey()} style={flexStyle}>
-        <Text style={[style, alignStyle]}>{children}</Text>
+        <Text style={[style, alignStyle, rtlStyle]}>{children}</Text>
       </View>
     );
   },

--- a/apps/live/src/lib/pdf/plane-pdf-exporter.tsx
+++ b/apps/live/src/lib/pdf/plane-pdf-exporter.tsx
@@ -6,6 +6,7 @@
 
 import { createRequire } from "module";
 import path from "path";
+import { fileURLToPath } from "url";
 import { Document, Font, Page, pdf, Text } from "@react-pdf/renderer";
 import { createKeyGenerator, renderNode } from "./node-renderers";
 import { pdfStyles } from "./styles";
@@ -50,10 +51,11 @@ Font.register({
   ],
 });
 
-// Resolve Vazirmatn font files from the fonts directory at the package root.
+// Resolve Vazirmatn font files relative to the compiled bundle (dist/start.js),
+// so the path is stable regardless of where the process is started from.
 // Place the woff files at apps/live/fonts/vazirmatn/ before starting the server.
 // Download from: https://github.com/rastikerdar/vazirmatn/releases
-const vazirmatnFontDir = path.resolve(process.cwd(), "fonts/vazirmatn");
+const vazirmatnFontDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../fonts/vazirmatn");
 
 Font.register({
   family: "Vazirmatn",

--- a/apps/live/src/lib/pdf/plane-pdf-exporter.tsx
+++ b/apps/live/src/lib/pdf/plane-pdf-exporter.tsx
@@ -50,6 +50,25 @@ Font.register({
   ],
 });
 
+// Resolve Vazirmatn font files from the fonts directory at the package root.
+// Place the woff files at apps/live/fonts/vazirmatn/ before starting the server.
+// Download from: https://github.com/rastikerdar/vazirmatn/releases
+const vazirmatnFontDir = path.resolve(process.cwd(), "fonts/vazirmatn");
+
+Font.register({
+  family: "Vazirmatn",
+  fonts: [
+    {
+      src: path.join(vazirmatnFontDir, "vazirmatn-regular.woff"),
+      fontWeight: 400,
+    },
+    {
+      src: path.join(vazirmatnFontDir, "vazirmatn-bold.woff"),
+      fontWeight: 700,
+    },
+  ],
+});
+
 export const createPdfDocument = (doc: TipTapDocument, options: PDFExportOptions = {}) => {
   const { title, author, subject, pageSize = "A4", pageOrientation = "portrait", metadata, noAssets } = options;
 

--- a/apps/live/src/lib/pdf/plane-pdf-exporter.tsx
+++ b/apps/live/src/lib/pdf/plane-pdf-exporter.tsx
@@ -62,11 +62,11 @@ Font.register({
   fonts: [
     {
       src: path.join(vazirmatnFontDir, "vazirmatn-regular.woff"),
-      fontWeight: 400,
+      fontWeight: "normal",
     },
     {
       src: path.join(vazirmatnFontDir, "vazirmatn-bold.woff"),
-      fontWeight: 700,
+      fontWeight: "bold",
     },
   ],
 });

--- a/apps/web/core/components/editor/pdf/document.tsx
+++ b/apps/web/core/components/editor/pdf/document.tsx
@@ -17,6 +17,11 @@ import interSemibold from "@/app/assets/fonts/inter/semibold.ttf?url";
 import interThin from "@/app/assets/fonts/inter/thin.ttf?url";
 import interUltraBold from "@/app/assets/fonts/inter/ultrabold.ttf?url";
 import interUltraLight from "@/app/assets/fonts/inter/ultralight.ttf?url";
+// Vazirmatn — Persian/Arabic font for RTL content.
+// Place font files at apps/web/app/assets/fonts/vazirmatn/ before building.
+// Download from: https://github.com/rastikerdar/vazirmatn/releases
+import vazirmatnBold from "@/app/assets/fonts/vazirmatn/bold.ttf?url";
+import vazirmatnRegular from "@/app/assets/fonts/vazirmatn/regular.ttf?url";
 // constants
 import { EDITOR_PDF_DOCUMENT_STYLESHEET } from "@/constants/editor";
 
@@ -41,6 +46,14 @@ Font.register({
     { src: interUltraBold, fontWeight: "ultrabold", fontStyle: "italic" },
     { src: interHeavy, fontWeight: "heavy" },
     { src: interHeavy, fontWeight: "heavy", fontStyle: "italic" },
+  ],
+});
+
+Font.register({
+  family: "Vazirmatn",
+  fonts: [
+    { src: vazirmatnRegular, fontWeight: "normal" },
+    { src: vazirmatnBold, fontWeight: "bold" },
   ],
 });
 

--- a/apps/web/core/constants/editor.ts
+++ b/apps/web/core/constants/editor.ts
@@ -236,6 +236,12 @@ const EDITOR_PDF_FONT_FAMILY_STYLES: Styles = {
   ".courier-bold": {
     fontFamily: "Courier-Bold",
   },
+  // RTL content (Persian, Arabic, Hebrew, etc.) — use a font that carries
+  // the required Unicode shaping tables so letters connect correctly.
+  "[dir='rtl']": {
+    fontFamily: "Vazirmatn",
+    textAlign: "right",
+  },
 };
 
 const EDITOR_PDF_TYPOGRAPHY_STYLES: Styles = {


### PR DESCRIPTION
### Description

Pages' PDF export was broken for RTL languages (Persian, Arabic, Hebrew): exported text appeared as **disconnected, isolated glyphs flowing left-to-right** — unreadable and unusable.

**Root cause (three compounding issues):**

1. **Wrong font** — only Inter Latin subsets were registered. Inter Latin carries no Arabic/Persian Unicode code points and no OpenType GSUB shaping tables. Without GSUB tables the renderer cannot connect letters into their contextual forms (initial/medial/final/isolated), so every character renders isolated.
2. **`dir` attribute ignored** — TipTap sets `dir="rtl"` on paragraph and heading nodes for RTL content, but the PDF node renderers never read it. Layout always defaulted to LTR.
3. **No default alignment** — RTL paragraphs with no explicit `textAlign` were left-aligned instead of right-aligned.

**Fix:**

- **`plane-pdf-exporter.tsx`** — registers [Vazirmatn](https://github.com/rastikerdar/vazirmatn) (a permissively-licensed Persian/Arabic font with full GSUB/GPOS shaping tables) alongside Inter. Path is resolved relative to `import.meta.url` so it stays stable regardless of CWD.
- **`node-renderers.tsx`** — `paragraph` and `heading` renderers now read `node.attrs.dir`; when `dir === "rtl"`, `fontFamily: "Vazirmatn"` is applied and `textAlign` defaults to `"right"` (explicit alignment by the user is always respected).
- **`document.tsx`** — mirrors the same Vazirmatn `Font.register` for the frontend client-side PDF path.
- **`editor.ts`** — adds a `[dir='rtl']` rule to the HTML→PDF stylesheet used by `react-pdf-html`.

LTR content is completely unchanged — Inter is still used for all non-RTL text.

> **Self-hosted setup note:** Vazirmatn `.woff` files must be placed at `apps/live/fonts/vazirmatn/` and `.ttf` files at `apps/web/app/assets/fonts/vazirmatn/` before building. Download from the [Vazirmatn releases page](https://github.com/rastikerdar/vazirmatn/releases).

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### Test Scenarios

1. Write a Persian paragraph in a Page → export to PDF → verify letters are **connected** and text flows right-to-left.
2. Mix Persian headings (H1–H3) with English body text → export → Persian headings right-aligned with Vazirmatn, English paragraphs left-aligned with Inter.
3. Persian paragraph with explicit `textAlign: center` → export → center alignment preserved, not overridden to right.
4. Export a purely English page → no visual regression, Inter used throughout.

### References

Fixes #8922