### PR TITLE
fix: Require at least one alphanumeric char in workspace name

### DIFF
--- a/packages/utils/src/validation.ts
+++ b/packages/utils/src/validation.ts
@@ -42,6 +42,12 @@ export const DISPLAY_NAME_REGEX = /^[\p{L}\p{N}_.-]+$/u;
 export const COMPANY_NAME_REGEX = /^[\p{L}\p{N}\s_-]+$/u;
 
 /**
+ * Requires at least one Unicode letter or digit in a string.
+ * Used to reject symbol-only inputs like "-_________-" in workspace/company names.
+ */
+export const HAS_ALPHANUMERIC_REGEX = /[\p{L}\p{N}]/u;
+
+/**
  * URL Slug Pattern (for workspace slugs, URL-safe identifiers)
  * Allows: Unicode letters (\p{L}), numbers (\p{N}), underscores, hyphens
  * Use case: International URL-safe identifiers like "josé-workspace", "李明-project"
@@ -140,6 +146,10 @@ export const validateCompanyName = (companyName: string, required: boolean = fal
     return "Company name can only contain letters, numbers, spaces, hyphens, and underscores";
   }
 
+  if (!HAS_ALPHANUMERIC_REGEX.test(companyName)) {
+    return "Company name must contain at least one letter or number";
+  }
+
   return true;
 };
 
@@ -168,6 +178,10 @@ export const validateWorkspaceName = (workspaceName: string, required: boolean =
 
   if (!COMPANY_NAME_REGEX.test(workspaceName)) {
     return "Workspace name can only contain letters, numbers, spaces, hyphens, and underscores";
+  }
+
+  if (!HAS_ALPHANUMERIC_REGEX.test(workspaceName)) {
+    return "Workspace name must contain at least one letter or number";
   }
 
   return true;


### PR DESCRIPTION
`COMPANY_NAME_REGEX` only blocks disallowed characters — it never checks that the name actually contains a letter or digit. So names like `-_________-` or `---` pass validation cleanly.

Added a second check using `\p{L}\p{N}` (Unicode-aware) in both `validateCompanyName` and `validateWorkspaceName`. International names (Japanese, Arabic, accented chars) still pass fine since `\p{L}` covers all Unicode letters.

Closes #9255

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for company and workspace names to require at least one letter or number in addition to existing allowlist rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->