### PR TITLE
fix: quick links widget overlap with plane ai promo on mobile

### DIFF
--- a/apps/web/core/components/home/widgets/links/root.tsx
+++ b/apps/web/core/components/home/widgets/links/root.tsx
@@ -46,8 +46,8 @@ export const DashboardQuickLinks = observer(function DashboardQuickLinks(props: 
         linkOperations={linkOperations}
         preloadedData={linkData}
       />
-      <div className="mb-2">
-        <div className="mb-4 flex items-center justify-between">
+      <div className="mb-2 max-sm:mb-6">
+        <div className="mb-4 flex flex-wrap items-center justify-between gap-2">
           <div className="text-14 font-semibold text-tertiary">{t("home.quick_links.title_plural")}</div>
           <button
             onClick={handleCreateLinkModal}


### PR DESCRIPTION
## Description
Quick Links widget text overflowed into Plane AI promo section below on mobile viewports (<640px). The "Add quick Link" button (3 words) + "Quicklinks" title in `justify-between` flex had no wrap behavior, causing text collision. Insufficient bottom margin made the overlap visible.

## Changes
- `apps/web/core/components/home/widgets/links/root.tsx` two class changes:
- `mb-2` → `mb-2 max-sm:mb-6`: triple bottom clearance on small screens, preventing bleed into next widget
- `flex` → `flex flex-wrap gap-2`: title and button wrap to separate lines with proper spacing instead of colliding

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots and Media
<!-- Optional: attach before/after screenshots -->

## Test Scenarios
1. Open Home page at 360px viewport width
2. Verify Quick Links header does not overlap with Plane AI promo section
3. Resize to 640px+ and confirm layout unchanged

## References
Closes #9084

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted spacing and layout for the quick links section on the dashboard.
  * Improved header alignment and wrapping behavior for better display on smaller screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->