### PR TITLE
[WEB-7854] fix: prevent workspace invite token disclosure and invite hijack

### DIFF
--- a/apps/api/plane/app/serializers/__init__.py
+++ b/apps/api/plane/app/serializers/__init__.py
@@ -18,6 +18,7 @@ from .workspace import (
     WorkSpaceSerializer,
     WorkSpaceMemberSerializer,
     WorkSpaceMemberInviteSerializer,
+    WorkSpaceMemberInvitePublicSerializer,
     WorkspaceLiteSerializer,
     WorkspaceThemeSerializer,
     WorkspaceMemberAdminSerializer,

--- a/apps/api/plane/app/serializers/workspace.py
+++ b/apps/api/plane/app/serializers/workspace.py
@@ -137,6 +137,33 @@ class WorkSpaceMemberInviteSerializer(BaseSerializer):
         ]
 
 
+class WorkSpaceMemberInvitePublicSerializer(BaseSerializer):
+    """Safe read-only serializer for the public workspace invite GET endpoint.
+
+    Intentionally excludes ``token`` and ``invite_link`` so that an
+    unauthenticated caller cannot retrieve the acceptance token and use it to
+    hijack an invitation (GHSA-86mg-259g-pwgg / GHSA-gf48-p6jp-cwc4).
+    """
+
+    workspace = WorkspaceLiteSerializer(read_only=True)
+
+    class Meta:
+        model = WorkspaceMemberInvite
+        fields = [
+            "id",
+            "email",
+            "workspace",
+            "role",
+            "message",
+            "accepted",
+            "responded_at",
+            "created_at",
+            "updated_at",
+            "created_by",
+        ]
+        read_only_fields = fields
+
+
 class WorkspaceThemeSerializer(BaseSerializer):
     class Meta:
         model = WorkspaceTheme

--- a/apps/api/plane/app/views/workspace/invite.py
+++ b/apps/api/plane/app/views/workspace/invite.py
@@ -22,6 +22,7 @@ from rest_framework.response import Response
 from plane.app.permissions import WorkSpaceAdminPermission
 from plane.app.serializers import (
     WorkSpaceMemberInviteSerializer,
+    WorkSpaceMemberInvitePublicSerializer,
     WorkSpaceMemberSerializer,
 )
 from plane.app.views.base import BaseAPIView
@@ -172,6 +173,21 @@ class WorkspaceJoinEndpoint(BaseAPIView):
                 status=status.HTTP_403_FORBIDDEN,
             )
 
+        # Require an authenticated session — the accepting user must be the
+        # person who was invited.  Without this check an attacker who registers
+        # with the invited address (email-squat) and obtains the token via the
+        # GET endpoint can steal the workspace membership (GHSA-4vj8-p63v-8p24).
+        if not request.user.is_authenticated:
+            return Response(
+                {"error": "Authentication required to accept workspace invitation"},
+                status=status.HTTP_401_UNAUTHORIZED,
+            )
+        if request.user.email.lower() != workspace_invite.email.lower():
+            return Response(
+                {"error": "You do not have permission to accept this invitation"},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
         # If already responded then return error
         if workspace_invite.responded_at is None:
             workspace_invite.accepted = request.data.get("accepted", False)
@@ -237,7 +253,10 @@ class WorkspaceJoinEndpoint(BaseAPIView):
 
     def get(self, request, slug, pk):
         workspace_invitation = WorkspaceMemberInvite.objects.get(workspace__slug=slug, pk=pk)
-        serializer = WorkSpaceMemberInviteSerializer(workspace_invitation)
+        # Use the public serializer that omits the token and invite_link fields so
+        # that an unauthenticated caller cannot retrieve the acceptance token
+        # (GHSA-86mg-259g-pwgg / GHSA-gf48-p6jp-cwc4).
+        serializer = WorkSpaceMemberInvitePublicSerializer(workspace_invitation)
         return Response(serializer.data, status=status.HTTP_200_OK)
 
 


### PR DESCRIPTION
## Summary

- **Token disclosure** (GHSA-86mg-259g-pwgg / GHSA-gf48-p6jp-cwc4): `WorkspaceJoinEndpoint.get()` was `AllowAny` and the serializer used `fields = "__all__"` plus a `get_invite_link` method that embedded the token in the response. Any caller who knew the workspace slug and invite UUID could retrieve the acceptance token unauthenticated. Fixed by introducing `WorkSpaceMemberInvitePublicSerializer` that explicitly lists safe fields and excludes `token` and `invite_link`.
- **Invite hijack** (GHSA-4vj8-p63v-8p24): The POST accept handler validated the token but never verified that the accepting user's email matched `workspace_invite.email`. An attacker who registered with the invited email address and obtained the token could steal workspace membership. Fixed by requiring an authenticated session and asserting `request.user.email == workspace_invite.email` (case-insensitive) before processing acceptance.

## Files changed

- `apps/api/plane/app/serializers/workspace.py` — add `WorkSpaceMemberInvitePublicSerializer`
- `apps/api/plane/app/serializers/__init__.py` — export new serializer
- `apps/api/plane/app/views/workspace/invite.py` — use safe serializer on GET; add auth + email-match guard on POST

## Test plan

- [ ] Unauthenticated GET `/api/workspaces/<slug>/invitations/<id>/join/` returns invite details (workspace name, role, message) but **no** `token` or `invite_link` fields
- [ ] Authenticated user with the correct email can accept a workspace invitation successfully
- [ ] Authenticated user with a **different** email gets 403 when trying to accept
- [ ] Unauthenticated POST to accept returns 401
- [ ] Invalid/missing token still returns 403 (existing behaviour unchanged)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Workspace invitations now require user authentication before acceptance
* Added email verification to ensure only the intended recipient can accept an invitation  
* Sensitive invitation tokens and metadata are no longer exposed to unauthenticated users

<!-- end of auto-generated comment: release notes by coderabbit.ai -->