### PR TITLE
feat(api): support mentioning users in work-item comments

### DIFF
--- a/apps/api/plane/api/serializers/issue.py
+++ b/apps/api/plane/api/serializers/issue.py
@@ -2,16 +2,21 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # See the LICENSE file for details.
 
+# Python imports
+import uuid
+
 # Django imports
 from django.utils import timezone
 from lxml import html
 from django.db import IntegrityError
+from django.db.models import Q
 
 #  Third party imports
 from rest_framework import serializers
 
 # Module imports
 from plane.db.models import (
+    BotTypeEnum,
     Issue,
     IssueType,
     IssueActivity,
@@ -27,6 +32,7 @@ from plane.db.models import (
     User,
     EstimatePoint,
 )
+from plane.bgtasks.notification_task import extract_comment_mentions
 from plane.utils.content_validator import (
     validate_html_content,
     validate_binary_data,
@@ -687,13 +693,72 @@ class IssueAttachmentSerializer(BaseSerializer):
         ]
 
 
+# The editor represents an in-text user mention as a ``<mention-component>`` node
+# tagged with ``entity_name="user_mention"``. The reference/notification pipeline
+# (see ``plane.bgtasks.notification_task.extract_comment_mentions``) parses
+# ``comment_html`` for exactly these tags, so rendering the same markup server-side
+# is what makes an API-supplied mention behave like one typed in the web app.
+USER_MENTION_ENTITY_NAME = "user_mention"
+
+
+def render_user_mention(user_id) -> str:
+    """Render the internal editor markup for a single user mention.
+
+    Mirrors the ``<mention-component>`` node produced by the web editor. The
+    ``id`` attribute is a per-node identifier (the editor uses a random UUID);
+    ``entity_identifier`` carries the mentioned user's id and ``entity_name`` is
+    fixed to ``user_mention`` so the notification pipeline recognises it.
+    """
+    return (
+        f'<mention-component id="{uuid.uuid4()}" '
+        f'entity_identifier="{user_id}" '
+        f'entity_name="{USER_MENTION_ENTITY_NAME}"></mention-component>'
+    )
+
+
+def append_user_mentions(comment_html, user_ids) -> str:
+    """Append user mention markup to a comment's HTML body.
+
+    The mentions are added as a trailing paragraph so the markup round-trips
+    through the editor's block-based document model.
+    """
+    mention_markup = " ".join(render_user_mention(user_id) for user_id in user_ids)
+    return f"{comment_html or ''}<p>{mention_markup}</p>"
+
+
 class IssueCommentCreateSerializer(BaseSerializer):
     """
     Serializer for creating work item comments.
 
     Handles comment creation with JSON and HTML content support,
-    access control, and external integration tracking.
+    access control, and external integration tracking. Accepts an optional
+    ``mentions`` list of user ids; the corresponding mention markup is rendered
+    into ``comment_html`` server-side so mentioned users are notified without the
+    caller having to hand-craft ``<mention-component>`` tags.
     """
+
+    # The `values_list("id", flat=True)` queryset makes each PrimaryKeyRelatedField
+    # child resolve to the user's UUID (not a User instance). validate() below relies
+    # on this: it filters ProjectMember with `member_id__in=<uuids>` and tests
+    # `user_id in valid_member_ids` (a set of UUIDs). Do NOT change this to a queryset
+    # of User instances — those comparisons would break. This mirrors the `assignees`
+    # and `labels` fields on IssueSerializer.
+    mentions = serializers.ListField(
+        child=serializers.PrimaryKeyRelatedField(queryset=User.objects.values_list("id", flat=True)),
+        write_only=True,
+        required=False,
+        # Bound the input so a single comment cannot render an unbounded amount of
+        # mention markup / drive an unbounded member_id__in query. 100 comfortably
+        # covers any realistic mention set while preventing abuse.
+        max_length=100,
+        help_text=(
+            "List of user ids to mention in the comment (max 100). Each id must belong to an "
+            "existing user (unknown ids are rejected). Only active project members that are "
+            "human users or service accounts (bot_type=SERVICE) can be mentioned; other bots "
+            "(e.g. workspace-seed) are ignored. The server renders the mention markup into "
+            "comment_html and notifies the mentioned users."
+        ),
+    )
 
     class Meta:
         model = IssueComment
@@ -703,6 +768,7 @@ class IssueCommentCreateSerializer(BaseSerializer):
             "access",
             "external_source",
             "external_id",
+            "mentions",
         ]
         read_only_fields = [
             "id",
@@ -718,6 +784,66 @@ class IssueCommentCreateSerializer(BaseSerializer):
             "comment_stripped",
             "edited_at",
         ]
