### PR TITLE
fix(api): register logger and webhook background tasks in CELERY_IMPORTS (Solves Issue #9357)

### DIFF
--- a/apps/api/plane/settings/common.py
+++ b/apps/api/plane/settings/common.py
@@ -348,6 +348,9 @@ CELERY_IMPORTS = (
     # issue version tasks
     "plane.bgtasks.issue_version_sync",
     "plane.bgtasks.issue_description_version_sync",
+    # background tasks
+    "plane.bgtasks.logger_task",
+    "plane.bgtasks.webhook_task",
 )
 
 FILE_SIZE_LIMIT = int(os.environ.get("FILE_SIZE_LIMIT", 5242880))

--- a/apps/api/plane/tests/unit/settings/test_celery_imports.py
+++ b/apps/api/plane/tests/unit/settings/test_celery_imports.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""
+Unit tests for Celery task imports configuration.
+"""
+
+import pytest
+from django.conf import settings
+from celery import current_app
+
+
+@pytest.mark.unit
+class TestCeleryImports:
+    def test_celery_imports_contains_logger_and_webhook_tasks(self):
+        assert "plane.bgtasks.logger_task" in settings.CELERY_IMPORTS
+        assert "plane.bgtasks.webhook_task" in settings.CELERY_IMPORTS
+
+    def test_logger_and_webhook_tasks_are_registered(self):
+        # Force celery to import registered modules
+        current_app.loader.import_default_modules()
+
+        assert "plane.bgtasks.logger_task.process_logs" in current_app.tasks
+        assert "plane.bgtasks.webhook_task.webhook_send_task" in current_app.tasks


### PR DESCRIPTION
### Description
Fixes a production and self-hosted issue where the Celery worker rejects and discards all API activity log tasks (`plane.bgtasks.logger_task.process_logs`) enqueued by `APITokenLogMiddleware`, returning `Received unregistered task` / `KeyError`.

**Root cause:** The `plane.bgtasks.logger_task` and `plane.bgtasks.webhook_task` modules were not loaded by Celery at startup, preventing their tasks from being registered on the Celery application.

**Fix:** 
1. Added both background task modules explicitly to the `CELERY_IMPORTS` tuple in `apps/api/plane/settings/common.py`.
2. Created a new unit test in `apps/api/plane/tests/unit/settings/test_celery_imports.py` to check that both modules are declared in settings and successfully registered in the Celery registry.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
N/A (Backend task registration fix)

### Test Scenarios 
1. Verify settings: Run unit tests to check that task files are imported by default loader and registered on the Celery application.
2. In production/worker logs, verify that enqueuing `process_logs` tasks does not result in unregistered task errors.

### References
Fixes #9357


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved background task loading so event logging and webhook processing are available more reliably.
  * Added test coverage to verify the expected background tasks are registered and ready to run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->