### PR TITLE
[WEB-7895] fix: scope UserProjectInvitationsViewset to workspace-validated project IDs (GHSA-45hc-q4mw-jhxm)

### DIFF
--- a/apps/api/plane/app/views/project/invite.py
+++ b/apps/api/plane/app/views/project/invite.py
@@ -145,10 +145,16 @@ class UserProjectInvitationsViewset(BaseViewSet):
         workspace_role = workspace_member.role
         workspace = workspace_member.workspace
 
+        # Use the workspace-scoped, network-validated project IDs only.
+        # Raw project_ids may contain UUIDs from other workspaces; those are
+        # absent from the `projects` queryset and therefore bypass the SECRET
+        # network check above (GHSA-45hc-q4mw-jhxm).
+        validated_project_ids = [str(p.id) for p in projects]
+
         # If the user was already part of workspace
-        _ = ProjectMember.objects.filter(workspace__slug=slug, project_id__in=project_ids, member=request.user).update(
-            is_active=True
-        )
+        _ = ProjectMember.objects.filter(
+            workspace__slug=slug, project_id__in=validated_project_ids, member=request.user
+        ).update(is_active=True)
 
         ProjectMember.objects.bulk_create(
             [
@@ -159,7 +165,7 @@ class UserProjectInvitationsViewset(BaseViewSet):
                     workspace=workspace,
                     created_by=request.user,
                 )
-                for project_id in project_ids
+                for project_id in validated_project_ids
             ],
             ignore_conflicts=True,
         )
@@ -172,7 +178,7 @@ class UserProjectInvitationsViewset(BaseViewSet):
                     workspace=workspace,
                     created_by=request.user,
                 )
-                for project_id in project_ids
+                for project_id in validated_project_ids
             ],
             ignore_conflicts=True,
         )


### PR DESCRIPTION
## Summary

- **Advisory:** GHSA-45hc-q4mw-jhxm (High)
- **Root cause:** `UserProjectInvitationsViewset.create()` validated the `network` (SECRET/PUBLIC) check against a workspace-scoped queryset, but used the raw client-supplied `project_ids` list for all subsequent DB writes. An attacker could include UUIDs of projects from other workspaces — those are absent from the validation queryset (bypassing the SECRET check) yet get inserted as `ProjectMember` rows via `bulk_create(ignore_conflicts=True)`, granting cross-workspace project access.
- **Fix:** Derive `validated_project_ids = [str(p.id) for p in projects]` from the already workspace-scoped, network-checked queryset, and use it exclusively for all `ProjectMember` and `ProjectUserProperty` writes.

## Changes

`apps/api/plane/app/views/project/invite.py`
- Added `validated_project_ids` derived from the workspace-filtered `projects` queryset
- Replaced `project_ids` with `validated_project_ids` in the `ProjectMember.objects.filter().update()`, `ProjectMember.objects.bulk_create()`, and `ProjectUserProperty.objects.bulk_create()` calls

## Test plan

- [ ] Join a PUBLIC project in own workspace → succeeds
- [ ] Join a SECRET project as MEMBER → blocked with 403
- [ ] Join a SECRET project as ADMIN → succeeds
- [ ] Send `project_ids` containing UUID of a project in a different workspace → not joined (absent from `validated_project_ids`)
- [ ] Send mix of valid + cross-workspace IDs → only the valid workspace projects are joined

Co-authored-by: Plane AI <noreply@plane.so>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project invite handling to ensure only validated projects are processed.
  * Prevented invites from affecting projects outside the selected workspace.
  * Made membership and project settings updates apply only to eligible projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->