### PR TITLE
fix(typescript-config): include react-router.json in published files

### DIFF
--- a/packages/typescript-config/package.json
+++ b/packages/typescript-config/package.json
@@ -7,6 +7,7 @@
     "base.json",
     "nextjs.json",
     "react-library.json",
+    "react-router.json",
     "node-library.json"
   ]
 }


### PR DESCRIPTION
### Description
The `react-router.json` TypeScript config preset exists in `packages/typescript-config/` and is referenced by `apps/web`, `apps/admin` and `apps/space` via `"extends": "@plane/typescript-config/react-router.json"`. However it is missing from the `files` array in the package's `package.json`, which lists only the other four presets (`base.json`, `nextjs.json`, `react-library.json`, `node-library.json`).

The manifest therefore does not match the package contents:
- the preset is excluded from `npm pack` / publish output;
- stricter `extends` resolvers — including the VS Code TypeScript language server — fail to resolve it and report `Cannot find base config file "@plane/typescript-config/react-router.json"`.

This PR adds `react-router.json` to `files` so the manifest matches the directory. One-line, non-breaking; no change to compiler behavior.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

### Screenshots and Media (if applicable)
N/A — manifest-only change.

### Test Scenarios
- `npm pack --dry-run` in `packages/typescript-config` now includes `react-router.json` in the tarball (previously omitted).
- `tsc -p apps/web/tsconfig.json --showConfig` resolves the `extends` chain without errors.

### References
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package distribution to include React Router TypeScript configuration file alongside other exported TypeScript configs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->