### PR TITLE
fix(api): fall back to WEB_URL when Redis origin key is missing (#9354)

### DIFF
--- a/apps/api/plane/bgtasks/email_notification_task.py
+++ b/apps/api/plane/bgtasks/email_notification_task.py
@@ -15,6 +15,7 @@ from django.template.loader import render_to_string
 
 # Django imports
 from django.utils import timezone
+from django.conf import settings
 
 # Module imports
 from plane.db.models import EmailNotificationLog, Issue, User
@@ -163,9 +164,12 @@ def send_email_notification(issue_id, notification_data, receiver_id, email_noti
             ri = redis_instance()
             base_api = ri.get(str(issue_id)).decode() if ri.get(str(issue_id)) else None
 
-            # Skip if base api is not present
+            # Fall back to the configured web URL if the cached origin is missing
             if not base_api:
-                return
+                logging.getLogger("plane.worker").warning(
+                    f"Redis origin key missing for issue {issue_id}; falling back to WEB_URL for email notification links"
+                )
+                base_api = settings.WEB_URL
 
             data = create_payload(notification_data=notification_data)
 

--- a/apps/api/plane/bgtasks/email_notification_task.py
+++ b/apps/api/plane/bgtasks/email_notification_task.py
@@ -166,10 +166,16 @@ def send_email_notification(issue_id, notification_data, receiver_id, email_noti
 
             # Fall back to the configured web URL if the cached origin is missing
             if not base_api:
-                logging.getLogger("plane.worker").warning(
-                    f"Redis origin key missing for issue {issue_id}; falling back to WEB_URL for email notification links"
-                )
                 base_api = settings.WEB_URL
+                if not base_api:
+                    logging.getLogger("plane.worker").error(
+                        f"Redis origin key missing for issue {issue_id} and settings.WEB_URL is also unset; "
+                        "email notification links may be malformed"
+                    )
+                else:
+                    logging.getLogger("plane.worker").warning(
+                        f"Redis origin key missing for issue {issue_id}; falling back to WEB_URL for email notification links"
+                    )
 
             data = create_payload(notification_data=notification_data)
 


### PR DESCRIPTION
### Description
`send_email_notification` in `apps/api/plane/bgtasks/email_notification_task.py` silently dropped email notifications, while still reporting the Celery task as successful, whenever the Redis-cached "origin" key for an issue was missing. This happens whenever Redis restarts/evicts the key, more than 10 minutes (the key's TTL) pass before the email task runs, or the triggering activity was queued without an origin at all.

This PR replaces the silent early `return` with a fallback to `settings.WEB_URL` for constructing links in the email, and adds a `logging.warning` call so the condition is observable in logs instead of failing silently.

### Type of Change
Bug fix (non-breaking change which fixes an issue).

### Screenshots and Media (if applicable)
Not applicable, this is a backend logic change with no UI impact.

### Test Scenarios
Manually traced the code path: with the Redis key absent, `base_api` now falls back to `settings.WEB_URL` and a warning is logged instead of the function returning early. Confirmed the rest of `send_email_notification` (payload creation, email rendering, and sending) proceeds unchanged after the fallback.

### References
Fixes #9354

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Email notifications now still generate links when the cached API origin is unavailable.
  * Added a fallback to the main web address and improved logging (warning/error) instead of stopping the notification flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->