### PR TITLE
fix: declare @tailwindcss/postcss in admin/space/web Docker builds

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -52,6 +52,7 @@
     "@plane/tailwind-config": "workspace:*",
     "@plane/typescript-config": "workspace:*",
     "@react-router/dev": "catalog:",
+    "@tailwindcss/postcss": "catalog:",
     "@types/lodash-es": "catalog:",
     "@types/node": "catalog:",
     "@types/react": "catalog:",

--- a/apps/space/package.json
+++ b/apps/space/package.json
@@ -56,6 +56,7 @@
     "@plane/tailwind-config": "workspace:*",
     "@plane/typescript-config": "workspace:*",
     "@react-router/dev": "catalog:",
+    "@tailwindcss/postcss": "catalog:",
     "@tailwindcss/typography": "catalog:",
     "@types/lodash-es": "catalog:",
     "@types/node": "catalog:",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -76,6 +76,7 @@
     "@plane/tailwind-config": "workspace:*",
     "@plane/typescript-config": "workspace:*",
     "@react-router/dev": "catalog:",
+    "@tailwindcss/postcss": "catalog:",
     "@tailwindcss/typography": "catalog:",
     "@types/lodash-es": "catalog:",
     "@types/node": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -706,6 +706,9 @@ importers:
       '@react-router/dev':
         specifier: 'catalog:'
         version: 7.13.1(@react-router/serve@7.13.1(react-router@7.12.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.8.3))(@types/node@22.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(react-router@7.12.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.43.1)(tsx@4.20.6)(typescript@5.8.3)(vite@7.3.2(@types/node@22.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))(yaml@2.8.3)
+      '@tailwindcss/postcss':
+        specifier: 'catalog:'
+        version: 4.1.17
       '@types/lodash-es':
         specifier: 'catalog:'
         version: 4.17.12
@@ -993,6 +996,9 @@ importers:
       '@react-router/dev':
         specifier: 'catalog:'
         version: 7.13.1(@react-router/serve@7.13.1(react-router@7.12.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.8.3))(@types/node@22.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(react-router@7.12.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.43.1)(tsx@4.20.6)(typescript@5.8.3)(vite@7.3.2(@types/node@22.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))(yaml@2.8.3)
+      '@tailwindcss/postcss':
+        specifier: 'catalog:'
+        version: 4.1.17
       '@tailwindcss/typography':
         specifier: 'catalog:'
         version: 0.5.19
@@ -1195,6 +1201,9 @@ importers:
       '@react-router/dev':
         specifier: 'catalog:'
         version: 7.13.1(@react-router/serve@7.13.1(react-router@7.12.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.8.3))(@types/node@22.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(react-router@7.12.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.43.1)(tsx@4.20.6)(typescript@5.8.3)(vite@7.3.2(@types/node@22.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))(yaml@2.8.3)
+      '@tailwindcss/postcss':
+        specifier: 'catalog:'
+        version: 4.1.17
       '@tailwindcss/typography':
         specifier: 'catalog:'
         version: 0.5.19


### PR DESCRIPTION
### Description

The **Web**, **Admin**, and **Space** Docker image builds in the "Branch Build CE" workflow fail at the Vite/PostCSS step with:

```
[vite:css] Failed to load PostCSS config (searchPath: /app/apps/admin):
Loading PostCSS Plugin failed: Cannot find module '@tailwindcss/postcss'
```

**Root cause:** `apps/{admin,space,web}/postcss.config.js` re-export the shared `@plane/tailwind-config/postcss.config.js`, which references the `@tailwindcss/postcss` plugin by name. The plugin was declared only as a dependency of `packages/tailwind-config`, never of the apps themselves.

The Docker build installs deps via `turbo prune --docker` → `pnpm fetch` → `pnpm install --offline`. That flow lays out `node_modules` so PostCSS resolves the plugin relative to the **app** directory (`apps/<app>`), where it is not reachable. A plain `pnpm install` happens to resolve it from `tailwind-config`'s context instead — which is why local builds passed and masked the bug. (Note: this is pre-existing and not caused by the recent pnpm-catalog migration — earlier runs failed identically. Hoisting via `.npmrc` is not an option because pnpm v11 ignores the repo's `.npmrc` pnpm-settings.)

**Fix:** Declare `@tailwindcss/postcss: catalog:` as a direct devDependency of the three apps that run Vite/PostCSS, alongside the already-direct `@tailwindcss/typography`. Under the isolated linker, direct deps are always symlinked into the package's own `node_modules`, so the plugin resolves from each app's context regardless of the install flow. `pnpm-lock.yaml` is updated with the three importer edges only (no version changes).

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)

<!-- Add screenshots here -->

### Test Scenarios

Verified by reproducing the **exact CI Docker install flow** locally (`turbo prune --scope=<app> --docker` → `pnpm fetch` → `pnpm install --offline --frozen-lockfile --prod=false` → `turbo run build --filter=<app>`) for all three apps:

| App   | Frozen-lockfile install | Build           | Tailwind output       |
|-------|-------------------------|-----------------|-----------------------|
| admin | ✅ in sync              | ✅ 8/8 tasks    | globals.css 110.89 kB |
| space | ✅ in sync              | ✅ 10/10 tasks  | globals.css 164.32 kB |
| web   | ✅ in sync              | ✅ 11/11 tasks  | globals.css 232.72 kB |

- The `--frozen-lockfile` install passing confirms the lockfile is in sync with the `package.json` changes (no CI drift).
- The CI jobs to watch: **Build-Push Admin / Space / Web Docker Image** should now go green.

### References

- CI run that surfaced this: https://github.com/makeplane/plane/actions/runs/26710070319

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated styling framework dependencies across multiple applications to enhance development infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->