### PR TITLE
[WEB-7730] fix(security): scope cascade deletes to workspace in BulkDeleteIssuesEndpoint

### DIFF
--- a/apps/api/plane/app/views/issue/base.py
+++ b/apps/api/plane/app/views/issue/base.py
@@ -771,7 +771,6 @@ class BulkDeleteIssuesEndpoint(BaseAPIView):
         total_issues = len(issues)
 
         # First, delete all related cycle issues
-        # Use scoped `issues` queryset (not raw issue_ids) to prevent cross-WS deletion (GHSA-2rr4-rp7r-32p4)
         CycleIssue.objects.filter(issue__in=issues).delete()
 
         # Then, delete all related module issues

--- a/apps/api/plane/app/views/issue/base.py
+++ b/apps/api/plane/app/views/issue/base.py
@@ -771,10 +771,11 @@ class BulkDeleteIssuesEndpoint(BaseAPIView):
         total_issues = len(issues)
 
         # First, delete all related cycle issues
-        CycleIssue.objects.filter(issue_id__in=issue_ids).delete()
+        # Use scoped `issues` queryset (not raw issue_ids) to prevent cross-WS deletion (GHSA-2rr4-rp7r-32p4)
+        CycleIssue.objects.filter(issue__in=issues).delete()
 
         # Then, delete all related module issues
-        ModuleIssue.objects.filter(issue_id__in=issue_ids).delete()
+        ModuleIssue.objects.filter(issue__in=issues).delete()
 
         # Finally, delete the issues themselves
         issues.delete()


### PR DESCRIPTION
## Summary

- `BulkDeleteIssuesEndpoint.delete()` correctly scoped the `issues` queryset to workspace+project, but the cascade deletes on `CycleIssue` and `ModuleIssue` used the raw `issue_ids` from the request
- An attacker could pass issue IDs from another workspace to delete `CycleIssue`/`ModuleIssue` records they don't own
- Fix: replace `issue_id__in=issue_ids` (raw user input) with `issue__in=issues` (the already-scoped queryset) in both cascade deletes

## Affected advisories (Cluster H)

- GHSA-6cw7-h92q-p9hg — Cross-WS destruction via unscoped BulkDeleteIssues
- GHSA-2rr4-rp7r-32p4 — Cross-WS CycleIssue/ModuleIssue deletion via BulkDelete cascade
- GHSA-7q7r-mrr4-2wwx — Cross-WS parent reassign via SubIssues (covered in WEB-7727 / PR #9269)

## Changes

| File | Change |
|:-----|:-------|
| `apps/api/plane/app/views/issue/base.py` | Replace `issue_id__in=issue_ids` → `issue__in=issues` in CycleIssue and ModuleIssue cascade deletes |

## Test plan

- [ ] Call bulk delete with issue IDs from workspace B while authenticated in workspace A — CycleIssue/ModuleIssue records from workspace B should not be deleted
- [ ] Verify normal bulk delete still works — issues and their cycle/module memberships in the correct workspace are deleted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed bulk deletion of issues so related cycle and module associations are removed using the same already-scoped workspace and project filtering, preventing leftover orphaned records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->