### PR TITLE
feat(admin): User Management tab for admins

### DIFF
--- a/apps/admin/app/(all)/(dashboard)/users/page.tsx
+++ b/apps/admin/app/(all)/(dashboard)/users/page.tsx
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2023-present Plane Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { observer } from "mobx-react";
+import useSWR from "swr";
+import { Loader as LoaderIcon } from "lucide-react";
+// plane imports
+import { Button } from "@plane/propel/button";
+import { Loader } from "@plane/ui";
+// components
+import { PageWrapper } from "@/components/common/page-wrapper";
+import { UserListItem } from "@/components/users/list-item";
+// hooks
+import { useInstanceUser } from "@/hooks/store";
+// types
+import type { Route } from "./+types/page";
+
+const UserManagementPage = observer(function UserManagementPage(_props: Route.ComponentProps) {
+  // store
+  const { userIds, loader, paginationInfo, fetchUsers, fetchNextUsers } = useInstanceUser();
+  // derived values
+  const hasNextPage = paginationInfo?.next_page_results && paginationInfo?.next_cursor !== undefined;
+
+  // fetch data
+  useSWR("INSTANCE_USERS", () => fetchUsers());
+
+  return (
+    <PageWrapper
+      header={{
+        title: "Users on this instance",
+        description: "View all users and deactivate or reactivate their accounts.",
+      }}
+    >
+      {loader !== "init-loader" ? (
+        <>
+          <div className="flex items-center gap-2 text-16 font-medium pt-6 pb-2">
+            All users on this instance
+            <span className="text-tertiary">• {paginationInfo?.total_results ?? userIds.length}</span>
+            {loader && ["mutation", "pagination"].includes(loader) && (
+              <LoaderIcon className="h-4 w-4 animate-spin" />
+            )}
+          </div>
+          <div className="flex flex-col gap-3">
+            {userIds.map((userId) => (
+              <UserListItem key={userId} userId={userId} />
+            ))}
+          </div>
+          {hasNextPage && (
+            <div className="flex justify-center pt-4">
+              <Button
+                variant="link"
+                size="lg"
+                onClick={() => fetchNextUsers()}
+                disabled={loader === "pagination"}
+              >
+                Load more
+                {loader === "pagination" && <LoaderIcon className="h-3 w-3 animate-spin" />}
+              </Button>
+            </div>
+          )}
+        </>
+      ) : (
+        <Loader className="space-y-10 py-8">
+          <Loader.Item height="24px" width="20%" />
+          <Loader.Item height="64px" width="100%" />
+          <Loader.Item height="64px" width="100%" />
+          <Loader.Item height="64px" width="100%" />
+          <Loader.Item height="64px" width="100%" />
+        </Loader>
+      )}
+    </PageWrapper>
+  );
+});
+
+export const meta: Route.MetaFunction = () => [{ title: "User Management - God Mode" }];
+
+export default UserManagementPage;

