### PR TITLE
[WEB-7894] fix: eliminate TOCTOU race in InstanceAdminSignUp (GHSA-p548-28jp-wr4p)

### DIFF
--- a/apps/api/plane/license/api/views/admin.py
+++ b/apps/api/plane/license/api/views/admin.py
@@ -107,7 +107,9 @@ class InstanceAdminSignUpEndpoint(View):
 
         # Fast pre-check outside the lock (avoids contention when setup is
         # already done — the common path after first boot).
-        if instance.is_setup_done or InstanceAdmin.objects.filter(instance=instance).exists():
+        # Use a global exists() check (not scoped to this instance row) so that
+        # a stray second Instance row cannot bypass the guard (coderabbit).
+        if instance.is_setup_done or InstanceAdmin.objects.exists():
             exc = AuthenticationException(
                 error_code=AUTHENTICATION_ERROR_CODES["ADMIN_ALREADY_EXIST"],
                 error_message="ADMIN_ALREADY_EXIST",
@@ -218,8 +220,9 @@ class InstanceAdminSignUpEndpoint(View):
                 instance = Instance.objects.select_for_update().get(pk=instance.pk)
 
                 # Re-check inside the lock — the pre-check above is racy; this
-                # is the authoritative guard.
-                if instance.is_setup_done or InstanceAdmin.objects.filter(instance=instance).exists():
+                # is the authoritative guard. Global exists() (not scoped to
+                # this instance row) matches the pre-check (coderabbit).
+                if instance.is_setup_done or InstanceAdmin.objects.exists():
                     exc = AuthenticationException(
                         error_code=AUTHENTICATION_ERROR_CODES["ADMIN_ALREADY_EXIST"],
                         error_message="ADMIN_ALREADY_EXIST",

--- a/apps/api/plane/license/api/views/admin.py
+++ b/apps/api/plane/license/api/views/admin.py
@@ -15,6 +15,7 @@ from django.core.exceptions import ValidationError
 from django.utils import timezone
 from django.contrib.auth.hashers import make_password
 from django.contrib.auth import logout
+from django.db import transaction
 
 # Third party imports
 from rest_framework.response import Response
@@ -91,7 +92,7 @@ class InstanceAdminSignUpEndpoint(View):
 
     @invalidate_cache(path="/api/instances/", user=False)
     def post(self, request):
-        # Check instance first
+        # Check instance first (outside the transaction — no need to lock yet)
         instance = Instance.objects.first()
         if instance is None:
             exc = AuthenticationException(
@@ -104,8 +105,9 @@ class InstanceAdminSignUpEndpoint(View):
             )
             return HttpResponseRedirect(url)
 
-        # check if the instance has already an admin registered
-        if InstanceAdmin.objects.first():
+        # Fast pre-check outside the lock (avoids contention when setup is
+        # already done — the common path after first boot).
+        if instance.is_setup_done or InstanceAdmin.objects.filter(instance=instance).exists():
             exc = AuthenticationException(
                 error_code=AUTHENTICATION_ERROR_CODES["ADMIN_ALREADY_EXIST"],
                 error_message="ADMIN_ALREADY_EXIST",
@@ -207,33 +209,55 @@ class InstanceAdminSignUpEndpoint(View):
                 )
                 return HttpResponseRedirect(url)
 
-            user = User.objects.create(
-                first_name=first_name,
-                last_name=last_name,
-                email=email,
-                username=uuid.uuid4().hex,
-                password=make_password(password),
-                is_password_autoset=False,
-            )
-            _ = Profile.objects.create(user=user, company_name=company_name)
-            # settings last active for the user
-            user.is_active = True
-            user.last_active = timezone.now()
-            user.last_login_time = timezone.now()
-            user.last_login_ip = get_client_ip(request=request)
-            user.last_login_uagent = request.META.get("HTTP_USER_AGENT")
-            user.token_updated_at = timezone.now()
-            user.save()
+            # Atomic check-and-create to eliminate the TOCTOU race
+            # (GHSA-p548-28jp-wr4p).  Lock the Instance singleton row so that
+            # two concurrent signup requests cannot both pass the "no admin yet"
+            # check and then both create an InstanceAdmin.
+            with transaction.atomic():
+                # Re-acquire instance under a row-level lock.
+                instance = Instance.objects.select_for_update().get(pk=instance.pk)
 
-            # Register the user as an instance admin
-            _ = InstanceAdmin.objects.create(user=user, instance=instance)
-            # Make the setup flag True
-            instance.is_setup_done = True
-            instance.instance_name = company_name
-            instance.is_telemetry_enabled = is_telemetry_enabled
-            instance.save()
+                # Re-check inside the lock — the pre-check above is racy; this
+                # is the authoritative guard.
+                if instance.is_setup_done or InstanceAdmin.objects.filter(instance=instance).exists():
+                    exc = AuthenticationException(
+                        error_code=AUTHENTICATION_ERROR_CODES["ADMIN_ALREADY_EXIST"],
+                        error_message="ADMIN_ALREADY_EXIST",
+                    )
+                    url = urljoin(
+                        base_host(request=request, is_admin=True),
+                        "?" + urlencode(exc.get_error_dict()),
+                    )
+                    return HttpResponseRedirect(url)
 
-            # get tokens for user
+                user = User.objects.create(
+                    first_name=first_name,
+                    last_name=last_name,
+                    email=email,
+                    username=uuid.uuid4().hex,
+                    password=make_password(password),
+                    is_password_autoset=False,
+                )
+                _ = Profile.objects.create(user=user, company_name=company_name)
+                # settings last active for the user
+                user.is_active = True
+                user.last_active = timezone.now()
+                user.last_login_time = timezone.now()
+                user.last_login_ip = get_client_ip(request=request)
+                user.last_login_uagent = request.META.get("HTTP_USER_AGENT")
+                user.token_updated_at = timezone.now()
+                user.save()
+
+                # Register the user as an instance admin
+                _ = InstanceAdmin.objects.create(user=user, instance=instance)
+                # Make the setup flag True
+                instance.is_setup_done = True
+                instance.instance_name = company_name
+                instance.is_telemetry_enabled = is_telemetry_enabled
+                instance.save()
+
+            # get tokens for user (outside the transaction — session writes must
+            # not be held under the DB lock)
             user_login(request=request, user=user, is_admin=True)
             url = urljoin(base_host(request=request, is_admin=True), "general/")
             return HttpResponseRedirect(url)


### PR DESCRIPTION
## Summary

- **Advisory:** GHSA-p548-28jp-wr4p (High)
- **Root cause:** `InstanceAdminSignUpEndpoint.post()` checked for an existing `InstanceAdmin` with a non-atomic read (`InstanceAdmin.objects.first()`) and then created one in a separate write. Two concurrent requests could both pass the check and create two instance admins.
- **Fix:** Wrapped the check + create in `transaction.atomic()` with `select_for_update()` on the `Instance` singleton row. The pre-check outside the lock (`is_setup_done` / existing admin) is a fast early-exit for the common post-setup path; the re-check inside the lock is the authoritative race-free guard.

## Changes

`apps/api/plane/license/api/views/admin.py`
- Added `from django.db import transaction`
- Added fast pre-check on `instance.is_setup_done` (secondary guard)
- Wrapped user + admin creation in `transaction.atomic()` with `Instance.objects.select_for_update().get(pk=instance.pk)` to serialize concurrent signups
- Moved `user_login()` outside the transaction to avoid holding the DB lock during session writes

## Test plan

- [ ] Fresh instance: single signup → creates one admin, `is_setup_done=True`, login redirect works
- [ ] Fresh instance: simulate concurrent requests → only one admin created, second gets `ADMIN_ALREADY_EXIST` redirect
- [ ] Already-setup instance: signup attempt → blocked immediately by pre-check (no DB lock contention)

Co-authored-by: Plane AI <noreply@plane.so>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the admin sign-up flow to handle simultaneous requests more safely.
  * Reduced the chance of duplicate or conflicting instance setup during first-time admin creation.
  * Ensured the setup/admin creation process is validated and applied consistently, preventing race-condition outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->