### PR TITLE
fix: add requestIdleCallback polyfill at app entry for iOS WebKit (Fixes #9231)

### DIFF
--- a/apps/admin/app/entry.client.tsx
+++ b/apps/admin/app/entry.client.tsx
@@ -8,6 +8,19 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 import { HydratedRouter } from "react-router/dom";
 
+if (typeof window !== "undefined" && typeof window.requestIdleCallback !== "function") {
+  window.requestIdleCallback = (cb: any) => {
+    const start = Date.now();
+    return setTimeout(() => {
+      cb({
+        didTimeout: false,
+        timeRemaining: () => Math.max(0, 50 - (Date.now() - start)),
+      });
+    }, 1) as any;
+  };
+  window.cancelIdleCallback = (id: any) => clearTimeout(id);
+}
+
 startTransition(() => {
   hydrateRoot(
     document,

--- a/apps/space/app/entry.client.tsx
+++ b/apps/space/app/entry.client.tsx
@@ -8,6 +8,19 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 import { HydratedRouter } from "react-router/dom";
 
+if (typeof window !== "undefined" && typeof window.requestIdleCallback !== "function") {
+  window.requestIdleCallback = (cb: any) => {
+    const start = Date.now();
+    return setTimeout(() => {
+      cb({
+        didTimeout: false,
+        timeRemaining: () => Math.max(0, 50 - (Date.now() - start)),
+      });
+    }, 1) as any;
+  };
+  window.cancelIdleCallback = (id: any) => clearTimeout(id);
+}
+
 startTransition(() => {
   hydrateRoot(
     document,

--- a/apps/web/app/entry.client.tsx
+++ b/apps/web/app/entry.client.tsx
@@ -12,6 +12,18 @@ import polyfills from "@/lib/polyfills";
 
 void polyfills;
 
+if (typeof window !== "undefined" && typeof window.requestIdleCallback !== "function") {
+  window.requestIdleCallback = (cb: any) => {
+    const start = Date.now();
+    return setTimeout(() => {
+      cb({
+        didTimeout: false,
+        timeRemaining: () => Math.max(0, 50 - (Date.now() - start)),
+      });
+    }, 1) as any;
+  };
+  window.cancelIdleCallback = (id: any) => clearTimeout(id);
+}
 startTransition(() => {
   hydrateRoot(
     document,


### PR DESCRIPTION
### Description
This PR fixes a bug where the `gantt-layout-loader` chunk throws an error on iOS WebKit devices (Safari, iOS Chrome, iOS Firefox) due to the absence of the native `window.requestIdleCallback` API. 

The missing API caused the React Error Boundary to catch the thrown error, resulting in a generic "Looks like something went wrong" page whenever users navigated to project views containing the layout loader on iPad/iOS devices.

### Changes Made
- Added a fallback polyfill for `window.requestIdleCallback` and `window.cancelIdleCallback` directly at the app entry points (`apps/web/app/entry.client.tsx`, `apps/admin/app/entry.client.tsx`, `apps/space/app/entry.client.tsx`).
- The polyfill safely checks for the function's existence and uses `setTimeout` to mimic idle time deferral for layout measurement, completely preventing the crash on iOS WebKit environments.

Fixes #9231


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browser compatibility by adding a fallback for idle callback scheduling when the native browser support is unavailable.
  * This helps pages load and hydrate more reliably in more environments without changing the app experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->