### PR TITLE
[WEB-7776] fix(security): scope FileAsset queries to prevent cross-project IDOR (Cluster F)

### DIFF
--- a/apps/api/plane/app/permissions/__init__.py
+++ b/apps/api/plane/app/permissions/__init__.py
@@ -9,6 +9,7 @@ from .workspace import (
     WorkspaceEntityPermission,
     WorkspaceViewerPermission,
     WorkspaceUserPermission,
+    WorkspaceMemberPermission,
 )
 from .project import (
     ProjectBasePermission,

--- a/apps/api/plane/app/permissions/workspace.py
+++ b/apps/api/plane/app/permissions/workspace.py
@@ -108,3 +108,30 @@ class WorkspaceUserPermission(BasePermission):
         return WorkspaceMember.objects.filter(
             member=request.user, workspace__slug=view.workspace_slug, is_active=True
         ).exists()
+
+
+class WorkspaceMemberPermission(BasePermission):
+    """Allows access only to active workspace members.
+
+    Resolves the workspace via 'slug' or 'workspace_id' in URL kwargs so this
+    class can be used on endpoints that identify the workspace by either
+    identifier (e.g. FileAssetEndpoint which mixes both URL patterns).
+    """
+
+    def has_permission(self, request, view):
+        if request.user.is_anonymous:
+            return False
+
+        workspace_id = view.kwargs.get("workspace_id")
+        if workspace_id:
+            return WorkspaceMember.objects.filter(
+                workspace_id=workspace_id, member=request.user, is_active=True
+            ).exists()
+
+        slug = view.kwargs.get("slug")
+        if slug:
+            return WorkspaceMember.objects.filter(
+                workspace__slug=slug, member=request.user, is_active=True
+            ).exists()
+
+        return False

--- a/apps/api/plane/app/views/asset/base.py
+++ b/apps/api/plane/app/views/asset/base.py
@@ -4,29 +4,26 @@
 
 # Third party imports
 from rest_framework import status
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.parsers import MultiPartParser, FormParser, JSONParser
 
 # Module imports
 from ..base import BaseAPIView, BaseViewSet
-from plane.db.models import FileAsset, Workspace, WorkspaceMember
+from plane.app.permissions import WorkspaceMemberPermission
+from plane.db.models import FileAsset, Workspace
 from plane.app.serializers import FileAssetSerializer
 
 
 class FileAssetEndpoint(BaseAPIView):
     parser_classes = (MultiPartParser, FormParser, JSONParser)
+    permission_classes = [IsAuthenticated, WorkspaceMemberPermission]
 
     """
     A viewset for viewing and editing task instances.
     """
 
     def get(self, request, workspace_id, asset_key):
-        # Verify the requesting user is a member of this workspace
-        if not WorkspaceMember.objects.filter(workspace_id=workspace_id, member=request.user, is_active=True).exists():
-            return Response(
-                {"error": "Requested resource could not be found.", "status": False},
-                status=status.HTTP_404_NOT_FOUND,
-            )
         asset_key = str(workspace_id) + "/" + asset_key
         files = FileAsset.objects.filter(asset=asset_key)
         if files.exists():
@@ -39,15 +36,9 @@ class FileAssetEndpoint(BaseAPIView):
             )
 
     def post(self, request, slug):
-        # Verify the requesting user is a member of this workspace
         workspace = Workspace.objects.filter(slug=slug).first()
         if not workspace:
             return Response({"error": "Workspace not found.", "status": False}, status=status.HTTP_404_NOT_FOUND)
-        if not WorkspaceMember.objects.filter(workspace=workspace, member=request.user, is_active=True).exists():
-            return Response(
-                {"error": "Requested resource could not be found.", "status": False},
-                status=status.HTTP_404_NOT_FOUND,
-            )
         serializer = FileAssetSerializer(data=request.data)
         if serializer.is_valid():
             serializer.save(workspace_id=workspace.id)
@@ -55,9 +46,6 @@ class FileAssetEndpoint(BaseAPIView):
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
     def delete(self, request, workspace_id, asset_key):
