### PR TITLE
[GIT-227] fix: handle missing comment reaction in activity task #9175

### DIFF
--- a/apps/api/plane/bgtasks/issue_activities_task.py
+++ b/apps/api/plane/bgtasks/issue_activities_task.py
@@ -1149,7 +1149,7 @@ def create_comment_reaction_activity(
 ):
     requested_data = json.loads(requested_data) if requested_data is not None else None
     if requested_data and requested_data.get("reaction") is not None:
-        comment_reaction_id, comment_id = (
+        reaction_data = (
             CommentReaction.objects.filter(
                 reaction=requested_data.get("reaction"),
                 project_id=project_id,
@@ -1158,6 +1158,9 @@ def create_comment_reaction_activity(
             .values_list("id", "comment__id")
             .first()
         )
+        if reaction_data is None:
+            return
+        comment_reaction_id, comment_id = reaction_data
         comment = IssueComment.objects.get(pk=comment_id, project_id=project_id)
         if comment is not None and comment_reaction_id is not None and comment_id is not None:
             issue_activities.append(


### PR DESCRIPTION
## Description

### Bug

The Celery background task `issue_activity` crashes with:

```python
TypeError: cannot unpack non-iterable NoneType object
```

when a comment reaction is deleted before the task processes the corresponding event. This creates a race condition where the `CommentReaction` record no longer exists by the time the worker executes.

### Root Cause

In `apps/api/plane/bgtasks/issue_activities_task.py`, `create_comment_reaction_activity` directly unpacks the result of `.first()`:

```python
comment_reaction_id, comment_id = (
    CommentReaction.objects.filter(...)
    .values_list("id", "comment__id")
    .first()
)
```

When the reaction has already been deleted, `.first()` returns `None`, causing Python to raise:

```python
TypeError: cannot unpack non-iterable NoneType object
```

### Fix

Store the query result in a temporary variable and return early when no record is found, following the same guard pattern already used in `create_issue_reaction_activity`:

```python
reaction_data = (
    CommentReaction.objects.filter(...)
    .values_list("id", "comment__id")
    .first()
)

if reaction_data is None:
    return

comment_reaction_id, comment_id = reaction_data
```

This prevents the Celery task from failing when the reaction no longer exists.

## Type of Change

* Bug fix (non-breaking change which fixes an issue)

## Screenshots and Media

N/A

## Test Scenarios

1. Add a reaction to a comment.
2. Delete the reaction before the Celery task processes the event.
3. Verify that the Celery worker logs contain no `TypeError` traceback.
4. Verify that other activity events in the same batch continue processing normally.

## References

Closes #9175


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved stability when processing comment reactions by adding validation to handle edge cases where reaction data might be unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->