### PR TITLE
[WEB-8019] fix(security): scope CycleIssue reassignment lookup to workspace/project

### DIFF
--- a/apps/api/plane/api/views/issue.py
+++ b/apps/api/plane/api/views/issue.py
@@ -80,7 +80,11 @@ from plane.db.models import (
 )
 from plane.settings.storage import S3Storage
 from plane.utils.path_validator import sanitize_filename
-from plane.utils.order_queryset import ACTIVITY_ORDER_BY_ALLOWLIST, sanitize_order_by
+from plane.utils.order_queryset import (
+    ACTIVITY_ORDER_BY_ALLOWLIST,
+    ISSUE_ORDER_BY_ALLOWLIST,
+    sanitize_order_by,
+)
 from plane.bgtasks.storage_metadata_task import get_asset_object_metadata
 from .base import BaseAPIView
 from plane.utils.host import base_host
@@ -329,7 +333,14 @@ class IssueListCreateAPIEndpoint(BaseAPIView):
         priority_order = ["urgent", "high", "medium", "low", "none"]
         state_order = ["backlog", "unstarted", "started", "completed", "cancelled"]
 
-        order_by_param = request.GET.get("order_by", "-created_at")
+        # Reject any field not in the allowlist before it reaches .order_by().
+        # An unrecognised value is replaced with the safe default, preventing
+        # ORM order_by injection via relational traversal (GHSA-p885-6jpg-cr2p).
+        order_by_param = sanitize_order_by(
+            request.GET.get("order_by", "-created_at"),
+            ISSUE_ORDER_BY_ALLOWLIST,
+            default="-created_at",
+        )
 
         issue_queryset = (
             self.get_queryset()

--- a/apps/api/plane/api/views/project.py
+++ b/apps/api/plane/api/views/project.py
@@ -41,6 +41,7 @@ from plane.bgtasks.webhook_task import model_activity, webhook_activity
 from plane.utils.exception_logger import log_exception
 from .base import BaseAPIView
 from plane.utils.host import base_host
+from plane.utils.order_queryset import PROJECT_ORDER_BY_ALLOWLIST, sanitize_order_by
 from plane.api.serializers import (
     ProjectSerializer,
     ProjectCreateSerializer,
@@ -184,7 +185,13 @@ class ProjectListCreateAPIEndpoint(BaseAPIView):
                     ),
                 )
             )
-            .order_by(request.GET.get("order_by", "sort_order"))
+            .order_by(
+                sanitize_order_by(
+                    request.GET.get("order_by", "sort_order"),
+                    PROJECT_ORDER_BY_ALLOWLIST,
+                    default="sort_order",
+                )
+            )
         )
         return self.paginate(
             request=request,

--- a/apps/api/plane/app/views/cycle/issue.py
+++ b/apps/api/plane/app/views/cycle/issue.py
@@ -236,7 +236,17 @@ class CycleIssueViewSet(BaseViewSet):
             )
 
         # Get all CycleIssues already created
-        cycle_issues = list(CycleIssue.objects.filter(~Q(cycle_id=cycle_id), issue_id__in=issues))
+        # Scope to workspace+project to prevent cross-tenant IDOR: without this
+        # scope, foreign-tenant CycleIssue rows matched by issue_id would be
+        # reassigned to the caller's cycle (GHSA-4w5x-wc9w-f47x).
+        cycle_issues = list(
+            CycleIssue.objects.filter(
+                ~Q(cycle_id=cycle_id),
+                issue_id__in=issues,
+                workspace__slug=slug,
+                project_id=project_id,
+            )
+        )
         existing_issues = [str(cycle_issue.issue_id) for cycle_issue in cycle_issues]
         new_issues = list(set(issues) - set(existing_issues))
 

