### PR TITLE
docs: fix typos in code comments

### DIFF
--- a/apps/web/core/store/issue/helpers/base-issues.store.ts
+++ b/apps/web/core/store/issue/helpers/base-issues.store.ts
@@ -1204,7 +1204,7 @@ export abstract class BaseIssuesStore implements IBaseIssuesStore {
     const issueId = issue?.id ?? issueBeforeUpdate?.id;
     if (!issueId) return;
 
-    // Get display filters to check if 'Show sub Work items' is enabled - Donot add Work item to main list if disabled.
+    // Get display filters to check if 'Show sub Work items' is enabled - Do not add Work item to main list if disabled.
     const isShowWorkItemsEnabled = this.issueFilterStore.issueFilters?.displayFilters?.sub_issue ?? false;
 
     // get issueUpdates from another method by passing down the three arguments

--- a/packages/propel/src/popover/popover.stories.tsx
+++ b/packages/propel/src/popover/popover.stories.tsx
@@ -10,7 +10,7 @@ import { useArgs } from "storybook/preview-api";
 import { CloseIcon } from "../icons/actions/close-icon";
 import { Popover } from "./root";
 
-// cannot use satifies here because base-ui does not have portable types.
+// cannot use satisfies here because base-ui does not have portable types.
 const meta: Meta<typeof Popover> = {
   title: "Components/Popover",
   component: Popover,


### PR DESCRIPTION
## Summary

Fixes two spelling typos in code comments. Comment-only, no code or behavior changes.

## Details

- packages/propel/src/popover/popover.stories.tsx: `satifies` to `satisfies`
- apps/web/core/store/issue/helpers/base-issues.store.ts: `Donot` to `Do not`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a couple of inline comments for clearer wording and spelling.
  * Updated a note about how sub-work items behave when the related view option is turned off.
  * Improved a Storybook comment for readability.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->