### PR TITLE
feat(web): show estimate point sums in list view group headers

### DIFF
--- a/apps/web/core/components/issues/issue-layouts/filters/header/display-filters/display-filters-selection.tsx
+++ b/apps/web/core/components/issues/issue-layouts/filters/header/display-filters/display-filters-selection.tsx
@@ -130,6 +130,7 @@ export const DisplayFiltersSelection = observer(function DisplayFiltersSelection
             selectedExtraOptions={{
               show_empty_groups: displayFilters?.show_empty_groups ?? true,
               sub_issue: displayFilters?.sub_issue ?? true,
+              show_estimates: displayFilters?.show_estimates ?? false,
             }}
             handleUpdate={(key, val) =>
               handleDisplayFiltersUpdate({

--- a/apps/web/core/components/issues/issue-layouts/filters/header/display-filters/extra-options.tsx
+++ b/apps/web/core/components/issues/issue-layouts/filters/header/display-filters/extra-options.tsx
@@ -24,12 +24,17 @@ const ISSUE_EXTRA_OPTIONS: {
     key: "show_empty_groups",
     titleTranslationKey: "issue.display.extra.show_empty_groups",
   }, // filter on front-end
+  {
+    key: "show_estimates",
+    titleTranslationKey: "issue.display.extra.show_estimates",
+  },
 ];
 
 type Props = {
   selectedExtraOptions: {
     sub_issue: boolean;
     show_empty_groups: boolean;
+    show_estimates: boolean;
   };
   handleUpdate: (key: keyof IIssueDisplayFilterOptions, val: boolean) => void;
   enabledExtraOptions: TIssueExtraOptions[];

--- a/apps/web/core/components/issues/issue-layouts/list/base-list-root.tsx
+++ b/apps/web/core/components/issues/issue-layouts/list/base-list-root.tsx
@@ -80,6 +80,7 @@ export const BaseListRoot = observer(function BaseListRoot(props: IBaseListRoot)
 
   const group_by = (displayFilters?.group_by || null) as GroupByColumnTypes | null;
   const showEmptyGroup = displayFilters?.show_empty_groups ?? false;
+  const showEstimates = displayFilters?.show_estimates ?? false;
 
   const { workspaceSlug, projectId } = useParams();
   const { updateFilters } = useIssuesActions(storeType);
@@ -165,6 +166,7 @@ export const BaseListRoot = observer(function BaseListRoot(props: IBaseListRoot)
           groupedIssueIds={groupedIssueIds ?? {}}
           loadMoreIssues={loadMoreIssues}
           showEmptyGroup={showEmptyGroup}
+          showEstimates={showEstimates}
           quickAddCallback={quickAddIssue}
           enableIssueQuickAdd={!!enableQuickAdd}
           canEditProperties={canEditProperties}

--- a/apps/web/core/components/issues/issue-layouts/list/default.tsx
+++ b/apps/web/core/components/issues/issue-layouts/list/default.tsx
@@ -46,6 +46,7 @@ export interface IList {
   displayProperties: IIssueDisplayProperties | undefined;
   enableIssueQuickAdd: boolean;
   showEmptyGroup?: boolean;
+  showEstimates?: boolean;
   canEditProperties: (projectId: string | undefined) => boolean;
   quickAddCallback?: (projectId: string | null | undefined, data: TIssue) => Promise<TIssue | undefined>;
   disableIssueCreation?: boolean;
@@ -69,6 +70,7 @@ export const List = observer(function List(props: IList) {
     displayProperties,
     enableIssueQuickAdd,
     showEmptyGroup,
+    showEstimates,
     canEditProperties,
     quickAddCallback,
     disableIssueCreation,
@@ -157,6 +159,7 @@ export const List = observer(function List(props: IList) {
                     displayProperties={displayProperties}
                     enableIssueQuickAdd={enableIssueQuickAdd}
                     showEmptyGroup={showEmptyGroup}
+                    showEstimates={showEstimates}
                     canEditProperties={canEditProperties}
                     quickAddCallback={quickAddCallback}
                     disableIssueCreation={disableIssueCreation}

--- a/apps/web/core/components/issues/issue-layouts/list/headers/group-by-card.tsx
+++ b/apps/web/core/components/issues/issue-layouts/list/headers/group-by-card.tsx
@@ -8,7 +8,7 @@ import { useState } from "react";
 import { observer } from "mobx-react";
 import { useParams } from "next/navigation";
 import { CircleDashed } from "lucide-react";
-import { PlusIcon } from "@plane/propel/icons";
+import { PlusIcon, EstimatePropertyIcon } from "@plane/propel/icons";
 // types
 import { TOAST_TYPE, setToast } from "@plane/propel/toast";
 import type { TIssue, ISearchIssueResponse, TIssueGroupByOptions } from "@plane/types";
@@ -33,6 +33,8 @@ interface IHeaderGroupByCard {
   icon?: React.ReactNode;
   title: string;
   count: number;
+  estimateSum?: number | null;
+  isPartialCount?: boolean;
   issuePayload: Partial<TIssue>;
   canEditProperties: (projectId: string | undefined) => boolean;
   disableIssueCreation?: boolean;
@@ -49,6 +51,8 @@ export const HeaderGroupByCard = observer(function HeaderGroupByCard(props: IHea
     icon,
     title,
     count,
+    estimateSum,
+    isPartialCount,
     issuePayload,
     canEditProperties,
     disableIssueCreation,
@@ -120,6 +124,13 @@ export const HeaderGroupByCard = observer(function HeaderGroupByCard(props: IHea
         >
           <div className="line-clamp-1 inline-block truncate font-medium text-primary">{title}</div>
           <div className="pl-2 text-13 font-medium text-tertiary">{count || 0}</div>
+          {estimateSum != null && estimateSum > 0 && (
+            <span className="ml-1.5 inline-flex items-center gap-1 rounded-full border border-subtle px-1.5 text-13 font-medium text-tertiary">
+              <EstimatePropertyIcon className="h-2.5 w-2.5 flex-shrink-0" />
+              {isPartialCount ? "\u2265 " : ""}
+              {estimateSum}
+            </span>
+          )}
           <div className="px-2.5">
             <WorkFlowGroupTree groupBy={groupBy} groupId={groupID} />
           </div>

--- a/apps/web/core/components/issues/issue-layouts/list/list-group.tsx
+++ b/apps/web/core/components/issues/issue-layouts/list/list-group.tsx
@@ -126,17 +126,23 @@ export const ListGroup = observer(function ListGroup(props: Props) {
     if (!groupIssueIds || groupIssueIds.length === 0) return null;
 
     const firstIssue = issuesMap[groupIssueIds[0]];
-    const issueProjectId = firstIssue?.project_id;
-    if (!issueProjectId) return null;
+    const projectId = firstIssue?.project_id;
+    if (!projectId) return null;
 
-    if (!areEstimateEnabledByProjectId(issueProjectId)) return null;
+    // safeguard: don't sum up across multiple projects  
+    for (const issueId of groupIssueIds) {
+      const issue = issuesMap[issueId];
+      if (issue?.project_id && issue.project_id !== projectId) return null;
+    }
 
-    const activeEstimateId = currentActiveEstimateIdByProjectId(issueProjectId);
+    if (!areEstimateEnabledByProjectId(projectId)) return null;
+    const activeEstimateId = currentActiveEstimateIdByProjectId(projectId);
     if (!activeEstimateId) return null;
     const activeEstimate = estimateById(activeEstimateId);
     if (!activeEstimate?.type || activeEstimate.type === EEstimateSystem.CATEGORIES) return null;
 
     let sum = 0;
+    let hasAnyEstimate = false;
     for (const issueId of groupIssueIds) {
       const issue = issuesMap[issueId];
       if (!issue?.estimate_point) continue;
@@ -145,9 +151,10 @@ export const ListGroup = observer(function ListGroup(props: Props) {
       const numericValue = Number(point.value);
       if (!Number.isNaN(numericValue)) {
         sum += numericValue;
+        hasAnyEstimate = true;
       }
     }
-    return sum;
+    return hasAnyEstimate ? sum : null;
   })();
 
   const [intersectionElement, setIntersectionElement] = useState<HTMLDivElement | null>(null);

--- a/apps/web/core/components/issues/issue-layouts/list/list-group.tsx
+++ b/apps/web/core/components/issues/issue-layouts/list/list-group.tsx
@@ -22,12 +22,14 @@ import type {
   IIssueDisplayProperties,
   TIssueKanbanFilters,
 } from "@plane/types";
+import { EEstimateSystem } from "@plane/types";
 import { EIssueLayoutTypes } from "@plane/types";
 import { Row } from "@plane/ui";
 import { cn } from "@plane/utils";
 // components
 import { ListLoaderItemRow } from "@/components/ui/loader/layouts/list-layout-loader";
 // hooks
+import { useProjectEstimates } from "@/hooks/store/estimates";
 import { useProjectState } from "@/hooks/store/use-project-state";
 import { useIntersectionObserver } from "@/hooks/use-intersection-observer";
 import { useIssuesStore } from "@/hooks/use-issue-layout-store";
@@ -67,6 +69,7 @@ interface Props {
   addIssuesToView?: (issueIds: string[]) => Promise<TIssue>;
   isCompletedCycle?: boolean;
   showEmptyGroup?: boolean;
+  showEstimates?: boolean;
   loadMoreIssues: (groupId?: string) => void;
   selectionHelpers: TSelectionHelper;
   handleCollapsedGroups: (value: string) => void;
@@ -94,6 +97,7 @@ export const ListGroup = observer(function ListGroup(props: Props) {
     addIssuesToView,
     isCompletedCycle,
     showEmptyGroup,
+    showEstimates,
     loadMoreIssues,
     selectionHelpers,
     handleCollapsedGroups,
@@ -107,20 +111,50 @@ export const ListGroup = observer(function ListGroup(props: Props) {
   const groupRef = useRef<HTMLDivElement | null>(null);
   const { t } = useTranslation();
   const projectState = useProjectState();
+  const { areEstimateEnabledByProjectId, currentActiveEstimateIdByProjectId, estimateById } = useProjectEstimates();
 
   const {
     issues: { getGroupIssueCount, getPaginationData, getIssueLoader },
   } = useIssuesStore();
+
+  const groupIssueCount = getGroupIssueCount(group.id, undefined, false) ?? 0;
+  const nextPageResults = getPaginationData(group.id, undefined)?.nextPageResults;
+  const isPaginating = !!getIssueLoader(group.id);
+  const isPartialGroup = groupIssueIds ? groupIssueIds.length < groupIssueCount || !!nextPageResults : false;
+  const estimateSum = (() => {
+    if (!showEstimates) return null;
+    if (!groupIssueIds || groupIssueIds.length === 0) return null;
+
+    const firstIssue = issuesMap[groupIssueIds[0]];
+    const issueProjectId = firstIssue?.project_id;
+    if (!issueProjectId) return null;
+
+    if (!areEstimateEnabledByProjectId(issueProjectId)) return null;
+
+    const activeEstimateId = currentActiveEstimateIdByProjectId(issueProjectId);
+    if (!activeEstimateId) return null;
+    const activeEstimate = estimateById(activeEstimateId);
+    if (!activeEstimate?.type || activeEstimate.type === EEstimateSystem.CATEGORIES) return null;
+
+    let sum = 0;
+    for (const issueId of groupIssueIds) {
+      const issue = issuesMap[issueId];
+      if (!issue?.estimate_point) continue;
+      const point = activeEstimate.estimatePointById(issue.estimate_point);
+      if (!point?.value) continue;
+      const numericValue = Number(point.value);
+      if (!Number.isNaN(numericValue)) {
+        sum += numericValue;
+      }
+    }
+    return sum;
+  })();
 
   const [intersectionElement, setIntersectionElement] = useState<HTMLDivElement | null>(null);
 
   const { workflowDisabledSource, isWorkflowDropDisabled, handleWorkFlowState, getIsWorkflowWorkItemCreationDisabled } =
     useWorkFlowFDragNDrop(group_by);
   const isWorkflowIssueCreationDisabled = getIsWorkflowWorkItemCreationDisabled(group.id);
-
-  const groupIssueCount = getGroupIssueCount(group.id, undefined, false) ?? 0;
-  const nextPageResults = getPaginationData(group.id, undefined)?.nextPageResults;
-  const isPaginating = !!getIssueLoader(group.id);
 
   useIntersectionObserver(containerRef, isPaginating ? null : intersectionElement, loadMoreIssues, `100% 0% 100% 0%`);
 
@@ -237,14 +271,13 @@ export const ListGroup = observer(function ListGroup(props: Props) {
       })
     );
   }, [
-    groupRef?.current,
-    group,
-    orderBy,
-    getGroupIndex,
-    setDragColumnOrientation,
-    setIsDraggingOverColumn,
-    isWorkflowDropDisabled,
-  ]);
+	group,
+	orderBy,
+	getGroupIndex,
+	setDragColumnOrientation,
+	setIsDraggingOverColumn,
+	isWorkflowDropDisabled
+]);
 
   const isDragAllowed = group_by ? DRAG_ALLOWED_GROUPS.includes(group_by) : true;
   const canOverlayBeVisible = isWorkflowDropDisabled || orderBy !== "sort_order" || !!group.isDropDisabled;
@@ -272,6 +305,8 @@ export const ListGroup = observer(function ListGroup(props: Props) {
           icon={group.icon}
           title={group.name}
           count={groupIssueCount}
+          estimateSum={estimateSum}
+          isPartialCount={isPartialGroup}
           issuePayload={group.payload}
           canEditProperties={canEditProperties}
           disableIssueCreation={

--- a/packages/constants/src/issue/filter.ts
+++ b/packages/constants/src/issue/filter.ts
@@ -227,7 +227,7 @@ export const ISSUE_DISPLAY_FILTERS_BY_PAGE: TIssueFiltersToDisplayByPageType = {
         },
         extra_options: {
           access: true,
-          values: ["show_empty_groups", "sub_issue"],
+          values: ["show_empty_groups", "sub_issue", "show_estimates"],
         },
       },
       kanban: {

--- a/packages/i18n/src/locales/en/work-item.json
+++ b/packages/i18n/src/locales/en/work-item.json
@@ -65,7 +65,8 @@
       },
       "extra": {
         "show_sub_issues": "Show sub-work items",
-        "show_empty_groups": "Show empty groups"
+        "show_empty_groups": "Show empty groups",
+        "show_estimates": "Show estimate totals"
       }
     },
     "layouts": {

--- a/packages/types/src/view-props.ts
+++ b/packages/types/src/view-props.ts
@@ -58,7 +58,7 @@ export type TIssueOrderByOptions =
 
 export type TIssueGroupingFilters = "active" | "backlog";
 
-export type TIssueExtraOptions = "show_empty_groups" | "sub_issue";
+export type TIssueExtraOptions = "show_empty_groups" | "sub_issue" | "show_estimates";
 
 export type TIssueParams =
   | "priority"
@@ -81,6 +81,7 @@ export type TIssueParams =
   | "type"
   | "sub_issue"
   | "show_empty_groups"
+  | "show_estimates"
   | "cursor"
   | "per_page"
   | "issue_type"
@@ -157,6 +158,7 @@ export interface IIssueDisplayFilterOptions {
   order_by?: TIssueOrderByOptions;
   show_empty_groups?: boolean;
   sub_issue?: boolean;
+  show_estimates?: boolean;
 }
 export interface IIssueDisplayProperties {
   assignee?: boolean;

--- a/packages/utils/src/work-item/base.ts
+++ b/packages/utils/src/work-item/base.ts
@@ -283,6 +283,7 @@ export const getComputedDisplayFilters = (
     sub_group_by: filters?.sub_group_by || null,
     sub_issue: filters?.sub_issue || false,
     show_empty_groups: filters?.show_empty_groups || false,
+    show_estimates: filters?.show_estimates || false,
   };
 };
 


### PR DESCRIPTION
### Description

Adds estimate point sum badges to list view group headers when using a summable estimate system (Points or Time).

- New "Show estimate totals" toggle in the list layout's display filter extra options
- Each group header shows a badge with the sum of estimate points for items in that group
- Shows a `≥` prefix when the group has more items not yet loaded (partial sum)
- Only appears for summable estimate systems (Points, Time), not Categories

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
#### Activated estimations for groups show group estimation totals
<img width="2996" height="1546" alt="image" src="https://github.com/user-attachments/assets/964deade-b340-4121-8dac-23b0632c673d" />

#### Activated estimations for paginated groups (>50) show a lower bound based on loaded issues
<img width="1496" height="772" alt="image" src="https://github.com/user-attachments/assets/9a7fc3ee-cb76-48f5-90cf-1dbb3c5f4939" />

### Test Scenarios

- Enable/disable "Show estimate totals" toggle → badges appear/disappear
- Points estimate system → sums display correctly per group
- Time estimate system → sums display correctly per group (assumption, cannot test on CE)
- Categories estimate system → no badges shown
- No estimate system configured → no badges shown
- Partially loaded group → badge shows `≥` prefix
- Mix of estimated and unestimated items → only estimated items counted (not relevant after #settings
- All items unestimated → no badge shown

### References

Resolves #9213 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a display filter to toggle showing estimate summaries for issue groups in list view.
  * Group headers optionally show estimate badges and per-group estimate totals when enabled.
  * UI and translations updated to surface the new "show estimates" option across filtering controls and list displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->