### PR TITLE
[WEB-7892] fix(security): scope attachment PATCH/DELETE/GET by issue_id, drop created_by overwrite (GHSA-5mxw-g5mw-3v3w)

### DIFF
--- a/apps/api/plane/app/views/issue/attachment.py
+++ b/apps/api/plane/app/views/issue/attachment.py
@@ -148,7 +148,9 @@ class IssueAttachmentV2Endpoint(BaseAPIView):
 
     @allow_permission([ROLE.ADMIN], creator=True, model=FileAsset)
     def delete(self, request, slug, project_id, issue_id, pk):
-        issue_attachment = FileAsset.objects.get(pk=pk, workspace__slug=slug, project_id=project_id)
+        issue_attachment = FileAsset.objects.get(
+            pk=pk, workspace__slug=slug, project_id=project_id, issue_id=issue_id
+        )
         issue_attachment.is_deleted = True
         issue_attachment.deleted_at = timezone.now()
         issue_attachment.save()
@@ -171,7 +173,7 @@ class IssueAttachmentV2Endpoint(BaseAPIView):
     def get(self, request, slug, project_id, issue_id, pk=None):
         if pk:
             # Get the asset
-            asset = FileAsset.objects.get(id=pk, workspace__slug=slug, project_id=project_id)
+            asset = FileAsset.objects.get(id=pk, workspace__slug=slug, project_id=project_id, issue_id=issue_id)
 
             # Check if the asset is uploaded
             if not asset.is_uploaded:
@@ -202,7 +204,9 @@ class IssueAttachmentV2Endpoint(BaseAPIView):
 
     @allow_permission([ROLE.ADMIN, ROLE.MEMBER, ROLE.GUEST])
     def patch(self, request, slug, project_id, issue_id, pk):
-        issue_attachment = FileAsset.objects.get(pk=pk, workspace__slug=slug, project_id=project_id)
+        issue_attachment = FileAsset.objects.get(
+            pk=pk, workspace__slug=slug, project_id=project_id, issue_id=issue_id
+        )
         serializer = IssueAttachmentSerializer(issue_attachment)
 
         # Send this activity only if the attachment is not uploaded before
@@ -219,9 +223,9 @@ class IssueAttachmentV2Endpoint(BaseAPIView):
                 origin=base_host(request=request, is_app=True),
             )
 
-            # Update the attachment
+            # Update the attachment — do NOT overwrite created_by; it is set at
+            # creation time and must not be reassigned (GHSA-5mxw-g5mw-3v3w).
             issue_attachment.is_uploaded = True
-            issue_attachment.created_by = request.user
 
         # Get the storage metadata
         if not issue_attachment.storage_metadata:


### PR DESCRIPTION
## Summary

- Adds `issue_id=issue_id` to `FileAsset.objects.get()` in all three V2 issue attachment handlers that were missing it: `patch`, `delete`, and `get` (single asset path)
- Removes `issue_attachment.created_by = request.user` from `patch` — `created_by` is set at creation time and must not be overwritten by the upload-confirm call

## Security context

Advisory: **GHSA-5mxw-g5mw-3v3w** | Severity: High | CWE-639 (Authorization Bypass Through User-Controlled Key)

The PATCH, DELETE, and GET (single) handlers looked up `FileAsset` by `(pk, workspace, project_id)` only. The `issue_id` URL parameter was silently ignored. Any project member could supply their own `issue_id` in the URL while using a victim's attachment UUID as `pk` — the server found and operated on the attachment regardless. In PATCH, `created_by = request.user` transferred ownership to the attacker, locking the original uploader out of their own file's delete right.

The V1 delete handler already scoped by `issue_id` correctly — this PR brings the V2 handlers in line with that pattern.

## Files changed

- `apps/api/plane/app/views/issue/attachment.py`

## Test plan

- [ ] PATCH with mismatched `issue_id` (attacker's issue, victim's asset UUID) — verify 404
- [ ] DELETE with mismatched `issue_id` — verify 404
- [ ] GET single with mismatched `issue_id` — verify 404
- [ ] Normal upload flow: POST → PATCH with correct `issue_id` — verify 204, `created_by` unchanged
- [ ] Original uploader can still DELETE after PATCH confirm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Attachment actions now apply only to files belonging to the selected issue, reducing the risk of viewing, updating, or deleting the wrong attachment.
  * Upload completion updates no longer change who originally created an attachment, preserving the correct owner information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->