--- a/apps/api/plane/tests/contract/api/test_issues.py
+++ b/apps/api/plane/tests/contract/api/test_issues.py
@@ -1,0 +1,96 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+import pytest
+from rest_framework import status
+
+from plane.db.models import Issue, Project, ProjectMember, State
+
+
+@pytest.fixture
+def project(db, workspace, create_user):
+    """Create a test project with the requesting user as an active member."""
+    project = Project.objects.create(
+        name="Test Project",
+        identifier="TP",
+        workspace=workspace,
+        created_by=create_user,
+    )
+    ProjectMember.objects.create(
+        project=project,
+        member=create_user,
+        role=20,  # Admin
+        is_active=True,
+    )
+    return project
+
+
+@pytest.fixture
+def state(db, workspace, project):
+    return State.objects.create(
+        name="Todo",
+        project=project,
+        workspace=workspace,
+        group="backlog",
+        default=True,
+    )
+
+
+@pytest.fixture
+def issue(db, workspace, project, state, create_user):
+    return Issue.objects.create(
+        name="Test Issue",
+        workspace=workspace,
+        project=project,
+        state=state,
+        created_by=create_user,
+    )
+
+
+@pytest.mark.contract
+class TestIssueListOrderByInjection:
+    """Regression tests for GHSA-p885-6jpg-cr2p on the work-item list
+    endpoint: GET /api/v1/workspaces/{slug}/projects/{project_id}/issues/.
+
+    The raw ``order_by`` query parameter fell through the endpoint's hardcoded
+    branch logic to ``issue_queryset.order_by(order_by_param)``, letting an
+    attacker order by sensitive related columns (blind oracle) or crash the
+    endpoint with an unknown field (HTTP 500). The fix sanitizes the parameter
+    against ISSUE_ORDER_BY_ALLOWLIST before the branch logic runs.
+    """
+
+    def get_url(self, workspace_slug, project_id):
+        return f"/api/v1/workspaces/{workspace_slug}/projects/{project_id}/issues/"
+
+    @pytest.mark.django_db
+    def test_invalid_order_by_does_not_500(self, api_key_client, workspace, project, issue):
+        """Unknown field used to raise FieldError → HTTP 500; now sanitized to
+        the safe default and returns 200 (DoS half of the advisory)."""
+        url = self.get_url(workspace.slug, project.id)
+        response = api_key_client.get(url, {"order_by": "not_a_field"})
+
+        assert response.status_code == status.HTTP_200_OK, f"Got {response.status_code}: {response.data!r}"
+
+    @pytest.mark.django_db
+    def test_relational_order_by_injection_does_not_500(self, api_key_client, workspace, project, issue):
+        """Ordering by a related-table column (``created_by__password``) used to
+        reach ``.order_by()`` raw, forming a blind ordering oracle. It is now
+        neutralized to the safe default. (Deterministic neutralization is
+        asserted in tests/unit/utils/test_order_by_sanitize.py.)"""
+        url = self.get_url(workspace.slug, project.id)
+        response = api_key_client.get(url, {"order_by": "created_by__password"})
+
+        assert response.status_code == status.HTTP_200_OK, f"Got {response.status_code}: {response.data!r}"
+
+    @pytest.mark.django_db
+    def test_legitimate_order_by_still_works(self, api_key_client, workspace, project, issue):
+        """A valid, allowlisted ordering value continues to return 200 —
+        the sanitizer must not break legitimate ordering."""
+        url = self.get_url(workspace.slug, project.id)
+
+        for value in ["-created_at", "priority", "state__group", "sequence_id"]:
+            response = api_key_client.get(url, {"order_by": value})
+            assert response.status_code == status.HTTP_200_OK, (
+                f"order_by={value!r} got {response.status_code}: {response.data!r}"
+            )

--- a/apps/api/plane/tests/contract/api/test_projects.py
+++ b/apps/api/plane/tests/contract/api/test_projects.py
@@ -183,6 +183,51 @@ class TestProjectListCreateAPIEndpoint:
         # transaction.on_commit() callbacks only fire on a successful commit.
         mocked_activity.delay.assert_not_called()
 
