### PR TITLE
fix: scope workspace user preference filter to current user

### DIFF
--- a/apps/api/plane/app/views/workspace/user_preference.py
+++ b/apps/api/plane/app/views/workspace/user_preference.py
@@ -85,7 +85,9 @@ class WorkspaceUserPreferenceViewSet(BaseAPIView):
             if not key:
                 continue
 
-            preference = WorkspaceUserPreference.objects.filter(key=key, workspace__slug=slug, user=request.user).first()
+            preference = WorkspaceUserPreference.objects.filter(
+                key=key, workspace__slug=slug, user=request.user
+            ).first()
 
             if not preference:
                 continue

--- a/apps/api/plane/app/views/workspace/user_preference.py
+++ b/apps/api/plane/app/views/workspace/user_preference.py
@@ -85,7 +85,7 @@ class WorkspaceUserPreferenceViewSet(BaseAPIView):
             if not key:
                 continue
 
-            preference = WorkspaceUserPreference.objects.filter(key=key, workspace__slug=slug).first()
+            preference = WorkspaceUserPreference.objects.filter(key=key, workspace__slug=slug, user=request.user).first()
 
             if not preference:
                 continue

--- a/apps/api/plane/tests/contract/app/test_workspace_user_preference_app.py
+++ b/apps/api/plane/tests/contract/app/test_workspace_user_preference_app.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+from datetime import timedelta
+
+import pytest
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework import status
+
+from plane.db.models import User, WorkspaceMember
+from plane.db.models.workspace import WorkspaceUserPreference
+
+
+@pytest.mark.contract
+class TestWorkspaceUserPreferencePatch:
+    """Contract tests for the sidebar preference PATCH endpoint.
+
+    Regression coverage for #9260: ``patch`` filtered ``WorkspaceUserPreference``
+    by ``key``/``workspace__slug`` only, so in a workspace with multiple members
+    ``.first()`` (ordered by ``-created_at``) could return — and mutate — another
+    member's preference row instead of the requesting user's.
+    """
+
+    KEY = WorkspaceUserPreference.UserPreferenceKeys.ANALYTICS.value
+
+    @pytest.mark.django_db
+    def test_patch_only_updates_requesting_users_preference(self, session_client, create_user, workspace):
+        """A member's PATCH must update only their own preference, never another member's."""
+        # A second, more-recently-active member of the same workspace.
+        other_user = User.objects.create(
+            email="other@plane.so", username="other_user", first_name="Other", last_name="User"
+        )
+        WorkspaceMember.objects.create(workspace=workspace, member=other_user, role=15)
+
+        own_pref = WorkspaceUserPreference.objects.create(
+            workspace=workspace, user=create_user, key=self.KEY, is_pinned=False, sort_order=100
+        )
+        other_pref = WorkspaceUserPreference.objects.create(
+            workspace=workspace, user=other_user, key=self.KEY, is_pinned=False, sort_order=200
+        )
+
+        # Force the other member's row to sort first under the model's ``-created_at``
+        # ordering, so an unscoped ``.first()`` would deterministically pick it.
+        now = timezone.now()
+        WorkspaceUserPreference.objects.filter(pk=own_pref.pk).update(created_at=now)
+        WorkspaceUserPreference.objects.filter(pk=other_pref.pk).update(created_at=now + timedelta(minutes=1))
+
+        url = reverse("workspace-user-preference", kwargs={"slug": workspace.slug})
+        response = session_client.patch(
+            url, [{"key": self.KEY, "is_pinned": True, "sort_order": 999}], format="json"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+
+        own_pref.refresh_from_db()
+        other_pref.refresh_from_db()
+
+        # The requesting user's preference is updated...
+        assert own_pref.is_pinned is True
+        assert own_pref.sort_order == 999
+        # ...and the other member's preference is left untouched.
+        assert other_pref.is_pinned is False
+        assert other_pref.sort_order == 200
+
+    @pytest.mark.django_db
+    def test_patch_updates_own_preference(self, session_client, create_user, workspace):
+        """Baseline: a member's PATCH persists changes to their own preference row."""
+        preference = WorkspaceUserPreference.objects.create(
+            workspace=workspace, user=create_user, key=self.KEY, is_pinned=False, sort_order=100
+        )
+
+        url = reverse("workspace-user-preference", kwargs={"slug": workspace.slug})
+        response = session_client.patch(
+            url, [{"key": self.KEY, "is_pinned": True, "sort_order": 42}], format="json"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+
+        preference.refresh_from_db()
+        assert preference.is_pinned is True
+        assert preference.sort_order == 42


### PR DESCRIPTION
### Description

Fixes #9260 — in a workspace with multiple members, sidebar pin/unpin changes returned `200 OK` but were not persisted for the requesting user, so pins reverted after a refresh.

The `patch` method in `WorkspaceUserPreferenceViewSet` filtered `WorkspaceUserPreference` by `key` and `workspace__slug` only. Because the model is ordered by `-created_at`, `.first()` could return a *different* member's preference row — so the PATCH mutated the wrong user's data while the current user's preference appeared to revert. The `get` method already scoped its queries with `user=request.user`; this applies the same scoping to `patch`.

The one-line fix commit is from community PR #9261 (@okxint). This PR additionally adds regression test coverage:

- **`test_patch_only_updates_requesting_users_preference`** — sets up a 2-member workspace and forces the other member's row to sort first under the `-created_at` ordering, then verifies a member's PATCH updates only their own preference and leaves the other member's row untouched. Fails against the pre-fix code.
- **`test_patch_updates_own_preference`** — baseline that a member's PATCH persists to their own row.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots here -->

### Test Scenarios
- In a workspace with **2+ members**, log in as user A, pin a sidebar item (e.g. Analytics, Archives), then refresh — the pin now persists (previously reverted).
- Confirm user B's sidebar preferences are unaffected by user A's pin/unpin actions.
- Run the new contract tests: `pytest plane/tests/contract/app/test_workspace_user_preference_app.py` — both pass with the fix; the scoping test fails without it (verified RED → GREEN).

### References
- Closes #9260
- Based on / supersedes #9261

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the workspace user preference PATCH behavior so updates are scoped to the currently authenticated user, preventing accidental changes to other members’ preference records within the same workspace.

* **Tests**
  * Added contract tests for the `workspace-user-preference` PATCH endpoint to verify correct user scoping and persistence of updated preference values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->