### PR TITLE
[GIT-235] fix: remove unsupported styles from onboarding tour close button

### DIFF
--- a/apps/web/ce/components/onboarding/tour/root.tsx
+++ b/apps/web/ce/components/onboarding/tour/root.tsx
@@ -133,7 +133,7 @@ export const TourRoot = observer(function TourRoot(props: TOnboardingTourProps) 
         <div className="relative grid h-3/5 w-4/5 grid-cols-10 overflow-hidden rounded-[10px] bg-surface-1 sm:h-3/4 md:w-1/2 lg:w-3/5">
           <button
             type="button"
-            className="fixed top-[19%] right-[9%] z-10 translate-x-1/2 -translate-y-1/2 cursor-pointer rounded-full border border-strong p-1 sm:top-[11.5%] md:right-[24%] lg:right-[19%]"
+            className="fixed top-[19%] right-[9%] z-10 translate-x-1/2 -translate-y-1/2 cursor-pointer rounded-full border border-strong bg-surface-1 p-1 sm:top-[11.5%] md:right-[24%] lg:right-[19%]"
             onClick={onComplete}
           >
             <CloseIcon className="border-strong- h-3 w-3 text-primary" />


### PR DESCRIPTION
### Description
Improves close button visibility on the onboarding tour modal by increasing its contrast against the modal background. Additionally removes `shadow-md` and `hover:bg-surface-3` from the close button as they are not supported by the design system.

Picks up the fix contributed by @Marsssssssssssdsss in #9186.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Code refactoring

### Screenshots and Media (if applicable)
<img width="2180" height="1446" alt="image" src="https://github.com/user-attachments/assets/fc0e4033-93ad-42c4-92d2-80643ad0449f" />

### References
Closes #9186
[GIT-235](https://app.plane.so/plane/browse/GIT-235/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the onboarding tour’s close button styling for improved visual consistency.
  * Visual polish ensures the close control better matches surrounding interface elements and maintains existing layout and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->