### PR TITLE
fix: guard advance-analytics API calls on Community Edition

### DIFF
--- a/apps/web/app/(all)/[workspaceSlug]/(projects)/analytics/[tabId]/page.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/(projects)/analytics/[tabId]/page.tsx
@@ -18,6 +18,7 @@ import AnalyticsFilterActions from "@/components/analytics/analytics-filter-acti
 import { PageHead } from "@/components/core/page-title";
 // hooks
 import { useCommandPalette } from "@/hooks/store/use-command-palette";
+import { useInstance } from "@/hooks/store/use-instance";
 import { useProject } from "@/hooks/store/use-project";
 import { useWorkspace } from "@/hooks/store/use-workspace";
 import { useUserPermissions } from "@/hooks/store/user";
@@ -38,6 +39,9 @@ function AnalyticsPage({ params }: Route.ComponentProps) {
   const { workspaceProjectIds, loader } = useProject();
   const { currentWorkspace } = useWorkspace();
   const { allowPermissions } = useUserPermissions();
+  const { config: instanceConfig } = useInstance();
+
+  const isSelfManaged = instanceConfig?.is_self_managed ?? false;
 
   const pageTitle = currentWorkspace?.name
     ? t(`workspace_analytics.page_label`, { workspace: currentWorkspace?.name })
@@ -71,7 +75,16 @@ function AnalyticsPage({ params }: Route.ComponentProps) {
       <PageHead title={pageTitle} />
       {workspaceProjectIds && (
         <>
-          {workspaceProjectIds.length > 0 || loader === "init-loader" ? (
+          {isSelfManaged ? (
+            <div className="flex h-full w-full items-center justify-center">
+              <div className="flex flex-col items-center gap-3 text-center">
+                <h3 className="text-18 font-semibold">{t("workspace_analytics.not_available_ce.title")}</h3>
+                <p className="max-w-[400px] text-13 text-tertiary">
+                  {t("workspace_analytics.not_available_ce.description")}
+                </p>
+              </div>
+            </div>
+          ) : workspaceProjectIds.length > 0 || loader === "init-loader" ? (
             <div className="flex h-full overflow-hidden">
               <Tabs value={selectedTab} onValueChange={handleTabChange} className="h-full w-full">
                 <div className={"flex h-full w-full flex-col"}>

--- a/packages/i18n/src/locales/cs/workspace.json
+++ b/packages/i18n/src/locales/cs/workspace.json
@@ -148,7 +148,11 @@
     "workitem_resolved_vs_pending": "Vyřešené vs. čekající pracovní položky",
     "projects_by_status": "Projekty podle stavu",
     "active_users": "Aktivní uživatelé",
-    "intake_trends": "Trendy příjmů"
+    "intake_trends": "Trendy příjmů",
+    "not_available_ce": {
+      "title": "Analytics is not available on Community Edition",
+      "description": "Advanced analytics is a Pro feature. Upgrade to Plane Pro or Cloud to access workspace analytics."
+    }
   },
   "workspace_projects": {
     "label": "{count, plural, one {Projekt} few {Projekty} other {Projektů}}",

--- a/packages/i18n/src/locales/de/workspace.json
+++ b/packages/i18n/src/locales/de/workspace.json
@@ -148,7 +148,11 @@
     "workitem_resolved_vs_pending": "Gelöste vs. ausstehende Arbeitsaufgaben",
     "projects_by_status": "Projekte nach Status",
     "active_users": "Aktive Nutzer",
-    "intake_trends": "Aufnahmetrends"
+    "intake_trends": "Aufnahmetrends",
+    "not_available_ce": {
+      "title": "Analytics is not available on Community Edition",
+      "description": "Advanced analytics is a Pro feature. Upgrade to Plane Pro or Cloud to access workspace analytics."
+    }
   },
   "workspace_projects": {
     "label": "{count, plural, one {Projekt} few {Projekte} other {Projekte}}",

--- a/packages/i18n/src/locales/en/workspace.json
+++ b/packages/i18n/src/locales/en/workspace.json
@@ -148,7 +148,11 @@
     "workitem_resolved_vs_pending": "Work items resolved vs pending",
     "projects_by_status": "Projects by status",
     "active_users": "Active users",
-    "intake_trends": "Intake Trends"
+    "intake_trends": "Intake Trends",
+    "not_available_ce": {
+      "title": "Analytics is not available on Community Edition",
+      "description": "Advanced analytics is a Pro feature. Upgrade to Plane Pro or Cloud to access workspace analytics."
+    }
   },
   "workspace_projects": {
     "label": "{count, plural, one {Project} other {Projects}}",

--- a/packages/i18n/src/locales/es/workspace.json
+++ b/packages/i18n/src/locales/es/workspace.json
@@ -148,7 +148,11 @@
     "workitem_resolved_vs_pending": "Elementos de trabajo resueltos vs pendientes",
     "projects_by_status": "Proyectos por estado",
     "active_users": "Usuarios activos",
-    "intake_trends": "Tendencias de admisión"
+    "intake_trends": "Tendencias de admisión",
+    "not_available_ce": {
+      "title": "Analytics is not available on Community Edition",
+      "description": "Advanced analytics is a Pro feature. Upgrade to Plane Pro or Cloud to access workspace analytics."
+    }
   },
   "workspace_projects": {
     "label": "{count, plural, one {Proyecto} other {Proyectos}}",

--- a/packages/i18n/src/locales/fr/workspace.json
+++ b/packages/i18n/src/locales/fr/workspace.json
@@ -148,7 +148,11 @@
     "workitem_resolved_vs_pending": "Éléments de travail résolus vs en attente",
     "projects_by_status": "Projets par statut",
     "active_users": "Utilisateurs actifs",
-    "intake_trends": "Tendances des admissions"
+    "intake_trends": "Tendances des admissions",
+    "not_available_ce": {
+      "title": "Analytics is not available on Community Edition",
+      "description": "Advanced analytics is a Pro feature. Upgrade to Plane Pro or Cloud to access workspace analytics."
+    }
   },
   "workspace_projects": {
     "label": "{count, plural, one {Projet} other {Projets}}",

--- a/packages/i18n/src/locales/id/workspace.json
+++ b/packages/i18n/src/locales/id/workspace.json
@@ -148,7 +148,11 @@
     "workitem_resolved_vs_pending": "Item kerja yang diselesaikan vs tertunda",
     "projects_by_status": "Proyek berdasarkan status",
     "active_users": "Pengguna aktif",
-    "intake_trends": "Tren Penerimaan"
+    "intake_trends": "Tren Penerimaan",
+    "not_available_ce": {
+      "title": "Analytics is not available on Community Edition",
+      "description": "Advanced analytics is a Pro feature. Upgrade to Plane Pro or Cloud to access workspace analytics."
+    }
   },
   "workspace_projects": {
     "label": "{count, plural, one {Proyek} other {Proyek}}",

--- a/packages/i18n/src/locales/it/workspace.json
+++ b/packages/i18n/src/locales/it/workspace.json
@@ -148,7 +148,11 @@
     "workitem_resolved_vs_pending": "Elementi di lavoro risolti vs in sospeso",
     "projects_by_status": "Progetti per stato",
     "active_users": "Utenti attivi",
-    "intake_trends": "Tendenze di ammissione"
+    "intake_trends": "Tendenze di ammissione",
+    "not_available_ce": {
+      "title": "Analytics is not available on Community Edition",
+      "description": "Advanced analytics is a Pro feature. Upgrade to Plane Pro or Cloud to access workspace analytics."
+    }
   },
   "workspace_projects": {
     "label": "{count, plural, one {Progetto} other {Progetti}}",

--- a/packages/i18n/src/locales/ja/workspace.json
+++ b/packages/i18n/src/locales/ja/workspace.json
@@ -148,7 +148,11 @@
     "workitem_resolved_vs_pending": "解決済み vs 保留中の作業項目",
     "projects_by_status": "ステータス別のプロジェクト",
     "active_users": "アクティブユーザー",
-    "intake_trends": "受け入れの傾向"
+    "intake_trends": "受け入れの傾向",
+    "not_available_ce": {
+      "title": "Analytics is not available on Community Edition",
+      "description": "Advanced analytics is a Pro feature. Upgrade to Plane Pro or Cloud to access workspace analytics."
+    }
   },
   "workspace_projects": {
     "label": "{count, plural, one {プロジェクト} other {プロジェクト}}",

--- a/packages/i18n/src/locales/ko/workspace.json
+++ b/packages/i18n/src/locales/ko/workspace.json
@@ -148,7 +148,11 @@
     "workitem_resolved_vs_pending": "해결된 vs 대기 중인 작업 항목",
     "projects_by_status": "상태별 프로젝트",
     "active_users": "활성 사용자",
-    "intake_trends": "수용 추세"
+    "intake_trends": "수용 추세",
+    "not_available_ce": {
+      "title": "Analytics is not available on Community Edition",
+      "description": "Advanced analytics is a Pro feature. Upgrade to Plane Pro or Cloud to access workspace analytics."
+    }
   },
   "workspace_projects": {
     "label": "{count, plural, one {프로젝트} other {프로젝트}}",

--- a/packages/i18n/src/locales/pl/workspace.json
+++ b/packages/i18n/src/locales/pl/workspace.json
@@ -148,7 +148,11 @@
     "workitem_resolved_vs_pending": "Rozwiązane vs oczekujące elementy pracy",
     "projects_by_status": "Projekty według statusu",
     "active_users": "Aktywni użytkownicy",
-    "intake_trends": "Trendy przyjęć"
+    "intake_trends": "Trendy przyjęć",
+    "not_available_ce": {
+      "title": "Analytics is not available on Community Edition",
+      "description": "Advanced analytics is a Pro feature. Upgrade to Plane Pro or Cloud to access workspace analytics."
+    }
   },
   "workspace_projects": {
     "label": "{count, plural, one {Projekt} few {Projekty} other {Projektów}}",

--- a/packages/i18n/src/locales/pt-BR/workspace.json
+++ b/packages/i18n/src/locales/pt-BR/workspace.json
@@ -148,7 +148,11 @@
     "workitem_resolved_vs_pending": "Itens de trabalho resolvidos vs pendentes",
     "projects_by_status": "Projetos por status",
     "active_users": "Usuários ativos",
-    "intake_trends": "Tendências de entrada"
+    "intake_trends": "Tendências de entrada",
+    "not_available_ce": {
+      "title": "Analytics is not available on Community Edition",
+      "description": "Advanced analytics is a Pro feature. Upgrade to Plane Pro or Cloud to access workspace analytics."
+    }
   },
   "workspace_projects": {
     "label": "{count, plural, one {Projeto} other {Projetos}}",

--- a/packages/i18n/src/locales/ro/workspace.json
+++ b/packages/i18n/src/locales/ro/workspace.json
@@ -148,7 +148,11 @@
     "workitem_resolved_vs_pending": "Elemente de lucru rezolvate vs în așteptare",
     "projects_by_status": "Proiecte după statut",
     "active_users": "Utilizatori activi",
-    "intake_trends": "Tendințe de admitere"
+    "intake_trends": "Tendințe de admitere",
+    "not_available_ce": {
+      "title": "Analytics is not available on Community Edition",
+      "description": "Advanced analytics is a Pro feature. Upgrade to Plane Pro or Cloud to access workspace analytics."
+    }
   },
   "workspace_projects": {
     "label": "{count, plural, one {Proiect} other {Proiecte}}",

--- a/packages/i18n/src/locales/ru/workspace.json
+++ b/packages/i18n/src/locales/ru/workspace.json
@@ -148,7 +148,11 @@
     "workitem_resolved_vs_pending": "Решенные vs ожидающие рабочие элементы",
     "projects_by_status": "Проекты по статусу",
     "active_users": "Активные пользователи",
-    "intake_trends": "Тенденции приёма"
+    "intake_trends": "Тенденции приёма",
+    "not_available_ce": {
+      "title": "Analytics is not available on Community Edition",
+      "description": "Advanced analytics is a Pro feature. Upgrade to Plane Pro or Cloud to access workspace analytics."
+    }
   },
   "workspace_projects": {
     "label": "{count, plural, one {Проект} other {Проекты}}",

--- a/packages/i18n/src/locales/sk/workspace.json
+++ b/packages/i18n/src/locales/sk/workspace.json
@@ -148,7 +148,11 @@
     "workitem_resolved_vs_pending": "Vyriešené vs. čakajúce pracovné položky",
     "projects_by_status": "Projekty podľa stavu",
     "active_users": "Aktívni používatelia",
-    "intake_trends": "Trendy prijímania"
+    "intake_trends": "Trendy prijímania",
+    "not_available_ce": {
+      "title": "Analytics is not available on Community Edition",
+      "description": "Advanced analytics is a Pro feature. Upgrade to Plane Pro or Cloud to access workspace analytics."
+    }
   },
   "workspace_projects": {
     "label": "{count, plural, one {Projekt} few {Projekty} other {Projektov}}",

--- a/packages/i18n/src/locales/tr-TR/workspace.json
+++ b/packages/i18n/src/locales/tr-TR/workspace.json
@@ -148,7 +148,11 @@
     "workitem_resolved_vs_pending": "Çözülen vs bekleyen iş öğeleri",
     "projects_by_status": "Durumuna göre projeler",
     "active_users": "Aktif kullanıcılar",
-    "intake_trends": "Alım Eğilimleri"
+    "intake_trends": "Alım Eğilimleri",
+    "not_available_ce": {
+      "title": "Analytics is not available on Community Edition",
+      "description": "Advanced analytics is a Pro feature. Upgrade to Plane Pro or Cloud to access workspace analytics."
+    }
   },
   "workspace_projects": {
     "label": "{count, plural, one {Proje} other {Projeler}}",

--- a/packages/i18n/src/locales/ua/workspace.json
+++ b/packages/i18n/src/locales/ua/workspace.json
@@ -148,7 +148,11 @@
     "workitem_resolved_vs_pending": "Вирішені vs очікуючі робочі елементи",
     "projects_by_status": "Проєкти за статусом",
     "active_users": "Активні користувачі",
-    "intake_trends": "Тенденції прийому"
+    "intake_trends": "Тенденції прийому",
+    "not_available_ce": {
+      "title": "Analytics is not available on Community Edition",
+      "description": "Advanced analytics is a Pro feature. Upgrade to Plane Pro or Cloud to access workspace analytics."
+    }
   },
   "workspace_projects": {
     "label": "{count, plural, one {Проєкт} few {Проєкти} other {Проєктів}}",

--- a/packages/i18n/src/locales/vi-VN/workspace.json
+++ b/packages/i18n/src/locales/vi-VN/workspace.json
@@ -148,7 +148,11 @@
     "workitem_resolved_vs_pending": "Mục công việc đã giải quyết vs đang chờ",
     "projects_by_status": "Dự án theo trạng thái",
     "active_users": "Người dùng hoạt động",
-    "intake_trends": "Xu hướng tiếp nhận"
+    "intake_trends": "Xu hướng tiếp nhận",
+    "not_available_ce": {
+      "title": "Analytics is not available on Community Edition",
+      "description": "Advanced analytics is a Pro feature. Upgrade to Plane Pro or Cloud to access workspace analytics."
+    }
   },
   "workspace_projects": {
     "label": "{count, plural, one {dự án} other {dự án}}",

--- a/packages/i18n/src/locales/zh-CN/workspace.json
+++ b/packages/i18n/src/locales/zh-CN/workspace.json
@@ -148,7 +148,11 @@
     "workitem_resolved_vs_pending": "已解决 vs 待处理的工作项",
     "projects_by_status": "按状态分类的项目",
     "active_users": "活跃用户",
-    "intake_trends": "入学趋势"
+    "intake_trends": "入学趋势",
+    "not_available_ce": {
+      "title": "Analytics is not available on Community Edition",
+      "description": "Advanced analytics is a Pro feature. Upgrade to Plane Pro or Cloud to access workspace analytics."
+    }
   },
   "workspace_projects": {
     "label": "{count, plural, one {项目} other {项目}}",

--- a/packages/i18n/src/locales/zh-TW/workspace.json
+++ b/packages/i18n/src/locales/zh-TW/workspace.json
@@ -148,7 +148,11 @@
     "workitem_resolved_vs_pending": "已解決 vs 待處理的工作項目",
     "projects_by_status": "按狀態分類的專案",
     "active_users": "活躍使用者",
-    "intake_trends": "入學趨勢"
+    "intake_trends": "入學趨勢",
+    "not_available_ce": {
+      "title": "Analytics is not available on Community Edition",
+      "description": "Advanced analytics is a Pro feature. Upgrade to Plane Pro or Cloud to access workspace analytics."
+    }
   },
   "workspace_projects": {
     "label": "{count, plural, one {專案} other {專案}}",


### PR DESCRIPTION
On Community Edition, clicking the Analytics tab triggers `/advance-analytics`, `/advance-analytics-charts`, and `/advance-analytics-stats` API calls that don't exist on CE, resulting in 500s and a broken UI.

**Root cause:** The analytics page mounts `TotalInsights`, `ProjectInsights`, `CreatedVsResolved`, `PriorityChart`, and `WorkItemsInsightTable` unconditionally — all of which fire `advance-analytics` requests on mount. The instance config already exposes `is_self_managed: true` on CE, but the analytics page wasn't checking it.

**Fix:** In `apps/web/app/(all)/[workspaceSlug]/(projects)/analytics/[tabId]/page.tsx`, check `instanceConfig.is_self_managed` via `useInstance()`. When true, render an informational empty state instead of the tabs. No API calls fire. Also adds the `not_available_ce` i18n key to all 19 supported locales.

Closes #9237

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace analytics now displays a Community Edition restriction notice, guiding users to upgrade for access
  * Restriction messaging is available across 17 supported languages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->