### PR TITLE
Fix project member update authorization

### DIFF
--- a/apps/api/plane/app/views/project/member.py
+++ b/apps/api/plane/app/views/project/member.py
@@ -202,7 +202,7 @@ class ProjectMemberViewSet(BaseViewSet):
 
         return Response(serializer.data, status=status.HTTP_200_OK)
 
-    @allow_permission([ROLE.ADMIN, ROLE.MEMBER, ROLE.GUEST])
+    @allow_permission([ROLE.ADMIN])
     def partial_update(self, request, slug, project_id, pk):
         project_member = ProjectMember.objects.get(pk=pk, workspace__slug=slug, project_id=project_id, is_active=True)
 

--- a/apps/api/plane/tests/contract/app/test_project_app.py
+++ b/apps/api/plane/tests/contract/app/test_project_app.py
@@ -522,3 +522,33 @@ class TestProjectAPIPatchDelete(TestProjectBase):
 
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
         assert Project.objects.filter(id=project.id).exists()
+
+
+@pytest.mark.contract
+class TestProjectMemberAPI(TestProjectBase):
+    @pytest.mark.django_db
+    def test_guest_cannot_deactivate_another_project_member(self, session_client, workspace):
+        project = Project.objects.create(name="Member Protected", identifier="MP", workspace=workspace)
+
+        guest_user = User.objects.create_user(email="project-guest@example.com", username="project-guest")
+        victim_user = User.objects.create_user(email="project-member@example.com", username="project-member")
+
+        WorkspaceMember.objects.create(workspace=workspace, member=guest_user, role=5, is_active=True)
+        WorkspaceMember.objects.create(workspace=workspace, member=victim_user, role=15, is_active=True)
+
+        ProjectMember.objects.create(project=project, member=guest_user, role=5, is_active=True)
+        victim_project_member = ProjectMember.objects.create(
+            project=project,
+            member=victim_user,
+            role=15,
+            is_active=True,
+        )
+
+        session_client.force_authenticate(user=guest_user)
+
+        url = f"/api/workspaces/{workspace.slug}/projects/{project.id}/members/{victim_project_member.id}/"
+        response = session_client.patch(url, {"is_active": False}, format="json")
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        victim_project_member.refresh_from_db()
+        assert victim_project_member.is_active is True


### PR DESCRIPTION
## Finding

Niro `TC-1A95641A` found that a project guest could PATCH another project member record with `{ "is_active": false }`, deactivating that user's project membership.

## Original PoC

As a project guest, PATCH `/api/workspaces/<slug>/projects/<project_id>/members/<victim_membership_id>/` with JSON body `{ "is_active": false }`. Before this fix the API returned `200 OK`, persisted `is_active=false`, and the victim lost access to project member endpoints.

## Red test on unfixed code

```
plane/tests/contract/app/test_project_app.py F

___ TestProjectMemberAPI.test_guest_cannot_deactivate_another_project_member ___

>       assert response.status_code == status.HTTP_403_FORBIDDEN
E       assert 200 == 403
E        +  where 200 = <Response status_code=200, "application/json">.status_code
E        +  and   403 = status.HTTP_403_FORBIDDEN

FAILED plane/tests/contract/app/test_project_app.py::TestProjectMemberAPI::test_guest_cannot_deactivate_another_project_member
============================== 1 failed in 1.58s ===============================
```

## Green test on fixed code

```
plane/tests/contract/app/test_project_app.py .

============================== 1 passed in 1.00s ===============================
```

## Fix

Restrict `ProjectMemberViewSet.partial_update` to project admins, matching membership create/delete behavior. Added a regression test asserting guests cannot deactivate another project member and the victim remains active.

_Pentested and fixed by [Niro](https://github.com/apxlabs-ai/niro)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Tightened project member update permissions to administrators only. Members and guests are now prevented from modifying project member information and records. Unauthorized update attempts will result in a 403 Forbidden error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->