### PR TITLE
feat(api): add workspace_slug to webhook delivery payload

### DIFF
--- a/apps/api/plane/bgtasks/webhook_task.py
+++ b/apps/api/plane/bgtasks/webhook_task.py
@@ -288,6 +288,7 @@ def webhook_send_task(
             "action": action,
             "webhook_id": str(webhook.id),
             "workspace_id": str(webhook.workspace_id),
+            "workspace_slug": slug,
             "data": event_data,
             "activity": activity,
         }


### PR DESCRIPTION
### Description
Add `workspace_slug` to the webhook delivery payload. The slug wasn't included in the payload. Webhook users can now build workspace URLs or make API calls. Before it was impossible even with API call since there is no way to get slug from workspace_id.

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)


### Test Scenarios 
 Verified webhook payload now includes `workspace_slug` field alongside `workspace_id`.
 Confirmed HMAC signature still computes correctly.

### References
