### PR TITLE
fix(web): show correct validation error in quick add toast (Issue #9329)

### DIFF
--- a/apps/web/core/components/issues/issue-layouts/quick-add/root.tsx
+++ b/apps/web/core/components/issues/issue-layouts/quick-add/root.tsx
@@ -126,7 +126,26 @@ export const QuickAddIssueRoot = observer(function QuickAddIssueRoot(props: TQui
         },
         error: {
           title: t("common.error.label"),
-          message: (err) => err?.message || t("common.error.message"),
+          message: (err) => {
+            const getErrorMessage = (error: any): string | undefined => {
+              if (!error) return undefined;
+              if (typeof error === "string") return error;
+              if (Array.isArray(error)) {
+                return getErrorMessage(error[0]);
+              }
+              if (typeof error === "object") {
+                if (error.message && typeof error.message === "string") {
+                  return error.message;
+                }
+                const keys = Object.keys(error);
+                if (keys.length > 0) {
+                  return getErrorMessage(error[keys[0]]);
+                }
+              }
+              return undefined;
+            };
+            return getErrorMessage(err) || t("common.error.message");
+          },
         },
       });
 


### PR DESCRIPTION
### Description
When submitting a work item/issue using the inline quick-add input with an invalid title (e.g., exceeding 255 characters), the error toast displays a generic fallback message: `"Some error occurred. Please try again."` instead of the actual validation error returned by the Django backend.

**Root cause:** Django returns field-specific validation errors as a nested dictionary (e.g., `{"name": ["Ensure this field has no more than 255 characters."]}`). The quick-add error handler was directly reading error values as single strings or string arrays, failing to parse dictionary values and falling back to the generic message.

**Fix:** Updated the validation error helper in `apps/web/core/components/issues/issue-layouts/quick-add/root.tsx` to check if the error is a dictionary. If it is, it parses the keys using `Object.keys()` and extracts the first error message dynamically, displaying it in the toast.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
**Before:**
An error toast popped up saying: `"Some error occurred. Please try again."`

**After:**
<img width="1601" height="715" alt="Screenshot 2026-07-03 185814" src="https://github.com/user-attachments/assets/78685997-4bf2-4f04-8b41-5a41124f4656" />

Detailed validation error message showing `"Ensure this field has no more than 255 characters."` in the toast notification instead of the generic error fallback.

### Test Scenarios 
1. Navigate to the list or board layout of a project.
2. Click `+ New work item` under any group to open the inline quick-add input.
3. Paste a long title (>255 characters) and press Enter to submit.
4. **Before:** The toast output showed: `"Some error occurred. Please try again."`
5. **After:** The toast output now correctly displays: `"Ensure this field has no more than 255 characters."`

### References
Fixes #9329


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the error handling for quick-add issue submissions to display more meaningful, user-facing validation details.
  * The app now extracts a message from different error shapes (plain text, nested lists, or structured objects) instead of relying on a single `message` field.
  * If no specific message can be determined, it continues to fall back to the standard generic error message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->