### PR TITLE
fix: pin GitHub Actions to commit SHAs (#9108)

### DIFF
--- a/.github/workflows/feature-deployment.yml
+++ b/.github/workflows/feature-deployment.yml
@@ -58,7 +58,7 @@ jobs:
 
       - id: checkout_files
         name: Checkout Files
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
   full_build_push:
     runs-on: ubuntu-22.04
@@ -86,7 +86,7 @@ jobs:
           endpoint: ${{ env.BUILDX_ENDPOINT }}
 
       - name: Check out the repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Build and Push to Docker Hub
         uses: docker/build-push-action@v7.0.0
@@ -122,7 +122,7 @@ jobs:
           sudo apt-get install -y python3-pip
           pip3 install awscli
       - name: Tailscale
-        uses: tailscale/github-action@v4
+        uses: tailscale/github-action@v306e68a486fd2350f2bfc3b19fcd143891a4a2d8
         with:
           oauth-client-id: ${{ secrets.TAILSCALE_OAUTH_CLIENT_ID }}
           oauth-secret: ${{ secrets.TAILSCALE_OAUTH_SECRET }}

--- a/.github/workflows/feature-deployment.yml
+++ b/.github/workflows/feature-deployment.yml
@@ -122,7 +122,7 @@ jobs:
           sudo apt-get install -y python3-pip
           pip3 install awscli
       - name: Tailscale
-        uses: tailscale/github-action@v306e68a486fd2350f2bfc3b19fcd143891a4a2d8
+        uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8
         with:
           oauth-client-id: ${{ secrets.TAILSCALE_OAUTH_CLIENT_ID }}
           oauth-secret: ${{ secrets.TAILSCALE_OAUTH_SECRET }}

--- a/.github/workflows/pull-request-build-lint-api.yml
+++ b/.github/workflows/pull-request-build-lint-api.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
         with:
           python-version: "3.12.x"
           cache: 'pip'

--- a/.github/workflows/pull-request-build-lint-api.yml
+++ b/.github/workflows/pull-request-build-lint-api.yml
@@ -27,9 +27,9 @@ jobs:
       github.event.pull_request.draft == false &&
       github.event.pull_request.requested_reviewers != null
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.12.x"
           cache: 'pip'


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
Pinned GitHub Actions dependencies to immutable commit SHAs instead of mutable version tags.
Updated `actions/checkout`, `actions/setup-python`, and `tailscale/github-action` references in GitHub workflow files to prevent supply-chain security risks caused by mutable action tags.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [x] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->
- Verified all modified workflow files use commit SHA references instead of mutable tags.
- Reviewed the Git diff to confirm only GitHub Actions references were changed.
- Confirmed no remaining `actions/checkout@v6`, `actions/setup-python@v6`, or `tailscale/github-action@v4` references exist in the updated workflows.

### References
<!-- Link related issues if there are any -->
Fixes #9108

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned continuous integration and deployment workflow actions to specific revisions for more consistent, reliable runs.
  * Updated repository checkout and Python setup actions to fixed commit references while keeping build and lint behavior unchanged.
  * Updated the deployment networking-related action to a pinned revision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->