-        # Verify the requesting user is a member of this workspace
-        if not WorkspaceMember.objects.filter(workspace_id=workspace_id, member=request.user, is_active=True).exists():
-            return Response({"error": "Requested resource could not be found."}, status=status.HTTP_404_NOT_FOUND)
         asset_key = str(workspace_id) + "/" + asset_key
         file_asset = FileAsset.objects.get(asset=asset_key)
         file_asset.is_deleted = True
@@ -66,10 +54,9 @@ class FileAssetEndpoint(BaseAPIView):
 
 
 class FileAssetViewSet(BaseViewSet):
+    permission_classes = [IsAuthenticated, WorkspaceMemberPermission]
+
     def restore(self, request, workspace_id, asset_key):
-        # Verify the requesting user is a member of this workspace
-        if not WorkspaceMember.objects.filter(workspace_id=workspace_id, member=request.user, is_active=True).exists():
-            return Response({"error": "Requested resource could not be found."}, status=status.HTTP_404_NOT_FOUND)
         asset_key = str(workspace_id) + "/" + asset_key
         file_asset = FileAsset.objects.get(asset=asset_key)
         file_asset.is_deleted = False

--- a/apps/api/plane/app/views/asset/base.py
+++ b/apps/api/plane/app/views/asset/base.py
@@ -36,9 +36,9 @@ class FileAssetEndpoint(BaseAPIView):
             )
 
     def post(self, request, slug):
-        workspace = Workspace.objects.filter(slug=slug).first()
-        if not workspace:
-            return Response({"error": "Workspace not found.", "status": False}, status=status.HTTP_404_NOT_FOUND)
+        # WorkspaceMemberPermission already rejects unknown slugs before this runs.
+        # Use .get() so any TOCTOU race still surfaces as a 404 via ObjectDoesNotExist.
+        workspace = Workspace.objects.get(slug=slug)
         serializer = FileAssetSerializer(data=request.data)
         if serializer.is_valid():
             serializer.save(workspace_id=workspace.id)

--- a/apps/api/plane/app/views/asset/base.py
+++ b/apps/api/plane/app/views/asset/base.py
@@ -9,7 +9,7 @@ from rest_framework.parsers import MultiPartParser, FormParser, JSONParser
 
 # Module imports
 from ..base import BaseAPIView, BaseViewSet
-from plane.db.models import FileAsset, Workspace
+from plane.db.models import FileAsset, Workspace, WorkspaceMember
 from plane.app.serializers import FileAssetSerializer
 
 
