### PR TITLE
fix: hydration mismatch (React #418) in root HydrateFallback

### DIFF
--- a/apps/web/app/root.tsx
+++ b/apps/web/app/root.tsx
@@ -5,6 +5,7 @@
  */
 
 import type { ReactNode } from "react";
+import { useEffect, useState } from "react";
 import Script from "next/script";
 import { Links, Meta, Outlet, Scripts } from "react-router";
 import type { LinksFunction } from "react-router";
@@ -135,8 +136,18 @@ export default function Root() {
 export function HydrateFallback() {
   const { resolvedTheme } = useTheme();
 
-  // if we are on the server or the theme is not resolved, return an empty div
-  if (typeof window === "undefined" || resolvedTheme === undefined) return <div />;
+  // The SPA build (ssr: false) prerenders this component on the server, where
+  // `typeof window === "undefined"` yields an empty <div />. On the first
+  // client (hydration) render, next-themes has already resolved the theme
+  // synchronously from localStorage, so rendering the spinner subtree here
+  // mismatches the prerendered HTML — React throws error #418 on every page
+  // load and re-renders the shell client-side. Gate on `mounted` so the
+  // hydration pass renders the same empty <div /> as the prerender; the
+  // spinner appears immediately after mount.
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+
+  if (!mounted || resolvedTheme === undefined) return <div />;
 
   return (
     <div className="relative flex h-screen w-full items-center justify-center bg-canvas">


### PR DESCRIPTION
### Description

Every page load of the web app logs `Minified React error #418` (hydration mismatch) once, and React discards the prerendered shell and re-renders it client-side.

**Root cause:** with `ssr: false` (SPA mode), react-router prerenders `HydrateFallback` at build time, where `typeof window === "undefined"` → the guard returns an **empty `<div />`**. On the first client (hydration) render, however, `next-themes` resolves `resolvedTheme` **synchronously** from localStorage (its provider reads it in a `useState` initializer), so the guard falls through and renders the full spinner subtree. Server HTML ≠ first client render → React #418 by construction, on every page.

**Fix:** gate the spinner behind a `mounted` flag (the canonical next-themes SSR/SPA pattern). The hydration pass now renders the same empty `<div />` as the prerender; the spinner appears immediately after mount. The `resolvedTheme === undefined` guard is preserved.

`suppressHydrationWarning` was considered and rejected: it only silences attribute/text warnings on a single element — it neither covers a structurally different subtree nor prevents the client-side re-render.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### Screenshots and Media (if applicable)

Console before: one `Minified React error #418; visit https://reactjs.org/docs/error-decoder.html?invariant=418…` per page load (dev mode: `Warning: Expected server HTML to contain a matching <div> in <div>` pointing at `LogoSpinner` inside `HydrateFallback`). After: clean console.

### Test Scenarios

- Production build (`ssr: false` prerender) served and loaded on multiple routes (workspace home, project issues): React #418 no longer fires; zero console errors; pages boot normally.
- Dev mode: the hydration warning at `LogoSpinner`/`HydrateFallback` is gone.
- Spinner behaviour: still renders during app bootstrap once mounted (light/dark variants unaffected); on very fast hydration the fallback unmounts before painting the spinner — strictly less flash than before.
- StrictMode double-invoked effect is idempotent.

### References

None — happy to link an issue if you'd like one filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LDA1JjtePo7qPyE3CiQcVv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved theme loading during hydration to reduce visual mismatches between server-rendered and client-rendered content.
  * Delayed rendering until the app is mounted and a theme is available, helping prevent flicker or inconsistent initial display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->