+
+    def validate(self, data):
+        # Render server-side mention markup for the supplied user ids. Unknown user
+        # ids are already rejected by the field above; here we keep only active
+        # project members that can receive a mention and ignore the rest, mirroring
+        # assignee/label handling and the notification pipeline's own member filter
+        # (bgtasks.notification_task).
+        #
+        # Mentionable = human users OR service accounts (bot_type=SERVICE); service
+        # accounts are first-class actors that external systems react to via webhooks.
+        # Other bots (e.g. workspace-seed) are excluded — they have no notification
+        # preference and are not addressable teammates. The Q(...) is passed as the
+        # leading positional filter arg per Django's requirement.
+        mention_user_ids = data.pop("mentions", None)
+        if mention_user_ids:
+            valid_member_ids = set(
+                ProjectMember.objects.filter(
+                    Q(member__is_bot=False) | Q(member__bot_type=BotTypeEnum.SERVICE),
+                    project_id=self.context.get("project_id"),
+                    is_active=True,
+                    member_id__in=mention_user_ids,
+                ).values_list("member_id", flat=True)
+            )
+
+            # Preserve caller order and de-duplicate the mentioned users.
+            ordered_mentions = []
+            seen = set()
+            for user_id in mention_user_ids:
+                if user_id in valid_member_ids and user_id not in seen:
+                    seen.add(user_id)
+                    ordered_mentions.append(user_id)
+
+            if ordered_mentions:
+                base_html = data.get("comment_html")
+                if base_html is None and self.instance is not None:
+                    base_html = self.instance.comment_html
+                base_html = base_html or ""
+                # Skip users already mentioned in the body so repeated updates stay
+                # idempotent instead of accumulating duplicate mention markup. The body
+                # is parsed for real <mention-component> nodes — using the same parser
+                # the notification pipeline uses — rather than substring-matching the
+                # id, which would false-positive on an id that merely appears as text
+                # or in some other attribute and silently drop the mention.
+                already_mentioned = set(extract_comment_mentions(base_html))
+                new_mentions = [user_id for user_id in ordered_mentions if str(user_id) not in already_mentioned]
+                if new_mentions:
+                    data["comment_html"] = append_user_mentions(base_html, new_mentions)
+
+        # Sanitize the (possibly mention-augmented) HTML with the same rules the
+        # internal app applies, so external clients cannot store unsafe or invalid
+        # markup. This runs after mention rendering; the whitelisted
+        # <mention-component> markup survives sanitization.
+        if data.get("comment_html"):
+            is_valid, error_msg, sanitized_html = validate_html_content(data["comment_html"])
+            if not is_valid:
+                raise serializers.ValidationError({"comment_html": "HTML content is not valid"})
+            if sanitized_html is not None:
+                data["comment_html"] = sanitized_html
+
+        return data
 
 
 class IssueCommentSerializer(BaseSerializer):

--- a/apps/api/plane/api/views/issue.py
+++ b/apps/api/plane/api/views/issue.py
@@ -1463,24 +1463,39 @@ class IssueCommentListCreateAPIEndpoint(BaseAPIView):
                 status=status.HTTP_409_CONFLICT,
             )
 
-        serializer = IssueCommentCreateSerializer(data=request.data)
+        serializer = IssueCommentCreateSerializer(data=request.data, context={"project_id": project_id})
         if serializer.is_valid():
             serializer.save(project_id=project_id, issue_id=issue_id, actor=request.user)
             issue_comment = IssueComment.objects.get(pk=serializer.instance.id)
-            # Update the created_at and the created_by and save the comment
+            # Update the created_at and the created_by and save the comment.
+            # `actor` is deliberately left as the authenticated user set on save above:
+            # it was previously reassigned from the client-supplied `created_by` but
+            # never persisted (it is absent from update_fields), so the in-memory
+            # instance — which is serialized below for the activity payload and the
+            # response — disagreed with the stored row.
             issue_comment.created_at = request.data.get("created_at", timezone.now())
             issue_comment.created_by_id = request.data.get("created_by", request.user.id)
-            issue_comment.actor_id = request.data.get("created_by", request.user.id)
             issue_comment.save(update_fields=["created_at", "created_by"])
 
             issue_activity.delay(
                 type="comment.activity.created",
-                requested_data=json.dumps(serializer.data, cls=DjangoJSONEncoder),
-                actor_id=str(issue_comment.created_by_id),
+                # Serialize the persisted comment (not the create serializer) so the
+                # activity carries the comment id and the server-rendered mention
+                # markup in comment_html; the notification pipeline needs both to
+                # link the activity to the comment and fire mention notifications.
+                requested_data=json.dumps(IssueCommentSerializer(issue_comment).data, cls=DjangoJSONEncoder),
+                # The activity actor drives who notifications are attributed to (and who
+                # is skipped as the trigger), so it must be the authenticated caller —
+                # `created_by` is client-supplied and would let a caller make mention
+                # notifications appear to come from someone else. Matches the internal
+                # app comment view and the public work-item endpoints.
+                actor_id=str(request.user.id),
                 issue_id=str(self.kwargs.get("issue_id")),
                 project_id=str(self.kwargs.get("project_id")),
                 current_instance=None,
                 epoch=int(timezone.now().timestamp()),
+                notification=True,
+                origin=base_host(request=request, is_app=True),
             )
 
             # Send the model activity
