### PR TITLE
ci: pin softprops/action-gh-release to a commit SHA

### DIFF
--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -391,7 +391,7 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: softprops/action-gh-release@v2.6.1
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe  # v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         with:


### PR DESCRIPTION
### Description
Pins `softprops/action-gh-release` from the mutable `v2.6.1` tag to the exact commit that tag points to today (`153bb8e04406...`) in `.github/workflows/build-branch.yml`, keeping a `# v2.6.1` comment so the version stays legible. A mutable tag can be re-pointed by the upstream maintainer; pinning to an immutable commit SHA is the [GitHub-recommended hardening](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) for third-party actions.

### Type of Change
- [x] Improvement

### Screenshots and Media (if applicable)
N/A. CI configuration change with no user-facing behavior.

### Test Scenarios
Ref-only change: the pinned SHA is the exact commit `v2.6.1` resolves to today, so the release step runs identically. No application code is touched.

### References
A repository-specific security report with the other categories reviewed (public files only): https://www.task-bounty.com/fix-more?repo=makeplane/plane

<sub>Prepared by TaskBounty. Glad to adjust or close if this isn't useful.</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**No user-visible changes** in this release. This update involves internal infrastructure maintenance with no impact on application functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->