### PR TITLE
fix: Use APP_DOMAIN env var for bot user email

### DIFF
--- a/apps/api/plane/bgtasks/workspace_seed_task.py
+++ b/apps/api/plane/bgtasks/workspace_seed_task.py
@@ -526,7 +526,7 @@ def workspace_seed(workspace_id: uuid.UUID) -> None:
             last_name="",
             is_bot=True,
             bot_type=BotTypeEnum.WORKSPACE_SEED,
-            email=f"bot_user_{workspace.id}@plane.so",
+            email=f"bot_user_{workspace.id}@{os.environ.get('APP_DOMAIN', 'plane.so')}",
             password=make_password(uuid.uuid4().hex),
             is_password_autoset=True,
         )

--- a/apps/api/plane/bgtasks/workspace_seed_task.py
+++ b/apps/api/plane/bgtasks/workspace_seed_task.py
@@ -10,6 +10,7 @@ import uuid
 from typing import Dict
 import logging
 from datetime import timedelta
+from urllib.parse import urlparse
 
 # Django imports
 from django.conf import settings
@@ -526,7 +527,7 @@ def workspace_seed(workspace_id: uuid.UUID) -> None:
             last_name="",
             is_bot=True,
             bot_type=BotTypeEnum.WORKSPACE_SEED,
-            email=f"bot_user_{workspace.id}@{os.environ.get('APP_DOMAIN', 'plane.so')}",
+            email=f"bot_user_{workspace.id}@{urlparse(settings.WEB_URL or 'https://plane.so').hostname or 'plane.so'}",
             password=make_password(uuid.uuid4().hex),
             is_password_autoset=True,
         )


### PR DESCRIPTION
Bot user email was hardcoded as `bot_user_{id}@plane.so` during workspace seeding. Self-hosted instances with a custom `APP_DOMAIN` would end up with bot accounts on the wrong domain.

Replaced the hardcoded domain with `os.environ.get('APP_DOMAIN', 'plane.so')` — defaults to `plane.so` so Plane Cloud is unaffected.

Closes #9251

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced workspace initialization to derive the bot user’s seeded email domain from the configured web URL, with a sensible fallback to the default domain when not provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->