@@ -1588,7 +1603,6 @@ class IssueCommentDetailAPIEndpoint(BaseAPIView):
         Validates external ID uniqueness if provided.
         """
         issue_comment = IssueComment.objects.get(workspace__slug=slug, project_id=project_id, issue_id=issue_id, pk=pk)
-        requested_data = json.dumps(self.request.data, cls=DjangoJSONEncoder)
         current_instance = json.dumps(IssueCommentSerializer(issue_comment).data, cls=DjangoJSONEncoder)
 
         # Validation check if the issue already exists
@@ -1610,17 +1624,28 @@ class IssueCommentDetailAPIEndpoint(BaseAPIView):
                 status=status.HTTP_409_CONFLICT,
             )
 
-        serializer = IssueCommentCreateSerializer(issue_comment, data=request.data, partial=True)
+        serializer = IssueCommentCreateSerializer(
+            issue_comment, data=request.data, partial=True, context={"project_id": project_id}
+        )
         if serializer.is_valid():
-            serializer.save()
+            # Use the instance returned by save() rather than re-reading the row: it
+            # already holds exactly what this request persisted, and a re-fetch could
+            # pick up a concurrent update, making the activity payload (and the mention
+            # diff below) describe someone else's write.
+            issue_comment = serializer.save()
             issue_activity.delay(
                 type="comment.activity.updated",
-                requested_data=requested_data,
+                # Serialize the persisted comment so the activity sees the
+                # server-rendered mention markup in comment_html; diffing it
+                # against current_instance is what surfaces newly added mentions.
+                requested_data=json.dumps(IssueCommentSerializer(issue_comment).data, cls=DjangoJSONEncoder),
                 actor_id=str(request.user.id),
                 issue_id=str(issue_id),
                 project_id=str(project_id),
                 current_instance=current_instance,
                 epoch=int(timezone.now().timestamp()),
+                notification=True,
+                origin=base_host(request=request, is_app=True),
             )
             # Send the model activity
             model_activity.delay(
@@ -1633,7 +1658,6 @@ class IssueCommentDetailAPIEndpoint(BaseAPIView):
                 origin=base_host(request=request, is_app=True),
             )
 
-            issue_comment = IssueComment.objects.get(pk=serializer.instance.id)
             serializer = IssueCommentSerializer(issue_comment)
             return Response(serializer.data, status=status.HTTP_200_OK)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
@@ -1667,6 +1691,8 @@ class IssueCommentDetailAPIEndpoint(BaseAPIView):
             project_id=str(project_id),
             current_instance=current_instance,
             epoch=int(timezone.now().timestamp()),
+            notification=True,
+            origin=base_host(request=request, is_app=True),
         )
         return Response(status=status.HTTP_204_NO_CONTENT)
 

--- a/apps/api/plane/app/views/search/base.py
+++ b/apps/api/plane/app/views/search/base.py
@@ -30,6 +30,7 @@ from rest_framework.response import Response
 from plane.app.views.base import BaseAPIView
 from plane.app.permissions import WorkspaceUserPermission
 from plane.db.models import (
+    BotTypeEnum,
     Workspace,
     Project,
     Issue,
@@ -329,11 +330,14 @@ class SearchEndpoint(BaseAPIView):
                             q |= Q(**{f"{field}__icontains": query})
 
                     users = (
+                        # Mention candidates: human users OR service accounts
+                        # (bot_type=SERVICE), so agents are addressable from the
+                        # editor's @-autocomplete. Other bots (workspace-seed) stay
+                        # hidden. Mirrors IssueCommentCreateSerializer.validate.
                         ProjectMember.objects.filter(
-                            q,
+                            q & (Q(member__is_bot=False) | Q(member__bot_type=BotTypeEnum.SERVICE)),
                             is_active=True,
                             workspace__slug=slug,
-                            member__is_bot=False,
                             project_id=project_id,
                         )
                         .annotate(
@@ -541,11 +545,13 @@ class SearchEndpoint(BaseAPIView):
                         for field in fields:
                             q |= Q(**{f"{field}__icontains": query})
                     users = (
+                        # Mention candidates: human users OR service accounts
+                        # (bot_type=SERVICE); other bots stay hidden. Mirrors the
+                        # project branch above and IssueCommentCreateSerializer.
                         WorkspaceMember.objects.filter(
-                            q,
+                            q & (Q(member__is_bot=False) | Q(member__bot_type=BotTypeEnum.SERVICE)),
                             is_active=True,
                             workspace__slug=slug,
-                            member__is_bot=False,
                         )
                         .annotate(
                             member__avatar_url=Case(

--- a/apps/api/plane/bgtasks/notification_task.py
+++ b/apps/api/plane/bgtasks/notification_task.py
@@ -316,7 +316,11 @@ def notifications(
                 else:
                     sender = "in_app:issue_activities:subscribed"
 
-                preference = UserNotificationPreference.objects.get(user_id=subscriber)
+                # Bot recipients (e.g. service accounts) have no notification
+                # preference row; still create their in-app notification but never
+                # email them. filter().first() keeps a single preference-less
+                # recipient from aborting the whole task.
+                preference = UserNotificationPreference.objects.filter(user_id=subscriber).first()
 
                 for issue_activity in issue_activities_created:
                     # If activity done in blocking then blocked by email should not go
@@ -327,9 +331,13 @@ def notifications(
                     if issue_activity.get("field") == "description":
                         continue
 
-                    # Check if the value should be sent or not
+                    # Check if the value should be sent or not. No preference (bot
+                    # recipient) => never email, but the in-app notification below
+                    # is still created.
                     send_email = False
-                    if issue_activity.get("field") == "state" and preference.state_change:
+                    if preference is None:
+                        send_email = False
+                    elif issue_activity.get("field") == "state" and preference.state_change:
                         send_email = True
                     elif (
                         issue_activity.get("field") == "state"
@@ -464,7 +472,12 @@ def notifications(
 
             for mention_id in comment_mentions:
                 if mention_id != actor_id:
-                    preference = UserNotificationPreference.objects.get(user_id=mention_id)
+                    # Bot recipients (e.g. service accounts mentioned by a human) have
+                    # no preference row: still create the in-app mention notification —
+                    # external systems react to it — but never email their synthetic
+                    # address. filter().first() also stops one preference-less recipient
+                    # from aborting notifications for everyone else.
+                    preference = UserNotificationPreference.objects.filter(user_id=mention_id).first()
                     for issue_activity in issue_activities_created:
                         notification = create_mention_notification(
                             project=project,
@@ -476,8 +489,9 @@ def notifications(
                             activity=issue_activity,
                         )
 
-                        # check for email notifications
-                        if preference.mention:
+                        # check for email notifications (skipped for preference-less
+                        # bot recipients)
+                        if preference and preference.mention:
                             bulk_email_logs.append(
                                 EmailNotificationLog(
                                     triggered_by_id=actor_id,
@@ -521,7 +535,9 @@ def notifications(
 
             for mention_id in new_mentions:
                 if mention_id != actor_id:
-                    preference = UserNotificationPreference.objects.get(user_id=mention_id)
+                    # Bot recipients have no preference row: create the in-app mention
+                    # notification but skip email (see comment-mention loop above).
+                    preference = UserNotificationPreference.objects.filter(user_id=mention_id).first()
                     if (
                         last_activity is not None
                         and last_activity.field == "description"
@@ -569,11 +585,15 @@ def notifications(
                                 },
                             )
                         )
-                        if preference.mention:
+                        if preference and preference.mention:
                             bulk_email_logs.append(
                                 EmailNotificationLog(
                                     triggered_by_id=actor_id,
-                                    receiver_id=subscriber,
+                                    # The recipient is the mentioned user. `subscriber`
+                                    # here is the task's boolean parameter (or a value
+                                    # leaked from the subscriber loop above), never a
+                                    # receiver id.
+                                    receiver_id=mention_id,
                                     entity_identifier=issue_id,
                                     entity_name="issue",
                                     data={
@@ -618,11 +638,13 @@ def notifications(
                                 issue_id=issue_id,
                                 activity=issue_activity,
                             )
-                            if preference.mention:
+                            if preference and preference.mention:
                                 bulk_email_logs.append(
                                     EmailNotificationLog(
                                         triggered_by_id=actor_id,
-                                        receiver_id=subscriber,
+                                        # See above: the recipient is the mentioned
+                                        # user, not the leaked `subscriber` value.
+                                        receiver_id=mention_id,
                                         entity_identifier=issue_id,
                                         entity_name="issue",
                                         data={

--- a/apps/api/plane/tests/contract/api/conftest.py
+++ b/apps/api/plane/tests/contract/api/conftest.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+import pytest
+from django.core.cache import cache
+
+from plane.api.rate_limit import ApiKeyRateThrottle
+
+
+@pytest.fixture
+def api_key_client(api_client, api_token):
+    """API-key authenticated client with a clean rate-limit budget.
+
+    ``ApiKeyRateThrottle`` (``plane.api.rate_limit``) records request history in the
+    shared cache under ``"<scope>:<token>"``. These contract tests reuse a single
+    fixed token, so without a reset the request count accumulates across the whole
+    session and eventually trips the 60/minute limit, failing later tests with HTTP
+    429. Only this token's throttle key is deleted — flushing the whole cache would
+    be needlessly broad and could interfere with other tests.
+    """
+    cache.delete(f"{ApiKeyRateThrottle.scope}:{api_token.token}")
+    api_client.credentials(HTTP_X_API_KEY=api_token.token)
+    return api_client

--- a/apps/api/plane/tests/contract/api/test_issue_comment_mentions.py
+++ b/apps/api/plane/tests/contract/api/test_issue_comment_mentions.py
@@ -1,0 +1,684 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+import json
+from unittest.mock import patch
+
+import pytest
+from rest_framework import status
+
+from plane.api.serializers.issue import render_user_mention
+from plane.bgtasks.notification_task import extract_comment_mentions
+from plane.bgtasks.webhook_task import get_model_data
+from plane.db.models import (
+    BotTypeEnum,
+    EmailNotificationLog,
+    Issue,
+    IssueComment,
+    Notification,
+    Project,
+    ProjectMember,
+    State,
+    User,
+    WorkspaceMember,
+)
+from plane.utils.service_account import create_service_account
+
+
+@pytest.fixture
+def project(db, workspace, create_user):
+    """Create a test project with the user as an admin member and a default state."""
+    project = Project.objects.create(
+        name="Test Project",
+        identifier="TP",
+        workspace=workspace,
+        created_by=create_user,
+    )
+    ProjectMember.objects.create(
+        project=project,
+        member=create_user,
+        role=20,  # Admin role
+        is_active=True,
+    )
+    # A default state is required to create work items through the API
+    State.objects.create(
+        name="Backlog",
+        color="#000000",
+        group="backlog",
+        default=True,
+        project=project,
+        workspace=workspace,
+        created_by=create_user,
+    )
+    return project
+
+
+@pytest.fixture
+def create_issue(db, project, workspace, create_user):
+    """Create an existing work item to comment on in tests."""
+    return Issue.objects.create(
+        name="Existing Issue",
+        project=project,
+        workspace=workspace,
+        created_by=create_user,
+    )
+
+
+@pytest.fixture
+def mention_user(db, workspace, project):
+    """Create a second user who is an active member of the project (mentionable)."""
+    user = User.objects.create(
+        email="mention@plane.so",
+        username="mention-user",
+        first_name="Mention",
+        last_name="User",
+    )
+    WorkspaceMember.objects.create(workspace=workspace, member=user, role=15)
+    ProjectMember.objects.create(project=project, member=user, role=15, is_active=True)
+    return user
+
+
+@pytest.fixture
+def second_mention_user(db, workspace, project):
+    """Create another active project member (for multi-mention tests)."""
+    user = User.objects.create(
+        email="mention2@plane.so",
+        username="mention-user-2",
+        first_name="Mention",
+        last_name="Two",
+    )
+    WorkspaceMember.objects.create(workspace=workspace, member=user, role=15)
+    ProjectMember.objects.create(project=project, member=user, role=15, is_active=True)
+    return user
+
+
+@pytest.fixture
+def seed_bot_member(db, workspace, project):
+    """Create a WORKSPACE_SEED bot that is an active project member (NOT mentionable).
+
+    Non-service bots are not addressable teammates and have no notification
+    preference, so the serializer must keep filtering them out.
+    """
+    user = User.objects.create(
+        email="seedbot@plane.so",
+        username="seed-bot-user",
+        first_name="Seed",
+        last_name="Bot",
+        is_bot=True,
+        bot_type=BotTypeEnum.WORKSPACE_SEED,
+    )
+    WorkspaceMember.objects.create(workspace=workspace, member=user, role=15)
+    ProjectMember.objects.create(project=project, member=user, role=15, is_active=True)
+    return user
+
+
+@pytest.fixture
+def service_account_member(db, workspace, project):
+    """Create a SERVICE bot (service account) that is an active project member.
+
+    Service accounts are first-class, mentionable actors (an external system reacts
+    to the mention via webhooks). Built via the real provisioning util so the test
+    exercises the genuine is_bot=True / bot_type=SERVICE identity.
+    """
+    sa = create_service_account(workspace=workspace, name="Agent Smith", role="member")
+    ProjectMember.objects.create(project=project, member=sa.user, role=15, is_active=True)
+    return sa.user
+
+
+@pytest.fixture
+def non_member_user(db):
+    """Create a user who is NOT a member of the project (not mentionable)."""
+    return User.objects.create(
+        email="outsider@plane.so",
+        username="outsider-user",
+        first_name="Outsider",
+        last_name="User",
+    )
+
+
+@pytest.fixture
+def inactive_member_user(db, workspace, project):
+    """Create a deactivated project member (must NOT be mentionable)."""
+    user = User.objects.create(
+        email="inactive@plane.so",
+        username="inactive-user",
+        first_name="Inactive",
+        last_name="User",
+    )
+    WorkspaceMember.objects.create(workspace=workspace, member=user, role=15)
+    ProjectMember.objects.create(project=project, member=user, role=15, is_active=False)
+    return user
+
+
+@pytest.fixture
+def mock_comment_tasks():
+    """Patch the deferred tasks the comment views dispatch.
+
+    Returns the ``issue_activity`` mock so tests can assert on the dispatched
+    notification; ``model_activity`` is suppressed so the tests do not require a
+    running message broker.
+    """
+    with (
+        patch("plane.api.views.issue.issue_activity") as mock_issue_activity,
+        patch("plane.api.views.issue.model_activity"),
+    ):
+        yield mock_issue_activity
+
+
+@pytest.fixture
+def eager_celery():
+    """Run dispatched Celery tasks synchronously, restoring the flag afterwards.
+
+    Flips the Celery app conf directly (and restores it) rather than the Django
+    setting, so eager mode cannot leak into other tests.
+    """
+    from plane.celery import app
+
+    previous_eager = app.conf.task_always_eager
+    previous_propagates = app.conf.task_eager_propagates
+    app.conf.task_always_eager = True
+    app.conf.task_eager_propagates = True
+    try:
+        yield
+    finally:
+        app.conf.task_always_eager = previous_eager
+        app.conf.task_eager_propagates = previous_propagates
+
+
+@pytest.mark.contract
+class TestIssueCommentMentionContract:
+    """
+    Contract: the external REST API (``/api/v1/...``) exposes a first-class way to
+    mention users in a work item comment. Callers pass a ``mentions`` list of user
+    ids; the server renders the ``<mention-component>`` markup into ``comment_html``,
+    the ids are parseable back out of ``comment_html``, and a notifying activity is
+    dispatched so mentioned users are notified the same way the web app does.
+    """
+
+    def comments_url(self, workspace_slug, project_id, issue_id):
+        """Helper to build the work item comment list/create endpoint URL."""
+        return f"/api/v1/workspaces/{workspace_slug}/projects/{project_id}/issues/{issue_id}/comments/"
+
+    def comment_detail_url(self, workspace_slug, project_id, issue_id, comment_id):
+        """Helper to build the work item comment detail endpoint URL."""
+        return f"/api/v1/workspaces/{workspace_slug}/projects/{project_id}/issues/{issue_id}/comments/{comment_id}/"
+
+    @pytest.mark.django_db
+    def test_create_comment_with_mentions_renders_parseable_markup(
+        self, api_key_client, workspace, project, create_issue, mention_user, mock_comment_tasks
+    ):
+        """A mentioned user id is rendered as mention markup and is parseable back out."""
+        url = self.comments_url(workspace.slug, project.id, create_issue.id)
+
+        response = api_key_client.post(
+            url,
+            {"comment_html": "<p>Please take a look</p>", "mentions": [str(mention_user.id)]},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+
+        comment = IssueComment.objects.get(pk=response.data["id"])
+        # The original body is preserved and the mention markup is appended.
+        assert "<p>Please take a look</p>" in comment.comment_html
+        assert 'entity_name="user_mention"' in comment.comment_html
+        assert f'entity_identifier="{mention_user.id}"' in comment.comment_html
+        # The mentioned id round-trips through the notification parser.
+        assert extract_comment_mentions(comment.comment_html) == [str(mention_user.id)]
+
+    @pytest.mark.django_db
+    def test_create_comment_with_mentions_triggers_mention_notification(
+        self, api_key_client, workspace, project, create_issue, mention_user, mock_comment_tasks
+    ):
+        """Creating a comment with mentions dispatches a notifying comment activity."""
+        url = self.comments_url(workspace.slug, project.id, create_issue.id)
+
+        response = api_key_client.post(
+            url,
+            {"comment_html": "<p>ping</p>", "mentions": [str(mention_user.id)]},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+
+        mock_comment_tasks.delay.assert_called_once()
+        kwargs = mock_comment_tasks.delay.call_args.kwargs
+        assert kwargs["type"] == "comment.activity.created"
+        assert kwargs["notification"] is True
+        # The dispatched activity must carry the comment id and the rendered mention
+        # markup, otherwise the notification pipeline cannot fire mention notifications.
+        requested_data = json.loads(kwargs["requested_data"])
+        assert requested_data.get("id") == str(response.data["id"])
+        assert extract_comment_mentions(requested_data["comment_html"]) == [str(mention_user.id)]
+
+    @pytest.mark.django_db
+    def test_create_plain_comment_triggers_notification(
+        self, api_key_client, workspace, project, create_issue, mock_comment_tasks
+    ):
+        """Even a comment without mentions now dispatches a notifying activity."""
+        url = self.comments_url(workspace.slug, project.id, create_issue.id)
+
+        response = api_key_client.post(url, {"comment_html": "<p>hello</p>"}, format="json")
+
+        assert response.status_code == status.HTTP_201_CREATED
+        mock_comment_tasks.delay.assert_called_once()
+        kwargs = mock_comment_tasks.delay.call_args.kwargs
+        assert kwargs["type"] == "comment.activity.created"
+        assert kwargs["notification"] is True
+
+    @pytest.mark.django_db
+    def test_mention_non_project_member_is_ignored(
+        self, api_key_client, workspace, project, create_issue, non_member_user, mock_comment_tasks
+    ):
+        """User ids that are not active project members are dropped, not rendered."""
+        url = self.comments_url(workspace.slug, project.id, create_issue.id)
+
+        response = api_key_client.post(
+            url,
+            {"comment_html": "<p>hi</p>", "mentions": [str(non_member_user.id)]},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        comment = IssueComment.objects.get(pk=response.data["id"])
+        assert "mention-component" not in comment.comment_html
+        assert extract_comment_mentions(comment.comment_html) == []
+
+    @pytest.mark.django_db
+    def test_mention_unknown_user_id_is_rejected(
+        self, api_key_client, workspace, project, create_issue, mock_comment_tasks
+    ):
+        """A mentions entry that is not a real user id fails validation."""
+        url = self.comments_url(workspace.slug, project.id, create_issue.id)
+
+        response = api_key_client.post(
+            url,
+            {"comment_html": "<p>hi</p>", "mentions": ["00000000-0000-0000-0000-000000000000"]},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    @pytest.mark.django_db
+    def test_update_comment_with_mentions_renders_and_notifies(
+        self, api_key_client, workspace, project, create_issue, create_user, mention_user, mock_comment_tasks
+    ):
+        """Adding mentions on update appends markup and dispatches a notifying activity."""
+        comment = IssueComment.objects.create(
+            issue=create_issue,
+            project=project,
+            workspace=workspace,
+            comment_html="<p>Original</p>",
+            actor=create_user,
+            created_by=create_user,
+        )
+        url = self.comment_detail_url(workspace.slug, project.id, create_issue.id, comment.id)
+
+        response = api_key_client.patch(url, {"mentions": [str(mention_user.id)]}, format="json")
+
+        assert response.status_code == status.HTTP_200_OK
+        comment.refresh_from_db()
+        # Existing body is kept and the mention markup is appended.
+        assert "<p>Original</p>" in comment.comment_html
+        assert extract_comment_mentions(comment.comment_html) == [str(mention_user.id)]
+
+        mock_comment_tasks.delay.assert_called_once()
+        kwargs = mock_comment_tasks.delay.call_args.kwargs
+        assert kwargs["type"] == "comment.activity.updated"
+        assert kwargs["notification"] is True
+
+    @pytest.mark.django_db
+    def test_create_comment_with_multiple_mentions_deduplicated(
+        self, api_key_client, workspace, project, create_issue, mention_user, second_mention_user, mock_comment_tasks
+    ):
+        """Multiple mentions render once each; duplicate ids are collapsed."""
+        url = self.comments_url(workspace.slug, project.id, create_issue.id)
+
+        response = api_key_client.post(
+            url,
+            {
+                "comment_html": "<p>team</p>",
+                # second_mention_user is listed twice to exercise de-duplication.
+                "mentions": [str(mention_user.id), str(second_mention_user.id), str(second_mention_user.id)],
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        comment = IssueComment.objects.get(pk=response.data["id"])
+        # Both users are mentioned, each exactly once (set compare avoids relying on
+        # extract_comment_mentions' non-deterministic ordering).
+        assert set(extract_comment_mentions(comment.comment_html)) == {
+            str(mention_user.id),
+            str(second_mention_user.id),
+        }
+        assert comment.comment_html.count('entity_name="user_mention"') == 2
+
+    @pytest.mark.django_db
+    def test_mention_inactive_project_member_is_ignored(
+        self, api_key_client, workspace, project, create_issue, inactive_member_user, mock_comment_tasks
+    ):
+        """A deactivated project member is not mentionable."""
+        url = self.comments_url(workspace.slug, project.id, create_issue.id)
+
+        response = api_key_client.post(
+            url,
+            {"comment_html": "<p>hi</p>", "mentions": [str(inactive_member_user.id)]},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        comment = IssueComment.objects.get(pk=response.data["id"])
+        assert "mention-component" not in comment.comment_html
+
+    @pytest.mark.django_db
+    def test_delete_comment_triggers_notification(
+        self, api_key_client, workspace, project, create_issue, create_user, mention_user, mock_comment_tasks
+    ):
+        """Deleting a comment dispatches a notifying activity with the request origin."""
+        comment = IssueComment.objects.create(
+            issue=create_issue,
+            project=project,
+            workspace=workspace,
+            comment_html=f"<p>bye</p><p>{render_user_mention(mention_user.id)}</p>",
+            actor=create_user,
+            created_by=create_user,
+        )
+        url = self.comment_detail_url(workspace.slug, project.id, create_issue.id, comment.id)
+
+        response = api_key_client.delete(url)
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        mock_comment_tasks.delay.assert_called_once()
+        kwargs = mock_comment_tasks.delay.call_args.kwargs
+        assert kwargs["type"] == "comment.activity.deleted"
+        assert kwargs["notification"] is True
+        assert kwargs["origin"]
+
+    @pytest.mark.django_db
+    def test_comment_activity_actor_is_authenticated_user(
+        self, api_key_client, workspace, project, create_issue, create_user, mention_user, mock_comment_tasks
+    ):
+        """A client-supplied created_by cannot spoof the notification actor."""
+        url = self.comments_url(workspace.slug, project.id, create_issue.id)
+
+        response = api_key_client.post(
+            url,
+            # Attempt to attribute the activity (and so the mention notification) to
+            # another user by passing their id as created_by.
+            {"comment_html": "<p>hi</p>", "created_by": str(mention_user.id)},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        kwargs = mock_comment_tasks.delay.call_args.kwargs
+        assert kwargs["actor_id"] == str(create_user.id)
+        assert kwargs["actor_id"] != str(mention_user.id)
+
+    @pytest.mark.django_db
+    def test_mention_seed_bot_is_ignored(
+        self, api_key_client, workspace, project, create_issue, seed_bot_member, mock_comment_tasks
+    ):
+        """A non-service (workspace-seed) bot is not mentionable and is not rendered.
+
+        Terminology matches the rest of the contract: unknown ids are *rejected*
+        (400), non-mentionable members are *ignored* (201, no markup rendered).
+        """
+        url = self.comments_url(workspace.slug, project.id, create_issue.id)
+
+        response = api_key_client.post(
+            url,
+            {"comment_html": "<p>hi</p>", "mentions": [str(seed_bot_member.id)]},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        comment = IssueComment.objects.get(pk=response.data["id"])
+        assert "mention-component" not in comment.comment_html
+
+    @pytest.mark.django_db
+    def test_mention_service_account_renders_parseable_markup(
+        self, api_key_client, workspace, project, create_issue, service_account_member, mock_comment_tasks
+    ):
+        """A service account (bot_type=SERVICE) is mentionable and its markup renders."""
+        url = self.comments_url(workspace.slug, project.id, create_issue.id)
+
+        response = api_key_client.post(
+            url,
+            {"comment_html": "<p>hey agent</p>", "mentions": [str(service_account_member.id)]},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        comment = IssueComment.objects.get(pk=response.data["id"])
+        assert f'entity_identifier="{service_account_member.id}"' in comment.comment_html
+        assert extract_comment_mentions(comment.comment_html) == [str(service_account_member.id)]
+
+    @pytest.mark.django_db
+    def test_service_account_mention_carried_in_webhook_payload(
+        self, api_key_client, workspace, project, create_issue, service_account_member, mock_comment_tasks
+    ):
+        """The issue_comment webhook payload (get_model_data) carries the mention."""
+        url = self.comments_url(workspace.slug, project.id, create_issue.id)
+
+        response = api_key_client.post(
+            url,
+            {"comment_html": "<p>ping</p>", "mentions": [str(service_account_member.id)]},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        # get_model_data is exactly what webhook_send_task serializes for delivery.
+        payload = get_model_data("issue_comment", str(response.data["id"]))
+        assert extract_comment_mentions(payload["comment_html"]) == [str(service_account_member.id)]
+
+    @pytest.mark.django_db
+    def test_mention_service_account_notifies_in_app_without_email(
+        self, api_key_client, workspace, project, create_issue, service_account_member, eager_celery
+    ):
+        """Mentioning a service account creates its in-app Notification but sends no email."""
+        url = self.comments_url(workspace.slug, project.id, create_issue.id)
+
+        with patch("plane.api.views.issue.model_activity"):
+            response = api_key_client.post(
+                url,
+                {"comment_html": "<p>ping</p>", "mentions": [str(service_account_member.id)]},
+                format="json",
+            )
+
+        # The comment succeeds despite the bot having no notification preference.
+        assert response.status_code == status.HTTP_201_CREATED
+        # In-app mention notification IS created (external systems react to it)...
+        assert Notification.objects.filter(
+            receiver=service_account_member,
+            entity_identifier=create_issue.id,
+            sender="in_app:issue_activities:mentioned",
+        ).exists()
+        # ...but no email is queued to the service account's synthetic address.
+        assert not EmailNotificationLog.objects.filter(receiver=service_account_member).exists()
+
+    @pytest.mark.django_db
+    def test_repeated_mention_update_is_idempotent(
+        self, api_key_client, workspace, project, create_issue, create_user, mention_user, mock_comment_tasks
+    ):
+        """Re-sending the same mention on update does not duplicate the markup."""
+        comment = IssueComment.objects.create(
+            issue=create_issue,
+            project=project,
+            workspace=workspace,
+            comment_html="<p>Original</p>",
+            actor=create_user,
+            created_by=create_user,
+        )
+        url = self.comment_detail_url(workspace.slug, project.id, create_issue.id, comment.id)
+
+        api_key_client.patch(url, {"mentions": [str(mention_user.id)]}, format="json")
+        api_key_client.patch(url, {"mentions": [str(mention_user.id)]}, format="json")
+
+        comment.refresh_from_db()
+        assert comment.comment_html.count('entity_name="user_mention"') == 1
+
+    @pytest.mark.django_db
+    def test_mention_renders_when_id_appears_in_body_text(
+        self, api_key_client, workspace, project, create_issue, mention_user, mock_comment_tasks
+    ):
+        """An id occurring outside a mention node must not suppress a real mention.
+
+        The already-mentioned check parses the body for <mention-component> nodes; a
+        substring match would treat this text as an existing mention, silently drop
+        the markup and never notify the user.
+        """
+        url = self.comments_url(workspace.slug, project.id, create_issue.id)
+
+        response = api_key_client.post(
+            url,
+            {
+                "comment_html": f'<p>entity_identifier="{mention_user.id}"</p>',
+                "mentions": [str(mention_user.id)],
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        comment = IssueComment.objects.get(pk=response.data["id"])
+        assert extract_comment_mentions(comment.comment_html) == [str(mention_user.id)]
+
+    @pytest.mark.django_db
+    def test_mention_creates_notification_end_to_end(
+        self, api_key_client, workspace, project, create_issue, mention_user, eager_celery
+    ):
+        """Running the real pipeline, a mentioned member gets a mention Notification row."""
+        # eager_celery executes the dispatched issue_activity (and the nested
+        # notifications task) synchronously so we can assert the Notification is created.
+        url = self.comments_url(workspace.slug, project.id, create_issue.id)
+
+        # Suppress the webhook task (unrelated side effect) while letting the
+        # notification pipeline run for real.
+        with patch("plane.api.views.issue.model_activity"):
+            response = api_key_client.post(
+                url,
+                {"comment_html": "<p>ping</p>", "mentions": [str(mention_user.id)]},
+                format="json",
+            )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert Notification.objects.filter(
+            receiver=mention_user,
+            entity_identifier=create_issue.id,
+            sender="in_app:issue_activities:mentioned",
+        ).exists()
+
+    @pytest.mark.django_db
+    def test_description_mention_email_log_targets_mentioned_user(
+        self, api_key_client, workspace, project, create_issue, mention_user, eager_celery
+    ):
+        """A description mention emails the mentioned user.
+
+        Regression: the description-mention email log addressed ``subscriber``, which
+        in that scope is the notification task's boolean parameter (or a user id left
+        over from the subscriber loop) rather than the mentioned user — so the log went
+        to the wrong recipient, or the write failed and silently dropped every
+        notification for that activity.
+        """
+        url = f"/api/v1/workspaces/{workspace.slug}/projects/{project.id}/issues/{create_issue.id}/"
+        description_html = f"<p>please look</p><p>{render_user_mention(mention_user.id)}</p>"
+
+        with patch("plane.api.views.issue.model_activity"):
+            response = api_key_client.patch(url, {"description_html": description_html}, format="json")
+
+        assert response.status_code == status.HTTP_200_OK
+        logs = EmailNotificationLog.objects.filter(entity_identifier=create_issue.id)
+        assert logs.exists()
+        # Every log for this activity is addressed to the mentioned user.
+        assert {str(log.receiver_id) for log in logs} == {str(mention_user.id)}
+
+    @pytest.mark.django_db
+    def test_create_comment_sanitizes_unsafe_html(
+        self, api_key_client, workspace, project, create_issue, mock_comment_tasks
+    ):
+        """Unsafe HTML in comment_html is sanitized on the public write path."""
+        url = self.comments_url(workspace.slug, project.id, create_issue.id)
+
+        response = api_key_client.post(
+            url,
+            {"comment_html": '<p>ok</p><script>alert(1)</script><p onclick="evil()">x</p>'},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        comment = IssueComment.objects.get(pk=response.data["id"])
+        assert "<script" not in comment.comment_html
+        assert "onclick" not in comment.comment_html
+        # Safe content is preserved.
+        assert "<p>ok</p>" in comment.comment_html
+
+    @pytest.mark.django_db
+    def test_mentions_exceeding_max_length_rejected(
+        self, api_key_client, workspace, project, create_issue, mention_user, mock_comment_tasks
+    ):
+        """More than 100 mentions is rejected by the field's max_length bound."""
+        url = self.comments_url(workspace.slug, project.id, create_issue.id)
+
+        response = api_key_client.post(
+            url,
+            {"comment_html": "<p>hi</p>", "mentions": [str(mention_user.id)] * 101},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    @pytest.mark.django_db
+    def test_mention_markup_survives_sanitization(
+        self, api_key_client, workspace, project, create_issue, mention_user, mock_comment_tasks
+    ):
+        """The rendered mention markup is whitelisted, so sanitization keeps it intact."""
+        url = self.comments_url(workspace.slug, project.id, create_issue.id)
+
+        response = api_key_client.post(
+            url,
+            {"comment_html": "<p>see</p><script>bad()</script>", "mentions": [str(mention_user.id)]},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        comment = IssueComment.objects.get(pk=response.data["id"])
+        assert "<script" not in comment.comment_html
+        # The mention still parses back out after sanitization.
+        assert extract_comment_mentions(comment.comment_html) == [str(mention_user.id)]
+
+
+@pytest.mark.contract
+class TestEntitySearchMentionCandidates:
+    """
+    Contract: the web editor's @-mention autocomplete is served by the app API
+    entity-search endpoint. Service accounts (bot_type=SERVICE) must appear as
+    mention candidates so humans can @-mention agents from the UI, while other
+    bots (workspace-seed) stay hidden.
+    """
+
+    def entity_search_url(self, workspace_slug):
+        return f"/api/workspaces/{workspace_slug}/entity-search/"
+
+    @pytest.mark.django_db
+    def test_user_mention_search_includes_service_account_excludes_seed_bot(
+        self,
+        session_client,
+        workspace,
+        project,
+        create_user,
+        mention_user,
+        service_account_member,
+        seed_bot_member,
+    ):
+        """user_mention suggestions include humans + service accounts, not seed bots."""
+        response = session_client.get(
+            self.entity_search_url(workspace.slug),
+            {"query_type": "user_mention", "project_id": str(project.id), "count": 50},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        ids = {str(row["member__id"]) for row in response.data["user_mention"]}
+        assert str(mention_user.id) in ids
+        assert str(service_account_member.id) in ids
+        assert str(seed_bot_member.id) not in ids

--- a/apps/api/plane/utils/openapi/examples.py
+++ b/apps/api/plane/utils/openapi/examples.py
@@ -188,20 +188,30 @@ ISSUE_COMMENT_CREATE_EXAMPLE = OpenApiExample(
     "IssueCommentCreateSerializer",
     value={
         "comment_html": "<p>New comment content</p>",
+        "mentions": ["b8f1e2a4-6c3d-4e5f-8a7b-9c0d1e2f3a4b"],
         "external_id": "1234567890",
         "external_source": "github",
     },
-    description="Example request for creating an issue comment",
+    description=(
+        "Example request for creating an issue comment. Pass a list of user ids in "
+        "'mentions' to mention those users; the server renders the mention markup into "
+        "comment_html and notifies them."
+    ),
 )
 
 ISSUE_COMMENT_UPDATE_EXAMPLE = OpenApiExample(
     "IssueCommentCreateSerializer",
     value={
         "comment_html": "<p>Updated comment content</p>",
+        "mentions": ["b8f1e2a4-6c3d-4e5f-8a7b-9c0d1e2f3a4b"],
         "external_id": "1234567890",
         "external_source": "github",
     },
-    description="Example request for updating an issue comment",
+    description=(
+        "Example request for updating an issue comment. Pass a list of user ids in "
+        "'mentions' to mention those users; the server renders the mention markup into "
+        "comment_html and notifies the newly mentioned users."
+    ),
 )
 
 # Issue Attachment Examples


### PR DESCRIPTION
### Description

Add a first-class `mentions` field to the public REST API comment create/update serializer. The server renders the internal <mention-component> markup into comment_html so mentioned members are notified without callers hand-crafting the markup, and the ids remain parseable back out of comment_html.

Also fix the public comment endpoints so notifications actually fire:
- pass notification=True (and origin) on comment create/update/delete, matching the internal app API (issue_activity defaults notification=False)
- dispatch the persisted comment (IssueCommentSerializer) as requested_data so the activity carries the comment id and rendered markup, without which the notification pipeline's comment-mention branch was skipped

Only active, non-bot project members can be mentioned; unknown ids are rejected and non-members are ignored. Adds contract tests (including an end-to-end assertion that a Notification row is created) and updates the OpenAPI example.

Depends on #9399

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added `mentions` support to issue comment create/update; mentioned users are rendered into the comment HTML with safe, whitelisted markup and receive mention notifications.
  * Updated user-mention autocomplete to include service-bot accounts (excluding workspace-seed bots).

* **Bug Fixes**
  * Comment activity events now use the server-rendered comment content and include consistent notification/origin details.
  * Mention/in-app notifications handle missing notification preferences more reliably, skipping emails for recipients without preferences.

* **Documentation**
  * Updated issue comment API examples to include `mentions`.

* **Tests**
  * Added contract tests covering rendering, sanitization, validation, notification behavior, mention idempotency/deduping, and mention search results, plus test cache isolation to prevent rate-limit flakiness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->