### PR TITLE
fix: allow special characters in project name

### DIFF
--- a/apps/api/plane/api/serializers/project.py
+++ b/apps/api/plane/api/serializers/project.py
@@ -105,11 +105,7 @@ class ProjectCreateSerializer(BaseSerializer):
         ]
 
     def validate(self, data):
-        project_name = data.get("name", None)
         project_identifier = data.get("identifier", None)
-
-        if project_name is not None and re.match(Project.FORBIDDEN_IDENTIFIER_CHARS_PATTERN, project_name):
-            raise serializers.ValidationError("Project name cannot contain special characters.")
 
         if project_identifier is not None and re.match(Project.FORBIDDEN_IDENTIFIER_CHARS_PATTERN, project_identifier):
             raise serializers.ValidationError("Project identifier cannot contain special characters.")
@@ -180,11 +176,7 @@ class ProjectUpdateSerializer(ProjectCreateSerializer):
         read_only_fields = ProjectCreateSerializer.Meta.read_only_fields
 
     def update(self, instance, validated_data):
-        project_name = validated_data.get("name", None)
         project_identifier = validated_data.get("identifier", None)
-
-        if project_name is not None and re.match(Project.FORBIDDEN_IDENTIFIER_CHARS_PATTERN, project_name):
-            raise serializers.ValidationError("Project name cannot contain special characters.")
 
         if project_identifier is not None and re.match(Project.FORBIDDEN_IDENTIFIER_CHARS_PATTERN, project_identifier):
             raise serializers.ValidationError("Project identifier cannot contain special characters.")
@@ -239,11 +231,7 @@ class ProjectSerializer(BaseSerializer):
         ]
 
     def validate(self, data):
-        project_name = data.get("name", None)
         project_identifier = data.get("identifier", None)
-
-        if project_name is not None and re.match(Project.FORBIDDEN_IDENTIFIER_CHARS_PATTERN, project_name):
-            raise serializers.ValidationError("Project name cannot contain special characters.")
 
         if project_identifier is not None and re.match(Project.FORBIDDEN_IDENTIFIER_CHARS_PATTERN, project_identifier):
             raise serializers.ValidationError("Project identifier cannot contain special characters.")

--- a/apps/api/plane/app/serializers/project.py
+++ b/apps/api/plane/app/serializers/project.py
@@ -40,9 +40,6 @@ class ProjectSerializer(BaseSerializer):
         project_id = self.instance.id if self.instance else None
         workspace_id = self.context["workspace_id"]
 
-        if re.match(Project.FORBIDDEN_IDENTIFIER_CHARS_PATTERN, name):
-            raise serializers.ValidationError(detail="PROJECT_NAME_CANNOT_CONTAIN_SPECIAL_CHARACTERS")
-
         project = Project.objects.filter(name=name, workspace_id=workspace_id)
 
         if project_id:


### PR DESCRIPTION
Resolves #9226 and #9280.

### Description
The project name (title) is a user-facing label and should be allowed to contain special characters such as hyphens -, ampersands &, etc. However, the serializers in the backend API and App endpoints were validating the project 
ame against Project.FORBIDDEN_IDENTIFIER_CHARS_PATTERN (which is meant only for project identifiers to ensure they are valid prefix patterns). This caused project creation and update requests containing special characters in their name to fail with PROJECT_NAME_CANNOT_CONTAIN_SPECIAL_CHARACTERS.

This change removes the validation of project names against the forbidden identifier characters regex, while keeping the validation in place for project identifiers.

### Changes
- Removed name validation using Project.FORBIDDEN_IDENTIFIER_CHARS_PATTERN from ProjectCreateSerializer, ProjectUpdateSerializer, and ProjectSerializer in pps/api/plane/api/serializers/project.py.
- Removed name validation using Project.FORBIDDEN_IDENTIFIER_CHARS_PATTERN from ProjectSerializer.validate_name in pps/api/plane/app/serializers/project.py.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Project names no longer reject certain special characters during creation or editing.
  * Identifier validation remains unchanged, so project identifiers still follow the existing character rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->