### PR TITLE
[WEB-7877] fix(security): enforce token + auth validation on project invite accept/reject

### DIFF
--- a/apps/api/plane/app/views/project/invite.py
+++ b/apps/api/plane/app/views/project/invite.py
@@ -211,13 +211,20 @@ class ProjectJoinEndpoint(BaseAPIView):
             )
 
         if project_invite.responded_at is None:
-            project_invite.accepted = request.data.get("accepted", False)
+            accepted = request.data.get("accepted", False)
+            if not isinstance(accepted, bool):
+                return Response(
+                    {"error": "`accepted` must be a boolean"},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+            project_invite.accepted = accepted
             project_invite.responded_at = timezone.now()
             project_invite.save()
 
             if project_invite.accepted:
-                # Check if the user account exists
-                user = User.objects.filter(email=project_invite.email).first()
+                # Use the authenticated user directly — they've already been
+                # validated as the invite recipient above.
+                user = request.user
 
                 # Check if user is a part of workspace
                 workspace_member = WorkspaceMember.objects.filter(workspace__slug=slug, member=user).first()

--- a/apps/api/plane/app/views/project/invite.py
+++ b/apps/api/plane/app/views/project/invite.py
@@ -186,11 +186,27 @@ class ProjectJoinEndpoint(BaseAPIView):
     def post(self, request, slug, project_id, pk):
         project_invite = ProjectMemberInvite.objects.get(pk=pk, project_id=project_id, workspace__slug=slug)
 
-        email = request.data.get("email", "")
+        token = request.data.get("token", "")
 
-        if email == "" or project_invite.email != email:
+        # Validate the token to verify the user received the invitation email
+        if not token or project_invite.token != token:
             return Response(
                 {"error": "You do not have permission to join the project"},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
+        # Require an authenticated session — the accepting user must be the
+        # person who was invited.  Without this check an attacker who knows the
+        # invitee email and obtains the token can hijack the project membership
+        # (GHSA-g36h-p63v-g9c7).
+        if not request.user.is_authenticated:
+            return Response(
+                {"error": "Authentication required to accept project invitation"},
+                status=status.HTTP_401_UNAUTHORIZED,
+            )
+        if request.user.email.lower() != project_invite.email.lower():
+            return Response(
+                {"error": "You do not have permission to accept this invitation"},
                 status=status.HTTP_403_FORBIDDEN,
             )
 
@@ -201,7 +217,7 @@ class ProjectJoinEndpoint(BaseAPIView):
 
             if project_invite.accepted:
                 # Check if the user account exists
-                user = User.objects.filter(email=email).first()
+                user = User.objects.filter(email=project_invite.email).first()
 
                 # Check if user is a part of workspace
                 workspace_member = WorkspaceMember.objects.filter(workspace__slug=slug, member=user).first()


### PR DESCRIPTION
## Summary

Fixes **GHSA-g36h-p63v-g9c7** — Cluster K.

`ProjectJoinEndpoint.post()` only validated that the caller-supplied email matched the invited email. There was no token requirement and no authentication requirement — anyone who knew the workspace slug, project ID, invite UUID, and invitee email could accept or reject a project invitation on the invitee's behalf.

### Changes

**`views/project/invite.py`** — `ProjectJoinEndpoint.post()`:
- Validate `token` from request body against `project_invite.token` → 403 on missing or mismatched token
- Require authenticated session → 401 if unauthenticated
- Validate `request.user.email` against `project_invite.email` → 403 on mismatch
- Remove the old `request.data["email"]` guard
- Use `project_invite.email` for downstream `User.objects.filter(...)` lookup

### Pattern

Mirrors `WorkspaceJoinEndpoint.post()` exactly (fixed in WEB-7854 / PR #9297).

## Test plan

- [ ] `POST` with correct token + authenticated as the invited user → accepts/declines successfully
- [ ] `POST` with wrong token → 403
- [ ] `POST` with no token → 403
- [ ] `POST` unauthenticated (even with correct token) → 401
- [ ] `POST` authenticated as a different user (even with correct token) → 403
- [ ] `GET` still works unauthenticated (public serializer, no token exposed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened project invitation acceptance by requiring a valid invitation token.
  * Added enforcement that requests come from an authenticated session.
  * Verified the authenticated user’s email matches the invite’s email (case-insensitive) before allowing acceptance.
  * Improved handling for invalid request values and mismatched invitation details, with clearer 4xx responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->