### PR TITLE
[WEB-7887] fix(security): prevent stored XSS via SVG attachment served inline (GHSA-ch8j-vr4r-qf6h)

### DIFF
--- a/apps/api/plane/api/views/asset.py
+++ b/apps/api/plane/api/views/asset.py
@@ -444,10 +444,19 @@ class GenericAssetEndpoint(BaseAPIView):
                     status=status.HTTP_400_BAD_REQUEST,
                 )
 
-            # Generate presigned URL for GET
+            # Generate presigned URL for GET.
+            # Force attachment disposition for script-capable MIME types (e.g. SVG)
+            # to prevent same-origin XSS when the asset URL shares the app's origin
+            # (default MinIO self-hosted setup).
             storage = S3Storage(request=request, is_server=True)
+            asset_mime_type = asset.attributes.get("type", "")
+            disposition = (
+                "attachment" if asset_mime_type in settings.SCRIPT_CAPABLE_MIME_TYPES else "inline"
+            )
             presigned_url = storage.generate_presigned_url(
-                object_name=asset.asset.name, filename=asset.attributes.get("name")
+                object_name=asset.asset.name,
+                filename=asset.attributes.get("name"),
+                disposition=disposition,
             )
 
             return Response(

--- a/apps/api/plane/api/views/asset.py
+++ b/apps/api/plane/api/views/asset.py
@@ -449,7 +449,7 @@ class GenericAssetEndpoint(BaseAPIView):
             # to prevent same-origin XSS when the asset URL shares the app's origin
             # (default MinIO self-hosted setup).
             storage = S3Storage(request=request, is_server=True)
-            asset_mime_type = asset.attributes.get("type", "")
+            asset_mime_type = (asset.attributes.get("type") or "").split(";")[0].strip().lower()
             disposition = (
                 "attachment" if asset_mime_type in settings.SCRIPT_CAPABLE_MIME_TYPES else "inline"
             )

--- a/apps/api/plane/app/views/asset/v2.py
+++ b/apps/api/plane/app/views/asset/v2.py
@@ -462,10 +462,19 @@ class StaticFileAssetEndpoint(BaseAPIView):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        # Get the presigned URL
+        # Get the presigned URL.
+        # Force attachment disposition for script-capable MIME types to prevent
+        # same-origin XSS when assets are served on the application's origin.
         storage = S3Storage(request=request)
+        asset_mime_type = asset.attributes.get("type", "")
+        disposition = (
+            "attachment" if asset_mime_type in settings.SCRIPT_CAPABLE_MIME_TYPES else "inline"
+        )
         # Generate a presigned URL to share an S3 object
-        signed_url = storage.generate_presigned_url(object_name=asset.asset.name)
+        signed_url = storage.generate_presigned_url(
+            object_name=asset.asset.name,
+            disposition=disposition,
+        )
         # Redirect to the signed URL
         return HttpResponseRedirect(signed_url)
 

--- a/apps/api/plane/app/views/asset/v2.py
+++ b/apps/api/plane/app/views/asset/v2.py
@@ -466,7 +466,7 @@ class StaticFileAssetEndpoint(BaseAPIView):
         # Force attachment disposition for script-capable MIME types to prevent
         # same-origin XSS when assets are served on the application's origin.
         storage = S3Storage(request=request)
-        asset_mime_type = asset.attributes.get("type", "")
+        asset_mime_type = (asset.attributes.get("type") or "").split(";")[0].strip().lower()
         disposition = (
             "attachment" if asset_mime_type in settings.SCRIPT_CAPABLE_MIME_TYPES else "inline"
         )

--- a/apps/api/plane/settings/common.py
+++ b/apps/api/plane/settings/common.py
@@ -544,6 +544,21 @@ ATTACHMENT_MIME_TYPES = [
     "text/markdown",
 ]
 
+# MIME types that browsers can execute as scripts when served inline.
+# These must always be served with Content-Disposition: attachment, even if they
+# somehow end up stored (e.g. uploaded before this restriction was added).
+SCRIPT_CAPABLE_MIME_TYPES: frozenset[str] = frozenset(
+    [
+        "image/svg+xml",  # SVG with onload / embedded <script> tags
+        "text/javascript",
+        "application/javascript",
+        "text/html",
+        "application/xhtml+xml",
+        "text/xml",
+        "application/xml",
+    ]
+)
+
 # Seed directory path
 SEED_DIR = os.path.join(BASE_DIR, "seeds")
 

--- a/apps/api/plane/space/views/asset.py
+++ b/apps/api/plane/space/views/asset.py
@@ -63,7 +63,7 @@ class EntityAssetEndpoint(BaseAPIView):
         # Force attachment disposition for script-capable MIME types to prevent
         # same-origin XSS when Spaces assets are served on the application's origin.
         storage = S3Storage(request=request)
-        asset_mime_type = asset.attributes.get("type", "")
+        asset_mime_type = (asset.attributes.get("type") or "").split(";")[0].strip().lower()
         disposition = (
             "attachment" if asset_mime_type in settings.SCRIPT_CAPABLE_MIME_TYPES else "inline"
         )

--- a/apps/api/plane/space/views/asset.py
+++ b/apps/api/plane/space/views/asset.py
@@ -59,10 +59,19 @@ class EntityAssetEndpoint(BaseAPIView):
                 status=status.HTTP_404_NOT_FOUND,
             )
 
