### PR TITLE
[WEB-7769] fix(security): scope EstimatePoint create/destroy to workspace and project

### DIFF
--- a/apps/api/plane/app/views/estimate/base.py
+++ b/apps/api/plane/app/views/estimate/base.py
@@ -159,6 +159,17 @@ class EstimatePointEndpoint(BaseViewSet):
                 {"error": "Key and value are required"},
                 status=status.HTTP_400_BAD_REQUEST,
             )
+        # Verify the estimate belongs to this workspace and project before creating a point
+        estimate = Estimate.objects.filter(
+            pk=estimate_id,
+            workspace__slug=slug,
+            project_id=project_id,
+        ).first()
+        if not estimate:
+            return Response(
+                {"error": "Estimate not found"},
+                status=status.HTTP_404_NOT_FOUND,
+            )
         key = request.data.get("key", 0)
         value = request.data.get("value", "")
         estimate_point = EstimatePoint.objects.create(
@@ -227,8 +238,18 @@ class EstimatePointEndpoint(BaseViewSet):
                     epoch=int(timezone.now().timestamp()),
                 )
 
-        # delete the estimate point
-        old_estimate_point = EstimatePoint.objects.filter(pk=estimate_point_id).first()
+        # delete the estimate point — scope to this estimate/project/workspace to prevent cross-tenant key manipulation
+        old_estimate_point = EstimatePoint.objects.filter(
+            pk=estimate_point_id,
+            estimate_id=estimate_id,
+            project_id=project_id,
+            workspace__slug=slug,
+        ).first()
+        if not old_estimate_point:
+            return Response(
+                {"error": "Estimate point not found"},
+                status=status.HTTP_404_NOT_FOUND,
+            )
 
         # rearrange the estimate points
         updated_estimate_points = []


### PR DESCRIPTION
## Summary

- **GHSA-933r-rxg8-f3h2** — `EstimatePointEndpoint.create`: added a workspace+project scoped `Estimate` ownership check before creating an estimate point. Previously the `estimate_id` URL parameter was trusted directly, allowing injection into any workspace's estimate.
- **GHSA-933r-rxg8-f3h2** (destroy): scoped the `old_estimate_point` lookup to `estimate_id + project_id + workspace__slug`; added 404 guard. Previously fetched by `pk` only — enabled cross-tenant key disclosure and manipulation during key-rearrangement.
- **GHSA-vm3j-5j49-gwrf** — `BulkEstimatePointEndpoint.partial_update`: already correctly scoped (lines 116, 125–130). No change needed.

## Files changed

- `apps/api/plane/app/views/estimate/base.py`

## Test plan

- [ ] Create estimate point with valid `estimate_id` in same workspace → succeeds
- [ ] Create estimate point with `estimate_id` from a different workspace → 404
- [ ] Delete estimate point with valid ID → succeeds, keys rearranged correctly
- [ ] Delete estimate point with ID from different workspace → 404, no side effects

Co-authored-by: Plane AI <noreply@plane.so>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for estimate point creation to ensure proper workspace scoping
  * Fixed estimate point deletion to enforce workspace isolation and prevent unauthorized access

<!-- end of auto-generated comment: release notes by coderabbit.ai -->