+    @pytest.mark.django_db
+    def test_list_invalid_order_by_does_not_500(self, api_key_client, workspace, create_user):
+        """Regression for GHSA-p885-6jpg-cr2p (DoS half).
+
+        An unknown ``order_by`` field used to reach Django's ``.order_by()``
+        raw and raise a ``FieldError`` → HTTP 500. After the fix the value is
+        sanitized to the safe default and the endpoint returns 200.
+        """
+        Project.objects.create(
+            name="Ordered Project",
+            identifier="OP",
+            workspace=workspace,
+            created_by=create_user,
+        )
+        ProjectMember.objects.create(project=Project.objects.get(identifier="OP"), member=create_user, role=20)
+
+        url = self.get_url(workspace.slug)
+        response = api_key_client.get(url, {"order_by": "not_a_field"})
+
+        assert response.status_code == status.HTTP_200_OK, f"Got {response.status_code}: {response.data!r}"
+
+    @pytest.mark.django_db
+    def test_list_relational_order_by_injection_does_not_500(self, api_key_client, workspace, create_user):
+        """Regression for GHSA-p885-6jpg-cr2p (relational-traversal leak half).
+
+        Ordering by a related-table column (``created_by__password``) used to
+        reach ``.order_by()`` raw, forming a blind ordering oracle. After the
+        fix the value is not in ``PROJECT_ORDER_BY_ALLOWLIST`` and is replaced
+        with the safe default, so it can no longer influence SQL ordering.
+        (That the payload maps to the default is asserted deterministically in
+        tests/unit/utils/test_order_by_sanitize.py.)
+        """
+        project = Project.objects.create(
+            name="Oracle Project",
+            identifier="OR",
+            workspace=workspace,
+            created_by=create_user,
+        )
+        ProjectMember.objects.create(project=project, member=create_user, role=20)
+
+        url = self.get_url(workspace.slug)
+        response = api_key_client.get(url, {"order_by": "created_by__password"})
+
+        assert response.status_code == status.HTTP_200_OK, f"Got {response.status_code}: {response.data!r}"
+
     @pytest.mark.django_db(transaction=True)
     def test_response_still_201_when_broker_dispatch_fails(self, api_key_client, workspace, create_user):
         """If model_activity.delay raises *after* the atomic block has

--- a/apps/api/plane/tests/contract/app/test_cycle_issue_app.py
+++ b/apps/api/plane/tests/contract/app/test_cycle_issue_app.py
@@ -1,0 +1,176 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Regression test for GHSA-4w5x-wc9w-f47x.
+
+CycleIssueViewSet.create reassigned any CycleIssue row matched by issue_id to
+the caller's cycle without scoping the lookup to the caller's
+workspace/project. An ADMIN/MEMBER of their own project could therefore pass a
+work-item UUID from a *different* tenant and silently evict the victim's work
+item from the victim's cycle (cross-tenant write / BOLA).
+"""
+
+from uuid import uuid4
+
+import pytest
+from rest_framework import status
+
+from plane.db.models import (
+    Cycle,
+    CycleIssue,
+    Issue,
+    Project,
+    ProjectMember,
+    State,
+    User,
+    Workspace,
+    WorkspaceMember,
+)
+
+
+@pytest.fixture
+def attacker_project(db, workspace, create_user):
+    """Project + cycle in the attacker's own workspace; attacker is admin."""
+    project = Project.objects.create(
+        name="Attacker Project",
+        identifier="ATK",
+        workspace=workspace,
+        created_by=create_user,
+    )
+    ProjectMember.objects.create(project=project, member=create_user, role=20, is_active=True)
+    return project
+
+
+@pytest.fixture
+def attacker_cycle(db, workspace, attacker_project, create_user):
+    return Cycle.objects.create(
+        name="Attacker Cycle",
+        project=attacker_project,
+        workspace=workspace,
+        owned_by=create_user,
+    )
+
+
+@pytest.fixture
+def victim_tenant(db):
+    """A completely separate workspace/project/cycle owning a work item that is
+    already assigned to the victim's own cycle."""
+    uid = uuid4().hex[:8]
+    victim_user = User.objects.create(
+        email=f"victim-{uid}@plane.so",
+        username=f"victim_{uid}",
+        first_name="Victim",
+        last_name="User",
+    )
+    victim_ws = Workspace.objects.create(name="Victim WS", owner=victim_user, slug=f"victim-{uid}")
+    WorkspaceMember.objects.create(workspace=victim_ws, member=victim_user, role=20)
+    victim_project = Project.objects.create(
+        name="Victim Project",
+        identifier="VIC",
+        workspace=victim_ws,
+        created_by=victim_user,
+    )
+    ProjectMember.objects.create(project=victim_project, member=victim_user, role=20, is_active=True)
+    state = State.objects.create(
+        name="Todo", project=victim_project, workspace=victim_ws, group="backlog", default=True
+    )
+    victim_issue = Issue.objects.create(
+        name="Victim Issue",
+        workspace=victim_ws,
+        project=victim_project,
+        state=state,
+        created_by=victim_user,
+    )
+    victim_cycle = Cycle.objects.create(
+        name="Victim Cycle", project=victim_project, workspace=victim_ws, owned_by=victim_user
+    )
+    cycle_issue = CycleIssue.objects.create(
+        issue=victim_issue,
+        cycle=victim_cycle,
+        project=victim_project,
+        workspace=victim_ws,
+        created_by=victim_user,
+    )
+    return {
+        "issue": victim_issue,
+        "cycle": victim_cycle,
+        "cycle_issue": cycle_issue,
+    }
+
+
+@pytest.mark.contract
+class TestCycleIssueCrossTenantBOLA:
+    def get_url(self, workspace_slug, project_id, cycle_id):
+        return f"/api/workspaces/{workspace_slug}/projects/{project_id}/cycles/{cycle_id}/cycle-issues/"
+
+    @pytest.mark.django_db
+    def test_foreign_tenant_cycle_issue_not_reassigned(
+        self, session_client, workspace, attacker_project, attacker_cycle, victim_tenant
+    ):
+        """The attacker adds a foreign-tenant work-item UUID to their own cycle.
+
+        Before the fix the victim's CycleIssue row was reassigned to the
+        attacker's cycle (cycle_id flipped). After the fix the foreign row is
+        excluded from the lookup, so it stays in the victim's cycle.
+        """
+        victim_issue = victim_tenant["issue"]
+        victim_cycle = victim_tenant["cycle"]
+        victim_cycle_issue = victim_tenant["cycle_issue"]
+
+        url = self.get_url(workspace.slug, attacker_project.id, attacker_cycle.id)
+        response = session_client.post(url, {"issues": [str(victim_issue.id)]}, format="json")
+
+        # The endpoint reports success regardless; the security property is that
+        # the foreign row is untouched.
+        assert response.status_code in (status.HTTP_201_CREATED, status.HTTP_200_OK), (
+            f"Got {response.status_code}: {response.data!r}"
+        )
+
+        victim_cycle_issue.refresh_from_db()
+        assert victim_cycle_issue.cycle_id == victim_cycle.id, (
+            "Cross-tenant reassignment: victim's CycleIssue was moved to the attacker's cycle"
+        )
+        # No CycleIssue for the victim's issue should exist under the attacker's cycle.
+        assert not CycleIssue.objects.filter(
+            cycle_id=attacker_cycle.id, issue_id=victim_issue.id
+        ).exists()
+
+    @pytest.mark.django_db
+    def test_same_tenant_reassignment_still_works(
+        self, session_client, workspace, attacker_project, attacker_cycle, create_user
+    ):
+        """A legitimate reassignment within the caller's own project must still
+        move the issue into the target cycle — the scope guard must not break
+        the normal flow."""
+        state = State.objects.create(
+            name="Todo", project=attacker_project, workspace=workspace, group="backlog", default=True
+        )
+        own_issue = Issue.objects.create(
+            name="Own Issue",
+            workspace=workspace,
+            project=attacker_project,
+            state=state,
+            created_by=create_user,
+        )
+        old_cycle = Cycle.objects.create(
+            name="Old Cycle", project=attacker_project, workspace=workspace, owned_by=create_user
+        )
+        own_cycle_issue = CycleIssue.objects.create(
+            issue=own_issue,
+            cycle=old_cycle,
+            project=attacker_project,
+            workspace=workspace,
+            created_by=create_user,
+        )
+
+        url = self.get_url(workspace.slug, attacker_project.id, attacker_cycle.id)
+        response = session_client.post(url, {"issues": [str(own_issue.id)]}, format="json")
+
+        assert response.status_code in (status.HTTP_201_CREATED, status.HTTP_200_OK), (
+            f"Got {response.status_code}: {response.data!r}"
+        )
+        own_cycle_issue.refresh_from_db()
+        assert own_cycle_issue.cycle_id == attacker_cycle.id, (
+            "Legitimate same-project reassignment must still move the issue to the target cycle"
+        )

