### PR TITLE
Fix project invitation authorization

### DIFF
--- a/apps/api/plane/app/views/project/invite.py
+++ b/apps/api/plane/app/views/project/invite.py
@@ -51,6 +51,14 @@ class ProjectInvitationsViewset(BaseViewSet):
         )
 
     @allow_permission([ROLE.ADMIN])
+    def list(self, request, slug, project_id):
+        return super().list(request, slug=slug, project_id=project_id)
+
+    @allow_permission([ROLE.ADMIN])
+    def retrieve(self, request, slug, project_id, pk):
+        return super().retrieve(request, slug=slug, project_id=project_id, pk=pk)
+
+    @allow_permission([ROLE.ADMIN])
     def create(self, request, slug, project_id):
         emails = request.data.get("emails", [])
 
@@ -111,6 +119,10 @@ class ProjectInvitationsViewset(BaseViewSet):
             )
 
         return Response({"message": "Email sent successfully"}, status=status.HTTP_200_OK)
+
+    @allow_permission([ROLE.ADMIN])
+    def destroy(self, request, slug, project_id, pk):
+        return super().destroy(request, slug=slug, project_id=project_id, pk=pk)
 
 
 class UserProjectInvitationsViewset(BaseViewSet):

--- a/apps/api/plane/tests/contract/app/test_project_invitation_app.py
+++ b/apps/api/plane/tests/contract/app/test_project_invitation_app.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+import pytest
+from rest_framework import status
+
+from plane.db.models import (
+    Project,
+    ProjectMember,
+    ProjectMemberInvite,
+    User,
+    Workspace,
+    WorkspaceMember,
+)
+
+
+@pytest.mark.contract
+class TestProjectInvitationAPI:
+    @pytest.mark.django_db
+    def test_foreign_workspace_user_cannot_read_project_invitations(self, session_client, workspace, create_user):
+        project = Project.objects.create(name="Invite Protected", identifier="IP", workspace=workspace)
+        ProjectMember.objects.create(project=project, member=create_user, role=20, is_active=True)
+        invitation = ProjectMemberInvite.objects.create(
+            project=project,
+            workspace=workspace,
+            email="invitee@example.com",
+            token="secret-project-invite-token",
+            role=15,
+            created_by=create_user,
+        )
+
+        foreign_user = User.objects.create_user(email="foreign@example.com", username="foreign")
+        foreign_workspace = Workspace.objects.create(name="Foreign Workspace", slug="foreign-workspace", owner=foreign_user)
+        WorkspaceMember.objects.create(workspace=foreign_workspace, member=foreign_user, role=15, is_active=True)
+
+        session_client.force_authenticate(user=foreign_user)
+
+        list_url = f"/api/workspaces/{workspace.slug}/projects/{project.id}/invitations/"
+        detail_url = f"{list_url}{invitation.id}/"
+
+        list_response = session_client.get(list_url)
+        detail_response = session_client.get(detail_url)
+
+        assert list_response.status_code == status.HTTP_403_FORBIDDEN
+        assert detail_response.status_code == status.HTTP_403_FORBIDDEN
+        assert b"secret-project-invite-token" not in list_response.content
+        assert b"secret-project-invite-token" not in detail_response.content


### PR DESCRIPTION
## Finding

Niro `TC-B92EA42A` found that an authenticated user from another workspace could list and retrieve invitation records for a private project, including invitee emails, roles, and raw invitation tokens.

## Original PoC

As a user who belongs only to another workspace, request:

- `GET /api/workspaces/<victim_slug>/projects/<victim_project_id>/invitations/`
- `GET /api/workspaces/<victim_slug>/projects/<victim_project_id>/invitations/<invitation_id>/`

Before this fix the API returned `200 OK` and serialized project invitation data.

## Red test on unfixed code

```
plane/tests/contract/app/test_project_invitation_app.py F

_ TestProjectInvitationAPI.test_foreign_workspace_user_cannot_read_project_invitations _

>       assert list_response.status_code == status.HTTP_403_FORBIDDEN
E       assert 200 == 403
E        +  where 200 = <Response status_code=200, "application/json">.status_code
E        +  and   403 = status.HTTP_403_FORBIDDEN

FAILED plane/tests/contract/app/test_project_invitation_app.py::TestProjectInvitationAPI::test_foreign_workspace_user_cannot_read_project_invitations
============================== 1 failed in 0.99s ===============================
```

## Green test on fixed code

```
plane/tests/contract/app/test_project_invitation_app.py .

============================== 1 passed in 0.98s ===============================
```

## Fix

Add explicit project-admin permission gates to project invitation `list`, `retrieve`, and `destroy`, matching the existing `create` gate. Added a regression test that verifies a user from another workspace receives 403 and cannot obtain the invitation token.

_Pentested and fixed by [Niro](https://github.com/apxlabs-ai/niro)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Project invitation endpoints now enforce explicit authorization restrictions
  * Prevents unauthorized access to invitation details across workspaces

* **Tests**
  * Added authorization validation tests for invitation endpoints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->