--- a/apps/admin/app/(all)/(dashboard)/users/page.tsx
+++ b/apps/admin/app/(all)/(dashboard)/users/page.tsx
@@ -25,7 +25,7 @@ const UserManagementPage = observer(function UserManagementPage(_props: Route.Co
   const hasNextPage = paginationInfo?.next_page_results && paginationInfo?.next_cursor !== undefined;
 
   // fetch data
-  useSWR("INSTANCE_USERS", () => fetchUsers());
+  const { error } = useSWR("INSTANCE_USERS", () => fetchUsers());
 
   return (
     <PageWrapper
@@ -34,7 +34,11 @@ const UserManagementPage = observer(function UserManagementPage(_props: Route.Co
         description: "View all users and deactivate or reactivate their accounts.",
       }}
     >
-      {loader !== "init-loader" ? (
+      {error ? (
+        <p className="pt-6 text-sm text-danger-secondary">
+          Failed to load users. Please refresh the page.
+        </p>
+      ) : loader !== "init-loader" ? (
         <>
           <div className="flex items-center gap-2 text-16 font-medium pt-6 pb-2">
             All users on this instance

--- a/apps/admin/app/routes.ts
+++ b/apps/admin/app/routes.ts
@@ -21,6 +21,7 @@ export default [
     route("authentication/gitea", "./(all)/(dashboard)/authentication/gitea/page.tsx"),
     route("ai", "./(all)/(dashboard)/ai/page.tsx"),
     route("image", "./(all)/(dashboard)/image/page.tsx"),
+    route("users", "./(all)/(dashboard)/users/page.tsx"),
   ]),
   // Catch-all route for 404 handling - must be last
   route("*", "./components/404.tsx"),

--- a/apps/admin/components/common/header/core.ts
+++ b/apps/admin/components/common/header/core.ts
@@ -16,4 +16,5 @@ export const CORE_HEADER_SEGMENT_LABELS: Record<string, string> = {
   gitea: "Gitea",
   workspace: "Workspace",
   create: "Create",
+  users: "Users",
 };

--- a/apps/admin/components/users/list-item.tsx
+++ b/apps/admin/components/users/list-item.tsx
@@ -7,6 +7,7 @@
 import { useState } from "react";
 import { observer } from "mobx-react";
 import { getFileURL } from "@plane/utils";
+import { Button } from "@plane/propel/button";
 import { setPromiseToast } from "@plane/propel/toast";
 // hooks
 import { useInstanceUser, useUser } from "@/hooks/store";
@@ -85,18 +86,15 @@ export const UserListItem = observer(function UserListItem({ userId }: TUserList
           </div>
         </div>
       </div>
-      <button
-        type="button"
-        disabled={isUpdating || isCurrentUser}
+      <Button
+        variant={user.is_active ? "error-outline" : "secondary"}
+        size="base"
+        disabled={isCurrentUser}
+        loading={isUpdating}
         onClick={toggleActive}
-        className={`shrink-0 rounded-md px-3 py-1.5 text-12 font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${
-          user.is_active
-            ? "border border-red-400 text-red-500 hover:bg-red-500/10"
-            : "border border-green-500 text-green-600 hover:bg-green-500/10"
-        }`}
       >
         {user.is_active ? "Deactivate" : "Activate"}
-      </button>
+      </Button>
     </div>
   );
 });

--- a/apps/admin/components/users/list-item.tsx
+++ b/apps/admin/components/users/list-item.tsx
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) 2023-present Plane Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { useState } from "react";
+import { observer } from "mobx-react";
+import { getFileURL } from "@plane/utils";
+import { setPromiseToast } from "@plane/propel/toast";
+// hooks
+import { useInstanceUser, useUser } from "@/hooks/store";
+
+type TUserListItemProps = {
+  userId: string;
+};
+
+export const UserListItem = observer(function UserListItem({ userId }: TUserListItemProps) {
+  const [isUpdating, setIsUpdating] = useState(false);
+  // store hooks
+  const { getUserById, updateUser } = useInstanceUser();
+  const { currentUser } = useUser();
+  // derived values
+  const user = getUserById(userId);
+
+  if (!user) return null;
+
+  const isCurrentUser = currentUser?.id === userId;
+  const avatarSrc = user.avatar_url ? getFileURL(user.avatar_url) : undefined;
+
+  const toggleActive = async () => {
+    setIsUpdating(true);
+    const promise = updateUser(userId, { is_active: !user.is_active });
+    setPromiseToast(promise, {
+      loading: user.is_active ? "Deactivating user..." : "Activating user...",
+      success: {
+        title: "Success",
+        message: () => (user.is_active ? "User deactivated" : "User activated"),
+      },
+      error: {
+        title: "Error",
+        message: () => "Failed to update user",
+      },
+    });
+    await promise.catch(() => {}).finally(() => setIsUpdating(false));
+  };
+
+  return (
+    <div className="flex items-center justify-between gap-4 rounded-lg border border-subtle bg-layer-1 p-3 hover:border-subtle-1 hover:bg-layer-1-hover hover:shadow-raised-100">
+      <div className="flex items-center gap-4 min-w-0">
+        <span className="relative flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full bg-accent-primary text-11 font-medium uppercase text-on-color overflow-hidden">
+          {avatarSrc ? (
+            <img src={avatarSrc} className="h-full w-full object-cover" alt={user.display_name} />
+          ) : (
+            (user.display_name?.[0] ?? user.email?.[0] ?? "?")
+          )}
+        </span>
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <span className="text-14 font-medium truncate">{user.display_name || `${user.first_name} ${user.last_name}`.trim() || "—"}</span>
+            {user.is_instance_admin && (
+              <span className="shrink-0 rounded-full bg-amber-500/10 px-2 py-0.5 text-10 font-medium text-amber-600">
+                Instance Admin
+              </span>
+            )}
+            {!user.is_active && (
+              <span className="shrink-0 rounded-full bg-red-500/10 px-2 py-0.5 text-10 font-medium text-red-500">
+                Deactivated
+              </span>
+            )}
+            {isCurrentUser && (
+              <span className="shrink-0 rounded-full bg-accent-primary/10 px-2 py-0.5 text-10 font-medium text-accent-primary">
+                You
+              </span>
+            )}
+          </div>
+          <div className="flex items-center gap-2 text-11 text-tertiary mt-0.5">
+            <span className="truncate">{user.email}</span>
+            {user.date_joined && (
+              <>
+                <span>•</span>
+                <span className="shrink-0">Joined {new Date(user.date_joined).toLocaleDateString()}</span>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+      <button
+        type="button"
+        disabled={isUpdating || isCurrentUser}
+        onClick={toggleActive}
+        className={`shrink-0 rounded-md px-3 py-1.5 text-12 font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${
+          user.is_active
+            ? "border border-red-400 text-red-500 hover:bg-red-500/10"
+            : "border border-green-500 text-green-600 hover:bg-green-500/10"
+        }`}
+      >
+        {user.is_active ? "Deactivate" : "Activate"}
+      </button>
+    </div>
+  );
+});

--- a/apps/admin/hooks/store/index.ts
+++ b/apps/admin/hooks/store/index.ts
@@ -8,3 +8,4 @@ export * from "./use-theme";
 export * from "./use-instance";
 export * from "./use-user";
 export * from "./use-workspace";
+export * from "./use-instance-user";

--- a/apps/admin/hooks/store/use-instance-user.tsx
+++ b/apps/admin/hooks/store/use-instance-user.tsx
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) 2023-present Plane Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { useContext } from "react";
+// store
+import { StoreContext } from "@/providers/store.provider";
+import type { IInstanceUserStore } from "@/store/instance-user.store";
+
+export const useInstanceUser = (): IInstanceUserStore => {
+  const context = useContext(StoreContext);
+  if (context === undefined) throw new Error("useInstanceUser must be used within StoreProvider");
+  return context.instanceUser;
+};

--- a/apps/admin/hooks/use-sidebar-menu/core.ts
+++ b/apps/admin/hooks/use-sidebar-menu/core.ts
@@ -4,13 +4,13 @@
  * See the LICENSE file for details.
  */
 
-import { Image, BrainCog, Cog, Mail } from "lucide-react";
+import { Image, BrainCog, Cog, Mail, Users } from "lucide-react";
 // plane imports
 import { LockIcon, WorkspaceIcon } from "@plane/propel/icons";
 // types
 import type { TSidebarMenuItem } from "./types";
 
-export type TCoreSidebarMenuKey = "general" | "email" | "workspace" | "authentication" | "ai" | "image";
+export type TCoreSidebarMenuKey = "general" | "email" | "workspace" | "authentication" | "ai" | "image" | "users";
 
 export const coreSidebarMenuLinks: Record<TCoreSidebarMenuKey, TSidebarMenuItem> = {
   general: {
@@ -30,6 +30,12 @@ export const coreSidebarMenuLinks: Record<TCoreSidebarMenuKey, TSidebarMenuItem>
     name: "Workspaces",
     description: "Manage all workspaces on this instance.",
     href: `/workspace/`,
+  },
+  users: {
+    Icon: Users,
+    name: "Users",
+    description: "Manage users and their access.",
+    href: `/users/`,
   },
   authentication: {
     Icon: LockIcon,

--- a/apps/admin/hooks/use-sidebar-menu/index.ts
+++ b/apps/admin/hooks/use-sidebar-menu/index.ts
@@ -14,6 +14,7 @@ export function useSidebarMenu(): TSidebarMenuItem[] {
     coreSidebarMenuLinks.email,
     coreSidebarMenuLinks.authentication,
     coreSidebarMenuLinks.workspace,
+    coreSidebarMenuLinks.users,
     coreSidebarMenuLinks.ai,
     coreSidebarMenuLinks.image,
   ];

--- a/apps/admin/store/instance-user.store.ts
+++ b/apps/admin/store/instance-user.store.ts
@@ -4,7 +4,6 @@
  * See the LICENSE file for details.
  */
 
-import { set } from "lodash-es";
 import { action, observable, runInAction, makeObservable, computed } from "mobx";
 // plane imports
 import { InstanceUserService } from "@plane/services";
@@ -67,10 +66,11 @@ export class InstanceUserStore implements IInstanceUserStore {
       const data = await this.instanceUserService.list();
       runInAction(() => {
         const { results, ...paginationInfo } = data;
+        this.users = {};
         results.forEach((user: IUser) => {
-          set(this.users, [user.id], user);
+          this.users[user.id] = user;
         });
-        set(this, "paginationInfo", paginationInfo);
+        this.paginationInfo = paginationInfo;
       });
       return data.results;
     } catch (error) {
@@ -89,9 +89,9 @@ export class InstanceUserStore implements IInstanceUserStore {
       runInAction(() => {
         const { results, ...paginationInfo } = data;
         results.forEach((user: IUser) => {
-          set(this.users, [user.id], user);
+          this.users[user.id] = user;
         });
-        set(this, "paginationInfo", paginationInfo);
+        this.paginationInfo = paginationInfo;
       });
       return data.results;
     } catch (error) {
@@ -108,7 +108,7 @@ export class InstanceUserStore implements IInstanceUserStore {
       this.loader = "mutation";
       const updated = await this.instanceUserService.update(userId, data);
       runInAction(() => {
-        set(this.users, [userId], updated);
+        this.users[userId] = updated;
       });
       return updated;
     } catch (error) {

--- a/apps/admin/store/instance-user.store.ts
+++ b/apps/admin/store/instance-user.store.ts
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) 2023-present Plane Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { set } from "lodash-es";
+import { action, observable, runInAction, makeObservable, computed } from "mobx";
+// plane imports
+import { InstanceUserService } from "@plane/services";
+import type { IUser, TLoader, TPaginationInfo } from "@plane/types";
+// root store
+import type { RootStore } from "@/store/root.store";
+
+export interface IInstanceUserStore {
+  // observables
+  loader: TLoader;
+  users: Record<string, IUser>;
+  paginationInfo: TPaginationInfo | undefined;
+  // computed
+  userIds: string[];
+  // helper actions
+  getUserById: (userId: string) => IUser | undefined;
+  // fetch actions
+  fetchUsers: () => Promise<IUser[]>;
+  fetchNextUsers: () => Promise<IUser[]>;
+  // update actions
+  updateUser: (userId: string, data: { is_active: boolean }) => Promise<IUser>;
+}
+
+export class InstanceUserStore implements IInstanceUserStore {
+  // observables
+  loader: TLoader = "init-loader";
+  users: Record<string, IUser> = {};
+  paginationInfo: TPaginationInfo | undefined = undefined;
+  // services
+  instanceUserService: InstanceUserService;
+
+  constructor(private store: RootStore) {
+    makeObservable(this, {
+      // observables
+      loader: observable,
+      users: observable,
+      paginationInfo: observable,
+      // computed
+      userIds: computed,
+      // helper actions
+      getUserById: action,
+      // fetch actions
+      fetchUsers: action,
+      fetchNextUsers: action,
+      // update actions
+      updateUser: action,
+    });
+    this.instanceUserService = new InstanceUserService();
+  }
+
+  // computed
+  get userIds() {
+    return Object.keys(this.users);
+  }
+
+  // helper actions
+  getUserById = (userId: string) => this.users[userId];
+
+  // fetch actions
+  fetchUsers = async (): Promise<IUser[]> => {
+    try {
+      this.loader = this.userIds.length > 0 ? "mutation" : "init-loader";
+      const data = await this.instanceUserService.list();
+      runInAction(() => {
+        const { results, ...paginationInfo } = data;
+        results.forEach((user: IUser) => {
+          set(this.users, [user.id], user);
+        });
+        set(this, "paginationInfo", paginationInfo);
+      });
+      return data.results;
+    } catch (error) {
+      console.error("Error fetching users", error);
+      throw error;
+    } finally {
+      this.loader = "loaded";
+    }
+  };
+
+  fetchNextUsers = async (): Promise<IUser[]> => {
+    if (!this.paginationInfo || this.paginationInfo.next_page_results === false) return [];
+    try {
+      this.loader = "pagination";
+      const data = await this.instanceUserService.list(this.paginationInfo.next_cursor);
+      runInAction(() => {
+        const { results, ...paginationInfo } = data;
+        results.forEach((user: IUser) => {
+          set(this.users, [user.id], user);
+        });
+        set(this, "paginationInfo", paginationInfo);
+      });
+      return data.results;
+    } catch (error) {
+      console.error("Error fetching next users", error);
+      throw error;
+    } finally {
+      this.loader = "loaded";
+    }
+  };
+
+  // update actions
+  updateUser = async (userId: string, data: { is_active: boolean }): Promise<IUser> => {
+    try {
+      this.loader = "mutation";
+      const updated = await this.instanceUserService.update(userId, data);
+      runInAction(() => {
+        set(this.users, [userId], updated);
+      });
+      return updated;
+    } catch (error) {
+      console.error("Error updating user", error);
+      throw error;
+    } finally {
+      this.loader = "loaded";
+    }
+  };
+}

--- a/apps/admin/store/instance-user.store.ts
+++ b/apps/admin/store/instance-user.store.ts
@@ -19,7 +19,7 @@ export interface IInstanceUserStore {
   paginationInfo: TPaginationInfo | undefined;
   // computed
   userIds: string[];
-  // helper actions
+  // helpers
   getUserById: (userId: string) => IUser | undefined;
   // fetch actions
   fetchUsers: () => Promise<IUser[]>;
@@ -44,8 +44,6 @@ export class InstanceUserStore implements IInstanceUserStore {
       paginationInfo: observable,
       // computed
       userIds: computed,
-      // helper actions
-      getUserById: action,
       // fetch actions
       fetchUsers: action,
       fetchNextUsers: action,
@@ -60,7 +58,6 @@ export class InstanceUserStore implements IInstanceUserStore {
     return Object.keys(this.users);
   }
 
-  // helper actions
   getUserById = (userId: string) => this.users[userId];
 
   // fetch actions
@@ -80,7 +77,7 @@ export class InstanceUserStore implements IInstanceUserStore {
       console.error("Error fetching users", error);
       throw error;
     } finally {
-      this.loader = "loaded";
+      runInAction(() => { this.loader = "loaded"; });
     }
   };
 
@@ -101,7 +98,7 @@ export class InstanceUserStore implements IInstanceUserStore {
       console.error("Error fetching next users", error);
       throw error;
     } finally {
-      this.loader = "loaded";
+      runInAction(() => { this.loader = "loaded"; });
     }
   };
 
@@ -118,7 +115,7 @@ export class InstanceUserStore implements IInstanceUserStore {
       console.error("Error updating user", error);
       throw error;
     } finally {
-      this.loader = "loaded";
+      runInAction(() => { this.loader = "loaded"; });
     }
   };
 }

--- a/apps/admin/store/root.store.ts
+++ b/apps/admin/store/root.store.ts
@@ -14,6 +14,8 @@ import type { IUserStore } from "./user.store";
 import { UserStore } from "./user.store";
 import type { IWorkspaceStore } from "./workspace.store";
 import { WorkspaceStore } from "./workspace.store";
+import type { IInstanceUserStore } from "./instance-user.store";
+import { InstanceUserStore } from "./instance-user.store";
 
 enableStaticRendering(typeof window === "undefined");
 
@@ -22,12 +24,14 @@ export class RootStore {
   instance: IInstanceStore;
   user: IUserStore;
   workspace: IWorkspaceStore;
+  instanceUser: IInstanceUserStore;
 
   constructor() {
     this.theme = new ThemeStore(this);
     this.instance = new InstanceStore(this);
     this.user = new UserStore(this);
     this.workspace = new WorkspaceStore(this);
+    this.instanceUser = new InstanceUserStore(this);
   }
 
   hydrate(initialData: any) {
@@ -43,5 +47,6 @@ export class RootStore {
     this.user = new UserStore(this);
     this.theme = new ThemeStore(this);
     this.workspace = new WorkspaceStore(this);
+    this.instanceUser = new InstanceUserStore(this);
   }
 }

--- a/apps/api/plane/license/api/serializers/__init__.py
+++ b/apps/api/plane/license/api/serializers/__init__.py
@@ -7,3 +7,4 @@ from .instance import InstanceSerializer
 from .configuration import InstanceConfigurationSerializer
 from .admin import InstanceAdminSerializer, InstanceAdminMeSerializer
 from .workspace import WorkspaceSerializer
+from .user import InstanceUserSerializer

--- a/apps/api/plane/license/api/serializers/user.py
+++ b/apps/api/plane/license/api/serializers/user.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # See the LICENSE file for details.
 
+from rest_framework import serializers
+
 from .base import BaseSerializer
 from plane.db.models import User
 
@@ -10,3 +12,43 @@ class UserLiteSerializer(BaseSerializer):
     class Meta:
         model = User
         fields = ["id", "email", "first_name", "last_name"]
+
+
+class InstanceUserSerializer(BaseSerializer):
+    is_instance_admin = serializers.SerializerMethodField()
+
+    def get_is_instance_admin(self, obj):
+        # Relies on the `is_instance_admin` annotation set by the view queryset.
+        return getattr(obj, "is_instance_admin", False)
+
+    class Meta:
+        model = User
+        fields = [
+            "id",
+            "display_name",
+            "first_name",
+            "last_name",
+            "email",
+            "avatar",
+            "avatar_url",
+            "is_active",
+            "is_bot",
+            "is_email_verified",
+            "is_instance_admin",
+            "date_joined",
+            "last_active",
+        ]
+        read_only_fields = [
+            "id",
+            "display_name",
+            "first_name",
+            "last_name",
+            "email",
+            "avatar",
+            "avatar_url",
+            "is_bot",
+            "is_email_verified",
+            "is_instance_admin",
+            "date_joined",
+            "last_active",
+        ]

--- a/apps/api/plane/license/api/views/__init__.py
+++ b/apps/api/plane/license/api/views/__init__.py
@@ -26,3 +26,5 @@ from .workspace import (
     InstanceWorkSpaceAvailabilityCheckEndpoint,
     InstanceWorkSpaceEndpoint,
 )
+
+from .user import InstanceUserEndpoint

--- a/apps/api/plane/license/api/views/user.py
+++ b/apps/api/plane/license/api/views/user.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+# Third party imports
+from rest_framework.response import Response
+from rest_framework import status
+from django.db.models import Exists, OuterRef
+
+# Module imports
+from .base import BaseAPIView
+from plane.license.api.permissions import InstanceAdminPermission
+from plane.db.models import User
+from plane.license.models import InstanceAdmin
+from plane.license.api.serializers import InstanceUserSerializer
+
+
+class InstanceUserEndpoint(BaseAPIView):
+    permission_classes = [InstanceAdminPermission]
+
+    def get(self, request):
+        users = User.objects.filter(is_bot=False).annotate(
+            is_instance_admin=Exists(
+                InstanceAdmin.objects.filter(user=OuterRef("pk"))
+            )
+        ).order_by("-date_joined")
+
+        search = request.query_params.get("search", None)
+        if search:
+            users = users.filter(email__icontains=search) | users.filter(display_name__icontains=search)
+
+        return self.paginate(
+            request=request,
+            queryset=users,
+            on_results=lambda results: InstanceUserSerializer(results, many=True).data,
+            max_per_page=50,
+            default_per_page=50,
+        )
+
+    def patch(self, request, pk):
+        user = User.objects.filter(pk=pk, is_bot=False).first()
+        if not user:
+            return Response({"error": "User not found"}, status=status.HTTP_404_NOT_FOUND)
+
+        # Only allow toggling is_active
+        is_active = request.data.get("is_active")
+        if is_active is None:
+            return Response({"error": "is_active is required"}, status=status.HTTP_400_BAD_REQUEST)
+
+        # Prevent admins from deactivating themselves
+        if user.pk == request.user.pk and not is_active:
+            return Response(
+                {"error": "You cannot deactivate your own account"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        user.is_active = bool(is_active)
+        user.save(update_fields=["is_active"])
+
+        return Response(InstanceUserSerializer(user).data, status=status.HTTP_200_OK)

--- a/apps/api/plane/license/api/views/user.py
+++ b/apps/api/plane/license/api/views/user.py
@@ -38,23 +38,25 @@ class InstanceUserEndpoint(BaseAPIView):
         )
 
     def patch(self, request, pk):
-        user = User.objects.filter(pk=pk, is_bot=False).first()
+        user = User.objects.filter(pk=pk, is_bot=False).annotate(
+            is_instance_admin=Exists(InstanceAdmin.objects.filter(user=OuterRef("pk")))
+        ).first()
         if not user:
             return Response({"error": "User not found"}, status=status.HTTP_404_NOT_FOUND)
 
-        # Only allow toggling is_active
         is_active = request.data.get("is_active")
         if is_active is None:
             return Response({"error": "is_active is required"}, status=status.HTTP_400_BAD_REQUEST)
+        if not isinstance(is_active, bool):
+            return Response({"error": "is_active must be a boolean"}, status=status.HTTP_400_BAD_REQUEST)
 
-        # Prevent admins from deactivating themselves
         if user.pk == request.user.pk and not is_active:
             return Response(
                 {"error": "You cannot deactivate your own account"},
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        user.is_active = bool(is_active)
+        user.is_active = is_active
         user.save(update_fields=["is_active"])
 
         return Response(InstanceUserSerializer(user).data, status=status.HTTP_200_OK)

--- a/apps/api/plane/license/urls.py
+++ b/apps/api/plane/license/urls.py
@@ -18,6 +18,7 @@ from plane.license.api.views import (
     InstanceAdminUserSessionEndpoint,
     InstanceWorkSpaceAvailabilityCheckEndpoint,
     InstanceWorkSpaceEndpoint,
+    InstanceUserEndpoint,
 )
 
 urlpatterns = [
@@ -71,4 +72,6 @@ urlpatterns = [
         name="instance-workspace-availability",
     ),
     path("workspaces/", InstanceWorkSpaceEndpoint.as_view(), name="instance-workspace"),
+    path("users/", InstanceUserEndpoint.as_view(), name="instance-users"),
+    path("users/<uuid:pk>/", InstanceUserEndpoint.as_view(), name="instance-user"),
 ]

--- a/apps/api/plane/tests/contract/app/test_instance_user.py
+++ b/apps/api/plane/tests/contract/app/test_instance_user.py
@@ -1,0 +1,170 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+import uuid
+import pytest
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework import status
+
+from plane.db.models import User
+from plane.license.models import Instance, InstanceAdmin
+
+
+@pytest.fixture
+def instance(db):
+    return Instance.objects.create(
+        instance_name="Test Instance",
+        instance_id=str(uuid.uuid4()),
+        current_version="1.0.0",
+        domain="http://localhost:8000",
+        last_checked_at=timezone.now(),
+        is_setup_done=True,
+    )
+
+
+@pytest.fixture
+def admin_client(api_client, create_user, instance):
+    """Authenticated client whose user is registered as an instance admin."""
+    InstanceAdmin.objects.create(instance=instance, user=create_user, role=20)
+    api_client.force_authenticate(user=create_user)
+    return api_client
+
+
+@pytest.fixture
+def other_user(db):
+    user = User.objects.create(
+        email="other@plane.so",
+        username=f"other_{uuid.uuid4().hex[:8]}",
+        first_name="Other",
+        last_name="User",
+        is_active=True,
+    )
+    user.set_password("other@123")
+    user.save()
+    return user
+
+
+@pytest.fixture
+def bot_user(db):
+    user = User.objects.create(
+        email="bot@plane.so",
+        username=f"bot_{uuid.uuid4().hex[:8]}",
+        is_bot=True,
+        is_active=True,
+    )
+    user.save()
+    return user
+
+
+@pytest.mark.contract
+class TestInstanceUserList:
+    """GET /api/instances/users/"""
+
+    @pytest.mark.django_db
+    def test_requires_authentication(self, api_client, instance):
+        url = reverse("instance-users")
+        response = api_client.get(url)
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    @pytest.mark.django_db
+    def test_requires_instance_admin(self, api_client, create_user, instance):
+        """Authenticated non-admin cannot access the list."""
+        api_client.force_authenticate(user=create_user)
+        url = reverse("instance-users")
+        response = api_client.get(url)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    @pytest.mark.django_db
+    def test_returns_paginated_users(self, admin_client, create_user, other_user):
+        url = reverse("instance-users")
+        response = admin_client.get(url)
+        assert response.status_code == status.HTTP_200_OK
+        assert "results" in response.data
+        emails = [u["email"] for u in response.data["results"]]
+        assert create_user.email in emails
+        assert other_user.email in emails
+
+    @pytest.mark.django_db
+    def test_excludes_bot_users(self, admin_client, bot_user):
+        url = reverse("instance-users")
+        response = admin_client.get(url)
+        assert response.status_code == status.HTTP_200_OK
+        emails = [u["email"] for u in response.data["results"]]
+        assert bot_user.email not in emails
+
+    @pytest.mark.django_db
+    def test_instance_admin_flag_present(self, admin_client, create_user, other_user):
+        url = reverse("instance-users")
+        response = admin_client.get(url)
+        assert response.status_code == status.HTTP_200_OK
+        by_email = {u["email"]: u for u in response.data["results"]}
+        assert by_email[create_user.email]["is_instance_admin"] is True
+        assert by_email[other_user.email]["is_instance_admin"] is False
+
+    @pytest.mark.django_db
+    def test_search_by_email(self, admin_client, create_user, other_user):
+        url = reverse("instance-users")
+        response = admin_client.get(url, {"search": "other"})
+        assert response.status_code == status.HTTP_200_OK
+        emails = [u["email"] for u in response.data["results"]]
+        assert other_user.email in emails
+        assert create_user.email not in emails
+
+
+@pytest.mark.contract
+class TestInstanceUserPatch:
+    """PATCH /api/instances/users/<uuid>/"""
+
+    @pytest.mark.django_db
+    def test_deactivate_user(self, admin_client, other_user):
+        url = reverse("instance-user", kwargs={"pk": other_user.pk})
+        response = admin_client.patch(url, {"is_active": False}, format="json")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["is_active"] is False
+        other_user.refresh_from_db()
+        assert other_user.is_active is False
+
+    @pytest.mark.django_db
+    def test_reactivate_user(self, admin_client, other_user):
+        other_user.is_active = False
+        other_user.save()
+        url = reverse("instance-user", kwargs={"pk": other_user.pk})
+        response = admin_client.patch(url, {"is_active": True}, format="json")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["is_active"] is True
+        other_user.refresh_from_db()
+        assert other_user.is_active is True
+
+    @pytest.mark.django_db
+    def test_cannot_deactivate_self(self, admin_client, create_user):
+        url = reverse("instance-user", kwargs={"pk": create_user.pk})
+        response = admin_client.patch(url, {"is_active": False}, format="json")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        create_user.refresh_from_db()
+        assert create_user.is_active is True
+
+    @pytest.mark.django_db
+    def test_missing_is_active_field(self, admin_client, other_user):
+        url = reverse("instance-user", kwargs={"pk": other_user.pk})
+        response = admin_client.patch(url, {}, format="json")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    @pytest.mark.django_db
+    def test_unknown_user_returns_404(self, admin_client):
+        url = reverse("instance-user", kwargs={"pk": uuid.uuid4()})
+        response = admin_client.patch(url, {"is_active": False}, format="json")
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    @pytest.mark.django_db
+    def test_cannot_patch_bot_user(self, admin_client, bot_user):
+        url = reverse("instance-user", kwargs={"pk": bot_user.pk})
+        response = admin_client.patch(url, {"is_active": False}, format="json")
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    @pytest.mark.django_db
+    def test_requires_authentication(self, api_client, other_user, instance):
+        url = reverse("instance-user", kwargs={"pk": other_user.pk})
+        response = api_client.patch(url, {"is_active": False}, format="json")
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED

--- a/apps/api/plane/tests/contract/app/test_instance_user.py
+++ b/apps/api/plane/tests/contract/app/test_instance_user.py
@@ -152,6 +152,21 @@ class TestInstanceUserPatch:
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     @pytest.mark.django_db
+    def test_non_boolean_is_active_rejected(self, admin_client, other_user):
+        url = reverse("instance-user", kwargs={"pk": other_user.pk})
+        response = admin_client.patch(url, {"is_active": "false"}, format="json")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        other_user.refresh_from_db()
+        assert other_user.is_active is True
+
+    @pytest.mark.django_db
+    def test_deactivate_preserves_instance_admin_flag(self, admin_client, create_user, instance):
+        url = reverse("instance-user", kwargs={"pk": create_user.pk})
+        response = admin_client.patch(url, {"is_active": True}, format="json")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["is_instance_admin"] is True
+
+    @pytest.mark.django_db
     def test_unknown_user_returns_404(self, admin_client):
         url = reverse("instance-user", kwargs={"pk": uuid.uuid4()})
         response = admin_client.patch(url, {"is_active": False}, format="json")

--- a/packages/services/src/instance/index.ts
+++ b/packages/services/src/instance/index.ts
@@ -5,3 +5,4 @@
  */
 
 export * from "./instance.service";
+export * from "./instance-user.service";

--- a/packages/services/src/instance/instance-user.service.ts
+++ b/packages/services/src/instance/instance-user.service.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2023-present Plane Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { API_BASE_URL } from "@plane/constants";
+import type { IUser, TInstanceUserPaginationInfo } from "@plane/types";
+import { APIService } from "../api.service";
+
+export class InstanceUserService extends APIService {
+  constructor(BASE_URL?: string) {
+    super(BASE_URL || API_BASE_URL);
+  }
+
+  async list(nextPageCursor?: string): Promise<TInstanceUserPaginationInfo> {
+    return this.get("/api/instances/users/", {
+      params: { cursor: nextPageCursor },
+    })
+      .then((response) => response?.data)
+      .catch((error) => {
+        throw error?.response?.data;
+      });
+  }
+
+  async update(userId: string, data: { is_active: boolean }): Promise<IUser> {
+    return this.patch(`/api/instances/users/${userId}/`, data)
+      .then((response) => response?.data)
+      .catch((error) => {
+        throw error?.response?.data;
+      });
+  }
+}

--- a/packages/types/src/users.ts
+++ b/packages/types/src/users.ts
@@ -7,6 +7,7 @@
 import type { TUserPermissions } from "./enums";
 import type { IIssueActivity, TIssuePriorities, TStateGroups } from ".";
 import type { TLoginMediums } from "./instance";
+import type { TPaginationInfo } from "./common";
 
 /**
  * @description The start of the week for the user
@@ -42,6 +43,7 @@ export interface IUser extends IUserLite {
   email: string;
   is_active: boolean;
   is_email_verified: boolean;
+  is_instance_admin?: boolean;
   is_password_autoset: boolean;
   is_tour_completed: boolean;
   mobile_number: string | null;
@@ -51,6 +53,10 @@ export interface IUser extends IUserLite {
   last_login_medium: TLoginMediums;
   theme: IUserTheme;
 }
+
+export type TInstanceUserPaginationInfo = TPaginationInfo & {
+  results: IUser[];
+};
 
 export interface IUserAccount {
   provider_account_id: string;


### PR DESCRIPTION
### Description
Adds a user management tab to the god-mode admin screen. I was surprised upon setting up Plane that this didn't exist. This is currently a simple interface that displays basic user information and allows the admin to deactivate/reactivate user accounts. Hopefully this can act as a launching pad to build out some more substantial user management functionality!

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<img width="895" height="498" alt="Screenshot 2026-07-08 at 7 09 13 PM" src="https://github.com/user-attachments/assets/48746929-613b-4193-bceb-1c9410d582ef" />

### Test Scenarios 
- Wrote unit tests to exercise this functionality with RBAC checks.
- Loaded the locally built images into my running service.

### References
Related to #3373 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an admin **Users on this instance** page with search, total count, and paginated “Load more”.
  * Added instance-user activation/deactivation from the admin interface with clear loading and error states.
  * Updated navigation with a new sidebar entry and page title.
* **Bug Fixes**
  * Prevented deactivating the currently signed-in user.
  * Added validation for missing/invalid `is_active` values and improved handling of bot/unknown users.
* **Tests**
  * Added contract tests for listing (with pagination/search/bot exclusion) and updating active status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->