### PR TITLE
fix(ui): ignore Enter during IME composition in select dropdowns

### DIFF
--- a/packages/ui/src/hooks/use-dropdown-key-pressed.ts
+++ b/packages/ui/src/hooks/use-dropdown-key-pressed.ts
@@ -27,7 +27,7 @@ export const useDropdownKeyPressed: TUseDropdownKeyPressed = (onEnterKeyDown, on
 
   const handleKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLElement>) => {
-      if (event.key === "Enter") {
+      if (event.key === "Enter" && !event.nativeEvent.isComposing) {
         stopEventPropagation(event);
         onEnterKeyDown();
       } else if (event.key === "Escape") {


### PR DESCRIPTION
### Description

`MultiSelectDropdown` and `SingleSelectDropdown` attach their `Combobox` `onKeyDown` to `useDropdownKeyPressed`, which calls `onEnterKeyDown` (`toggleDropdown`) on every `Enter`. The search input inside the dropdown only stops propagation for `Escape`, so the `Enter` that confirms an IME composition bubbles up from the input to the combobox and toggles the dropdown closed before anything is selected.

For a CJK IME (Japanese, Chinese, Korean), the first `Enter` is meant to commit the conversion, not to act on the dropdown. As a result the search field is hard to use with an IME: committing the text closes the menu.

The sibling hook `useDropdownKeyDown` already guards against this with `!event.nativeEvent.isComposing`. This change applies the same guard to `useDropdownKeyPressed`. Non-IME `Enter` is unaffected (`isComposing` is `false`), so it still toggles as before; only the `Enter` that ends a composition is ignored.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### Screenshots and Media (if applicable)

<!-- Add screenshots here -->

### Test Scenarios

With an IME enabled (for example Japanese):

1. Open a dropdown backed by `MultiSelectDropdown` or `SingleSelectDropdown` with search enabled.
2. Type into the search field and press `Enter` to confirm the IME conversion.
3. Before this change the dropdown closes. After it, the conversion is committed and the dropdown stays open.

Without an IME, pressing `Enter` still toggles the dropdown exactly as before.

I verified by inspection that this matches the existing `useDropdownKeyDown` guard and leaves non-composing `Enter` unchanged. I don't have a CJK IME configured locally to run the end-to-end flow, so a confirmation from someone who does would be welcome.

### References

The `!event.nativeEvent.isComposing` guard already exists in `useDropdownKeyDown` (`packages/ui/src/hooks/use-dropdown-key-down.tsx`) and in the label create handlers; this brings `useDropdownKeyPressed` in line. IME Enter handling has come up before in Plane (for example #7022).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard behavior in dropdowns by preventing the Enter key action from firing during text input composition, helping users with IME input avoid accidental selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->