### PR TITLE
[WEB-8103] fix: stop leaking webhook HMAC secret_key on reads

### DIFF
--- a/apps/api/plane/app/serializers/webhook.py
+++ b/apps/api/plane/app/serializers/webhook.py
@@ -61,7 +61,7 @@ class WebhookSerializer(DynamicBaseSerializer):
         # never on list/retrieve/update.
         #
         # This context flag — not the fields= allowlists in views/webhook/base.py —
-        # is the sole enforcement point (GHSA-83rj). Those fields= kwargs are dead
+        # is the sole enforcement point. Those fields= kwargs are dead
         # on two independent levels, so do not assume fixing either one re-activates
         # them:
         #   1. DynamicBaseSerializer.__init__ pops the caller's fields= and then

--- a/apps/api/plane/app/serializers/webhook.py
+++ b/apps/api/plane/app/serializers/webhook.py
@@ -58,9 +58,22 @@ class WebhookSerializer(DynamicBaseSerializer):
         data = super().to_representation(instance)
         # secret_key is the HMAC signing secret. It is only revealed on creation
         # and secret regeneration (opt-in via the show_secret_key context flag),
-        # never on list/retrieve/update. The per-request fields= allowlist that
-        # the webhook views pass to exclude it is silently dropped by
-        # DynamicBaseSerializer.__init__, so filter it here (GHSA-83rj).
+        # never on list/retrieve/update.
+        #
+        # This context flag — not the fields= allowlists in views/webhook/base.py —
+        # is the sole enforcement point (GHSA-83rj). Those fields= kwargs are dead
+        # on two independent levels, so do not assume fixing either one re-activates
+        # them:
+        #   1. DynamicBaseSerializer.__init__ pops the caller's fields= and then
+        #      overwrites it with self.expand (serializers/base.py:16-18), so the
+        #      requested allowlist never reaches _filter_fields at all.
+        #   2. _filter_fields never *removes* anything even when it does receive a
+        #      list — it builds `allowed` purely to add expansion serializers for
+        #      names not already present, then returns self.fields unfiltered
+        #      (serializers/base.py:45-119).
+        # A future one-line `fields = fields or self.expand` fix addresses only (1);
+        # (2) still has to be made restrictive before any fields= allowlist can be
+        # relied on for confidentiality.
         if not self.context.get("show_secret_key"):
             data.pop("secret_key", None)
         return data

--- a/apps/api/plane/app/serializers/webhook.py
+++ b/apps/api/plane/app/serializers/webhook.py
@@ -54,6 +54,17 @@ class WebhookSerializer(DynamicBaseSerializer):
         if any(hostname == domain or hostname.endswith("." + domain) for domain in disallowed_domains):
             raise serializers.ValidationError({"url": "URL domain or its subdomain is not allowed."})
 
+    def to_representation(self, instance):
+        data = super().to_representation(instance)
+        # secret_key is the HMAC signing secret. It is only revealed on creation
+        # and secret regeneration (opt-in via the show_secret_key context flag),
+        # never on list/retrieve/update. The per-request fields= allowlist that
+        # the webhook views pass to exclude it is silently dropped by
+        # DynamicBaseSerializer.__init__, so filter it here (GHSA-83rj).
+        if not self.context.get("show_secret_key"):
+            data.pop("secret_key", None)
+        return data
+
     def create(self, validated_data):
         url = validated_data.get("url", None)
         self._validate_webhook_url(url)

--- a/apps/api/plane/app/views/webhook/base.py
+++ b/apps/api/plane/app/views/webhook/base.py
@@ -22,7 +22,10 @@ class WebhookEndpoint(BaseAPIView):
     def post(self, request, slug):
         workspace = Workspace.objects.get(slug=slug)
         try:
-            serializer = WebhookSerializer(data=request.data, context={"request": request})
+            serializer = WebhookSerializer(
+                data=request.data,
+                context={"request": request, "show_secret_key": True},
+            )
             if serializer.is_valid():
                 serializer.save(workspace_id=workspace.id)
                 return Response(serializer.data, status=status.HTTP_201_CREATED)
@@ -114,7 +117,7 @@ class WebhookSecretRegenerateEndpoint(BaseAPIView):
         webhook = Webhook.objects.get(workspace__slug=slug, pk=pk)
         webhook.secret_key = generate_token()
         webhook.save()
