### PR TITLE
fix: Scope workspace user preference filter to current user

### DIFF
--- a/apps/api/plane/app/views/workspace/user_preference.py
+++ b/apps/api/plane/app/views/workspace/user_preference.py
@@ -85,7 +85,7 @@ class WorkspaceUserPreferenceViewSet(BaseAPIView):
             if not key:
                 continue
 
-            preference = WorkspaceUserPreference.objects.filter(key=key, workspace__slug=slug).first()
+            preference = WorkspaceUserPreference.objects.filter(key=key, workspace__slug=slug, user=request.user).first()
 
             if not preference:
                 continue


### PR DESCRIPTION
The `patch` method in `WorkspaceUserPreference` was filtering by `key` and `workspace__slug` only. In a workspace with multiple users, `.first()` could grab a different user's preference row, so updating pin/sort state would either mutate the wrong user's data or leave the current user's preference unchanged — making sidebar state look like it didn't persist after refresh.

The `get` method already had `user=request.user` on its queries. Added the same filter to `patch`.

Closes #9260

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where personal workspace preferences were not properly isolated between users within the same workspace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #9260