### PR TITLE
Fix dummy issue parent assignments

### DIFF
--- a/apps/api/plane/bgtasks/dummy_data_task.py
+++ b/apps/api/plane/bgtasks/dummy_data_task.py
@@ -384,6 +384,7 @@ def create_issue_parent(workspace, project, user_id, issue_count):
     bulk_sub_issues = []
     for sub_issue in sub_issues:
         sub_issue.parent_id = parent_issues[random.randint(0, int(parent_count - 1))]
+        bulk_sub_issues.append(sub_issue)
 
     Issue.objects.bulk_update(bulk_sub_issues, ["parent"], batch_size=1000)
 

--- a/apps/api/plane/tests/unit/bg_tasks/test_dummy_data_task.py
+++ b/apps/api/plane/tests/unit/bg_tasks/test_dummy_data_task.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+import pytest
+
+from plane.bgtasks import dummy_data_task
+
+
+class _ParentIssues:
+    def __init__(self, parent_ids):
+        self.parent_ids = parent_ids
+
+    def values_list(self, *_args, **_kwargs):
+        return self.parent_ids
+
+
+class _SubIssues:
+    def __init__(self, sub_issues):
+        self.sub_issues = sub_issues
+
+    def exclude(self, **_kwargs):
+        return self
+
+    def __getitem__(self, value):
+        return self.sub_issues[value]
+
+
+class _Issue:
+    def __init__(self):
+        self.parent_id = None
+
+
+class _IssueManager:
+    def __init__(self, parent_ids, sub_issues):
+        self.parent_ids = parent_ids
+        self.sub_issues = sub_issues
+        self.filter_calls = 0
+        self.bulk_update_args = None
+
+    def filter(self, **_kwargs):
+        self.filter_calls += 1
+        if self.filter_calls == 1:
+            return _ParentIssues(self.parent_ids)
+        return _SubIssues(self.sub_issues)
+
+    def bulk_update(self, items, fields, batch_size):
+        self.bulk_update_args = (items, fields, batch_size)
+
+
+@pytest.mark.unit
+class TestCreateIssueParent:
+    def test_bulk_updates_generated_sub_issue_parents(self, monkeypatch):
+        sub_issues = [_Issue(), _Issue(), _Issue(), _Issue()]
+        manager = _IssueManager(["parent-1", "parent-2"], sub_issues)
+        fake_issue_model = type("Issue", (), {"objects": manager})
+
+        monkeypatch.setattr(dummy_data_task, "Issue", fake_issue_model)
+        monkeypatch.setattr(dummy_data_task.random, "randint", lambda _start, _end: 0)
+
+        dummy_data_task.create_issue_parent("workspace", "project", "user-id", issue_count=8)
+
+        items, fields, batch_size = manager.bulk_update_args
+        assert items == sub_issues
+        assert fields == ["parent"]
+        assert batch_size == 1000
+        assert [issue.parent_id for issue in sub_issues] == ["parent-1"] * len(sub_issues)


### PR DESCRIPTION
## Summary
- Add generated sub-issues to the bulk update list after assigning parent IDs
- Add unit coverage for persisting dummy issue parent assignments

Fixes #9176

## Tests
- `git diff --check origin/preview...fix/dummy-parent-assignments`
- `python -m compileall -q apps/api/plane/bgtasks/dummy_data_task.py apps/api/plane/tests/unit/bg_tasks/test_dummy_data_task.py`

Not run:
- `python -m pytest plane/tests/unit/bg_tasks/test_dummy_data_task.py` (local environment is missing the project dependency `celery`)
- `python -m ruff check ...` (local environment is missing `ruff`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved background task for initializing sample data to ensure proper data relationships.

* **Tests**
  * Added test coverage for sample data initialization functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->