--- a/apps/api/plane/tests/unit/utils/test_order_by_sanitize.py
+++ b/apps/api/plane/tests/unit/utils/test_order_by_sanitize.py
@@ -1,0 +1,132 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Regression tests for order_by injection on the external REST API.
+
+Covers GHSA-p885-6jpg-cr2p: the external-API project list and work-item
+list endpoints passed a raw ``order_by`` query parameter to Django's
+``.order_by()``. Because Django resolves ``__``-separated relational paths,
+an attacker could order by sensitive columns on related tables
+(``created_by__password``, ``created_by__token``, ``created_by__email``,
+``workspace__owner__password`` ...) to build a blind ordering oracle, or
+crash the endpoint (HTTP 500) with an unknown field.
+
+The fix routes both endpoints through ``sanitize_order_by()`` with the
+appropriate allowlist. These tests assert that the two allowlists used by
+those endpoints neutralise the disclosed attack strings and preserve every
+legitimate ordering value.
+"""
+
+import pytest
+
+from plane.utils.order_queryset import (
+    ISSUE_ORDER_BY_ALLOWLIST,
+    PROJECT_ORDER_BY_ALLOWLIST,
+    sanitize_order_by,
+)
+
+# Relational-traversal payloads from the advisory PoC plus common variants.
+INJECTION_PAYLOADS = [
+    "created_by__password",
+    "created_by__token",
+    "created_by__email",
+    "-created_by__password",
+    "workspace__owner__password",
+    "updated_by__password",
+    "not_a_field",
+    "id; drop table",
+    "--created_at",  # malformed double-dash prefix
+]
+
+
+@pytest.mark.unit
+class TestProjectOrderBySanitization:
+    """order_by sanitization for GET /api/v1/workspaces/<slug>/projects/."""
+
+    DEFAULT = "sort_order"
+
+    @pytest.mark.parametrize("payload", INJECTION_PAYLOADS)
+    def test_injection_payload_falls_back_to_default(self, payload):
+        """Any non-allowlisted / relational value is replaced with the
+        endpoint's safe default instead of reaching .order_by()."""
+        assert (
+            sanitize_order_by(payload, PROJECT_ORDER_BY_ALLOWLIST, default=self.DEFAULT)
+            == self.DEFAULT
+        )
+
+    @pytest.mark.parametrize(
+        "value",
+        ["created_at", "updated_at", "name", "network", "sort_order"],
+    )
+    def test_legitimate_ascending_values_pass_through(self, value):
+        assert (
+            sanitize_order_by(value, PROJECT_ORDER_BY_ALLOWLIST, default=self.DEFAULT)
+            == value
+        )
+
+    @pytest.mark.parametrize(
+        "value",
+        ["-created_at", "-updated_at", "-name", "-network", "-sort_order"],
+    )
+    def test_legitimate_descending_values_pass_through(self, value):
+        assert (
+            sanitize_order_by(value, PROJECT_ORDER_BY_ALLOWLIST, default=self.DEFAULT)
+            == value
+        )
+
+    def test_empty_value_uses_default(self):
+        assert (
+            sanitize_order_by("", PROJECT_ORDER_BY_ALLOWLIST, default=self.DEFAULT)
+            == self.DEFAULT
+        )
+
+
+@pytest.mark.unit
+class TestIssueOrderBySanitization:
+    """order_by sanitization for
+    GET /api/v1/workspaces/<slug>/projects/<project_id>/issues/."""
+
+    DEFAULT = "-created_at"
+
+    @pytest.mark.parametrize("payload", INJECTION_PAYLOADS)
+    def test_injection_payload_falls_back_to_default(self, payload):
+        assert (
+            sanitize_order_by(payload, ISSUE_ORDER_BY_ALLOWLIST, default=self.DEFAULT)
+            == self.DEFAULT
+        )
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "created_at",
+            "updated_at",
+            "sequence_id",
+            "sort_order",
+            "target_date",
+            "start_date",
+            "priority",
+            "state__name",
+            "state__group",
+            "assignees__first_name",
+            "labels__name",
+        ],
+    )
+    def test_legitimate_values_pass_through(self, value):
+        """Every value the endpoint's branch logic special-cases must survive
+        sanitization, otherwise legitimate ordering would silently break."""
+        assert (
+            sanitize_order_by(value, ISSUE_ORDER_BY_ALLOWLIST, default=self.DEFAULT)
+            == value
+        )
+        # Descending variant is equally valid.
+        assert (
+            sanitize_order_by(f"-{value}", ISSUE_ORDER_BY_ALLOWLIST, default=self.DEFAULT)
+            == f"-{value}"
+        )
+
+    def test_default_is_preserved_for_missing_param(self):
+        assert (
+            sanitize_order_by(None, ISSUE_ORDER_BY_ALLOWLIST, default=self.DEFAULT)
+            == self.DEFAULT
+        )