-        # Get the presigned URL
+        # Get the presigned URL.
+        # Force attachment disposition for script-capable MIME types to prevent
+        # same-origin XSS when Spaces assets are served on the application's origin.
         storage = S3Storage(request=request)
+        asset_mime_type = asset.attributes.get("type", "")
+        disposition = (
+            "attachment" if asset_mime_type in settings.SCRIPT_CAPABLE_MIME_TYPES else "inline"
+        )
         # Generate a presigned URL to share an S3 object
-        signed_url = storage.generate_presigned_url(object_name=asset.asset.name)
+        signed_url = storage.generate_presigned_url(
+            object_name=asset.asset.name,
+            disposition=disposition,
+        )
         # Redirect to the signed URL
         return HttpResponseRedirect(signed_url)
 


### PR DESCRIPTION
## Summary

- Adds `SCRIPT_CAPABLE_MIME_TYPES` frozenset to `common.py` listing MIME types browsers can execute as scripts when served inline (`image/svg+xml`, `text/javascript`, `application/javascript`, `text/html`, `application/xhtml+xml`, `text/xml`, `application/xml`)
- Three download endpoints that previously defaulted to `Content-Disposition: inline` now check the stored asset MIME type and force `attachment` for any script-capable type:
  - `GenericAssetEndpoint.get` — `apps/api/plane/api/views/asset.py`
  - `StaticFileAssetEndpoint.get` — `apps/api/plane/app/views/asset/v2.py`
  - `EntityAssetEndpoint.get` — `apps/api/plane/space/views/asset.py`
- `ATTACHMENT_MIME_TYPES` is **unchanged** — users can still upload SVG, JS, and XML files; the fix only affects how they are served on download

## Security context

Advisory: **GHSA-ch8j-vr4r-qf6h** | Severity: High | CWE-79 (Stored XSS)

A Guest-level workspace member could upload a malicious `image/svg+xml` attachment. In the default self-hosted MinIO deployment the presigned download URL is on the **same origin** as the Plane app. With `Content-Disposition: inline`, the browser renders the SVG and executes any embedded `onload` / `<script>` JavaScript in the application's security context → session theft and account takeover of any user who opened the link.

Forcing `Content-Disposition: attachment` for script-capable types causes the browser to download the file instead of rendering it, removing the execution context entirely.

## Test plan

- [ ] Upload an SVG file as an issue attachment — upload should succeed
- [ ] Fetch the download URL for the SVG — verify `Content-Disposition: attachment` in the presigned URL response headers
- [ ] Upload a normal image (JPEG/PNG) — verify it still serves with `Content-Disposition: inline`
- [ ] Upload a JS file as a generic asset — verify download URL returns `Content-Disposition: attachment`
- [ ] Verify existing non-script attachments (PDF, DOCX, MP4) are unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Asset download and preview presigned links now choose `Content-Disposition` based on the asset’s MIME type, forcing script-capable types to download instead of opening inline.
  * Normal (non-script) file types continue to render inline for expected previews, preserving the browsing experience while improving safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->