### PR TITLE
[WEB-7805] fix: remove hardcoded SECRET_KEY from community deployment manifests

### DIFF
--- a/apps/api/plane/settings/common.py
+++ b/apps/api/plane/settings/common.py
@@ -8,7 +8,6 @@
 import ipaddress
 import logging
 import os
-import sys
 from urllib.parse import urlparse
 from urllib.parse import urljoin
 
@@ -26,11 +25,13 @@ from plane.utils.url import is_valid_url
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
+_logger = logging.getLogger("plane")
+
 # Secret Key — use `or` so an explicitly empty env var is treated the same as unset,
 # falling back to a random key rather than passing "" to Django (GHSA-cmwv-pjmw-8483).
 SECRET_KEY = os.environ.get("SECRET_KEY") or get_random_secret_key()
 # Refuse to run silently with a publicly-known or placeholder SECRET_KEY
-# (GHSA-cmwv-pjmw-8483). Print a loud error so operators notice immediately.
+# (GHSA-cmwv-pjmw-8483). Emit a critical log so operators notice immediately.
 # The `or get_random_secret_key()` above means the only way to reach this branch
 # is if the environment explicitly passes one of the flagged values.
 _INSECURE_SECRET_KEYS = {
@@ -38,15 +39,12 @@ _INSECURE_SECRET_KEYS = {
     "change-this-key-on-deployment",  # placeholder shipped in community templates
 }
 if SECRET_KEY in _INSECURE_SECRET_KEYS:
-    print(
-        "\n"
-        "CRITICAL SECURITY WARNING: SECRET_KEY is set to a known insecure or placeholder value.\n"
-        "This makes your installation vulnerable to session forgery, CSRF bypass, and\n"
-        "password-reset token forging. Set a unique SECRET_KEY before deploying to production.\n"
+    _logger.critical(
+        "SECURITY: SECRET_KEY is set to a known insecure or placeholder value. "
+        "This makes your installation vulnerable to session forgery, CSRF bypass, and "
+        "password-reset token forging. Set a unique SECRET_KEY before deploying to production. "
         "Generate one with: "
-        "python3 -c \"from django.utils.crypto import get_random_secret_key; print(get_random_secret_key())\"\n",
-        file=sys.stderr,
-        flush=True,
+        "python3 -c \"from django.utils.crypto import get_random_secret_key; print(get_random_secret_key())\""
     )
 
 # SECURITY WARNING: don't run with debug turned on in production!
@@ -60,7 +58,6 @@ IS_SELF_MANAGED = True
 # Example: "10.0.0.0/8,192.168.1.0/24,172.16.0.5"
 _webhook_allowed_ips_raw = os.environ.get("WEBHOOK_ALLOWED_IPS", "")
 WEBHOOK_ALLOWED_IPS = []
-_logger = logging.getLogger("plane")
 for _cidr in _webhook_allowed_ips_raw.split(","):
     _cidr = _cidr.strip()
     if not _cidr:

--- a/apps/api/plane/settings/common.py
+++ b/apps/api/plane/settings/common.py
@@ -8,6 +8,7 @@
 import ipaddress
 import logging
 import os
+import sys
 from urllib.parse import urlparse
 from urllib.parse import urljoin
 
@@ -25,8 +26,28 @@ from plane.utils.url import is_valid_url
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
-# Secret Key
-SECRET_KEY = os.environ.get("SECRET_KEY", get_random_secret_key())
+# Secret Key — use `or` so an explicitly empty env var is treated the same as unset,
+# falling back to a random key rather than passing "" to Django (GHSA-cmwv-pjmw-8483).
+SECRET_KEY = os.environ.get("SECRET_KEY") or get_random_secret_key()
+# Refuse to run silently with a publicly-known or placeholder SECRET_KEY
+# (GHSA-cmwv-pjmw-8483). Print a loud error so operators notice immediately.
+# The `or get_random_secret_key()` above means the only way to reach this branch
+# is if the environment explicitly passes one of the flagged values.
+_INSECURE_SECRET_KEYS = {
+    "60gp0byfz2dvffa45cxl20p1scy9xbpf6d8c5y0geejgkyp1b5",  # old publicly-known default
+    "change-this-key-on-deployment",  # placeholder shipped in community templates
+}
+if SECRET_KEY in _INSECURE_SECRET_KEYS:
+    print(
+        "\n"
+        "CRITICAL SECURITY WARNING: SECRET_KEY is set to a known insecure or placeholder value.\n"
+        "This makes your installation vulnerable to session forgery, CSRF bypass, and\n"
+        "password-reset token forging. Set a unique SECRET_KEY before deploying to production.\n"
+        "Generate one with: "
+        "python3 -c \"from django.utils.crypto import get_random_secret_key; print(get_random_secret_key())\"\n",
+        file=sys.stderr,
+        flush=True,
+    )
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = int(os.environ.get("DEBUG", "0"))

--- a/deployments/aio/community/start.sh
+++ b/deployments/aio/community/start.sh
@@ -15,8 +15,8 @@ print_header(){
     echo "    SITE_ADDRESS (default: ':80')"
     echo "    FILE_SIZE_LIMIT (default: 5242880)"
     echo "    APP_PROTOCOL (http or https)"
-    echo "    SECRET_KEY (default: 60gp0byfz2dvffa45cxl20p1scy9xbpf6d8c5y0geejgkyp1b5)"
-    echo "    LIVE_SERVER_SECRET_KEY (default: htbqvBJAgpm9bzvf3r4urJer0ENReatceh)"
+    echo "    SECRET_KEY (auto-generated on first boot if not set)"
+    echo "    LIVE_SERVER_SECRET_KEY (auto-generated on first boot if not set)"
     echo ""
     echo ""
 }
@@ -145,9 +145,35 @@ update_env_file(){
     update_env_value "USE_MINIO" "0"
 
     # Optional environment variables
-    update_env_value "SECRET_KEY" "${SECRET_KEY:-60gp0byfz2dvffa45cxl20p1scy9xbpf6d8c5y0geejgkyp1b5}"
+    # SECRET_KEY: if absent or set to a known placeholder/insecure value, preserve whatever
+    # is already stored in plane.env (survives restarts), or generate a fresh random value on
+    # first boot. Never write a publicly-known or placeholder value into plane.env.
+    local _insecure_sk="60gp0byfz2dvffa45cxl20p1scy9xbpf6d8c5y0geejgkyp1b5"
+    local _placeholder_sk="change-this-key-on-deployment"
+    if [ -z "$SECRET_KEY" ] || [ "$SECRET_KEY" = "$_insecure_sk" ] || [ "$SECRET_KEY" = "$_placeholder_sk" ]; then
+        local _stored_sk
+        _stored_sk=$(grep "^SECRET_KEY=" plane.env 2>/dev/null | cut -d'=' -f2-)
+        if [ -n "$_stored_sk" ] && [ "$_stored_sk" != "$_insecure_sk" ] && [ "$_stored_sk" != "$_placeholder_sk" ]; then
+            SECRET_KEY="$_stored_sk"
+        else
+            SECRET_KEY=$(tr -dc 'a-zA-Z0-9' < /dev/urandom | head -c50)
+        fi
+    fi
+    update_env_value "SECRET_KEY" "$SECRET_KEY"
     update_env_value "FILE_SIZE_LIMIT" "${FILE_SIZE_LIMIT:-5242880}"
-    update_env_value "LIVE_SERVER_SECRET_KEY" "${LIVE_SERVER_SECRET_KEY:-htbqvBJAgpm9bzvf3r4urJer0ENReatceh}"
+    # LIVE_SERVER_SECRET_KEY: same first-boot generation strategy.
+    local _insecure_lssk="htbqvBJAgpm9bzvf3r4urJer0ENReatceh"
+    local _placeholder_lssk="change-this-key-on-deployment"
+    if [ -z "$LIVE_SERVER_SECRET_KEY" ] || [ "$LIVE_SERVER_SECRET_KEY" = "$_insecure_lssk" ] || [ "$LIVE_SERVER_SECRET_KEY" = "$_placeholder_lssk" ]; then
+        local _stored_lssk
+        _stored_lssk=$(grep "^LIVE_SERVER_SECRET_KEY=" plane.env 2>/dev/null | cut -d'=' -f2-)
+        if [ -n "$_stored_lssk" ] && [ "$_stored_lssk" != "$_insecure_lssk" ] && [ "$_stored_lssk" != "$_placeholder_lssk" ]; then
+            LIVE_SERVER_SECRET_KEY="$_stored_lssk"
+        else
+            LIVE_SERVER_SECRET_KEY=$(tr -dc 'a-zA-Z0-9' < /dev/urandom | head -c50)
+        fi
+    fi
+    update_env_value "LIVE_SERVER_SECRET_KEY" "$LIVE_SERVER_SECRET_KEY"
 
     update_env_value "API_KEY_RATE_LIMIT" "${API_KEY_RATE_LIMIT:-60/minute}"
 

--- a/deployments/aio/community/variables.env
+++ b/deployments/aio/community/variables.env
@@ -25,8 +25,12 @@ REDIS_URL=
 # RabbitMQ Settings
 AMQP_URL=
 
-# Secret Key
-SECRET_KEY=60gp0byfz2dvffa45cxl20p1scy9xbpf6d8c5y0geejgkyp1b5
+# Secret Key — change this before deploying to production.
+# Generate a secure value with: python3 -c "from django.utils.crypto import get_random_secret_key; print(get_random_secret_key())"
+# or: openssl rand -hex 32
+# The startup script auto-generates and persists a random key on first boot if the
+# placeholder value below is left unchanged.
+SECRET_KEY=change-this-key-on-deployment
 
 # DATA STORE SETTINGS
 USE_MINIO=0
@@ -54,8 +58,11 @@ API_KEY_RATE_LIMIT=60/minute
 # where period is second/minute/hour/day.
 AUTHENTICATION_RATE_LIMIT=10/minute
 
-# Live Server Secret Key
-LIVE_SERVER_SECRET_KEY=htbqvBJAgpm9bzvf3r4urJer0ENReatceh
+# Live Server Secret Key — change this before deploying to production.
+# Generate a secure value with: openssl rand -hex 32
+# The startup script auto-generates and persists a random key on first boot if the
+# placeholder value below is left unchanged.
+LIVE_SERVER_SECRET_KEY=change-this-key-on-deployment
 
 # Webhook IP allowlist — comma-separated IPs or CIDR ranges allowed as webhook targets
 # even if they resolve to private networks (e.g. "10.0.0.0/8,192.168.1.0/24,172.16.0.5")

--- a/deployments/cli/community/docker-compose.yml
+++ b/deployments/cli/community/docker-compose.yml
@@ -44,7 +44,7 @@ x-mq-env: &mq-env # RabbitMQ Settings
 
 x-live-env: &live-env
   API_BASE_URL: ${API_BASE_URL:-http://api:8000}
-  LIVE_SERVER_SECRET_KEY: ${LIVE_SERVER_SECRET_KEY:-2FiJk1U2aiVPEQtzLehYGlTSnTnrs7LW}
+  LIVE_SERVER_SECRET_KEY: ${LIVE_SERVER_SECRET_KEY}
 
 x-app-env: &app-env
   WEB_URL: ${WEB_URL:-http://localhost}
@@ -53,11 +53,11 @@ x-app-env: &app-env
   GUNICORN_WORKERS: 1
   USE_MINIO: ${USE_MINIO:-1}
   DATABASE_URL: ${DATABASE_URL:-postgresql://plane:plane@plane-db/plane}
-  SECRET_KEY: ${SECRET_KEY:-60gp0byfz2dvffa45cxl20p1scy9xbpf6d8c5y0geejgkyp1b5}
+  SECRET_KEY: ${SECRET_KEY}
   AMQP_URL: ${AMQP_URL:-amqp://plane:plane@plane-mq:5672/plane}
   API_KEY_RATE_LIMIT: ${API_KEY_RATE_LIMIT:-60/minute}
   MINIO_ENDPOINT_SSL: ${MINIO_ENDPOINT_SSL:-0}
-  LIVE_SERVER_SECRET_KEY: ${LIVE_SERVER_SECRET_KEY:-2FiJk1U2aiVPEQtzLehYGlTSnTnrs7LW}
+  LIVE_SERVER_SECRET_KEY: ${LIVE_SERVER_SECRET_KEY}
   WEBHOOK_ALLOWED_IPS: ${WEBHOOK_ALLOWED_IPS:-}
   WEBHOOK_ALLOWED_HOSTS: ${WEBHOOK_ALLOWED_HOSTS:-}
 

--- a/deployments/cli/community/variables.env
+++ b/deployments/cli/community/variables.env
@@ -53,8 +53,10 @@ CERT_EMAIL=
 CERT_ACME_DNS=
 
 
-# Secret Key
-SECRET_KEY=60gp0byfz2dvffa45cxl20p1scy9xbpf6d8c5y0geejgkyp1b5
+# Secret Key — change this before deploying to production.
+# Generate a secure value with: python3 -c "from django.utils.crypto import get_random_secret_key; print(get_random_secret_key())"
+# or: openssl rand -hex 32
+SECRET_KEY=change-this-key-on-deployment
 
 # DATA STORE SETTINGS
 USE_MINIO=1
@@ -82,9 +84,9 @@ API_KEY_RATE_LIMIT=60/minute
 # where period is second/minute/hour/day.
 AUTHENTICATION_RATE_LIMIT=10/minute
 
-# Live server environment variables
-# WARNING: You must set a secure value for LIVE_SERVER_SECRET_KEY in production environments.
-LIVE_SERVER_SECRET_KEY=
+# Live server environment variables — change this before deploying to production.
+# Generate a secure value with: openssl rand -hex 32
+LIVE_SERVER_SECRET_KEY=change-this-key-on-deployment
 
 # Webhook IP allowlist — comma-separated IPs or CIDR ranges allowed as webhook targets
 # even if they resolve to private networks (e.g. "10.0.0.0/8,192.168.1.0/24,172.16.0.5")


### PR DESCRIPTION
## Summary

- **Advisory**: GHSA-cmwv-pjmw-8483 (Critical — Hardcoded SECRET\_KEY)
- Replaces the publicly-known default `SECRET_KEY` and `LIVE_SERVER_SECRET_KEY` in AIO and CLI community deployment templates with a safe placeholder (`change-this-key-on-deployment`)
- AIO `start.sh` now auto-generates a cryptographically random key on first boot and persists it across restarts — no operator action required; also detects and replaces the old insecure default on upgrade
- CLI `docker-compose.yml` removes all `:-hardcoded-value` fallbacks
- `common.py` strengthens `SECRET_KEY` resolution to treat an empty env var the same as unset (using `or`), and prints a `CRITICAL SECURITY WARNING` to stderr if the known insecure default or placeholder is active at startup

## Files changed

| File | Change |
|:-----|:-------|
| `deployments/aio/community/variables.env` | Replace hardcoded `SECRET_KEY` + `LIVE_SERVER_SECRET_KEY` with placeholder |
| `deployments/aio/community/start.sh` | Auto-generate random keys on first boot; remove help text that documented defaults |
| `deployments/cli/community/variables.env` | Replace hardcoded `SECRET_KEY` + `LIVE_SERVER_SECRET_KEY` with placeholder |
| `deployments/cli/community/docker-compose.yml` | Remove `:-hardcoded` fallbacks for both secret keys |
| `apps/api/plane/settings/common.py` | Use `or` for empty-env fallback; warn on startup for insecure/placeholder keys |

## Upgrade behaviour

- **AIO**: on the next `start.sh` run, any instance using the old compromised default is automatically rotated to a fresh random key. Existing custom keys are preserved.
- **CLI**: instances using the old compromised key continue to work with a loud warning on stderr until the operator updates `variables.env`.

## Test plan

- [ ] Fresh AIO install: confirm `plane.env` gets a random `SECRET_KEY` (not the old default or placeholder)
- [ ] AIO restart with existing random key: confirm key is preserved (sessions survive restart)
- [ ] AIO upgrade from old install (old default in `plane.env`): confirm key is rotated to new random value
- [ ] CLI install: confirm `SECRET_KEY=change-this-key-on-deployment` in `variables.env` works for local dev
- [ ] CLI with old default: confirm `CRITICAL SECURITY WARNING` appears in container logs
- [ ] CLI with proper key set: confirm no warning

Co-authored-by: Plane AI <noreply@plane.so>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Added detection and critical warnings for commonly insecure or placeholder secret key values to make misconfigurations immediately visible.
  * Updated secret key handling to treat empty values as unset, generating new keys automatically on first boot/first deployment when needed.
  * Improved deployment configuration and messaging, including clearer guidance for generating secure `SECRET_KEY` and `LIVE_SERVER_SECRET_KEY`.
  * Tightened environment requirements in container setup to avoid accidental fallback defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->