### PR TITLE
fix(web): add window.requestIdleCallback polyfill for Safari/iOS

### DIFF
--- a/apps/web/core/lib/idle-task.ts
+++ b/apps/web/core/lib/idle-task.ts
@@ -36,10 +36,14 @@ export const cancelIdle = (id: number) => {
 };
 
 export const installIdleCallbackPolyfill = () => {
-  if (typeof globalThis === "undefined") return;
-
-  globalThis.requestIdleCallback = globalThis.requestIdleCallback ?? requestIdleFallback;
-  globalThis.cancelIdleCallback = globalThis.cancelIdleCallback ?? cancelIdleFallback;
+  if (typeof globalThis !== "undefined") {
+    globalThis.requestIdleCallback = globalThis.requestIdleCallback ?? requestIdleFallback;
+    globalThis.cancelIdleCallback = globalThis.cancelIdleCallback ?? cancelIdleFallback;
+  }
+  if (typeof window !== "undefined") {
+    (window as any).requestIdleCallback = (window as any).requestIdleCallback ?? requestIdleFallback;
+    (window as any).cancelIdleCallback = (window as any).cancelIdleCallback ?? cancelIdleFallback;
+  }
 };
 
 /**


### PR DESCRIPTION
Fixes #9134. Safari and iOS browsers do not support requestIdleCallback natively. This adds a fallback polyfill in idle-task.ts to prevent Error Boundary crashes (e.g. in gantt-layout-loader).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved robustness of idle callback polyfill to handle different runtime environments more defensively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->