### PR TITLE
feat(api): manage workspace webhooks via the public token API

### DIFF
--- a/apps/api/plane/api/serializers/__init__.py
+++ b/apps/api/plane/api/serializers/__init__.py
@@ -64,3 +64,4 @@ from .asset import (
 from .invite import WorkspaceInviteSerializer
 from .member import ProjectMemberSerializer
 from .sticky import StickySerializer
+from .webhook import WebhookSerializer

--- a/apps/api/plane/api/serializers/__init__.py
+++ b/apps/api/plane/api/serializers/__init__.py
@@ -64,4 +64,4 @@ from .asset import (
 from .invite import WorkspaceInviteSerializer
 from .member import ProjectMemberSerializer
 from .sticky import StickySerializer
-from .webhook import WebhookSerializer
+from .webhook import WebhookSerializer, WebhookLiteSerializer

--- a/apps/api/plane/api/serializers/webhook.py
+++ b/apps/api/plane/api/serializers/webhook.py
@@ -6,21 +6,29 @@
 from rest_framework import serializers
 
 # Module imports
-from .base import DynamicBaseSerializer
-from plane.db.models import Webhook, WebhookLog
+from .base import BaseSerializer
+from plane.db.models import Webhook
 from plane.db.models.webhook import validate_domain, validate_schema
 from plane.utils.webhook import validate_webhook_url
 
 
-class WebhookSerializer(DynamicBaseSerializer):
+class WebhookSerializer(BaseSerializer):
+    """Public token-API serializer for workspace webhooks.
+
+    Mirrors the internal app-API webhook serializer: enforces the schema/domain
+    validators plus the shared SSRF/disallowed-domain guard, and keeps
+    ``secret_key`` server-generated (read-only) so it is returned on create but
+    never accepted as input.
+    """
+
     url = serializers.URLField(validators=[validate_schema, validate_domain])
 
     def _validate_webhook_url(self, url):
         """Validate a webhook URL against SSRF and disallowed-domain rules.
 
         Thin adapter binding the serializer's request context to the shared
-        ``validate_webhook_url`` guard so the SSRF/URL checks live in a single
-        place shared with the public token API.
+        ``validate_webhook_url`` guard, mirroring the internal app-API
+        serializer so the SSRF/URL checks cannot drift between the two.
         """
         validate_webhook_url(url, self.context.get("request"))
 
@@ -37,12 +45,23 @@ class WebhookSerializer(DynamicBaseSerializer):
 
     class Meta:
         model = Webhook
-        fields = "__all__"
-        read_only_fields = ["workspace", "secret_key", "deleted_at"]
-
-
-class WebhookLogSerializer(DynamicBaseSerializer):
-    class Meta:
-        model = WebhookLog
-        fields = "__all__"
-        read_only_fields = ["workspace", "webhook"]
+        fields = [
+            "id",
+            "url",
+            "is_active",
+            "secret_key",
+            "project",
+            "issue",
+            "module",
+            "cycle",
+            "issue_comment",
+            "created_at",
+            "updated_at",
+        ]
+        read_only_fields = [
+            "id",
+            "workspace",
+            "secret_key",
+            "created_at",
+            "updated_at",
+        ]

--- a/apps/api/plane/api/serializers/webhook.py
+++ b/apps/api/plane/api/serializers/webhook.py
@@ -65,3 +65,21 @@ class WebhookSerializer(BaseSerializer):
             "created_at",
             "updated_at",
         ]
+
+
+class WebhookLiteSerializer(BaseSerializer):
+    """Read-side webhook shape — everything ``WebhookSerializer`` exposes except
+    the signing ``secret_key``.
+
+    The secret is surfaced exactly once, in the create response; list, retrieve
+    and update responses use this serializer so it is never returned on a read.
+    Deriving the field list from ``WebhookSerializer`` (minus the secret) makes
+    that exclusion structural rather than a hand-maintained parallel list, and
+    because the runtime response and the published OpenAPI schema are both
+    generated from this one class they cannot contradict each other.
+    """
+
+    class Meta:
+        model = Webhook
+        fields = [field for field in WebhookSerializer.Meta.fields if field != "secret_key"]
+        read_only_fields = fields

--- a/apps/api/plane/api/urls/__init__.py
+++ b/apps/api/plane/api/urls/__init__.py
@@ -14,6 +14,7 @@ from .user import urlpatterns as user_patterns
 from .work_item import urlpatterns as work_item_patterns
 from .invite import urlpatterns as invite_patterns
 from .sticky import urlpatterns as sticky_patterns
+from .webhook import urlpatterns as webhook_patterns
 
 urlpatterns = [
     *asset_patterns,
@@ -28,4 +29,5 @@ urlpatterns = [
     *work_item_patterns,
     *invite_patterns,
     *sticky_patterns,
+    *webhook_patterns,
 ]

--- a/apps/api/plane/api/urls/webhook.py
+++ b/apps/api/plane/api/urls/webhook.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+from django.urls import path
+
+from plane.api.views import WebhookAPIEndpoint, WebhookDetailAPIEndpoint
+
+urlpatterns = [
+    path(
+        "workspaces/<str:slug>/webhooks/",
+        WebhookAPIEndpoint.as_view(http_method_names=["get", "post"]),
+        name="webhooks",
+    ),
+    path(
+        "workspaces/<str:slug>/webhooks/<uuid:pk>/",
+        WebhookDetailAPIEndpoint.as_view(http_method_names=["get", "patch", "delete"]),
+        name="webhook-detail",
+    ),
+]

--- a/apps/api/plane/api/views/__init__.py
+++ b/apps/api/plane/api/views/__init__.py
@@ -63,3 +63,5 @@ from .user import UserEndpoint
 from .invite import WorkspaceInvitationsViewset
 
 from .sticky import StickyViewSet
+
+from .webhook import WebhookAPIEndpoint, WebhookDetailAPIEndpoint

--- a/apps/api/plane/api/views/webhook.py
+++ b/apps/api/plane/api/views/webhook.py
@@ -1,0 +1,217 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+# Django imports
+from django.db import IntegrityError
+
+# Third party imports
+from rest_framework import status
+from rest_framework.response import Response
+from drf_spectacular.utils import (
+    extend_schema,
+    OpenApiResponse,
+    OpenApiRequest,
+    OpenApiParameter,
+    OpenApiTypes,
+)
+
+# Module imports
+from .base import BaseAPIView
+from plane.api.serializers import WebhookSerializer
+from plane.db.models import Webhook, Workspace
+from plane.utils.permissions import WorkspaceOwnerPermission
+from plane.utils.openapi import (
+    WORKSPACE_SLUG_PARAMETER,
+    UNAUTHORIZED_RESPONSE,
+    FORBIDDEN_RESPONSE,
+    WORKSPACE_NOT_FOUND_RESPONSE,
+    CONFLICT_RESPONSE,
+)
+
+# Fields returned to clients everywhere except the create response — the
+# server-generated ``secret_key`` is intentionally withheld here and only ever
+# surfaced once, in the create response, so it is not leaked on every read.
+WEBHOOK_READ_FIELDS = (
+    "id",
+    "url",
+    "is_active",
+    "created_at",
+    "updated_at",
+    "project",
+    "issue",
+    "cycle",
+    "module",
+    "issue_comment",
+)
+
+WEBHOOK_PK_PARAMETER = OpenApiParameter(
+    name="pk",
+    description="Webhook ID",
+    required=True,
+    type=OpenApiTypes.UUID,
+    location=OpenApiParameter.PATH,
+)
+
+
+class WebhookAPIEndpoint(BaseAPIView):
+    """Manage workspace webhooks via the token API.
+
+    Mirrors the internal app-API webhook endpoint: workspace-admin only,
+    enforces the shared URL schema/domain validators and the SSRF /
+    ``WEBHOOK_ALLOWED_IPS`` guard, and generates the signing ``secret_key``
+    server-side (returned only in the create response).
+    """
+
+    permission_classes = [WorkspaceOwnerPermission]
+    serializer_class = WebhookSerializer
+
+    @extend_schema(
+        operation_id="create_webhook",
+        summary="Create webhook",
+        description=(
+            "Register a webhook for the workspace. The signing `secret_key` is "
+            "generated server-side and returned only in this response. The target "
+            "`url` is validated against the SSRF/URL guards (localhost, private "
+            "networks and non-http(s) schemes are rejected)."
+        ),
+        tags=["Webhooks"],
+        parameters=[WORKSPACE_SLUG_PARAMETER],
+        request=OpenApiRequest(request=WebhookSerializer),
+        responses={
+            201: OpenApiResponse(description="Webhook created", response=WebhookSerializer),
+            400: OpenApiResponse(description="Invalid or disallowed webhook URL"),
+            401: UNAUTHORIZED_RESPONSE,
+            403: FORBIDDEN_RESPONSE,
+            404: WORKSPACE_NOT_FOUND_RESPONSE,
+            409: CONFLICT_RESPONSE,
+        },
+    )
+    def post(self, request, slug):
+        workspace = Workspace.objects.get(slug=slug)
+        try:
+            serializer = WebhookSerializer(data=request.data, context={"request": request})
+            if serializer.is_valid():
+                serializer.save(workspace_id=workspace.id)
+                return Response(serializer.data, status=status.HTTP_201_CREATED)
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+        except IntegrityError as e:
+            # Only the unique webhook-URL violation maps to 409; any other
+            # integrity error (FK / NOT NULL / ...) is re-raised so it is not
+            # masked as a duplicate-URL conflict.
+            if "already exists" in str(e):
+                return Response(
+                    {"error": "URL already exists for the workspace"},
+                    status=status.HTTP_409_CONFLICT,
+                )
+            raise
+
+    @extend_schema(
+        operation_id="list_webhooks",
+        summary="List webhooks",
+        description=("List all webhooks for the workspace. The `secret_key` is never included in these responses."),
+        tags=["Webhooks"],
+        parameters=[WORKSPACE_SLUG_PARAMETER],
+        responses={
+            200: OpenApiResponse(description="Webhooks", response=WebhookSerializer(many=True)),
+            401: UNAUTHORIZED_RESPONSE,
+            403: FORBIDDEN_RESPONSE,
+            404: WORKSPACE_NOT_FOUND_RESPONSE,
+        },
+    )
+    def get(self, request, slug):
+        webhooks = Webhook.objects.filter(workspace__slug=slug)
+        serializer = WebhookSerializer(webhooks, fields=WEBHOOK_READ_FIELDS, many=True)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+
+class WebhookDetailAPIEndpoint(BaseAPIView):
+    """Retrieve, update or delete a single workspace webhook via the token API.
+
+    Split from ``WebhookAPIEndpoint`` so the collection ``GET`` (list) and the
+    detail ``GET`` (retrieve) get distinct, semantically correct OpenAPI
+    ``operationId``s instead of colliding on one shared handler.
+    """
+
+    permission_classes = [WorkspaceOwnerPermission]
+    serializer_class = WebhookSerializer
+
+    @extend_schema(
+        operation_id="retrieve_webhook",
+        summary="Retrieve webhook",
+        description="Retrieve a single webhook by ID. The `secret_key` is never included in this response.",
+        tags=["Webhooks"],
+        parameters=[WORKSPACE_SLUG_PARAMETER, WEBHOOK_PK_PARAMETER],
+        responses={
+            200: OpenApiResponse(description="Webhook", response=WebhookSerializer),
+            401: UNAUTHORIZED_RESPONSE,
+            403: FORBIDDEN_RESPONSE,
+            404: WORKSPACE_NOT_FOUND_RESPONSE,
+        },
+    )
+    def get(self, request, slug, pk):
+        webhook = Webhook.objects.get(workspace__slug=slug, pk=pk)
+        serializer = WebhookSerializer(webhook, fields=WEBHOOK_READ_FIELDS)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+    @extend_schema(
+        operation_id="update_webhook",
+        summary="Update webhook",
+        description=(
+            "Update a webhook's target `url`, active state or entity toggles. A "
+            "changed `url` is re-validated against the SSRF/URL guards. The "
+            "`secret_key` cannot be changed here."
+        ),
+        tags=["Webhooks"],
+        parameters=[WORKSPACE_SLUG_PARAMETER, WEBHOOK_PK_PARAMETER],
+        request=OpenApiRequest(request=WebhookSerializer),
+        responses={
+            200: OpenApiResponse(description="Webhook updated", response=WebhookSerializer),
+            400: OpenApiResponse(description="Invalid or disallowed webhook URL"),
+            401: UNAUTHORIZED_RESPONSE,
+            403: FORBIDDEN_RESPONSE,
+            404: WORKSPACE_NOT_FOUND_RESPONSE,
+            409: CONFLICT_RESPONSE,
+        },
+    )
+    def patch(self, request, slug, pk):
+        webhook = Webhook.objects.get(workspace__slug=slug, pk=pk)
+        try:
+            serializer = WebhookSerializer(
+                webhook,
+                data=request.data,
+                context={"request": request},
+                partial=True,
+                fields=WEBHOOK_READ_FIELDS,
+            )
+            if serializer.is_valid():
+                serializer.save()
+                return Response(serializer.data, status=status.HTTP_200_OK)
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+        except IntegrityError as e:
+            # Only the unique webhook-URL violation maps to 409; any other
+            # integrity error is re-raised rather than masked as a conflict.
+            if "already exists" in str(e):
+                return Response(
+                    {"error": "URL already exists for the workspace"},
+                    status=status.HTTP_409_CONFLICT,
+                )
+            raise
+
+    @extend_schema(
+        operation_id="delete_webhook",
+        summary="Delete webhook",
+        description="Delete a workspace webhook by ID.",
+        tags=["Webhooks"],
+        parameters=[WORKSPACE_SLUG_PARAMETER, WEBHOOK_PK_PARAMETER],
+        responses={
+            204: OpenApiResponse(description="Webhook deleted"),
+            401: UNAUTHORIZED_RESPONSE,
+            403: FORBIDDEN_RESPONSE,
+            404: WORKSPACE_NOT_FOUND_RESPONSE,
+        },
+    )
+    def delete(self, request, slug, pk):
+        webhook = Webhook.objects.get(workspace__slug=slug, pk=pk)
+        webhook.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/apps/api/plane/api/views/webhook.py
+++ b/apps/api/plane/api/views/webhook.py
@@ -18,7 +18,7 @@ from drf_spectacular.utils import (
 
 # Module imports
 from .base import BaseAPIView
-from plane.api.serializers import WebhookSerializer
+from plane.api.serializers import WebhookSerializer, WebhookLiteSerializer
 from plane.db.models import Webhook, Workspace
 from plane.utils.permissions import WorkspaceOwnerPermission
 from plane.utils.openapi import (
@@ -29,21 +29,11 @@ from plane.utils.openapi import (
     CONFLICT_RESPONSE,
 )
 
-# Fields returned to clients everywhere except the create response — the
-# server-generated ``secret_key`` is intentionally withheld here and only ever
-# surfaced once, in the create response, so it is not leaked on every read.
-WEBHOOK_READ_FIELDS = (
-    "id",
-    "url",
-    "is_active",
-    "created_at",
-    "updated_at",
-    "project",
-    "issue",
-    "cycle",
-    "module",
-    "issue_comment",
-)
+# Reads (list/retrieve/update) serialize through WebhookLiteSerializer, which
+# omits the server-generated ``secret_key`` — the secret is surfaced exactly
+# once, in the create response, so it is not leaked on every read. Using a
+# dedicated serializer rather than runtime field filtering keeps the published
+# OpenAPI schema identical to what the endpoint actually returns.
 
 WEBHOOK_PK_PARAMETER = OpenApiParameter(
     name="pk",
@@ -113,7 +103,7 @@ class WebhookAPIEndpoint(BaseAPIView):
         tags=["Webhooks"],
         parameters=[WORKSPACE_SLUG_PARAMETER],
         responses={
-            200: OpenApiResponse(description="Webhooks", response=WebhookSerializer(many=True)),
+            200: OpenApiResponse(description="Webhooks", response=WebhookLiteSerializer(many=True)),
             401: UNAUTHORIZED_RESPONSE,
             403: FORBIDDEN_RESPONSE,
             404: WORKSPACE_NOT_FOUND_RESPONSE,
@@ -121,7 +111,7 @@ class WebhookAPIEndpoint(BaseAPIView):
     )
     def get(self, request, slug):
         webhooks = Webhook.objects.filter(workspace__slug=slug)
-        serializer = WebhookSerializer(webhooks, fields=WEBHOOK_READ_FIELDS, many=True)
+        serializer = WebhookLiteSerializer(webhooks, many=True)
         return Response(serializer.data, status=status.HTTP_200_OK)
 
 
@@ -143,7 +133,7 @@ class WebhookDetailAPIEndpoint(BaseAPIView):
         tags=["Webhooks"],
         parameters=[WORKSPACE_SLUG_PARAMETER, WEBHOOK_PK_PARAMETER],
         responses={
-            200: OpenApiResponse(description="Webhook", response=WebhookSerializer),
+            200: OpenApiResponse(description="Webhook", response=WebhookLiteSerializer),
             401: UNAUTHORIZED_RESPONSE,
             403: FORBIDDEN_RESPONSE,
             404: WORKSPACE_NOT_FOUND_RESPONSE,
@@ -151,7 +141,7 @@ class WebhookDetailAPIEndpoint(BaseAPIView):
     )
     def get(self, request, slug, pk):
         webhook = Webhook.objects.get(workspace__slug=slug, pk=pk)
-        serializer = WebhookSerializer(webhook, fields=WEBHOOK_READ_FIELDS)
+        serializer = WebhookLiteSerializer(webhook)
         return Response(serializer.data, status=status.HTTP_200_OK)
 
     @extend_schema(
@@ -166,7 +156,7 @@ class WebhookDetailAPIEndpoint(BaseAPIView):
         parameters=[WORKSPACE_SLUG_PARAMETER, WEBHOOK_PK_PARAMETER],
         request=OpenApiRequest(request=WebhookSerializer),
         responses={
-            200: OpenApiResponse(description="Webhook updated", response=WebhookSerializer),
+            200: OpenApiResponse(description="Webhook updated", response=WebhookLiteSerializer),
             400: OpenApiResponse(description="Invalid or disallowed webhook URL"),
             401: UNAUTHORIZED_RESPONSE,
             403: FORBIDDEN_RESPONSE,
@@ -177,16 +167,19 @@ class WebhookDetailAPIEndpoint(BaseAPIView):
     def patch(self, request, slug, pk):
         webhook = Webhook.objects.get(workspace__slug=slug, pk=pk)
         try:
+            # Validate/save with the full serializer (it carries the URL schema,
+            # domain and SSRF guards); serialize the response with the lite one so
+            # the secret is not echoed back on update. secret_key is read-only on
+            # both, so it can never be written here either.
             serializer = WebhookSerializer(
                 webhook,
                 data=request.data,
                 context={"request": request},
                 partial=True,
-                fields=WEBHOOK_READ_FIELDS,
             )
             if serializer.is_valid():
-                serializer.save()
-                return Response(serializer.data, status=status.HTTP_200_OK)
+                updated = serializer.save()
+                return Response(WebhookLiteSerializer(updated).data, status=status.HTTP_200_OK)
             return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
         except IntegrityError as e:
             # Only the unique webhook-URL violation maps to 409; any other

--- a/apps/api/plane/bgtasks/webhook_task.py
+++ b/apps/api/plane/bgtasks/webhook_task.py
@@ -319,6 +319,7 @@ def webhook_send_task(
             webhook.url,
             allowed_ips=settings.WEBHOOK_ALLOWED_IPS,
             allowed_hosts=settings.WEBHOOK_ALLOWED_HOSTS,
+            allow_private=settings.WEBHOOK_ALLOW_PRIVATE_URLS,
             headers=headers,
             json=payload,
             timeout=30,

--- a/apps/api/plane/settings/common.py
+++ b/apps/api/plane/settings/common.py
@@ -90,6 +90,16 @@ WEBHOOK_DISALLOWED_DOMAINS = [
     if _d.strip()
 ]
 
+# Dev-only escape hatch: when set, webhook targets that resolve to
+# private/loopback/link-local addresses (e.g. http://host.docker.internal:<port>/
+# for a service running on the docker host) are permitted instead of rejected by
+# the SSRF guard. Scheme (http/https) and URL well-formedness are still enforced,
+# and outbound delivery is still pinned to the resolved IP (no DNS rebinding).
+# SECURITY WARNING: this disables the SSRF private-network protection for webhook
+# registration AND delivery — never enable it in production. Intended only for
+# local / docker-compose development against an engine on the host.
+WEBHOOK_ALLOW_PRIVATE_URLS = os.environ.get("WEBHOOK_ALLOW_PRIVATE_URLS", "0") == "1"
+
 # Allowed Hosts
 ALLOWED_HOSTS = os.environ.get("ALLOWED_HOSTS", "*").split(",")
 

--- a/apps/api/plane/tests/contract/api/test_webhooks.py
+++ b/apps/api/plane/tests/contract/api/test_webhooks.py
@@ -221,9 +221,25 @@ class TestWebhookReadUpdateDeleteAPIEndpoint:
         )
 
         assert response.status_code == status.HTTP_200_OK
+        assert "secret_key" not in response.data
         create_webhook.refresh_from_db()
         assert create_webhook.is_active is False
         assert create_webhook.cycle is True
+
+    @pytest.mark.django_db
+    def test_update_ignores_client_supplied_secret(self, api_key_client, workspace, create_webhook):
+        """secret_key is read-only on update too — a supplied value is discarded."""
+        original_secret = create_webhook.secret_key
+
+        response = api_key_client.patch(
+            _webhook_detail_url(workspace.slug, create_webhook.id),
+            {"secret_key": "attacker-controlled", "is_active": False},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        create_webhook.refresh_from_db()
+        assert create_webhook.secret_key == original_secret
 
     @pytest.mark.django_db
     def test_update_rejects_ssrf_target(self, api_key_client, workspace, create_webhook):
@@ -240,6 +256,27 @@ class TestWebhookReadUpdateDeleteAPIEndpoint:
 
         assert response.status_code == status.HTTP_204_NO_CONTENT
         assert not Webhook.objects.filter(id=create_webhook.id).exists()
+
+
+@pytest.mark.contract
+class TestWebhookSerializerShapes:
+    """The read serializer is what the OpenAPI schema is generated from, so its
+    shape IS the published contract — these assertions keep the documented
+    response identical to the one the endpoints actually return."""
+
+    def test_read_shape_excludes_secret_but_create_shape_includes_it(self):
+        from plane.api.serializers import WebhookLiteSerializer, WebhookSerializer
+
+        # The secret is surfaced exactly once, in the create response ...
+        assert "secret_key" in WebhookSerializer().fields
+        # ... and never on a read (list / retrieve / update).
+        assert "secret_key" not in WebhookLiteSerializer().fields
+
+    def test_read_shape_is_the_full_shape_minus_the_secret(self):
+        """Adding a field to the webhook API must not silently drop it from reads."""
+        from plane.api.serializers import WebhookLiteSerializer, WebhookSerializer
+
+        assert set(WebhookLiteSerializer().fields) == set(WebhookSerializer().fields) - {"secret_key"}
 
 
 @pytest.mark.contract

--- a/apps/api/plane/tests/contract/api/test_webhooks.py
+++ b/apps/api/plane/tests/contract/api/test_webhooks.py
@@ -1,0 +1,319 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""
+Contract tests for the public token-API workspace webhook endpoints.
+
+Covers CRUD via ``/api/v1/workspaces/{slug}/webhooks/`` and proves the two
+security-critical guarantees:
+
+* create returns a usable, server-generated ``secret_key`` (and it is not
+  leaked on subsequent reads), and
+* a delivery built from that secret signs the payload correctly with
+  ``X-Plane-Signature`` (HMAC-SHA256).
+"""
+
+import hashlib
+import hmac
+import json
+from unittest import mock
+from uuid import uuid4
+
+import pytest
+from django.db import IntegrityError
+from rest_framework import serializers, status
+from rest_framework.test import APIClient
+
+from plane.db.models import Webhook, WorkspaceMember
+from plane.db.models.api import APIToken
+
+
+def _webhooks_url(slug):
+    return f"/api/v1/workspaces/{slug}/webhooks/"
+
+
+def _webhook_detail_url(slug, pk):
+    return f"/api/v1/workspaces/{slug}/webhooks/{pk}/"
+
+
+@pytest.fixture
+def webhook_data():
+    """A valid webhook payload targeting a public IP literal.
+
+    Using a public IP literal keeps ``validate_url`` (which resolves the host)
+    deterministic and offline — no DNS lookup happens for a numeric address —
+    while still exercising the real SSRF guard.
+    """
+    return {
+        "url": "https://8.8.8.8/webhook",
+        "issue": True,
+        "issue_comment": True,
+        "cycle": True,
+        "module": True,
+        "project": True,
+    }
+
+
+@pytest.fixture
+def create_webhook(db, workspace):
+    """An existing active webhook for the workspace."""
+    return Webhook.objects.create(
+        workspace=workspace,
+        url="https://8.8.8.8/existing",
+        issue=True,
+    )
+
+
+@pytest.fixture
+def member_api_key_client(db, workspace):
+    """An API-key client whose user is a workspace *member* (role 15).
+
+    Used to prove webhook management is admin-only, mirroring the app API.
+    """
+    from plane.db.models import User
+
+    member = User.objects.create(
+        email="member@plane.so",
+        username="member@plane.so",
+        first_name="Member",
+    )
+    member.set_password("member-password")
+    member.save()
+    WorkspaceMember.objects.create(workspace=workspace, member=member, role=15)
+    token = APIToken.objects.create(user=member, label="Member Token")
+
+    client = APIClient()
+    client.credentials(HTTP_X_API_KEY=token.token)
+    return client
+
+
+@pytest.mark.contract
+class TestWebhookCreateAPIEndpoint:
+    @pytest.mark.django_db
+    def test_create_returns_usable_secret(self, api_key_client, workspace, webhook_data):
+        """Create generates a server-side secret and returns it once."""
+        response = api_key_client.post(_webhooks_url(workspace.slug), webhook_data, format="json")
+
+        assert response.status_code == status.HTTP_201_CREATED
+
+        secret = response.data["secret_key"]
+        assert secret
+        assert secret.startswith("plane_wh_")
+
+        # The secret is not client-supplied — it matches the persisted value.
+        webhook = Webhook.objects.get(id=response.data["id"])
+        assert webhook.secret_key == secret
+        assert webhook.workspace_id == workspace.id
+
+        # Entity toggles round-trip.
+        assert webhook.issue is True
+        assert webhook.issue_comment is True
+        assert webhook.cycle is True
+        assert webhook.module is True
+        assert webhook.project is True
+
+    @pytest.mark.django_db
+    def test_create_ignores_client_supplied_secret(self, api_key_client, workspace, webhook_data):
+        """secret_key is read-only: a client-supplied value is discarded."""
+        payload = {**webhook_data, "secret_key": "attacker-controlled"}
+        response = api_key_client.post(_webhooks_url(workspace.slug), payload, format="json")
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.data["secret_key"] != "attacker-controlled"
+        assert response.data["secret_key"].startswith("plane_wh_")
+
+    @pytest.mark.django_db
+    def test_create_ignores_client_supplied_internal_and_version(self, api_key_client, workspace, webhook_data):
+        """is_internal and version are server-controlled: client values are ignored."""
+        payload = {**webhook_data, "is_internal": True, "version": "v99"}
+        response = api_key_client.post(_webhooks_url(workspace.slug), payload, format="json")
+
+        assert response.status_code == status.HTTP_201_CREATED
+
+        # Neither field is exposed on the public serializer, and the persisted
+        # webhook keeps the server-controlled model defaults.
+        webhook = Webhook.objects.get(id=response.data["id"])
+        assert webhook.is_internal is False
+        assert webhook.version == "v1"
+
+    @pytest.mark.django_db
+    def test_create_rejects_ssrf_target(self, api_key_client, workspace):
+        """The SSRF guard blocks loopback/private targets (not weakened)."""
+        response = api_key_client.post(
+            _webhooks_url(workspace.slug),
+            {"url": "http://127.0.0.1:9000/hook"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    @pytest.mark.django_db
+    def test_create_rejects_non_http_scheme(self, api_key_client, workspace):
+        """Only http(s) schemes are accepted."""
+        response = api_key_client.post(
+            _webhooks_url(workspace.slug),
+            {"url": "ftp://8.8.8.8/hook"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    @pytest.mark.django_db
+    def test_create_duplicate_url_conflict(self, api_key_client, workspace, create_webhook):
+        """A duplicate URL for the workspace returns 409."""
+        response = api_key_client.post(
+            _webhooks_url(workspace.slug),
+            {"url": create_webhook.url},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_409_CONFLICT
+
+    @pytest.mark.django_db
+    def test_create_non_unique_integrity_error_not_masked(self, api_key_client, workspace, webhook_data):
+        """A non-unique IntegrityError must not be misreported as a 409 duplicate-URL conflict."""
+        with mock.patch(
+            "plane.api.views.webhook.WebhookSerializer.save",
+            side_effect=IntegrityError("null value in column violates not-null constraint"),
+        ):
+            response = api_key_client.post(_webhooks_url(workspace.slug), webhook_data, format="json")
+
+        assert response.status_code != status.HTTP_409_CONFLICT
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "already exists" not in str(response.data)
+
+    @pytest.mark.django_db
+    def test_create_requires_workspace_admin(self, member_api_key_client, workspace, webhook_data):
+        """Webhook management is workspace-admin only, mirroring the app API."""
+        response = member_api_key_client.post(_webhooks_url(workspace.slug), webhook_data, format="json")
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.contract
+class TestWebhookReadUpdateDeleteAPIEndpoint:
+    @pytest.mark.django_db
+    def test_list_hides_secret(self, api_key_client, workspace, create_webhook):
+        response = api_key_client.get(_webhooks_url(workspace.slug))
+
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data) == 1
+        assert "secret_key" not in response.data[0]
+        assert response.data[0]["url"] == create_webhook.url
+
+    @pytest.mark.django_db
+    def test_retrieve_hides_secret(self, api_key_client, workspace, create_webhook):
+        response = api_key_client.get(_webhook_detail_url(workspace.slug, create_webhook.id))
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["id"] == create_webhook.id
+        assert "secret_key" not in response.data
+
+    @pytest.mark.django_db
+    def test_retrieve_not_found(self, api_key_client, workspace):
+        response = api_key_client.get(_webhook_detail_url(workspace.slug, uuid4()))
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    @pytest.mark.django_db
+    def test_update_toggle_and_active(self, api_key_client, workspace, create_webhook):
+        response = api_key_client.patch(
+            _webhook_detail_url(workspace.slug, create_webhook.id),
+            {"is_active": False, "cycle": True},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        create_webhook.refresh_from_db()
+        assert create_webhook.is_active is False
+        assert create_webhook.cycle is True
+
+    @pytest.mark.django_db
+    def test_update_rejects_ssrf_target(self, api_key_client, workspace, create_webhook):
+        response = api_key_client.patch(
+            _webhook_detail_url(workspace.slug, create_webhook.id),
+            {"url": "http://169.254.169.254/latest/meta-data/"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    @pytest.mark.django_db
+    def test_delete_webhook(self, api_key_client, workspace, create_webhook):
+        response = api_key_client.delete(_webhook_detail_url(workspace.slug, create_webhook.id))
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        assert not Webhook.objects.filter(id=create_webhook.id).exists()
+
+
+@pytest.mark.contract
+class TestWebhookDeliverySigning:
+    @pytest.mark.django_db
+    def test_delivery_signs_with_created_secret(self, api_key_client, workspace, webhook_data):
+        """A delivery built from the API-issued secret signs the payload with
+        an HMAC-SHA256 ``X-Plane-Signature`` the receiver can verify."""
+        from plane.bgtasks.webhook_task import webhook_send_task
+
+        # 1. Provision the webhook through the public API and capture its secret.
+        create_response = api_key_client.post(_webhooks_url(workspace.slug), webhook_data, format="json")
+        assert create_response.status_code == status.HTTP_201_CREATED
+        secret = create_response.data["secret_key"]
+        webhook_id = create_response.data["id"]
+
+        captured = {}
+
+        class _FakeResponse:
+            status_code = 200
+            headers = {}
+            text = "ok"
+
+        def _fake_pinned_fetch(method, url, **kwargs):
+            captured["headers"] = kwargs["headers"]
+            captured["json"] = kwargs["json"]
+            return _FakeResponse()
+
+        # 2. Run the real delivery task with the network pinned-fetch stubbed out.
+        with mock.patch("plane.bgtasks.webhook_task.pinned_fetch", side_effect=_fake_pinned_fetch):
+            webhook_send_task.apply(
+                kwargs=dict(
+                    webhook_id=str(webhook_id),
+                    slug=workspace.slug,
+                    event="issue",
+                    event_data={"id": str(uuid4())},
+                    action="POST",
+                    current_site="http://example.com",
+                    activity=None,
+                )
+            )
+
+        # 3. The receiver recomputes the signature from the shared secret.
+        headers = captured["headers"]
+        payload = captured["json"]
+        expected_signature = hmac.new(
+            secret.encode("utf-8"),
+            json.dumps(payload).encode("utf-8"),
+            hashlib.sha256,
+        ).hexdigest()
+
+        assert headers["X-Plane-Signature"] == expected_signature
+        assert headers["X-Plane-Event"] == "issue"
+        assert payload["event"] == "issue"
+        assert payload["webhook_id"] == str(webhook_id)
+
+
+@pytest.mark.contract
+class TestWebhookLoopbackGuard:
+    """The request-host loop-back guard must handle bracketed IPv6 hosts."""
+
+    def test_ipv6_request_host_is_parsed_correctly(self):
+        from plane.utils.webhook import validate_webhook_url
+
+        request = mock.MagicMock()
+        # Plane served on an IPv6 host with a port — get_host() returns it bracketed.
+        request.get_host.return_value = "[2001:db8::5]:8000"
+
+        # Bypass the SSRF resolver so the test targets only the request-host
+        # loop-back guard (the piece that must parse "[::1]:8000"-style hosts).
+        with mock.patch("plane.utils.webhook.validate_url"):
+            # A webhook pointed at the instance's own IPv6 host is rejected —
+            # a naive split(":")[0] would yield "[2001" and fail to match.
+            with pytest.raises(serializers.ValidationError):
+                validate_webhook_url("http://[2001:db8::5]/hook", request)
+
+            # An unrelated public host still passes.
+            validate_webhook_url("https://8.8.8.8/hook", request)

--- a/apps/api/plane/tests/contract/api/test_webhooks.py
+++ b/apps/api/plane/tests/contract/api/test_webhooks.py
@@ -22,6 +22,7 @@ from uuid import uuid4
 
 import pytest
 from django.db import IntegrityError
+from django.test import override_settings
 from rest_framework import serializers, status
 from rest_framework.test import APIClient
 
@@ -294,6 +295,55 @@ class TestWebhookDeliverySigning:
         assert headers["X-Plane-Event"] == "issue"
         assert payload["event"] == "issue"
         assert payload["webhook_id"] == str(webhook_id)
+
+
+def _addr(ip):
+    """Build a getaddrinfo-style result tuple for a resolved IP (no real DNS)."""
+    family = 6 if ":" in ip else 2
+    return (family, None, None, None, (ip, 0))
+
+
+@pytest.mark.contract
+class TestWebhookAllowPrivateFlag:
+    """The dev-only WEBHOOK_ALLOW_PRIVATE_URLS escape hatch for local development.
+
+    The flag only lifts the private/internal-IP block — scheme and URL
+    well-formedness are still enforced regardless of the flag.
+    """
+
+    PRIVATE_URL = "http://internal.example.com/hook"
+
+    def _validate(self, url):
+        from plane.utils.webhook import validate_webhook_url
+
+        # Resolve the host to a private IP without touching real DNS.
+        with mock.patch(
+            "plane.utils.ip_address.socket.getaddrinfo",
+            return_value=[_addr("10.0.0.5")],
+        ):
+            validate_webhook_url(url)
+
+    def test_private_url_rejected_by_default(self):
+        # Guard active by default: a private/internal target is rejected.
+        with pytest.raises(serializers.ValidationError):
+            self._validate(self.PRIVATE_URL)
+
+    @override_settings(WEBHOOK_ALLOW_PRIVATE_URLS=True)
+    def test_flag_permits_private_url(self):
+        # Flag on: the same private target is permitted (no exception).
+        self._validate(self.PRIVATE_URL)
+
+    @override_settings(WEBHOOK_ALLOW_PRIVATE_URLS=True)
+    def test_non_http_scheme_rejected_regardless_of_flag(self):
+        # The flag must NOT bypass scheme validation.
+        with pytest.raises(serializers.ValidationError):
+            self._validate("ftp://internal.example.com/hook")
+
+    @override_settings(WEBHOOK_ALLOW_PRIVATE_URLS=True)
+    def test_malformed_url_rejected_regardless_of_flag(self):
+        # The flag must NOT bypass URL well-formedness validation.
+        with pytest.raises(serializers.ValidationError):
+            self._validate("http:///nohost")
 
 
 @pytest.mark.contract

--- a/apps/api/plane/tests/unit/bg_tasks/test_url_security.py
+++ b/apps/api/plane/tests/unit/bg_tasks/test_url_security.py
@@ -129,6 +129,75 @@ class TestResolveAndValidate:
 
 
 # ---------------------------------------------------------------------------
+# Dev-only allow_private escape hatch (WEBHOOK_ALLOW_PRIVATE_URLS)
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestValidateUrlAllowPrivate:
+    def test_allow_private_permits_private_ip_but_default_blocks(self):
+        with patch("plane.utils.ip_address.socket.getaddrinfo") as dns:
+            dns.return_value = [_addr("10.0.0.5")]
+            # Default (guard active): private target is blocked.
+            with pytest.raises(ValueError, match="private/internal"):
+                validate_url("http://internal.example.com/x")
+            # allow_private=True: the block is lifted (no raise).
+            validate_url("http://internal.example.com/x", allow_private=True)
+
+    def test_allow_private_still_enforces_scheme(self):
+        with patch("plane.utils.ip_address.socket.getaddrinfo") as dns:
+            dns.return_value = [_addr("10.0.0.5")]
+            with pytest.raises(ValueError, match="scheme"):
+                validate_url("ftp://internal.example.com/x", allow_private=True)
+
+
+@pytest.mark.unit
+class TestPinnedFetchAllowPrivate:
+    """allow_private lifts the delivery-time block check but preserves pinning."""
+
+    @patch("plane.utils.url_security.requests.Session")
+    @patch("plane.utils.url_security.resolve_and_validate")
+    def test_allow_private_skips_block_but_still_pins(self, mock_resolve, mock_session_cls):
+        mock_resolve.return_value = ["10.0.0.5"]
+        session = mock_session_cls.return_value
+        session.request.return_value = _resp(200)
+
+        pinned_fetch("POST", "http://host.docker.internal:8000/hook", allow_private=True, json={"a": 1})
+
+        # The private-IP block check is skipped ...
+        assert mock_resolve.call_args.kwargs["require_safe"] is False
+        # ... but the socket is STILL pinned to the resolved IP literal (no
+        # DNS-rebinding window), and the Host header keeps the real hostname.
+        _, url = session.request.call_args.args
+        assert url == "http://10.0.0.5:8000/hook"
+        assert session.request.call_args.kwargs["headers"]["Host"] == "host.docker.internal:8000"
+
+    @patch("plane.utils.url_security.requests.Session")
+    @patch("plane.utils.url_security.resolve_and_validate")
+    def test_default_keeps_block_check_on(self, mock_resolve, mock_session_cls):
+        mock_resolve.return_value = ["93.184.216.34"]
+        session = mock_session_cls.return_value
+        session.request.return_value = _resp(200)
+
+        pinned_fetch("POST", "https://example.com/hook")
+
+        # Default (no allow_private, non-trusted host): block check stays on.
+        assert mock_resolve.call_args.kwargs["require_safe"] is True
+
+    @patch("plane.utils.url_security.requests.Session")
+    @patch("plane.utils.url_security.resolve_and_validate")
+    def test_redirect_follower_never_inherits_allow_private(self, mock_resolve, mock_session_cls):
+        # The redirect-following path (OAuth avatar / link unfurl) must stay
+        # fully guarded — it must NOT inherit the webhook-only escape hatch even
+        # if a caller mistakenly threads allow_private=True via kwargs.
+        mock_resolve.return_value = ["93.184.216.34"]
+        session = mock_session_cls.return_value
+        session.request.return_value = _resp(200)
+
+        pinned_fetch_following_redirects("GET", "https://example.com/x", allow_private=True)
+
+        assert mock_resolve.call_args.kwargs["require_safe"] is True
+
+
+# ---------------------------------------------------------------------------
 # Cluster B — connection pinned to the validated IP (DNS-rebinding TOCTOU)
 # ---------------------------------------------------------------------------
 @pytest.mark.unit
@@ -186,9 +255,7 @@ class TestPinnedFetch:
 
     @patch("plane.utils.url_security.resolve_and_validate")
     def test_blocked_target_raises_before_any_request(self, mock_resolve):
-        mock_resolve.side_effect = ValueError(
-            "Access to private/internal networks is not allowed"
-        )
+        mock_resolve.side_effect = ValueError("Access to private/internal networks is not allowed")
         with pytest.raises(ValueError, match="private/internal"):
             pinned_fetch("POST", "https://attacker.com/hook")
 
@@ -275,9 +342,7 @@ class TestPinnedFetchRedirects:
             ValueError("Access to private/internal networks is not allowed"),
         ]
         session = mock_session_cls.return_value
-        session.request.return_value = _resp(
-            302, headers={"Location": "http://169.254.169.254/latest/meta-data/"}
-        )
+        session.request.return_value = _resp(302, headers={"Location": "http://169.254.169.254/latest/meta-data/"})
         with pytest.raises(ValueError, match="private/internal"):
             pinned_fetch_following_redirects("GET", "https://evil.com/r")
 
@@ -286,13 +351,9 @@ class TestPinnedFetchRedirects:
     def test_too_many_redirects(self, mock_resolve, mock_session_cls):
         mock_resolve.return_value = ["93.184.216.34"]
         session = mock_session_cls.return_value
-        session.request.return_value = _resp(
-            302, headers={"Location": "https://example.com/loop"}
-        )
+        session.request.return_value = _resp(302, headers={"Location": "https://example.com/loop"})
         with pytest.raises(requests.TooManyRedirects):
-            pinned_fetch_following_redirects(
-                "GET", "https://example.com/start", max_redirects=3
-            )
+            pinned_fetch_following_redirects("GET", "https://example.com/start", max_redirects=3)
 
 
 # ---------------------------------------------------------------------------

--- a/apps/api/plane/utils/ip_address.py
+++ b/apps/api/plane/utils/ip_address.py
@@ -156,7 +156,7 @@ def resolve_and_validate(hostname, allowed_ips=None, require_safe=True):
     return validated
 
 
-def validate_url(url, allowed_ips=None, allowed_hosts=None):
+def validate_url(url, allowed_ips=None, allowed_hosts=None, allow_private=False):
     """
     Validate that a URL doesn't resolve to a private/internal IP address (SSRF protection).
 
@@ -174,6 +174,10 @@ def validate_url(url, allowed_ips=None, allowed_hosts=None):
                        Typically sourced from the WEBHOOK_ALLOWED_HOSTS setting and
                        used for trusted internal services (e.g. Silo) whose IPs are
                        dynamic in containerised deployments.
+        allow_private: When True, skip the private/internal-IP block check entirely
+                       (the host is still resolved). Scheme and hostname validation
+                       are unaffected. Dev-only escape hatch — see
+                       ``WEBHOOK_ALLOW_PRIVATE_URLS``; never enable in production.
 
     Raises:
         ValueError: If the URL is invalid or resolves to a blocked IP.
@@ -193,7 +197,7 @@ def validate_url(url, allowed_ips=None, allowed_hosts=None):
     }:
         return
 
-    resolve_and_validate(hostname, allowed_ips=allowed_ips)
+    resolve_and_validate(hostname, allowed_ips=allowed_ips, require_safe=not allow_private)
 
 
 def get_client_ip(request):

--- a/apps/api/plane/utils/url_security.py
+++ b/apps/api/plane/utils/url_security.py
@@ -157,7 +157,7 @@ def _request_to_ip(method, scheme, hostname, ip, port, path, *, headers, timeout
     return response
 
 
-def _fetch_validated_hop(method, url, *, allowed_ips, allowed_hosts, headers, timeout, **kwargs):
+def _fetch_validated_hop(method, url, *, allowed_ips, allowed_hosts, allow_private=False, headers, timeout, **kwargs):
     """
     Resolve ``url``'s host, validate it, then issue a single (non-redirecting)
     request pinned to a resolved IP. Returns ``(response, normalized_host)``.
@@ -166,6 +166,9 @@ def _fetch_validated_hop(method, url, *, allowed_ips, allowed_hosts, headers, ti
     whose IPs are dynamic): they skip the private-IP *block* check, but the
     connection is STILL pinned to the resolved IP so a trusted hostname cannot
     be rebound to a different internal target between validation and connect.
+
+    ``allow_private`` applies that same "skip the block check but still pin"
+    treatment globally (dev-only escape hatch — see ``WEBHOOK_ALLOW_PRIVATE_URLS``).
     """
     scheme, hostname, port, path, auth = _split_target(url)
 
@@ -174,10 +177,12 @@ def _fetch_validated_hop(method, url, *, allowed_ips, allowed_hosts, headers, ti
         (h or "").rstrip(".").lower() for h in allowed_hosts if h
     }
 
-    # Resolve once (and validate unless the host is operator-trusted), then pin
-    # the connection to a resolved IP literal — urllib3 performs no second DNS
-    # lookup, so the address validated here is exactly the one reached.
-    ips = resolve_and_validate(hostname, allowed_ips=allowed_ips, require_safe=not trusted)
+    # Resolve once (and validate unless the host is operator-trusted or the
+    # dev-only allow_private escape hatch is on), then pin the connection to a
+    # resolved IP literal — urllib3 performs no second DNS lookup, so the address
+    # validated here is exactly the one reached (pinning is preserved even when
+    # the block check is skipped).
+    ips = resolve_and_validate(hostname, allowed_ips=allowed_ips, require_safe=not (trusted or allow_private))
 
     last_exc = None
     for ip in ips:
@@ -201,6 +206,7 @@ def pinned_fetch(
     *,
     allowed_ips=None,
     allowed_hosts=None,
+    allow_private=False,
     headers=None,
     timeout=30,
     **kwargs,
@@ -210,13 +216,17 @@ def pinned_fetch(
     connection to a validated IP (defeating DNS rebinding). Does NOT follow
     redirects.
 
+    ``allow_private`` is a dev-only escape hatch (see ``WEBHOOK_ALLOW_PRIVATE_URLS``):
+    when True the private/internal-IP block is skipped, but the host is still
+    resolved and the connection is still pinned to the resolved IP.
+
     Raises:
         ValueError: if the URL is invalid or resolves to a blocked address.
         requests.RequestException: on network/transport errors.
     """
     response, _ = _fetch_validated_hop(
         method, url,
-        allowed_ips=allowed_ips, allowed_hosts=allowed_hosts,
+        allowed_ips=allowed_ips, allowed_hosts=allowed_hosts, allow_private=allow_private,
         headers=headers, timeout=timeout, **kwargs,
     )
     return response
@@ -243,12 +253,18 @@ def pinned_fetch_following_redirects(
         requests.TooManyRedirects: if the hop limit is exceeded.
         requests.RequestException: on network/transport errors.
     """
+    # The redirect-following path is used only by fully-guarded, non-webhook
+    # callers (OAuth avatar, link unfurling). Pin allow_private=False explicitly
+    # so the dev-only private-network escape hatch can never reach this path —
+    # even accidentally via **kwargs (a duplicate key would raise, not silently
+    # enable the bypass).
+    kwargs.pop("allow_private", None)
     current_url = url
     redirects = 0
     while True:
         response, _ = _fetch_validated_hop(
             method, current_url,
-            allowed_ips=allowed_ips, allowed_hosts=allowed_hosts,
+            allowed_ips=allowed_ips, allowed_hosts=allowed_hosts, allow_private=False,
             headers=headers, timeout=timeout, **kwargs,
         )
 

--- a/apps/api/plane/utils/webhook.py
+++ b/apps/api/plane/utils/webhook.py
@@ -28,6 +28,12 @@ def validate_webhook_url(url, request=None):
     then rejects hosts matching ``WEBHOOK_DISALLOWED_DOMAINS`` (and the request
     host, as a loop-back guard).
 
+    The ``WEBHOOK_ALLOW_PRIVATE_URLS`` setting is a dev-only escape hatch: when
+    enabled it permits private/loopback targets (e.g. ``host.docker.internal``)
+    for local development. It only lifts the private-IP block — the scheme
+    (http/https) and URL well-formedness are still enforced. Never enable it in
+    production (see ``settings/common.py``).
+
     Args:
         url: The webhook target URL to validate.
         request: The active request, used to append the request host to the
@@ -42,6 +48,7 @@ def validate_webhook_url(url, request=None):
             url,
             allowed_ips=settings.WEBHOOK_ALLOWED_IPS,
             allowed_hosts=settings.WEBHOOK_ALLOWED_HOSTS,
+            allow_private=settings.WEBHOOK_ALLOW_PRIVATE_URLS,
         )
     except ValueError as e:
         logger.warning("Webhook URL validation failed for %s: %s", url, e)

--- a/apps/api/plane/utils/webhook.py
+++ b/apps/api/plane/utils/webhook.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+# Python imports
+import logging
+from urllib.parse import urlparse
+
+# Third party imports
+from rest_framework import serializers
+
+# Django imports
+from django.conf import settings
+
+# Module imports
+from plane.utils.ip_address import validate_url
+
+logger = logging.getLogger(__name__)
+
+
+def validate_webhook_url(url, request=None):
+    """Validate a webhook URL against SSRF and disallowed-domain rules.
+
+    Shared by the internal app API and the public token API webhook
+    serializers so the SSRF/URL guards can never drift between the two
+    surfaces. Resolves the host and rejects private/internal targets (unless
+    explicitly allow-listed via ``WEBHOOK_ALLOWED_IPS``/``WEBHOOK_ALLOWED_HOSTS``),
+    then rejects hosts matching ``WEBHOOK_DISALLOWED_DOMAINS`` (and the request
+    host, as a loop-back guard).
+
+    Args:
+        url: The webhook target URL to validate.
+        request: The active request, used to append the request host to the
+            disallowed-domain list (loop-back guard). Optional.
+
+    Raises:
+        rest_framework.serializers.ValidationError: If the URL resolves to a
+            blocked/internal target or matches a disallowed domain.
+    """
+    try:
+        validate_url(
+            url,
+            allowed_ips=settings.WEBHOOK_ALLOWED_IPS,
+            allowed_hosts=settings.WEBHOOK_ALLOWED_HOSTS,
+        )
+    except ValueError as e:
+        logger.warning("Webhook URL validation failed for %s: %s", url, e)
+        raise serializers.ValidationError({"url": "Invalid or disallowed webhook URL."})
+
+    hostname = (urlparse(url).hostname or "").rstrip(".").lower()
+
+    # Hosts explicitly trusted via WEBHOOK_ALLOWED_HOSTS bypass the
+    # disallowed-domain check — they're already trusted for SSRF, so the
+    # loop-back guard would only get in the way of legitimate sibling services
+    # that share a parent domain with Plane.
+    if hostname in settings.WEBHOOK_ALLOWED_HOSTS:
+        return
+
+    disallowed_domains = list(settings.WEBHOOK_DISALLOWED_DOMAINS)
+    if request:
+        # Parse via urlparse (prefixing "//" so the host is read as a netloc)
+        # so a bracketed IPv6 literal with a port (e.g. "[::1]:8000") yields the
+        # bare host "::1" instead of the "[" that a naive split(":")[0] returns.
+        request_host = (urlparse("//" + request.get_host()).hostname or "").rstrip(".").lower()
+        if request_host:
+            disallowed_domains.append(request_host)
+
+    if any(hostname == domain or hostname.endswith("." + domain) for domain in disallowed_domains):
+        raise serializers.ValidationError({"url": "URL domain or its subdomain is not allowed."})

--- a/deployments/aio/community/variables.env
+++ b/deployments/aio/community/variables.env
@@ -72,3 +72,9 @@ WEBHOOK_ALLOWED_IPS=
 # SSRF check. Useful for trusted internal services whose container/service IPs are
 # dynamic (e.g. "silo,silo.namespace.svc.cluster.local")
 WEBHOOK_ALLOWED_HOSTS=
+
+# DEV ONLY — set to 1 to allow webhooks that target private/loopback addresses
+# (e.g. http://host.docker.internal:<port>/ for a service on the docker host).
+# This disables the SSRF private-network protection for webhook registration and
+# delivery. NEVER enable this in production; leave it unset in real deployments.
+# WEBHOOK_ALLOW_PRIVATE_URLS=1

--- a/deployments/cli/community/docker-compose.yml
+++ b/deployments/cli/community/docker-compose.yml
@@ -60,6 +60,8 @@ x-app-env: &app-env
   LIVE_SERVER_SECRET_KEY: ${LIVE_SERVER_SECRET_KEY}
   WEBHOOK_ALLOWED_IPS: ${WEBHOOK_ALLOWED_IPS:-}
   WEBHOOK_ALLOWED_HOSTS: ${WEBHOOK_ALLOWED_HOSTS:-}
+  # DEV ONLY — see variables.env; never enable in production.
+  WEBHOOK_ALLOW_PRIVATE_URLS: ${WEBHOOK_ALLOW_PRIVATE_URLS:-0}
 
 services:
   web:

--- a/deployments/cli/community/variables.env
+++ b/deployments/cli/community/variables.env
@@ -96,3 +96,9 @@ WEBHOOK_ALLOWED_IPS=
 # SSRF check. Useful for trusted internal services whose container/service IPs are
 # dynamic (e.g. "silo,silo.namespace.svc.cluster.local")
 WEBHOOK_ALLOWED_HOSTS=
+
+# DEV ONLY — set to 1 to allow webhooks that target private/loopback addresses
+# (e.g. http://host.docker.internal:<port>/ for a service on the docker host).
+# This disables the SSRF private-network protection for webhook registration and
+# delivery. NEVER enable this in production; leave it unset in real deployments.
+# WEBHOOK_ALLOW_PRIVATE_URLS=1


### PR DESCRIPTION
### Description

Add GET/POST/PATCH/DELETE /api/v1/workspaces/{slug}/webhooks/ to the public (X-Api-Key) token API, mirroring the internal app-API webhook endpoint so webhooks can be provisioned programmatically instead of only through the UI.

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added workspace webhook API endpoints for create, list, retrieve, partial update, and delete.
  * Webhook responses now omit server-generated secrets except on create; delivery remains signed with `X-Plane-Signature`.
* **Bug Fixes**
  * Improved webhook URL conflict handling and tightened workspace-owner access behavior.
* **Documentation**
  * Added a dev-only `WEBHOOK_ALLOW_PRIVATE_URLS=1` escape hatch for private/loopback webhook targets (not for production).
* **Tests**
  * Added contract and unit tests covering webhook CRUD, secret exposure rules, signing, and SSRF protections (including the dev escape hatch and redirect behavior).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->