### PR TITLE
fix(api): prevent race condition when creating logs directory (Issue #9352)

### DIFF
--- a/apps/api/plane/settings/local.py
+++ b/apps/api/plane/settings/local.py
@@ -34,8 +34,7 @@ MEDIA_ROOT = os.path.join(BASE_DIR, "uploads")  # noqa
 
 LOG_DIR = os.path.join(BASE_DIR, "logs")  # noqa
 
-if not os.path.exists(LOG_DIR):
-    os.makedirs(LOG_DIR)
+os.makedirs(LOG_DIR, exist_ok=True)
 
 LOGGING = {
     "version": 1,


### PR DESCRIPTION
### Description
Fixes a startup crash in the local Docker environment where backend containers (`api`, `migrator`, `worker`, `beat-worker`) concurrently load Django configurations and trigger a race condition on directory creation.

**Root cause:** Multiple Django processes checking `if not os.path.exists(LOG_DIR)` simultaneously on boot, resulting in a slower process throwing a `FileExistsError` on `os.makedirs(LOG_DIR)`.

**Fix:** Changed `os.makedirs(LOG_DIR)` to use `exist_ok=True` to make the directory creation thread-safe and prevent the startup crash.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
N/A (Backend startup fix)

### Test Scenarios 
1. Perform a clean docker-compose build (ensure the logs directory doesn't exist locally).
2. Run `docker compose -f docker-compose-local.yml up -d --build`.
3. Check container logs (`docker logs plane-migrator-1` and `docker logs plane-api-1`).
4. **Before:** Containers exit with `FileExistsError: [Errno 17] File exists: '/code/plane/logs'`.
5. **After:** All containers boot up, wait for database migrations, and start successfully without any crashes.

### References
Fixes #9352


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app startup reliability by ensuring the log directory is created automatically when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->