-        serializer = WebhookSerializer(webhook)
+        serializer = WebhookSerializer(webhook, context={"show_secret_key": True})
         return Response(serializer.data, status=status.HTTP_200_OK)
 
 

--- a/apps/api/plane/tests/contract/app/test_webhook_secret_key_scope_app.py
+++ b/apps/api/plane/tests/contract/app/test_webhook_secret_key_scope_app.py
@@ -3,7 +3,7 @@
 # See the LICENSE file for details.
 
 """
-Regression tests for GHSA-83rj-4282-x39v.
+Regression tests for WEB-8103.
 
 WebhookEndpoint list/retrieve/patch passed a fields= allowlist that excluded
 secret_key, but DynamicBaseSerializer.__init__ discards the allowlist, so the

--- a/apps/api/plane/tests/contract/app/test_webhook_secret_key_scope_app.py
+++ b/apps/api/plane/tests/contract/app/test_webhook_secret_key_scope_app.py
@@ -1,0 +1,99 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""
+Regression tests for GHSA-83rj-4282-x39v.
+
+WebhookEndpoint list/retrieve/patch passed a fields= allowlist that excluded
+secret_key, but DynamicBaseSerializer.__init__ discards the allowlist, so the
+HMAC secret_key leaked on every webhook read. WebhookSerializer now hides
+secret_key by default and only reveals it on create / secret regeneration.
+"""
+
+import pytest
+from rest_framework import status
+
+from plane.app.serializers import WebhookSerializer
+from plane.db.models import Webhook
+
+
+def _webhooks_url(slug, pk=None, regenerate=False):
+    base = f"/api/workspaces/{slug}/webhooks/"
+    if pk and regenerate:
+        return f"{base}{pk}/regenerate/"
+    if pk:
+        return f"{base}{pk}/"
+    return base
+
+
+def _make_webhook(workspace, url="https://example.com/hook"):
+    return Webhook.objects.create(workspace=workspace, url=url)
+
+
+@pytest.mark.contract
+class TestWebhookSecretKeyScope:
+    @pytest.mark.django_db
+    def test_list_does_not_leak_secret_key(self, session_client, workspace):
+        _make_webhook(workspace)
+
+        response = session_client.get(_webhooks_url(workspace.slug))
+
+        assert response.status_code == status.HTTP_200_OK
+        payload = response.json()
+        assert payload, "expected at least one webhook"
+        assert all("secret_key" not in item for item in payload)
+
+    @pytest.mark.django_db
+    def test_retrieve_does_not_leak_secret_key(self, session_client, workspace):
+        webhook = _make_webhook(workspace)
+
+        response = session_client.get(_webhooks_url(workspace.slug, pk=webhook.id))
+
+        assert response.status_code == status.HTTP_200_OK
+        assert "secret_key" not in response.json()
+
+    @pytest.mark.django_db
+    def test_patch_does_not_leak_secret_key(self, session_client, workspace):
+        webhook = _make_webhook(workspace)
+
+        # Patch a non-url field so URL SSRF validation is not exercised.
+        response = session_client.patch(
+            _webhooks_url(workspace.slug, pk=webhook.id), {"is_active": False}, format="json"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert "secret_key" not in response.json()
+        assert response.json()["is_active"] is False
+
+    @pytest.mark.django_db
+    def test_regenerate_reveals_secret_key(self, session_client, workspace):
+        webhook = _make_webhook(workspace)
+        old_secret = webhook.secret_key
+
+        response = session_client.post(_webhooks_url(workspace.slug, pk=webhook.id, regenerate=True))
+
+        assert response.status_code == status.HTTP_200_OK
+        body = response.json()
+        assert "secret_key" in body
+        assert body["secret_key"] and body["secret_key"] != old_secret
+
+    @pytest.mark.django_db
+    def test_create_reveals_secret_key(self, session_client, workspace, monkeypatch):
+        # Bypass the network-dependent SSRF URL validation for this unit.
+        monkeypatch.setattr(WebhookSerializer, "_validate_webhook_url", lambda self, url: None)
+
+        response = session_client.post(
+            _webhooks_url(workspace.slug), {"url": "https://example.com/hook"}, format="json"
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.json().get("secret_key")
+
+    @pytest.mark.django_db
+    def test_serializer_hides_secret_by_default_and_reveals_with_flag(self, workspace):
+        webhook = _make_webhook(workspace)
+
+        assert "secret_key" not in WebhookSerializer(webhook).data
+        revealed = WebhookSerializer(webhook, context={"show_secret_key": True}).data
+        assert revealed["secret_key"] == webhook.secret_key

--- a/apps/api/plane/tests/contract/app/test_webhook_secret_key_scope_app.py
+++ b/apps/api/plane/tests/contract/app/test_webhook_secret_key_scope_app.py
@@ -80,8 +80,10 @@ class TestWebhookSecretKeyScope:
 
     @pytest.mark.django_db
     def test_create_reveals_secret_key(self, session_client, workspace, monkeypatch):
-        # Bypass the network-dependent SSRF URL validation for this unit.
-        monkeypatch.setattr(WebhookSerializer, "_validate_webhook_url", lambda self, url: None)
+        # Bypass only the network boundary (DNS/IP SSRF resolution); the domain and
+        # schema checks in _validate_webhook_url still run for example.com, and the
+        # test survives a rename of the private method.
+        monkeypatch.setattr("plane.app.serializers.webhook.validate_url", lambda *a, **k: None)
 
         response = session_client.post(
             _webhooks_url(workspace.slug), {"url": "https://example.com/hook"}, format="json"
@@ -95,5 +97,10 @@ class TestWebhookSecretKeyScope:
         webhook = _make_webhook(workspace)
 
         assert "secret_key" not in WebhookSerializer(webhook).data
+        # An explicit fields= request must not re-open the leak either: enforcement
+        # lives in to_representation, not the (currently no-op) DynamicBaseSerializer
+        # field allowlist. Pins the enforcement point so a future _filter_fields fix
+        # can't silently re-expose the key.
+        assert "secret_key" not in WebhookSerializer(webhook, fields=("secret_key",)).data
         revealed = WebhookSerializer(webhook, context={"show_secret_key": True}).data
         assert revealed["secret_key"] == webhook.secret_key


### PR DESCRIPTION
Fixes WEB-8103 (MED, admin-only).

## Problem
`WebhookEndpoint` list/retrieve/patch pass a `fields=(...)` allowlist that deliberately excludes `secret_key`, but `DynamicBaseSerializer.__init__` discards the caller allowlist (`fields = self.expand`). Combined with `WebhookSerializer` using `fields="__all__"` and `secret_key` only in `read_only_fields` (read-only fields are still serialized), the HMAC signing `secret_key` was returned on every webhook read. All handlers are `@allow_permission([ADMIN], level="WORKSPACE")`, so exposure is workspace-admin-only.

## Fix
The advisory suggests `secret_key = serializers.CharField(write_only=True)`, but that would (a) let a client **inject** their own secret on create/patch (a downgrade — the secret is server-generated via `default=generate_token`) and (b) break the intended one-time reveal. Instead:

- `WebhookSerializer.to_representation` drops `secret_key` unless a `show_secret_key` context flag is set — **secure by default**. `secret_key` stays server-generated and non-writable.
- `POST create` and `WebhookSecretRegenerateEndpoint` pass `show_secret_key=True`, so the secret is still returned **once** for the caller to configure their receiver.
- list / retrieve / patch no longer emit it.

`WebhookSerializer` is only used in `app/views/webhook/base.py` (no external API / EE consumer), so the blast radius is contained.

## Tests
`tests/contract/app/test_webhook_secret_key_scope_app.py` — 6 tests: list/retrieve/patch do not leak, create + regenerate still reveal, and a serializer-level check of both branches of the flag. Fail-before verified (the four no-leak tests return `secret_key` before the fix). `ruff` + `manage.py check` green.

## Follow-up
The root `DynamicBaseSerializer.__init__` bug (silently discarding the `fields=` allowlist) also affects other serializers (workspace/project member over-exposure) — tracked as a separate audit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Webhook responses now keep `secret_key` hidden by default, including when explicitly requested.
  * Webhook creation responses include the secret for initial setup.
  * Secret regeneration returns the newly generated secret.
  * Listing, retrieving, and updating webhooks no longer expose the secret.

* **Tests**
  * Added coverage verifying secret visibility across webhook creation, listing, retrieval, updates, and regeneration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
