### PR TITLE
[WEB-7774] fix(security): sanitize comment_html and intake description_html with nh3

### DIFF
--- a/apps/api/plane/api/serializers/issue.py
+++ b/apps/api/plane/api/serializers/issue.py
@@ -745,14 +745,12 @@ class IssueCommentSerializer(BaseSerializer):
         exclude = ["comment_stripped", "comment_json"]
 
     def validate(self, data):
-        try:
-            if data.get("comment_html", None) is not None:
-                parsed = html.fromstring(data["comment_html"])
-                parsed_str = html.tostring(parsed, encoding="unicode")
-                data["comment_html"] = parsed_str
-
-        except Exception:
-            raise serializers.ValidationError("Invalid HTML passed")
+        if "comment_html" in data and data["comment_html"]:
+            is_valid, error_msg, sanitized_html = validate_html_content(data["comment_html"])
+            if not is_valid:
+                raise serializers.ValidationError({"comment_html": "HTML content is not valid"})
+            if sanitized_html is not None:
+                data["comment_html"] = sanitized_html
         return data
 
 

--- a/apps/api/plane/api/views/intake.py
+++ b/apps/api/plane/api/views/intake.py
@@ -29,6 +29,7 @@ from plane.app.permissions import ProjectLitePermission
 from plane.bgtasks.issue_activities_task import issue_activity
 from plane.db.models import Intake, IntakeIssue, Issue, Project, ProjectMember, State, StateGroup
 from plane.utils.host import base_host
+from plane.utils.content_validator import validate_html_content
 from .base import BaseAPIView
 from plane.db.models.intake import SourceType
 from plane.utils.openapi import (
@@ -187,10 +188,14 @@ class IntakeIssueListCreateAPIEndpoint(BaseAPIView):
         issue_data = request.data.get("issue", {})
         # Accept both "description" and "description_json" keys for the description_json field
         description_json = issue_data.get("description") or issue_data.get("description_json") or {}
+        # Sanitize description_html before saving to prevent stored XSS (GHSA-hh2r-3hwp-mvq3)
+        raw_description_html = issue_data.get("description_html", "<p></p>")
+        _, _, sanitized_description_html = validate_html_content(raw_description_html)
+        safe_description_html = sanitized_description_html if sanitized_description_html is not None else "<p></p>"
         issue = Issue.objects.create(
             name=issue_data.get("name"),
             description_json=description_json,
-            description_html=issue_data.get("description_html", "<p></p>"),
+            description_html=safe_description_html,
             priority=issue_data.get("priority", "none"),
             project_id=project_id,
             state_id=triage_state.id,

--- a/apps/api/plane/app/serializers/issue.py
+++ b/apps/api/plane/app/serializers/issue.py
@@ -715,6 +715,15 @@ class IssueCommentSerializer(BaseSerializer):
             "updated_at",
         ]
 
+    def validate(self, attrs):
+        if "comment_html" in attrs and attrs["comment_html"]:
+            is_valid, error_msg, sanitized_html = validate_html_content(attrs["comment_html"])
+            if not is_valid:
+                raise serializers.ValidationError({"comment_html": "HTML content is not valid"})
+            if sanitized_html is not None:
+                attrs["comment_html"] = sanitized_html
+        return attrs
+
 
 class IssueStateFlatSerializer(BaseSerializer):
     state_detail = StateLiteSerializer(read_only=True, source="state")

--- a/apps/api/plane/space/views/intake.py
+++ b/apps/api/plane/space/views/intake.py
@@ -23,6 +23,7 @@ from plane.app.serializers import (
     IssueCreateSerializer,
     IssueStateIntakeSerializer,
 )
+from plane.utils.content_validator import validate_html_content
 from plane.utils.issue_filters import issue_filters
 from plane.bgtasks.issue_activities_task import issue_activity
 from plane.db.models.intake import SourceType
@@ -141,11 +142,16 @@ class IntakeIssuePublicViewSet(BaseViewSet):
                 default=False,
             )
 
+        # Sanitize description_html before saving to prevent stored XSS (GHSA-hh2r-3hwp-mvq3)
+        raw_description_html = request.data.get("issue", {}).get("description_html", "<p></p>")
+        _, _, sanitized_description_html = validate_html_content(raw_description_html)
+        safe_description_html = sanitized_description_html if sanitized_description_html is not None else "<p></p>"
+
         # create an issue
         issue = Issue.objects.create(
             name=request.data.get("issue", {}).get("name"),
             description_json=request.data.get("issue", {}).get("description_json", {}),
-            description_html=request.data.get("issue", {}).get("description_html", "<p></p>"),
+            description_html=safe_description_html,
             priority=request.data.get("issue", {}).get("priority", "low"),
             project_id=project_deploy_board.project_id,
             state_id=triage_state.id,


### PR DESCRIPTION
## Summary

Fixes Cluster N stored XSS advisories — the `nh3` sanitizer (`validate_html_content`) already existed in `content_validator.py` but was not wired to comment serializers or the bare-ORM intake create paths.

- **GHSA-6qrq-f73q-r67j / GHSA-j9pv-f5wm-p4g2** — `IssueCommentSerializer` (app layer): added `validate()` calling `validate_html_content()` on `comment_html`
- **GHSA-6qrq-f73q-r67j / GHSA-j9pv-f5wm-p4g2** — `IssueCommentSerializer` (api layer): replaced lxml-only structural normalization with full nh3 sanitization
- **GHSA-hh2r-3hwp-mvq3** — `space/views/intake.py`: sanitize `description_html` before `Issue.objects.create()` (public board / unauthenticated intake)
- **GHSA-hh2r-3hwp-mvq3** — `api/views/intake.py`: same fix for authenticated API intake create path

The app-layer authenticated intake (`app/views/intake/base.py`) was already sanitized via `IssueCreateSerializer` — no change needed there.

## Files changed

- `apps/api/plane/app/serializers/issue.py`
- `apps/api/plane/api/serializers/issue.py`
- `apps/api/plane/space/views/intake.py`
- `apps/api/plane/api/views/intake.py`

## Test plan

- [ ] Create a comment with `<script>alert(1)</script>` in `comment_html` → script tag stripped, content saved safely
- [ ] Create a comment with `<a href="javascript:alert(1)">x</a>` → `javascript:` URI stripped
- [ ] Submit an intake issue (public board) with XSS payload in `description_html` → sanitized on save
- [ ] Submit an intake issue (API) with XSS payload in `description_html` → sanitized on save
- [ ] Normal rich-text HTML (bold, italic, mentions, lists) passes through unchanged

Co-authored-by: Plane AI <noreply@plane.so>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes & Improvements**
  * Issue comments now validate and sanitize HTML content
  * Issue descriptions in intake now validate and sanitize HTML content
  * Invalid HTML triggers validation errors with field-specific feedback
  * Sanitized HTML is persisted to ensure safe content storage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->