### PR TITLE
Fix module segment headers in analytics export

### DIFF
--- a/apps/api/plane/bgtasks/analytic_plot_export.py
+++ b/apps/api/plane/bgtasks/analytic_plot_export.py
@@ -277,7 +277,7 @@ def generate_segmented_rows(
 
     if segmented == MODULE_ID:
         for index, segm in enumerate(row_zero[2:]):
-            module = next((mod for mod in label_details if str(mod[MODULE_ID]) == str(segm)), None)
+            module = next((mod for mod in module_details if str(mod[MODULE_ID]) == str(segm)), None)
             if module:
                 row_zero[index + 2] = module["issue_module__module__name"]
 

--- a/apps/api/plane/bgtasks/analytic_plot_export.py
+++ b/apps/api/plane/bgtasks/analytic_plot_export.py
@@ -15,7 +15,7 @@ from django.core.mail import EmailMultiAlternatives, get_connection
 from django.template.loader import render_to_string
 from django.db.models import Q, Case, Value, When
 from django.db import models
-from django.db.models.functions import Concat
+from django.db.models.functions import Cast, Concat
 
 # Module imports
 from plane.db.models import Issue
@@ -103,7 +103,7 @@ def get_assignee_details(slug, filters):
                     assignees__avatar_asset__isnull=False,
                     then=Concat(
                         Value("/api/assets/v2/static/"),
-                        "assignees__avatar_asset",  # Assuming avatar_asset has an id or relevant field
+                        Cast("assignees__avatar_asset", models.CharField()),
                         Value("/"),
                     ),
                 ),

--- a/apps/api/plane/tests/unit/bg_tasks/test_analytic_plot_export.py
+++ b/apps/api/plane/tests/unit/bg_tasks/test_analytic_plot_export.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+import pytest
+
+from plane.bgtasks.analytic_plot_export import (
+    MODULE_ID,
+    generate_segmented_rows,
+)
+
+
+@pytest.mark.unit
+class TestGenerateSegmentedRows:
+    def test_module_segment_headers_use_module_names(self):
+        rows = generate_segmented_rows(
+            distribution={
+                "High": [
+                    {
+                        "segment": "module-1",
+                        "issue_count": 3,
+                    }
+                ]
+            },
+            x_axis="priority",
+            y_axis="issue_count",
+            segment=MODULE_ID,
+            key="issue_count",
+            assignee_details=[],
+            label_details=[],
+            state_details=[],
+            cycle_details=[],
+            module_details=[
+                {
+                    MODULE_ID: "module-1",
+                    "issue_module__module__name": "Launch Plan",
+                }
+            ],
+        )
+
+        assert rows[0] == ("Priority", "Issue Count", "Launch Plan")


### PR DESCRIPTION
## Summary
- Resolve module segment CSV headers from module details instead of label details
- Add unit coverage for module segment header mapping

Fixes #9174

## Tests
- `git diff --check origin/preview...fix/module-segment-export-headers`
- `python -m compileall -q apps/api/plane/bgtasks/analytic_plot_export.py apps/api/plane/tests/unit/bg_tasks/test_analytic_plot_export.py`

Not run:
- `python -m pytest plane/tests/unit/bg_tasks/test_analytic_plot_export.py` (local environment is missing the project dependency `celery`)
- `python -m ruff check ...` (local environment is missing `ruff`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected module name resolution in segmented analytics exports, ensuring accurate module names display in CSV exports when segmenting data by module dimension.
  * Improved avatar URL handling in analytics exports for more reliable display of assignee avatars.

* **Tests**
  * Added unit tests verifying that module segment headers correctly display the associated module names in exported analytics data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->