@@ -21,6 +21,12 @@ class FileAssetEndpoint(BaseAPIView):
     """
 
     def get(self, request, workspace_id, asset_key):
+        # Verify the requesting user is a member of this workspace
+        if not WorkspaceMember.objects.filter(workspace_id=workspace_id, member=request.user, is_active=True).exists():
+            return Response(
+                {"error": "Requested resource could not be found.", "status": False},
+                status=status.HTTP_404_NOT_FOUND,
+            )
         asset_key = str(workspace_id) + "/" + asset_key
         files = FileAsset.objects.filter(asset=asset_key)
         if files.exists():
@@ -33,15 +39,25 @@ class FileAssetEndpoint(BaseAPIView):
             )
 
     def post(self, request, slug):
+        # Verify the requesting user is a member of this workspace
+        workspace = Workspace.objects.filter(slug=slug).first()
+        if not workspace:
+            return Response({"error": "Workspace not found.", "status": False}, status=status.HTTP_404_NOT_FOUND)
+        if not WorkspaceMember.objects.filter(workspace=workspace, member=request.user, is_active=True).exists():
+            return Response(
+                {"error": "Requested resource could not be found.", "status": False},
+                status=status.HTTP_404_NOT_FOUND,
+            )
         serializer = FileAssetSerializer(data=request.data)
         if serializer.is_valid():
-            # Get the workspace
-            workspace = Workspace.objects.get(slug=slug)
             serializer.save(workspace_id=workspace.id)
             return Response(serializer.data, status=status.HTTP_201_CREATED)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
     def delete(self, request, workspace_id, asset_key):
+        # Verify the requesting user is a member of this workspace
+        if not WorkspaceMember.objects.filter(workspace_id=workspace_id, member=request.user, is_active=True).exists():
+            return Response({"error": "Requested resource could not be found."}, status=status.HTTP_404_NOT_FOUND)
         asset_key = str(workspace_id) + "/" + asset_key
         file_asset = FileAsset.objects.get(asset=asset_key)
         file_asset.is_deleted = True
@@ -51,6 +67,9 @@ class FileAssetEndpoint(BaseAPIView):
 
 class FileAssetViewSet(BaseViewSet):
     def restore(self, request, workspace_id, asset_key):
+        # Verify the requesting user is a member of this workspace
+        if not WorkspaceMember.objects.filter(workspace_id=workspace_id, member=request.user, is_active=True).exists():
+            return Response({"error": "Requested resource could not be found."}, status=status.HTTP_404_NOT_FOUND)
         asset_key = str(workspace_id) + "/" + asset_key
         file_asset = FileAsset.objects.get(asset=asset_key)
         file_asset.is_deleted = False

--- a/apps/api/plane/app/views/asset/v2.py
+++ b/apps/api/plane/app/views/asset/v2.py
@@ -327,6 +327,17 @@ class WorkspaceFileAssetEndpoint(BaseAPIView):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
+        # WORKSPACE_LOGO may only be uploaded by workspace admins
+        if entity_type == FileAsset.EntityTypeContext.WORKSPACE_LOGO:
+            workspace_member = WorkspaceMember.objects.filter(
+                workspace__slug=slug, member=request.user, is_active=True
+            ).first()
+            if not workspace_member or workspace_member.role != ROLE.ADMIN.value:
+                return Response(
+                    {"error": "Only workspace admins can upload a workspace logo."},
+                    status=status.HTTP_403_FORBIDDEN,
+                )
+
         # Check if the file type is allowed
         allowed_types = [
             "image/jpeg",
@@ -646,8 +657,8 @@ class ProjectBulkAssetEndpoint(BaseAPIView):
         if not asset_ids:
             return Response({"error": "No asset ids provided."}, status=status.HTTP_400_BAD_REQUEST)
 
-        # get the asset id
-        assets = FileAsset.objects.filter(id__in=asset_ids, workspace__slug=slug)
+        # get the asset id — scope to the project to prevent cross-project IDOR
+        assets = FileAsset.objects.filter(id__in=asset_ids, workspace__slug=slug, project_id=project_id)
 
         # Get the first asset
         asset = assets.first()
@@ -757,15 +768,11 @@ class DuplicateAssetEndpoint(BaseAPIView):
                 return Response({"error": "Project not found"}, status=status.HTTP_404_NOT_FOUND)
 
         storage = S3Storage(request=request)
-        # Scope the source asset lookup to workspaces the caller is a member of
-        user_workspace_ids = WorkspaceMember.objects.filter(
-            member=request.user,
-            is_active=True,
-        ).values_list("workspace_id", flat=True)
+        # Restrict the source asset to the same destination workspace to prevent cross-workspace asset copying
         original_asset = FileAsset.objects.filter(
             id=asset_id,
             is_uploaded=True,
-            workspace_id__in=user_workspace_ids,
+            workspace=workspace,
         ).first()
 
         if not original_asset:

--- a/apps/api/plane/space/views/asset.py
+++ b/apps/api/plane/space/views/asset.py
@@ -42,9 +42,10 @@ class EntityAssetEndpoint(BaseAPIView):
                 status=status.HTTP_404_NOT_FOUND,
             )
 
-        # get the asset id
+        # get the asset id — scope to project to prevent cross-project IDOR
         asset = FileAsset.objects.get(
             workspace_id=deploy_board.workspace_id,
+            project_id=deploy_board.project_id,
             pk=pk,
             entity_type__in=[
                 FileAsset.EntityTypeContext.ISSUE_DESCRIPTION,
@@ -140,8 +141,8 @@ class EntityAssetEndpoint(BaseAPIView):
         if not deploy_board:
             return Response({"error": "Project is not published"}, status=status.HTTP_404_NOT_FOUND)
 
-        # get the asset id
-        asset = FileAsset.objects.get(id=pk, workspace=deploy_board.workspace)
+        # get the asset id — scope to project to prevent cross-project IDOR
+        asset = FileAsset.objects.get(id=pk, workspace=deploy_board.workspace, project_id=deploy_board.project_id)
         # get the storage metadata
         asset.is_uploaded = True
         # get the storage metadata
@@ -180,8 +181,8 @@ class AssetRestoreEndpoint(BaseAPIView):
         if not deploy_board:
             return Response({"error": "Project is not published"}, status=status.HTTP_404_NOT_FOUND)
 
-        # Get the asset
-        asset = FileAsset.all_objects.get(id=pk, workspace=deploy_board.workspace)
+        # Get the asset — scope to project to prevent cross-project IDOR
+        asset = FileAsset.all_objects.get(id=pk, workspace=deploy_board.workspace, project_id=deploy_board.project_id)
         asset.is_deleted = False
         asset.deleted_at = None
         asset.save(update_fields=["is_deleted", "deleted_at"])


### PR DESCRIPTION
## Summary

Multiple asset endpoints were missing project-level scoping on `FileAsset` queryset filters, allowing authenticated users to access, mark-uploaded, or restore assets belonging to other projects or workspaces they are not members of.

### Fixes applied

| Priority | Endpoint | File | Fix |
|:---------|:---------|:-----|:----|
| P0 | `ProjectBulkAssetEndpoint.post` | `app/views/asset/v2.py` | Add `project_id=project_id` to asset filter |
| P0 | `EntityAssetEndpoint.get` | `space/views/asset.py` | Add `project_id=deploy_board.project_id` |
| P0 | `EntityAssetEndpoint.patch` | `space/views/asset.py` | Add `project_id=deploy_board.project_id` |
| P1 | `AssetRestoreEndpoint.post` | `space/views/asset.py` | Add `project_id=deploy_board.project_id` |
| P1 | `FileAssetEndpoint` V1 (get/post/delete) | `app/views/asset/base.py` | Add `WorkspaceMember` membership check |
| P1 | `FileAssetViewSet.restore` V1 | `app/views/asset/base.py` | Add `WorkspaceMember` membership check |
| P2 | `WorkspaceFileAssetEndpoint.post` | `app/views/asset/v2.py` | Gate `WORKSPACE_LOGO` upload on `ROLE.ADMIN` |
| P2 | `DuplicateAssetEndpoint.post` | `app/views/asset/v2.py` | Restrict source asset lookup to same workspace |

### Advisories addressed

GHSA-r2hw (critical), GHSA-jh4v (high), GHSA-8688 (high), GHSA-3hrj, GHSA-3892, GHSA-3ggg, GHSA-gcpp, GHSA-p57q, GHSA-c68q, GHSA-8chr, GHSA-58qm, GHSA-wrrw, GHSA-j4mj, GHSA-85h2, GHSA-29q3, GHSA-mwh2, GHSA-xrpv and related duplicates.

## Test plan

- [ ] Upload an asset to Project A, then attempt `POST /api/v1/workspaces/{slug}/projects/{projectB_id}/bulk-asset-save/` with the asset ID — should return 404
- [ ] On a public board, attempt `PATCH /spaces/{anchor}/assets/{asset_from_other_project}/` — should return 404
- [ ] On a public board, attempt `POST /spaces/{anchor}/assets/{id}/restore/` with asset from a different project — should return 404
- [ ] Attempt `GET /api/workspaces/{ws_id}/{asset_key}` from a user not in the workspace — should return 404
- [ ] As MEMBER, attempt `POST /api/v1/workspaces/{slug}/file-assets/` with `entity_type=WORKSPACE_LOGO` — should return 403
- [ ] As ADMIN, attempt same call — should succeed
- [ ] `DuplicateAssetEndpoint`: attempt to duplicate an asset from workspace B while calling endpoint in workspace A — should return 404

Co-authored-by: Plane AI <noreply@plane.so>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes / Security**
  * Asset endpoints now require authenticated users with active workspace membership.
  * Workspace logo uploads are restricted to workspace administrators.
  * Asset lookups were tightened to prevent cross-project access, including bulk updates, duplication, entity asset retrieval/patch, and restore operations.
  * File asset creation and restoration now properly enforce workspace/project scoping and return appropriate errors when targets are invalid or unauthorized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->