### PR TITLE
fix(api): annotate WorkspaceModulesEndpoint to avoid per-row lookups (N+1)

### DIFF
--- a/apps/api/plane/app/views/workspace/module.py
+++ b/apps/api/plane/app/views/workspace/module.py
@@ -3,7 +3,21 @@
 # See the LICENSE file for details.
 
 # Django imports
-from django.db.models import Prefetch, Q, Count
+from django.contrib.postgres.aggregates import ArrayAgg
+from django.contrib.postgres.fields import ArrayField
+from django.db.models import (
+    Count,
+    Exists,
+    FloatField,
+    OuterRef,
+    Prefetch,
+    Q,
+    Subquery,
+    Sum,
+    UUIDField,
+    Value,
+)
+from django.db.models.functions import Cast, Coalesce
 
 # Third party modules
 from rest_framework import status
@@ -11,7 +25,7 @@ from rest_framework.response import Response
 
 # Module imports
 from plane.app.views.base import BaseAPIView
-from plane.db.models import Module, ModuleLink
+from plane.db.models import Issue, Module, ModuleLink, UserFavorite
 from plane.app.permissions import WorkspaceViewerPermission
 from plane.app.serializers.module import ModuleSerializer
 
@@ -20,6 +34,37 @@ class WorkspaceModulesEndpoint(BaseAPIView):
     permission_classes = [WorkspaceViewerPermission]
 
     def get(self, request, slug):
+        # Subqueries for the computed fields that ModuleSerializer exposes.
+        # These mirror ModuleViewSet.get_queryset (the project-scoped endpoint)
+        # so the same serializer is fed the same annotations here.
+        favorite_subquery = UserFavorite.objects.filter(
+            user=request.user,
+            entity_type="module",
+            entity_identifier=OuterRef("pk"),
+            workspace__slug=slug,
+        )
+        total_estimate_point = (
+            Issue.issue_objects.filter(
+                estimate_point__estimate__type="points",
+                issue_module__module_id=OuterRef("pk"),
+                issue_module__deleted_at__isnull=True,
+            )
+            .values("issue_module__module_id")
+            .annotate(total_estimate_points=Sum(Cast("estimate_point__value", FloatField())))
+            .values("total_estimate_points")[:1]
+        )
+        completed_estimate_point = (
+            Issue.issue_objects.filter(
+                estimate_point__estimate__type="points",
+                state__group="completed",
+                issue_module__module_id=OuterRef("pk"),
+                issue_module__deleted_at__isnull=True,
+            )
+            .values("issue_module__module_id")
+            .annotate(completed_estimate_points=Sum(Cast("estimate_point__value", FloatField())))
+            .values("completed_estimate_points")[:1]
+        )
+
         modules = (
             Module.objects.filter(workspace__slug=slug)
             .select_related("project")
@@ -31,6 +76,34 @@ class WorkspaceModulesEndpoint(BaseAPIView):
                 Prefetch(
                     "link_module",
                     queryset=ModuleLink.objects.select_related("module", "created_by"),
+                )
+            )
+            # Computed fields required by ModuleSerializer. Without these
+            # annotations `member_ids`, `is_favorite` and the estimate-point
+            # fields are resolved per row while serializing, which turns the
+            # list into an N+1 (one members lookup per module).
+            .annotate(is_favorite=Exists(favorite_subquery))
+            .annotate(
+                member_ids=Coalesce(
+                    ArrayAgg(
+                        "members__id",
+                        distinct=True,
+                        filter=Q(
+                            members__id__isnull=False,
+                            modulemember__deleted_at__isnull=True,
+                        ),
+                    ),
+                    Value([], output_field=ArrayField(UUIDField())),
+                )
+            )
+            .annotate(
+                total_estimate_points=Coalesce(
+                    Subquery(total_estimate_point), Value(0, output_field=FloatField())
+                )
+            )
+            .annotate(
+                completed_estimate_points=Coalesce(
+                    Subquery(completed_estimate_point), Value(0, output_field=FloatField())
                 )
             )
             .annotate(


### PR DESCRIPTION
### Summary

`WorkspaceModulesEndpoint` (`GET /api/workspaces/<slug>/modules/`) serializes with `ModuleSerializer`, but builds a queryset that omits several computed fields the serializer exposes: `member_ids`, `is_favorite`, `total_estimate_points`, and `completed_estimate_points`.

The project-scoped `ModuleViewSet.get_queryset()` already annotates all of these (`ArrayAgg` for `member_ids`, `Exists` for `is_favorite`, `Subquery` for estimate points). Because the workspace endpoint does not, those fields end up resolved **per row** during serialization — most notably a separate `members` lookup for every module in the workspace. On workspaces with many modules this makes the endpoint scale as **O(number of modules)** database queries instead of a constant number, and it's a common source of slow initial page loads.

### Fix

Annotate the same computed fields on the workspace queryset, mirroring the existing project-scoped `ModuleViewSet` implementation:

- `is_favorite` → `Exists(...)`
- `member_ids` → `Coalesce(ArrayAgg("members__id", distinct=True, filter=...), [])`
- `total_estimate_points` / `completed_estimate_points` → `Subquery(...)`

The existing issue-count annotations are left **unchanged** to preserve current behavior; this PR only adds the missing annotations so no serializer field falls back to a per-row lookup. Net effect: the module list is served in a constant number of queries regardless of module count.

### Notes

- No API contract change — the serialized fields are identical, just sourced from annotations instead of per-row access.
- Pattern is a direct port of `plane/app/views/module/base.py::ModuleViewSet.get_queryset`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Workspace modules now return more reliable favorite status, member lists, and progress/estimate totals in the UI.
  * Completed and total estimate points are now calculated more consistently for each module.
* **Performance**
  * Module details are now prepared more efficiently, helping reduce load time for workspace module views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->