### PR TITLE
fix(api): reject API key auth for deactivated user accounts

### DIFF
--- a/apps/api/plane/api/middleware/api_authentication.py
+++ b/apps/api/plane/api/middleware/api_authentication.py
@@ -32,6 +32,7 @@ class APIKeyAuthentication(authentication.BaseAuthentication):
                 Q(Q(expired_at__gt=timezone.now()) | Q(expired_at__isnull=True)),
                 token=token,
                 is_active=True,
+                user__is_active=True,
             )
         except APIToken.DoesNotExist:
             raise AuthenticationFailed("Given API token is not valid")

--- a/apps/api/plane/app/middleware/api_authentication.py
+++ b/apps/api/plane/app/middleware/api_authentication.py
@@ -32,6 +32,7 @@ class APIKeyAuthentication(authentication.BaseAuthentication):
                 Q(Q(expired_at__gt=timezone.now()) | Q(expired_at__isnull=True)),
                 token=token,
                 is_active=True,
+                user__is_active=True,
             )
         except APIToken.DoesNotExist:
             raise AuthenticationFailed("Given API token is not valid")

--- a/apps/api/plane/tests/contract/api/test_authentication.py
+++ b/apps/api/plane/tests/contract/api/test_authentication.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""
+Contract tests for external API key authentication.
+
+End-to-end proof that an API key cannot be used to access the API once the
+owning user account has been deactivated.
+"""
+
+import pytest
+from rest_framework import status
+
+
+@pytest.mark.contract
+class TestAPIKeyAuthenticationContract:
+    """Test API key authentication behaviour against a live endpoint."""
+
+    USERS_ME_URL = "/api/v1/users/me/"
+
+    @pytest.mark.django_db
+    def test_active_user_can_access_with_api_key(self, api_key_client):
+        response = api_key_client.get(self.USERS_ME_URL)
+
+        assert response.status_code == status.HTTP_200_OK
+
+    @pytest.mark.django_db
+    def test_deactivated_user_cannot_access_with_api_key(
+        self, api_key_client, create_user
+    ):
+        # The account is disabled after the API key was generated.
+        create_user.is_active = False
+        create_user.save()
+
+        response = api_key_client.get(self.USERS_ME_URL)
+
+        # Access is denied once the account is deactivated. APIKeyAuthentication
+        # does not set a WWW-Authenticate header, so DRF surfaces the
+        # AuthenticationFailed as 403 Forbidden rather than 401.
+        assert response.status_code in (
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        )

--- a/apps/api/plane/tests/unit/middleware/test_api_authentication.py
+++ b/apps/api/plane/tests/unit/middleware/test_api_authentication.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""
+Unit tests for APIKeyAuthentication.
+
+Covers the access-control guarantees of the external API key authentication:
+- a valid token belonging to an active user authenticates successfully
+- a valid token is rejected once the underlying user account is deactivated
+  (prevents an authentication bypass via a disabled account that still holds
+  a previously generated API key)
+"""
+
+import pytest
+from rest_framework.exceptions import AuthenticationFailed
+
+from plane.api.middleware.api_authentication import APIKeyAuthentication
+from plane.db.models import APIToken
+
+
+@pytest.mark.unit
+class TestAPIKeyAuthentication:
+    @pytest.mark.django_db
+    def test_validate_api_token_authenticates_active_user(self, create_user):
+        token = APIToken.objects.create(
+            user=create_user, label="Active Token", token="active-user-token"
+        )
+
+        user, returned_token = APIKeyAuthentication().validate_api_token(token.token)
+
+        assert user == create_user
+        assert returned_token == token.token
+
+    @pytest.mark.django_db
+    def test_validate_api_token_rejects_deactivated_user(self, create_user):
+        token = APIToken.objects.create(
+            user=create_user, label="Stale Token", token="deactivated-user-token"
+        )
+
+        # Account is deactivated by an administrator after the token was issued.
+        create_user.is_active = False
+        create_user.save()
+
+        with pytest.raises(AuthenticationFailed):
+            APIKeyAuthentication().validate_api_token(token.token)


### PR DESCRIPTION
### Description

The external API's custom API key authentication (`APIKeyAuthentication.validate_api_token`) only verified that the `APIToken` row itself was active and unexpired — it never checked the owning user's `is_active` flag. DRF's `IsAuthenticated` only checks `user.is_authenticated`, which is always `True` for a real `User` instance regardless of `is_active`. As a result, a user whose account was deactivated by an administrator could continue to use a previously issued API key indefinitely, bypassing the deactivation.

This was reported via a bug-bounty submission (rated Critical). Deactivation does not revoke existing API tokens (the self-service deactivation flow deletes sessions but leaves tokens active), so the auth layer was the only gate — and it was missing the check.

**Fix:** add `user__is_active=True` to the `validate_api_token()` lookup so a token tied to a disabled account fails the query and is rejected with the existing generic `AuthenticationFailed` ("Given API token is not valid"). Folding it into the query keeps the change atomic (single query, matches existing idiom) and avoids disclosing account state to the caller.

Applied to both:
- `plane/api/middleware/api_authentication.py` — the external REST API (the reachable vulnerability, wired into `BaseAPIView`).
- `plane/app/middleware/api_authentication.py` — an identical, currently-unused copy, fixed for parity so the gap can't be silently reintroduced if it gets wired up later.

Note: because `APIKeyAuthentication` sets no `WWW-Authenticate` header, DRF surfaces the denial as **403 Forbidden** rather than 401 — either way, access is denied.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots here -->

### Test Scenarios

Added automated coverage (written test-first, both verified to fail before the fix):

- **Unit** (`plane/tests/unit/middleware/test_api_authentication.py`):
  - `validate_api_token` authenticates a token for an **active** user (unchanged behavior).
  - `validate_api_token` raises `AuthenticationFailed` once the owning user is deactivated.
- **Contract** (`plane/tests/contract/api/test_authentication.py`):
  - Active user can reach `GET /api/v1/users/me/` with their API key (200).
  - Deactivated user is **denied** at `GET /api/v1/users/me/` with the same key (403/401) — previously returned 200, demonstrating the bypass is closed end-to-end.

Manual scenario to confirm: generate an API key for a user, deactivate the account, then call any `/api/v1/...` endpoint with `X-Api-Key` — the request should be rejected instead of succeeding.

### References

- Bug-bounty report: "Authentication Bypass via Inactive User Account" (API key auth missing `user.is_active` check).
- Out of scope here: the same report's second item (rate-limiter DoS via `None` cache key) was assessed as **not exploitable** — throttles run after permission checks and django_redis tolerates a `None` key — so no change was made for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Security**
  * API key authentication now requires the associated user account to be active. Existing API keys belonging to deactivated users will no longer authenticate requests.

* **Tests**
  * Added test coverage to verify API key authentication behavior for both active and deactivated user accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->