### PR TITLE
fix: prevent Enter during IME composition from submitting comments and other inputs

### DIFF
--- a/apps/web/core/components/comments/card/edit-form.tsx
+++ b/apps/web/core/components/comments/card/edit-form.tsx
@@ -77,7 +77,8 @@ export const CommentCardEditForm = observer(function CommentCardEditForm(props: 
     <form className="flex flex-col gap-2">
       <div
         onKeyDown={(e) => {
-          if (e.key === "Enter" && !e.shiftKey && !e.ctrlKey && !e.metaKey && !isEmpty) handleSubmit(onEnter)(e);
+          if (e.key === "Enter" && !e.nativeEvent.isComposing && !e.shiftKey && !e.ctrlKey && !e.metaKey && !isEmpty)
+            handleSubmit(onEnter)(e);
         }}
       >
         <LiteTextEditor

--- a/apps/web/core/components/comments/comment-create.tsx
+++ b/apps/web/core/components/comments/comment-create.tsx
@@ -96,6 +96,7 @@ export const CommentCreate = observer(function CommentCreate(props: TCommentCrea
       onKeyDown={(e) => {
         if (
           e.key === "Enter" &&
+          !e.nativeEvent.isComposing &&
           !e.shiftKey &&
           !e.ctrlKey &&
           !e.metaKey &&

--- a/apps/web/core/components/core/modals/gpt-assistant-popover.tsx
+++ b/apps/web/core/components/core/modals/gpt-assistant-popover.tsx
@@ -153,7 +153,7 @@ export function GptAssistantPopover(props: Props) {
 
   useEffect(() => {
     const handleEnterKeyPress = (event: KeyboardEvent) => {
-      if (event.key === "Enter" && !event.shiftKey) {
+      if (event.key === "Enter" && !event.isComposing && !event.shiftKey) {
         event.preventDefault();
         handleSubmit(handleAIResponse)();
       }

--- a/apps/web/core/components/pages/editor/title.tsx
+++ b/apps/web/core/components/pages/editor/title.tsx
@@ -54,7 +54,7 @@ export const PageEditorTitle = observer(function PageEditorTitle(props: Props) {
             className={cn(titleFontClassName, "block w-full resize-none rounded-none border-none p-0 outline-none")}
             placeholder="Untitled"
             onKeyDown={(e) => {
-              if (e.key === "Enter") {
+              if (e.key === "Enter" && !e.nativeEvent.isComposing) {
                 e.preventDefault();
                 editorRef?.setFocusAtPosition(0);
               }

--- a/packages/editor/src/core/extensions/enter-key.ts
+++ b/packages/editor/src/core/extensions/enter-key.ts
@@ -15,6 +15,10 @@ export const EnterKeyExtension = (onEnterKeyPress?: () => void) =>
     addKeyboardShortcuts(this) {
       return {
         Enter: () => {
+          if (this.editor.view.composing) {
+            return false;
+          }
+
           const { activeDropbarExtensions } = this.editor.storage.utility;
 
           if (activeDropbarExtensions.length === 0) {


### PR DESCRIPTION
## Description

When typing Japanese (or Chinese/Korean) text with an IME, pressing `Enter` to confirm a text conversion is treated as a submit action. This causes issue comments to be posted mid-composition, page title editing to lose focus, and the AI assistant prompt to be submitted prematurely.

This PR adds `isComposing` checks so that Enter during IME composition only confirms the conversion and never triggers a submit:

- `comment-create.tsx` / comment `edit-form.tsx` — keydown handlers now ignore composition Enter
- `EnterKeyExtension` (`@plane/editor`) — returns `false` while `editor.view.composing`
- `gpt-assistant-popover.tsx` — window keydown handler ignores composition Enter
- `pages/editor/title.tsx` — title field no longer moves focus on composition Enter

The check pattern (`!e.nativeEvent.isComposing`) follows the existing convention already used in `label-select.tsx` and `label-dropdown.tsx`.

Related: #7022, and complements #8915 (credit to @wang2032 for the editor extension approach) by covering additional input surfaces.

## Testing

- `pnpm check:types` and `pnpm check:lint` pass (web + @plane/editor)
- Verified at runtime on a self-hosted CE instance (v1.3.1, patch cherry-picked, frontend image rebuilt): with Japanese IME, Enter now confirms the conversion without posting the comment; comment editing, page title, and normal Enter-to-submit (composition finished) all behave as expected.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed Enter key behavior across comment editing forms, comment creation, page title editing, assistant modal, and the editor extension to properly handle Input Method Editor (IME) text composition. This prevents unintended form submissions and editor actions when users are actively composing text using IME input methods for languages that require character composition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->