### PR TITLE
[WEB-7847] fix: enforce workspace membership on entity-search endpoint

### DIFF
--- a/apps/api/plane/app/views/search/base.py
+++ b/apps/api/plane/app/views/search/base.py
@@ -28,6 +28,7 @@ from rest_framework.response import Response
 
 # Module imports
 from plane.app.views.base import BaseAPIView
+from plane.app.permissions import WorkspaceUserPermission
 from plane.db.models import (
     Workspace,
     Project,
@@ -302,17 +303,9 @@ class GlobalSearchEndpoint(BaseAPIView):
 
 
 class SearchEndpoint(BaseAPIView):
-    def get(self, request, slug):
-        # Verify the requesting user is an active member of the target workspace.
-        # Without this guard any authenticated user can enumerate members of
-        # workspaces they do not belong to (GHSA-32q3-mqpc-3mhv).
-        if not WorkspaceMember.objects.filter(
-            member=request.user,
-            workspace__slug=slug,
-            is_active=True,
-        ).exists():
-            return Response({"error": "Forbidden"}, status=status.HTTP_403_FORBIDDEN)
+    permission_classes = (WorkspaceUserPermission,)
 
+    def get(self, request, slug):
         query = request.query_params.get("query", False)
         query_types = request.query_params.get("query_type", "user_mention").split(",")
         query_types = [qt.strip() for qt in query_types]

--- a/apps/api/plane/app/views/search/base.py
+++ b/apps/api/plane/app/views/search/base.py
@@ -303,6 +303,16 @@ class GlobalSearchEndpoint(BaseAPIView):
 
 class SearchEndpoint(BaseAPIView):
     def get(self, request, slug):
+        # Verify the requesting user is an active member of the target workspace.
+        # Without this guard any authenticated user can enumerate members of
+        # workspaces they do not belong to (GHSA-32q3-mqpc-3mhv).
+        if not WorkspaceMember.objects.filter(
+            member=request.user,
+            workspace__slug=slug,
+            is_active=True,
+        ).exists():
+            return Response({"error": "Forbidden"}, status=status.HTTP_403_FORBIDDEN)
+
         query = request.query_params.get("query", False)
         query_types = request.query_params.get("query_type", "user_mention").split(",")
         query_types = [qt.strip() for qt in query_types]


### PR DESCRIPTION
## Summary

- `SearchEndpoint` (`/workspaces/<slug>/entity-search/`) required authentication but did **not** verify the requesting user was a member of the queried workspace
- Any authenticated Plane user could enumerate members of workspaces they don't belong to by knowing or guessing the workspace slug
- Fixes **GHSA-32q3-mqpc-3mhv** (medium — cross-workspace member enumeration)

## Fix

Added a `WorkspaceMember` guard at the top of `SearchEndpoint.get()` — returns `403 Forbidden` if the requesting user is not an active member of the target workspace.

The EE version already had this protection via `@can(WorkspacePermissions.VIEW)`. This brings OSS to parity.

**Files changed:** `apps/api/plane/app/views/search/base.py` (+10 lines)

## Test plan

- [ ] Authenticated user queries `/workspaces/<own-slug>/entity-search/` → `200 OK` with results
- [ ] Authenticated user queries `/workspaces/<other-slug>/entity-search/` for a workspace they don't belong to → `403 Forbidden`
- [ ] Unauthenticated request → `401 Unauthorized` (unchanged, handled by `BaseAPIView`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security / Bug Fixes**
  * Updated search access controls to require proper workspace user authorization.  
  * Requests to the search feature are now restricted to active workspace members, helping prevent unauthorized access to workspace data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->