### PR TITLE
[GIT-221] fix(cycle): guard against no end_date when archiving cycle

### DIFF
--- a/apps/api/plane/api/views/cycle.py
+++ b/apps/api/plane/api/views/cycle.py
@@ -763,7 +763,7 @@ class CycleArchiveUnarchiveAPIEndpoint(BaseAPIView):
         Only cycles that have ended can be archived.
         """
         cycle = Cycle.objects.get(pk=cycle_id, project_id=project_id, workspace__slug=slug)
-        if cycle.end_date >= timezone.now():
+        if cycle.end_date is None or cycle.end_date >= timezone.now():
             return Response(
                 {"error": "Only completed cycles can be archived"},
                 status=status.HTTP_400_BAD_REQUEST,

--- a/apps/api/plane/app/views/cycle/archive.py
+++ b/apps/api/plane/app/views/cycle/archive.py
@@ -587,7 +587,7 @@ class CycleArchiveUnarchiveEndpoint(BaseAPIView):
     def post(self, request, slug, project_id, cycle_id):
         cycle = Cycle.objects.get(pk=cycle_id, project_id=project_id, workspace__slug=slug)
 
-        if cycle.end_date >= timezone.now():
+        if cycle.end_date is None or cycle.end_date >= timezone.now():
             return Response(
                 {"error": "Only completed cycles can be archived"},
                 status=status.HTTP_400_BAD_REQUEST,


### PR DESCRIPTION
### Description
Archiving a cycle with no end date caused a `TypeError` because `end_date` was compared directly to `timezone.now()` without a null check. Added an explicit `None` guard so cycles without an end date are treated as incomplete and return a `400` instead of crashing with a `500`.

`cycle.end_date >= timezone.now()` raises `TypeError: '>=' not supported between instances of 'NoneType' and 'datetime.datetime'` when `end_date` is not set.

Added `cycle.end_date is None` check before the comparison in both archive endpoints:
- `plane/api/views/cycle.py`
- `plane/app/views/cycle/archive.py

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

### Screenshots and Media (if applicable)
Before:
<img width="972" height="669" alt="image" src="https://github.com/user-attachments/assets/3f73eac2-b508-450b-bf4e-ade7dd75e243" />

After: 
<img width="968" height="648" alt="image" src="https://github.com/user-attachments/assets/734da83e-37b7-4e9b-90e9-deec5eb95eda" />


### Test Scenarios 
Create a cycle without start and end dates and make API call to archive the cycle, expected response status code is 400 and message is 
```
{
    "error": "Only completed cycles can be archived"
}
```

### References
Fixes #9169

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated cycle archiving validation to correctly handle cycles based on their end dates. Cycles can now only be archived when they have a past end date set.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/makeplane/plane/pull/9200?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->