### PR TITLE
fix(api): include module and cycle data in issue webhook payloads

### DIFF
--- a/apps/api/plane/api/serializers/issue.py
+++ b/apps/api/plane/api/serializers/issue.py
@@ -818,13 +818,25 @@ class IssueExpandSerializer(BaseSerializer):
     labels, assignees, and states for comprehensive data representation.
     """
 
-    cycle = CycleLiteSerializer(source="issue_cycle.cycle", read_only=True)
-    module = ModuleLiteSerializer(source="issue_module.module", read_only=True)
+    cycle = serializers.SerializerMethodField()
+    module = serializers.SerializerMethodField()
 
     labels = serializers.SerializerMethodField()
     assignees = serializers.SerializerMethodField()
     state = StateLiteSerializer(read_only=True)
     description = serializers.JSONField(source="description_json", read_only=True)
+
+    def get_cycle(self, obj):
+        expand = self.context.get("expand", [])
+        if "cycle" in expand:
+            return CycleLiteSerializer([ic.cycle for ic in obj.issue_cycle.all()], many=True).data
+        return [ic.cycle_id for ic in obj.issue_cycle.all()]
+
+    def get_module(self, obj):
+        expand = self.context.get("expand", [])
+        if "module" in expand:
+            return ModuleLiteSerializer([im.module for im in obj.issue_module.all()], many=True).data
+        return [im.module_id for im in obj.issue_module.all()]
 
     def get_labels(self, obj):
         expand = self.context.get("expand", [])

--- a/apps/api/plane/bgtasks/webhook_task.py
+++ b/apps/api/plane/bgtasks/webhook_task.py
@@ -87,6 +87,8 @@ def get_issue_prefetches():
     return [
         Prefetch("label_issue", queryset=IssueLabel.objects.select_related("label")),
         Prefetch("issue_assignee", queryset=IssueAssignee.objects.select_related("assignee")),
+        Prefetch("issue_module", queryset=ModuleIssue.objects.select_related("module")),
+        Prefetch("issue_cycle", queryset=CycleIssue.objects.select_related("cycle")),
     ]
 
 
@@ -161,7 +163,7 @@ def get_model_data(event: str, event_id: Union[str, List[str]], many: bool = Fal
                 issue_id = queryset.id
                 queryset = model.objects.filter(pk=issue_id).prefetch_related(*issue_prefetches).first()
 
-            return serializer(queryset, many=many, context={"expand": ["labels", "assignees"]}).data
+            return serializer(queryset, many=many, context={"expand": ["labels", "assignees", "module", "cycle"]}).data
         else:
             return serializer(queryset, many=many).data
     except ObjectDoesNotExist:


### PR DESCRIPTION
### Description
Webhooks were missing module and cycle fields from the payload due to a broken source= traversal on reverse foreign key relations in IssueExpandSerializer.

The source="issue_module.module" path tries to resolve issue.issue_module and then access .module on it. Since a queryset has no .module attribute, DRF silently catches the AttributeError via SkipField and the field is dropped from the output entirely. The same issue affected the cycle field.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
<!-- Link related issues if there are any -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API issue responses now conditionally expand cycle and module information based on request parameters.
  * Webhook payloads for issues now include expanded cycle and module details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->