### PR TITLE
fix: enforce FILE_SIZE_LIMIT on published Space asset upload

### DIFF
--- a/apps/api/plane/space/views/asset.py
+++ b/apps/api/plane/space/views/asset.py
@@ -80,6 +80,10 @@ class EntityAssetEndpoint(BaseAPIView):
         entity_type = request.data.get("entity_type", "")
         entity_identifier = request.data.get("entity_identifier")
 
+        # Cap the client-provided size to the instance limit so the signed
+        # upload policy cannot exceed settings.FILE_SIZE_LIMIT
+        size_limit = min(size, settings.FILE_SIZE_LIMIT)
+
         # Check if the entity type is allowed
         if entity_type not in FileAsset.EntityTypeContext.values:
             return Response(
@@ -109,9 +113,9 @@ class EntityAssetEndpoint(BaseAPIView):
 
         # Create a File Asset
         asset = FileAsset.objects.create(
-            attributes={"name": name, "type": type, "size": size},
+            attributes={"name": name, "type": type, "size": size_limit},
             asset=asset_key,
-            size=size,
+            size=size_limit,
             workspace=deploy_board.workspace,
             created_by=request.user,
             entity_type=entity_type,
@@ -122,7 +126,7 @@ class EntityAssetEndpoint(BaseAPIView):
         # Get the presigned URL
         storage = S3Storage(request=request)
         # Generate a presigned URL to share an S3 object
-        presigned_url = storage.generate_presigned_post(object_name=asset_key, file_type=type, file_size=size)
+        presigned_url = storage.generate_presigned_post(object_name=asset_key, file_type=type, file_size=size_limit)
         # Return the presigned URL
         return Response(
             {

--- a/apps/api/plane/space/views/asset.py
+++ b/apps/api/plane/space/views/asset.py
@@ -76,13 +76,20 @@ class EntityAssetEndpoint(BaseAPIView):
         # Get the asset
         name = sanitize_filename(request.data.get("name")) or "unnamed"
         type = request.data.get("type", "image/jpeg")
-        size = int(request.data.get("size", settings.FILE_SIZE_LIMIT))
+        try:
+            size = int(request.data.get("size", settings.FILE_SIZE_LIMIT))
+        except (TypeError, ValueError):
+            return Response(
+                {"error": "Invalid size.", "status": False},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         entity_type = request.data.get("entity_type", "")
         entity_identifier = request.data.get("entity_identifier")
 
-        # Cap the client-provided size to the instance limit so the signed
-        # upload policy cannot exceed settings.FILE_SIZE_LIMIT
-        size_limit = min(size, settings.FILE_SIZE_LIMIT)
+        # Clamp the client-provided size to [1, FILE_SIZE_LIMIT] so the signed
+        # upload policy cannot exceed the instance limit and always carries a
+        # valid content-length-range bound
+        size_limit = max(1, min(size, settings.FILE_SIZE_LIMIT))
 
         # Check if the entity type is allowed
         if entity_type not in FileAsset.EntityTypeContext.values:


### PR DESCRIPTION
### Description

The published Space asset upload endpoint `POST /api/public/assets/v2/anchor/{anchor}/` (`apps/api/plane/space/views/asset.py`) trusted the client-supplied `size` value end-to-end. It read `size = int(request.data.get("size", settings.FILE_SIZE_LIMIT))`, stored that value on the `FileAsset`, and passed it directly to `storage.generate_presigned_post(..., file_size=size)`, which uses it as the upper bound of the signed S3/MinIO policy (`["content-length-range", 1, file_size]`).

Because the policy is signed by the backend, an authenticated user could intercept the asset-metadata request, set `size` above the instance limit, and obtain a presigned POST policy permitting an oversized upload — bypassing the configured `FILE_SIZE_LIMIT` and enabling storage abuse / resource exhaustion through published issue-comment uploads.

This was the only asset upload path missing the cap that every other endpoint (`app/views/asset/v2.py`, `api/views/asset.py`, `app/views/issue/attachment.py`) already applies.

**Fix:** cap the client-provided size with `size_limit = min(size, settings.FILE_SIZE_LIMIT)` and use `size_limit` consistently for the stored asset metadata (`attributes` + `size`) and the `generate_presigned_post()` call, so the signed policy can never exceed the instance limit.

Reported via responsible disclosure to security@plane.so.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots here -->

### Test Scenarios
- With `FILE_SIZE_LIMIT=5242880` (5 MB), call `POST /api/public/assets/v2/anchor/{anchor}/` with `size` set to `10485760` (10 MB). Decode the returned presigned policy and confirm `content-length-range` upper bound is `5242880`, not the requested `10485760`.
- Confirm the stored `FileAsset.size` and `attributes.size` equal the capped value (≤ `FILE_SIZE_LIMIT`), not the client-supplied value.
- Attempt a direct MinIO/S3 upload of a file > 5 MB using the returned presigned fields and confirm it is rejected by the signed policy.
- Regression: upload a normal image under the limit through a published Space issue comment and confirm it still succeeds end-to-end (presigned POST → upload → `PATCH` mark uploaded).

### References
- Responsible disclosure: "Published Space Asset Upload Size Limit Bypass" (security@plane.so)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved file upload size handling by validating the provided size, rejecting invalid values, and enforcing the configured maximum size limit consistently.
  * Updated the upload policy used for direct uploads so it matches the capped size limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->