### PR TITLE
fix: strip whitespace and handle null values in instance configuration

### DIFF
--- a/apps/api/plane/license/api/views/configuration.py
+++ b/apps/api/plane/license/api/views/configuration.py
@@ -45,7 +45,8 @@ class InstanceConfigurationEndpoint(BaseAPIView):
 
         bulk_configurations = []
         for configuration in configurations:
-            value = request.data.get(configuration.key, configuration.value)
+            raw_value = request.data.get(configuration.key, configuration.value)
+            value = "" if raw_value is None else str(raw_value).strip()
             if configuration.is_encrypted:
                 configuration.value = encrypt_data(value)
             else:

--- a/apps/api/plane/license/api/views/configuration.py
+++ b/apps/api/plane/license/api/views/configuration.py
@@ -46,7 +46,12 @@ class InstanceConfigurationEndpoint(BaseAPIView):
         bulk_configurations = []
         for configuration in configurations:
             raw_value = request.data.get(configuration.key, configuration.value)
-            value = "" if raw_value is None else str(raw_value).strip()
+            if raw_value is None:
+                value = ""
+            elif isinstance(raw_value, bool):
+                value = "1" if raw_value else "0"
+            else:
+                value = str(raw_value).strip()
             if configuration.is_encrypted:
                 configuration.value = encrypt_data(value)
             else:


### PR DESCRIPTION
## What

The instance configuration PATCH endpoint stored raw values from `request.data` without sanitization, causing two issues:

1. **Null values** — `str(None)` produces the literal string `"None"` instead of an empty string, so clearing a field would store `"None"` in the DB.
2. **Whitespace** — values with leading/trailing spaces (e.g. copy-pasted URLs or tokens) were stored as-is, which can silently break downstream usage.

## Fix

```python
raw_value = request.data.get(configuration.key, configuration.value)
value = "" if raw_value is None else str(raw_value).strip()
```

Both issues are addressed in a single sanitization step before the value is encrypted or stored.

## Files changed

- `apps/api/plane/license/api/views/configuration.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed configuration value normalization to correctly handle null inputs, convert boolean values to `"1"`/`"0"`, and trim leading/trailing whitespace before storing values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->