### PR DESCRIPTION
## Summary

Fixes a cross-tenant write BOLA in `CycleIssueViewSet.create` (**GHSA-4w5x-wc9w-f47x**, medium).

`POST /api/workspaces/<slug>/projects/<project_id>/cycles/<cycle_id>/cycle-issues/` looked up work items "already in another cycle" with:

```python
CycleIssue.objects.filter(~Q(cycle_id=cycle_id), issue_id__in=issues)
```

This lookup was **not scoped to the caller's workspace/project**. An ADMIN/MEMBER of their own project could pass a work-item UUID belonging to a *different* workspace/project and have that foreign `CycleIssue` row reassigned to their own cycle — silently evicting the victim's work item from the victim's cycle and orphaning the row (`project_id` = victim, `cycle_id` = attacker).

The adjacent *create* path in the same handler was already scoped (with an explicit `# prevent cross-tenant IDOR` comment, added for GHSA-933r); the reassignment path above it was missed. Same class as GHSA-933r-rxg8-f3h2.

## Fix

Scope the lookup to `workspace__slug=slug` + `project_id=project_id`, mirroring the adjacent create-path guard. Foreign-tenant rows are excluded from reassignment and are already dropped from the create path by the scoped `new_issues` query — so foreign issue IDs no longer produce any write.

## Tests

`tests/contract/app/test_cycle_issue_app.py`:
- **Cross-tenant:** attacker adds a foreign-tenant issue UUID to their cycle → the victim's `CycleIssue` stays in the victim's cycle, and no `CycleIssue` is created under the attacker's cycle. **Fail-before verified via `git stash`** (row was reassigned without the fix).
- **Same-tenant:** a legitimate reassignment within the caller's own project still moves the issue to the target cycle (guard doesn't break the normal flow).

## Verification
- `ruff check` clean
- `python manage.py check` clean
- 2 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sorting safety in issue and project lists so invalid or unsafe `order_by` values no longer cause errors.
  * Cross-cycle issue updates now stay within the correct workspace and project, preventing unexpected reassignment across tenants.
  * Added regression coverage to ensure valid sorting options still work as expected while unsafe inputs are handled gracefully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->