### PR TITLE
[WEB-7787] fix(security): block deactivated user login and fix WorkspaceOwnerPermission (Cluster X)

### DIFF
--- a/apps/api/plane/app/permissions/workspace.py
+++ b/apps/api/plane/app/permissions/workspace.py
@@ -54,7 +54,7 @@ class WorkspaceOwnerPermission(BasePermission):
             return False
 
         return WorkspaceMember.objects.filter(
-            workspace__slug=view.workspace_slug, member=request.user, role=Admin
+            workspace__slug=view.workspace_slug, member=request.user, role=Admin, is_active=True
         ).exists()
 
 

--- a/apps/api/plane/authentication/adapter/base.py
+++ b/apps/api/plane/authentication/adapter/base.py
@@ -19,14 +19,11 @@ from django.utils import timezone
 # Third party imports
 from zxcvbn import zxcvbn
 
-from plane.bgtasks.user_activation_email_task import user_activation_email
-
 # Module imports
 from plane.db.models import FileAsset, Profile, User, WorkspaceMemberInvite
 from plane.license.utils.instance_value import get_configuration_value
 from plane.settings.storage import S3Storage
 from plane.utils.exception_logger import log_exception
-from plane.utils.host import base_host
 from plane.utils.ip_address import get_client_ip
 
 from .error import AUTHENTICATION_ERROR_CODES, AuthenticationException
@@ -239,11 +236,6 @@ class Adapter:
         user.last_login_ip = get_client_ip(request=self.request)
         user.last_login_uagent = self.request.META.get("HTTP_USER_AGENT")
         user.token_updated_at = timezone.now()
-        # If user is not active, send the activation email and set the user as active
-        if not user.is_active:
-            user_activation_email.delay(base_host(request=self.request), user.id)
-        # Set user as active
-        user.is_active = True
         user.save()
         return user
 
@@ -309,6 +301,16 @@ class Adapter:
 
         # Check if the user is present
         user = User.objects.filter(email=email).first()
+
+        # Reject deactivated accounts before any session or save logic.
+        # Without this check, save_user_data() would reactivate the account (GHSA-rmmf-rj2q-3rrg).
+        if user and not user.is_active:
+            raise AuthenticationException(
+                error_code=AUTHENTICATION_ERROR_CODES["USER_ACCOUNT_DEACTIVATED"],
+                error_message="USER_ACCOUNT_DEACTIVATED",
+                payload={"email": email},
+            )
+
         # Check if sign up case or login
         is_signup = bool(user)
         # If user is not present, create a new user

--- a/apps/api/plane/utils/permissions/workspace.py
+++ b/apps/api/plane/utils/permissions/workspace.py
@@ -54,7 +54,7 @@ class WorkspaceOwnerPermission(BasePermission):
             return False
 
         return WorkspaceMember.objects.filter(
-            workspace__slug=view.workspace_slug, member=request.user, role=Admin
+            workspace__slug=view.workspace_slug, member=request.user, role=Admin, is_active=True
         ).exists()
 
 


### PR DESCRIPTION
## Summary

Two vulnerabilities related to deactivated user accounts, both of which allow disabled accounts to retain or regain access.

## Changes

### GHSA-rmmf-rj2q-3rrg (high) — Deactivated user auto-reactivation on login

`save_user_data()` in `adapter/base.py` was unconditionally calling `user.is_active = True` on every successful authentication, silently reactivating any account that an admin had deactivated.

**Fix:** Add an early guard in `complete_login_or_signup()` — if the user exists and `is_active=False`, raise `AuthenticationException(USER_ACCOUNT_DEACTIVATED)` before any session or save logic. Remove the `is_active=True` assignment and the associated `user_activation_email` call from `save_user_data()`. Remove now-unused `user_activation_email` and `base_host` imports.

### GHSA-wjgv-cq7w-258v (medium) — Deactivated owner retains workspace access

`WorkspaceOwnerPermission` in both `plane/app/permissions/workspace.py` and `plane/utils/permissions/workspace.py` was filtering `WorkspaceMember` without `is_active=True`. Every other permission class (`WorkSpaceAdminPermission`, `WorkspaceEntityPermission`, etc.) correctly included this filter. The missing filter allowed a deactivated workspace owner/admin to still hit admin-gated API endpoints.

**Fix:** Add `is_active=True` to the `WorkspaceMember` filter in both copies.

## Test plan

- [ ] Deactivate a user via admin panel; attempt login via password — should return `USER_ACCOUNT_DEACTIVATED` error
- [ ] Deactivate a user; attempt login via magic link — same rejection
- [ ] Deactivate a user; attempt login via GitHub/Google OAuth — same rejection
- [ ] Normal active user login still works end-to-end
- [ ] Deactivate a workspace owner; attempt workspace invitation API (`POST /api/v1/workspaces/{slug}/invitations/`) — should return 403
- [ ] Active workspace owner can still use invitation API

Co-authored-by: Plane AI <noreply@plane.so>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deactivated user accounts are now properly blocked from logging in and can no longer be automatically reactivated.
  * Workspace membership status is now validated when checking access permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->