### PR TITLE
[WEB-7855] fix(security): prevent project invite email disclosure via unauthenticated GET

### DIFF
--- a/apps/api/plane/app/serializers/__init__.py
+++ b/apps/api/plane/app/serializers/__init__.py
@@ -35,6 +35,7 @@ from .project import (
     ProjectDetailSerializer,
     ProjectMemberSerializer,
     ProjectMemberInviteSerializer,
+    ProjectMemberInvitePublicSerializer,
     ProjectIdentifierSerializer,
     ProjectLiteSerializer,
     ProjectMemberLiteSerializer,

--- a/apps/api/plane/app/serializers/project.py
+++ b/apps/api/plane/app/serializers/project.py
@@ -203,6 +203,31 @@ class ProjectMemberInviteSerializer(BaseSerializer):
         fields = "__all__"
 
 
+class ProjectMemberInvitePublicSerializer(BaseSerializer):
+    """Safe read-only serializer for the public project invite GET endpoint.
+
+    Intentionally excludes ``email`` and ``token`` so that an unauthenticated
+    caller cannot retrieve the invitee's email address or the acceptance token
+    (GHSA-2r58-hgv7-635q).
+    """
+
+    project = ProjectLiteSerializer(read_only=True)
+    workspace = WorkspaceLiteSerializer(read_only=True)
+
+    class Meta:
+        model = ProjectMemberInvite
+        fields = [
+            "id",
+            "project",
+            "workspace",
+            "role",
+            "message",
+            "accepted",
+            "responded_at",
+        ]
+        read_only_fields = fields
+
+
 class ProjectIdentifierSerializer(BaseSerializer):
     class Meta:
         model = ProjectIdentifier

--- a/apps/api/plane/app/views/project/invite.py
+++ b/apps/api/plane/app/views/project/invite.py
@@ -19,7 +19,10 @@ from rest_framework.permissions import AllowAny
 
 # Module imports
 from .base import BaseViewSet, BaseAPIView
-from plane.app.serializers import ProjectMemberInviteSerializer
+from plane.app.serializers import (
+    ProjectMemberInviteSerializer,
+    ProjectMemberInvitePublicSerializer,
+)
 from plane.app.permissions import allow_permission, ROLE
 from plane.db.models import (
     ProjectMember,
@@ -250,5 +253,5 @@ class ProjectJoinEndpoint(BaseAPIView):
 
     def get(self, request, slug, project_id, pk):
         project_invitation = ProjectMemberInvite.objects.get(workspace__slug=slug, project_id=project_id, pk=pk)
-        serializer = ProjectMemberInviteSerializer(project_invitation)
+        serializer = ProjectMemberInvitePublicSerializer(project_invitation)
         return Response(serializer.data, status=status.HTTP_200_OK)


### PR DESCRIPTION
## Summary

Fixes **GHSA-2r58-hgv7-635q** — Cluster L part 2.

`ProjectJoinEndpoint.get()` is `AllowAny` and was serializing with `fields = "__all__"` via `ProjectMemberInviteSerializer`. Anyone who knew the workspace slug, project ID, and invite UUID could retrieve the invitee's email address unauthenticated.

### Changes

- **`serializers/project.py`** — adds `ProjectMemberInvitePublicSerializer` with an explicit safe field list (`id`, `project`, `workspace`, `role`, `message`, `accepted`, `responded_at`) that intentionally excludes `email` and `token`
- **`serializers/__init__.py`** — exports the new serializer
- **`views/project/invite.py`** — `ProjectJoinEndpoint.get()` now uses `ProjectMemberInvitePublicSerializer`; the full serializer is retained for authenticated admin viewsets

`post()` is unchanged — it still requires the caller to supply the invitee email in the request body as verification.

### Pattern

Mirrors the fix applied in WEB-7854 (`WorkSpaceMemberInvitePublicSerializer`) for workspace-level invites.

## Test plan

- [ ] `GET /api/v1/<slug>/projects/<project_id>/invite/<pk>/` returns no `email` or `token` fields
- [ ] `POST /api/v1/<slug>/projects/<project_id>/invite/<pk>/` with correct email still accepts/declines the invite
- [ ] `POST` with wrong email still returns 403
- [ ] Authenticated admin list endpoints (`ProjectInvitationsViewset`) still return full invite data including email

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Project invitation links now return a public-facing view with only the relevant invite details.

* **Bug Fixes**
  * Sensitive invitation information is no longer included in the invitation GET response.
  * The invite response now consistently exposes read-only fields for safer sharing and viewing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->