### PR TITLE
fix(api): filter "Updated At" by updated_at column, not created_at

### DIFF
--- a/apps/api/plane/tests/unit/utils/test_issue_filters.py
+++ b/apps/api/plane/tests/unit/utils/test_issue_filters.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+import pytest
+
+from plane.utils.issue_filters import filter_updated_at
+
+
+@pytest.mark.unit
+class TestFilterUpdatedAt:
+    """Regression test for the "Updated At" filter bug — the filter was
+    applying to the `created_at` column instead of `updated_at`, so work
+    items updated today but created earlier never showed up under
+    `Updated At -> is -> today`. See issue #9316."""
+
+    def test_get_method_targets_updated_at_column(self):
+        issue_filter = {}
+        params = {"updated_at": "2026-06-26"}
+        filter_updated_at(params, issue_filter, method="GET")
+        # The filter must key on updated_at, not created_at.
+        assert "updated_at__date" in issue_filter
+        assert not any("created_at" in key for key in issue_filter)
+
+    def test_get_method_with_csv_targets_updated_at_column(self):
+        issue_filter = {}
+        params = {"updated_at": "2026-06-25,2026-06-26"}
+        filter_updated_at(params, issue_filter, method="GET")
+        assert all("updated_at" in key for key in issue_filter)
+        assert not any("created_at" in key for key in issue_filter)
+
+    def test_post_method_targets_updated_at_column(self):
+        issue_filter = {}
+        params = {"updated_at": ["2026-06-26"]}
+        filter_updated_at(params, issue_filter, method="POST")
+        assert all("updated_at" in key for key in issue_filter)
+        assert not any("created_at" in key for key in issue_filter)
+
+    def test_get_method_with_prefix_targets_updated_at_column(self):
+        issue_filter = {}
+        params = {"updated_at": "2026-06-26"}
+        filter_updated_at(params, issue_filter, method="GET", prefix="cycle_issue__")
+        keys = list(issue_filter)
+        assert any("cycle_issue__updated_at" in k for k in keys)
+        assert not any("created_at" in k for k in keys)
+
+    def test_empty_get_filter_is_noop(self):
+        issue_filter = {}
+        params = {"updated_at": ""}
+        filter_updated_at(params, issue_filter, method="GET")
+        assert issue_filter == {}

--- a/apps/api/plane/utils/issue_filters.py
+++ b/apps/api/plane/utils/issue_filters.py
@@ -231,14 +231,14 @@ def filter_updated_at(params, issue_filter, method, prefix=""):
         if len(updated_ats) and "" not in updated_ats:
             date_filter(
                 issue_filter=issue_filter,
-                date_term=f"{prefix}created_at__date",
+                date_term=f"{prefix}updated_at__date",
                 queries=updated_ats,
             )
     else:
         if params.get("updated_at", None) and len(params.get("updated_at")):
             date_filter(
                 issue_filter=issue_filter,
-                date_term=f"{prefix}created_at__date",
+                date_term=f"{prefix}updated_at__date",
                 queries=params.get("updated_at", []),
             )
     return issue_filter


### PR DESCRIPTION
### Summary
`filter_updated_at` in `apps/api/plane/utils/issue_filters.py` was passing `created_at__date` as the `date_term` to `date_filter` — a copy-paste from `filter_created_at`. The "Updated At -> is -> today" filter was therefore checking the issue's creation date instead of its last-modified date. Work items created earlier but updated today silently disappeared from the results.

The typo was in both the GET and POST branches of `filter_updated_at`. Replaced `created_at__date` with `updated_at__date` and added a focused unit test in `apps/api/plane/tests/unit/utils/test_issue_filters.py` that pins the column name.

### Test plan
- New unit test `TestFilterUpdatedAt` covers the GET, GET-with-CSV, POST, and prefixed-`cycle_issue__` cases, asserting every emitted filter key references `updated_at` and none reference `created_at`.
- Existing tests in `tests/unit/utils/` continue to apply.

Refs #9316

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed issue date filtering so `updated_at` now matches against the correct update date field for both GET and POST inputs (including date-based filtering).

* **Tests**
  * Added unit test coverage to ensure `updated_at` filtering targets the right date field, supports comma-separated and list-style parameters, honors optional prefixes, and treats empty filter values as a no-op.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->