### PR TITLE
fix: layout dropdown button width fits its label

### DIFF
--- a/apps/web/core/components/dropdowns/layout.tsx
+++ b/apps/web/core/components/dropdowns/layout.tsx
@@ -74,7 +74,7 @@ export const LayoutDropDown = observer(function LayoutDropDown(props: TLayoutDro
       value={value?.toString()}
       keyExtractor={keyExtractor}
       options={options}
-      buttonContainerClassName={cn(getIconButtonStyling("secondary", "lg"), "w-auto px-2")}
+      buttonContainerClassName={cn(getIconButtonStyling("secondary", "lg"), "aspect-auto w-auto! px-2")}
       buttonContent={buttonContent}
       renderItem={itemContent}
       disableSearch


### PR DESCRIPTION
### Description

The view **Layout** dropdown button is clamped to a square, so its icon spills
outside the button and the label overflows the background. It's most visible in
the create-view toolbar, where the icon overlaps the access (public/private)
toggle to its left.

Root cause: the button uses `getIconButtonStyling("secondary", "lg")`, whose
base styling includes `aspect-square` + `size-7`. Together with the fixed
height this forces a 28px square regardless of the content width — the appended
`w-auto` can't win because tailwind-merge's `size → w/h` conflict is
one-directional.

Fix (one line in `apps/web/core/components/dropdowns/layout.tsx`): add
`aspect-auto` to drop the 1:1 ratio and `w-auto!` to size the button to its
content. Height (`h-7`) is preserved.

```diff
- buttonContainerClassName={cn(getIconButtonStyling("secondary", "lg"), "w-auto px-2")}
+ buttonContainerClassName={cn(getIconButtonStyling("secondary", "lg"), "aspect-auto w-auto! px-2")}
```

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)

**Before:** 
<img width="916" height="555" alt="image" src="https://github.com/user-attachments/assets/26acf89d-536d-4700-ad5c-05127d8a518e" />


**After:** 
<img width="885" height="549" alt="image" src="https://github.com/user-attachments/assets/60c3846d-2395-4283-a737-22246b768685" />


### Test Scenarios

- Open a project → **Views** → **Create view**.
- In the create-view toolbar, the **Layout** dropdown button now fits its label
  ("List"/"Kanban"/…); the icon stays inside the button and no longer overlaps
  the access toggle.
- Open the **Layout** dropdown — selection still works; the button keeps its
  `h-7` height and `secondary` styling.
- Verified the same dropdown renders correctly wherever `LayoutDropDown` is used
  (e.g. view header).

### References

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the visual styling of a dropdown button to improve layout appearance and sizing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->