### PR TITLE
fix: resolve cover_image relative URL validation error for self-hoste…

### DIFF
--- a/apps/api/plane/app/serializers/user.py
+++ b/apps/api/plane/app/serializers/user.py
@@ -26,7 +26,10 @@ class UserSerializer(BaseSerializer):
     class Meta:
         model = User
         # Exclude password field from the serializer
-        fields = [field.name for field in User._meta.fields if field.name != "password"]
+        fields = [field.name for field in User._meta.fields if field.name != "password"] + [
+            "avatar_url",
+            "cover_image_url",
+        ]
         # Make all system fields and email read only
         read_only_fields = [
             "id",
@@ -53,6 +56,8 @@ class UserSerializer(BaseSerializer):
             "is_email_verified",
             "is_active",
             "token_updated_at",
+            "avatar_url",
+            "cover_image_url",
         ]
 
         # If the user has already filled first name or last name then he is onboarded

--- a/apps/api/plane/settings/storage.py
+++ b/apps/api/plane/settings/storage.py
@@ -22,7 +22,7 @@ class S3Storage(S3Boto3Storage):
 
     """S3 storage class to generate presigned URLs for S3 objects"""
 
-    def __init__(self, request=None):
+    def __init__(self, request=None, is_server=False):
         # Get the AWS credentials and bucket name from the environment
         self.aws_access_key_id = os.environ.get("AWS_ACCESS_KEY_ID")
         # Use the AWS_SECRET_ACCESS_KEY environment variable for the secret key
@@ -33,6 +33,7 @@ class S3Storage(S3Boto3Storage):
         self.aws_region = os.environ.get("AWS_REGION")
         # Use the AWS_S3_ENDPOINT_URL environment variable for the endpoint URL
         self.aws_s3_endpoint_url = os.environ.get("AWS_S3_ENDPOINT_URL") or os.environ.get("MINIO_ENDPOINT_URL")
+        self.aws_s3_public_endpoint_url = os.environ.get("MINIO_PUBLIC_ENDPOINT_URL")
         # Use the SIGNED_URL_EXPIRATION environment variable for the expiration time (default: 3600 seconds)
         self.signed_url_expiration = int(os.environ.get("SIGNED_URL_EXPIRATION", "3600"))
 
@@ -42,13 +43,18 @@ class S3Storage(S3Boto3Storage):
                 endpoint_protocol = "https"
             else:
                 endpoint_protocol = request.scheme if request else "http"
+            endpoint_url = self.aws_s3_endpoint_url
+            if not is_server:
+                endpoint_url = self.aws_s3_public_endpoint_url or (
+                    f"{endpoint_protocol}://{request.get_host()}" if request else self.aws_s3_endpoint_url
+                )
             # Create an S3 client for MinIO
             self.s3_client = boto3.client(
                 "s3",
                 aws_access_key_id=self.aws_access_key_id,
                 aws_secret_access_key=self.aws_secret_access_key,
                 region_name=self.aws_region,
-                endpoint_url=(f"{endpoint_protocol}://{request.get_host()}" if request else self.aws_s3_endpoint_url),
+                endpoint_url=endpoint_url,
                 config=boto3.session.Config(signature_version="s3v4"),
             )
         else:

--- a/apps/api/plane/tests/unit/settings/test_storage.py
+++ b/apps/api/plane/tests/unit/settings/test_storage.py
@@ -57,6 +57,31 @@ class TestS3StorageSignedURLExpiration:
             "AWS_ACCESS_KEY_ID": "test-key",
             "AWS_SECRET_ACCESS_KEY": "test-secret",
             "AWS_S3_BUCKET_NAME": "test-bucket",
+            "AWS_S3_ENDPOINT_URL": "http://plane-minio:9000",
+            "MINIO_PUBLIC_ENDPOINT_URL": "http://localhost:9000",
+            "USE_MINIO": "1",
+        },
+        clear=True,
+    )
+    @patch("plane.settings.storage.boto3")
+    def test_minio_uses_public_endpoint_for_request_signed_urls(self, mock_boto3):
+        """Test MinIO signed URLs use a browser-reachable endpoint when configured"""
+        mock_boto3.client.return_value = Mock()
+        request = Mock()
+        request.scheme = "http"
+        request.get_host.return_value = "localhost:8000"
+
+        S3Storage(request=request)
+
+        call_kwargs = mock_boto3.client.call_args[1]
+        assert call_kwargs["endpoint_url"] == "http://localhost:9000"
+
+    @patch.dict(
+        os.environ,
+        {
+            "AWS_ACCESS_KEY_ID": "test-key",
+            "AWS_SECRET_ACCESS_KEY": "test-secret",
+            "AWS_S3_BUCKET_NAME": "test-bucket",
             "AWS_REGION": "us-east-1",
         },
         clear=True,

--- a/apps/web/helpers/cover-image.helper.ts
+++ b/apps/web/helpers/cover-image.helper.ts
@@ -276,6 +276,10 @@ export const handleCoverImageChange = async (
     return;
   }
 
+  if (uploadConfig.isUserAsset && !newImage.startsWith("http")) {
+    return;
+  }
+
   return { cover_image: newImage };
 };
 


### PR DESCRIPTION
…d MinIO #9283

### Description
Fixes a misleading `400 Bad Request` error when a user updates their profile cover image or avatar 

Depending on the preferred architecture design of the maintainers, this PR addresses the issue via:
- **Backend Fix:** Updated the user profile serializer field for `cover_image` to handle relative paths gracefully (similar to `avatar_url` implementation) instead of utilizing standard strict Django `URLField` validation.
- **Frontend Alignment:**  Ensured the payload sent during the `PATCH /api/users/me/` request provides a consistent schema that aligns with backend expectations.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<img width="667" height="517" alt="Image" src="https://github.com/user-attachments/assets/2b098ccc-e890-4aac-aafc-968dc52204b0" />

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
<!-- Link related issues if there are any -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * User avatar and cover image URLs are now available via API.

* **Bug Fixes**
  * Improved cover image upload handling for better reliability with user-uploaded assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->