### PR TITLE
fix: handle null values in instance configuration patch endpoint

### DIFF
--- a/apps/api/plane/license/api/views/configuration.py
+++ b/apps/api/plane/license/api/views/configuration.py
@@ -45,7 +45,8 @@ class InstanceConfigurationEndpoint(BaseAPIView):
 
         bulk_configurations = []
         for configuration in configurations:
-            value = request.data.get(configuration.key, configuration.value)
+            raw_value = request.data.get(configuration.key, configuration.value)
+            value = "" if raw_value is None else str(raw_value).strip()
             if configuration.is_encrypted:
                 configuration.value = encrypt_data(value)
             else:


### PR DESCRIPTION
## What

When patching instance configuration values via the PATCH endpoint, `request.data` can contain `None` for fields that should be cleared. Calling `str(None)` produces the literal string `"None"` instead of an empty string, which gets persisted as the field value.

## Fix

Added an explicit null check before coercing to string:

```python
raw_value = request.data.get(configuration.key, configuration.value)
value = "" if raw_value is None else str(raw_value).strip()
```

`None` values now become `""` (empty string) as expected.

## Files changed

- `apps/api/plane/license/api/views/configuration.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced configuration endpoint to normalize input values by trimming whitespace and consistently handling empty parameters, applicable to both encrypted and standard configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->