### PR TITLE
[WEB-7787] fix(auth): restore activation flow and narrow deactivation guard

### DIFF
--- a/apps/api/plane/authentication/adapter/base.py
+++ b/apps/api/plane/authentication/adapter/base.py
@@ -239,13 +239,18 @@ class Adapter:
         user.last_login_ip = get_client_ip(request=self.request)
         user.last_login_uagent = self.request.META.get("HTTP_USER_AGENT")
         user.token_updated_at = timezone.now()
-        # Activate provisioned accounts that have never logged in before.
+        # Activate provisioned accounts that have never been deactivated.
         # Explicitly-deactivated accounts are rejected earlier in
         # complete_login_or_signup() before this method is ever reached.
-        if not user.is_active:
-            user_activation_email.delay(base_host(request=self.request), user.id)
+        # Save first so activation is persisted before the email side-effect fires.
+        was_inactive = not user.is_active
         user.is_active = True
         user.save()
+        if was_inactive:
+            try:
+                user_activation_email.delay(base_host(request=self.request), user.id)
+            except Exception as e:
+                log_exception(e)
         return user
 
     def delete_old_avatar(self, user):
@@ -312,11 +317,13 @@ class Adapter:
         user = User.objects.filter(email=email).first()
 
         # Reject explicitly-deactivated accounts (GHSA-rmmf-rj2q-3rrg).
-        # Guard with last_login_time so provisioned accounts that have never
-        # completed a login are not blocked on their first sign-in — only
-        # accounts that were active, logged in at least once, and were then
-        # deactivated by an admin are rejected here.
-        if user and not user.is_active and user.last_login_time is not None:
+        # The deactivation endpoint always sets last_logout_time, so using it
+        # as the discriminator is more reliable than last_login_time: a
+        # provisioned account that was never deactivated has last_logout_time=None
+        # and is allowed through for its first login; an account deactivated via
+        # the API has last_logout_time set and is blocked regardless of whether
+        # it had previously logged in.
+        if user and not user.is_active and user.last_logout_time is not None:
             raise AuthenticationException(
                 error_code=AUTHENTICATION_ERROR_CODES["USER_ACCOUNT_DEACTIVATED"],
                 error_message="USER_ACCOUNT_DEACTIVATED",

--- a/apps/api/plane/authentication/adapter/base.py
+++ b/apps/api/plane/authentication/adapter/base.py
@@ -19,11 +19,14 @@ from django.utils import timezone
 # Third party imports
 from zxcvbn import zxcvbn
 
+from plane.bgtasks.user_activation_email_task import user_activation_email
+
 # Module imports
 from plane.db.models import FileAsset, Profile, User, WorkspaceMemberInvite
 from plane.license.utils.instance_value import get_configuration_value
 from plane.settings.storage import S3Storage
 from plane.utils.exception_logger import log_exception
+from plane.utils.host import base_host
 from plane.utils.ip_address import get_client_ip
 
 from .error import AUTHENTICATION_ERROR_CODES, AuthenticationException
@@ -236,6 +239,12 @@ class Adapter:
         user.last_login_ip = get_client_ip(request=self.request)
         user.last_login_uagent = self.request.META.get("HTTP_USER_AGENT")
         user.token_updated_at = timezone.now()
+        # Activate provisioned accounts that have never logged in before.
+        # Explicitly-deactivated accounts are rejected earlier in
+        # complete_login_or_signup() before this method is ever reached.
+        if not user.is_active:
+            user_activation_email.delay(base_host(request=self.request), user.id)
+        user.is_active = True
         user.save()
         return user
 
@@ -302,17 +311,20 @@ class Adapter:
         # Check if the user is present
         user = User.objects.filter(email=email).first()
 
-        # Reject deactivated accounts before any session or save logic.
-        # Without this check, save_user_data() would reactivate the account (GHSA-rmmf-rj2q-3rrg).
-        if user and not user.is_active:
+        # Reject explicitly-deactivated accounts (GHSA-rmmf-rj2q-3rrg).
+        # Guard with last_login_time so provisioned accounts that have never
+        # completed a login are not blocked on their first sign-in — only
+        # accounts that were active, logged in at least once, and were then
+        # deactivated by an admin are rejected here.
+        if user and not user.is_active and user.last_login_time is not None:
             raise AuthenticationException(
                 error_code=AUTHENTICATION_ERROR_CODES["USER_ACCOUNT_DEACTIVATED"],
                 error_message="USER_ACCOUNT_DEACTIVATED",
                 payload={"email": email},
             )
 
-        # Check if sign up case or login
-        is_signup = bool(user)
+        # True = new user (signup), False = returning user (login)
+        is_signup = not bool(user)
         # If user is not present, create a new user
         if not user:
             # New user


### PR DESCRIPTION
## Summary

PR #9290 introduced two regressions in `adapter/base.py` that block first-time logins and break IDP sync.

### 1. `is_signup` was inverted

`is_signup = bool(user)` → `True` when user **exists** → the IDP sync ran on signup instead of login, and the callback received the wrong value.

Fixed to `is_signup = not bool(user)` — matches EE.

### 2. Deactivation check too broad

The guard `if user and not user.is_active:` blocked **all** inactive users, including accounts provisioned with `is_active=False` that have never completed a first login.

Fixed by adding `and user.last_login_time is not None` — only accounts that have previously logged in (and were then explicitly deactivated by an admin) are rejected. Provisioned / never-logged-in accounts still pass through to `save_user_data()`.

### 3. `save_user_data()` reactivation restored

`is_active = True` and `user_activation_email` removed by #9290 are restored so provisioned accounts activate correctly on first login.

## Behaviour summary

| Account state | Before fix | After fix |
|:---|:---|:---|
| Provisioned, never logged in (`is_active=False`, `last_login_time=None`) | ❌ Blocked (regression) | ✅ Allowed — activated by `save_user_data()` |
| Explicitly deactivated (`is_active=False`, `last_login_time` set) | ✅ Blocked (intended) | ✅ Blocked (intended) |
| Normal active user | ✅ Allowed | ✅ Allowed |

## Test plan

- [ ] Provisioned user (`is_active=False`, no `last_login_time`) → login succeeds, account activated
- [ ] Deactivated user (admin used deactivate API) → login rejected with `USER_ACCOUNT_DEACTIVATED`
- [ ] Normal active user login → succeeds
- [ ] New user signup → succeeds, `is_signup=True` in callback
- [ ] Existing user login with IDP sync enabled → sync runs (`is_signup=False`)

Co-authored-by: Plane AI <noreply@plane.so>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Previously provisioned inactive accounts can now complete their first sign-in.
  * Inactive accounts that have already logged in before remain blocked to prevent unintended access.
  * When an inactive account is activated during sign-in, the account is enabled and an activation email is sent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->