### PR TITLE
chore: add justfile for local development tasks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,6 +81,8 @@ pnpm dev
 
 That’s it! You’re all set to begin coding. Remember to refresh your browser if changes don’t auto-reload. Happy contributing! 🎉
 
+> 💡 Tip: If you have [`just`](https://github.com/casey/just) installed, the repository includes a [`justfile`](./justfile) that wraps the commands above (`just setup`, `just up`, `just fe-dev`, `just migrate`, and more). Run `just` to see all available recipes.
+
 ## Missing a Feature?
 
 If a feature is missing, you can directly _request_ a new one [here](https://github.com/makeplane/plane/issues/new?assignees=&labels=feature&template=feature_request.yml&title=%F0%9F%9A%80+Feature%3A+). You also can do the same by choosing "🚀 Feature" when raising a [New Issue](https://github.com/makeplane/plane/issues/new/choose) on our GitHub Repository.

--- a/justfile
+++ b/justfile
@@ -1,0 +1,152 @@
+# Plane local development task runner.
+# Requires `just` (https://github.com/casey/just). Run `just` to list recipes.
+
+set fallback := true
+
+# Compose file used for every Docker recipe.
+compose := "docker compose -f docker-compose-local.yml"
+# Django settings module used by management commands inside the api container.
+settings := "plane.settings.local"
+
+# Show the list of available recipes (default).
+default:
+    @just --list
+
+# --- Environment setup ---
+
+# Generate .env files for every service and install node modules (runs setup.sh).
+setup:
+    ./setup.sh
+
+# --- Docker lifecycle ---
+
+# Build images, then start all services in the background.
+up:
+    {{compose}} up -d
+
+# Build images, then start all services attached (streams logs, Ctrl-C to stop).
+up-fg:
+    {{compose}} up
+
+# Stop and remove containers and networks (volumes are kept).
+down:
+    {{compose}} down
+
+# Start previously created (stopped) containers.
+start:
+    {{compose}} start
+
+# Stop running containers without removing them.
+stop:
+    {{compose}} stop
+
+# Restart all services (optional: pass a service name).
+restart service='':
+    {{compose}} restart {{service}}
+
+# Build or rebuild service images.
+build:
+    {{compose}} build
+
+# Rebuild service images from scratch, ignoring the cache.
+rebuild:
+    {{compose}} build --no-cache
+
+# Start only infrastructure services (db, redis, mq, minio).
+infra:
+    {{compose}} up -d plane-db plane-redis plane-mq plane-minio
+
+# --- Logs & status ---
+
+# Follow logs (optional: pass a service name, e.g. `just logs api`).
+logs service='':
+    {{compose}} logs -f {{service}}
+
+# Follow worker and beat-worker logs together.
+worker-logs:
+    {{compose}} logs -f worker beat-worker
+
+# List containers and their status.
+ps:
+    {{compose}} ps
+
+# Show live resource usage for running containers.
+stats:
+    {{compose}} stats
+
+# --- Backend (Django / api) ---
+
+# Run database migrations via the migrator service.
+migrate:
+    {{compose}} up migrator
+
+# Open a shell in a running service (default: api).
+shell service='api':
+    {{compose}} exec {{service}} /bin/bash
+
+# Run an arbitrary manage.py command in the api container, e.g. `just manage showmigrations`.
+manage *args:
+    {{compose}} exec api python manage.py {{args}} --settings={{settings}}
+
+# Generate new Django migrations (optional: pass an app label).
+makemigrations app='':
+    {{compose}} exec api python manage.py makemigrations {{app}} --settings={{settings}}
+
+# Open the Django shell.
+django-shell:
+    {{compose}} exec api python manage.py shell --settings={{settings}}
+
+# Create a Django superuser interactively.
+createsuperuser:
+    {{compose}} exec api python manage.py createsuperuser --settings={{settings}}
+
+# Collect static files.
+collectstatic:
+    {{compose}} exec api python manage.py collectstatic --noinput --settings={{settings}}
+
+# --- Database ---
+
+# Open a psql session against the local Postgres database.
+dbshell:
+    {{compose}} exec plane-db sh -c 'psql -U "$POSTGRES_USER" "$POSTGRES_DB"'
+
+# Dump the database to a local file (default: plane-backup.sql).
+db-backup file='plane-backup.sql':
+    {{compose}} exec -T plane-db sh -c 'pg_dump -U "$POSTGRES_USER" "$POSTGRES_DB"' > "{{file}}"
+
+# Restore the database from a dump file (default: plane-backup.sql).
+db-restore file='plane-backup.sql':
+    {{compose}} exec -T plane-db sh -c 'psql -U "$POSTGRES_USER" "$POSTGRES_DB"' < "{{file}}"
+
+# --- Frontend / Node ---
+
+# Install node modules with pnpm.
+fe-install:
+    pnpm install
+
+# Start the frontend dev servers (web: 3000, admin: 3001/god-mode).
+fe-dev:
+    pnpm dev
+
+# Build all packages and apps.
+fe-build:
+    pnpm build
+
+# Run all frontend checks (format, lint, types).
+fe-check:
+    pnpm check
+
+# Auto-fix frontend format and lint issues.
+fe-fix:
+    pnpm fix
+
+# --- Cleanup ---
+
+# Stop and remove containers, networks, and named volumes (deletes local data).
+clean:
+    {{compose}} down -v
+
+# Remove this project's containers, networks, and locally-built images.
+# keeps volumes/data; does not touch other Docker projects.
+prune:
+    {{compose}} down --rmi local --remove-orphans


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->

Adds a comprehensive `justfile` for local-development task runner and documents it.

- Organizes recipes into clear sections: environment setup, Docker lifecycle, logs & status, backend (Django/api), database, frontend, and cleanup.
- Introduces `compose` and `settings` variables so the compose-file path and Django settings module are defined once.
- Adds recipes for everyday workflows that were previously manual: `manage` (arbitrary `manage.py` commands), `makemigrations`, `django-shell`, `createsuperuser`, `collectstatic`, `dbshell`, `db-backup/db-restore`, `rebuild`, `up-fg`, `stats`, and `prune`.
- Every recipe is aligned with the actual `docker-compose-local.yml` service names and the api container's `plane.settings.local` module.
- Documents the runner in `README.md` and `CONTRIBUTING.md` so contributors can discover it via `just`.

No application code is touched — this is dev tooling and documentation only.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [x] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

- Run `just` (or `just default`) and confirm all recipes are listed without parse errors.
- `just setup` generates `.env` files and installs dependencies.
- `just up` builds and starts services; just ps shows them running; `just down` stops them.
- `just infra` starts only db/redis/mq/minio.
- `just migrate` applies migrations via the migrator service.
- `just manage showmigrations` runs inside the api container against `plane.settings.local`.
- `just dbshell` opens a psql session; `just db-backup` writes a dump and just db-restore reads it back.
- `just fe-dev` starts web (:3000) and admin (:3001/god-mode); `just fe-check` and `just fe-fix` run.
- Verify README and CONTRIBUTING render and links to the `justfile` resolve.

### References
<!-- Link related issues if there are any -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidelines with a tip about optionally using the repository's local development task runner for common setup and dev commands.

* **Chores**
  * Added a comprehensive local development task runner to automate Docker lifecycle, database migrations/backups, Django management and shell access, frontend install/dev/build/check/fix, logs, and cleanup tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->