### PR TITLE
Prevent links from opening twice in read-only mode

### DIFF
--- a/packages/editor/src/core/extensions/custom-link/helpers/clickHandler.ts
+++ b/packages/editor/src/core/extensions/custom-link/helpers/clickHandler.ts
@@ -21,45 +21,39 @@ export function clickHandler(options: ClickHandlerOptions): Plugin {
           return false;
         }
 
-        if (!view.editable) {
-          return false;
-        }
+        const eventTarget = event.target as HTMLElement | null;
+        const link = eventTarget?.closest?.("a") as HTMLLinkElement | null;
 
-        let a = event.target as HTMLElement;
-        const els: HTMLElement[] = [];
-
-        while (a?.nodeName !== "DIV") {
-          els.push(a);
-          a = a?.parentNode as HTMLElement;
-        }
-
-        if (!els.find((value) => value.nodeName === "A")) {
+        if (!link || !view.dom.contains(link)) {
           return false;
         }
 
         const attrs = getAttributes(view.state, options.type.name);
-        const link = event.target as HTMLLinkElement;
+        const href = link.href ?? attrs.href;
+        const target = link.target ?? attrs.target;
 
-        const href = link?.href ?? attrs.href;
-        const target = link?.target ?? attrs.target;
+        if (!href) {
+          return false;
+        }
 
-        if (link && href) {
-          // Defence-in-depth: link.href is the browser-resolved URL (whitespace
-          // already stripped by the browser's WHATWG URL parser), so a protocol
-          // check here is sufficient to catch any dangerous URI that slipped past
-          // the editor's parse/render-time guards. Matches the blocked-scheme list
-          // in isValidHttpUrl (javascript:, data:, vbscript:, file:, about:)
-          // to keep the policy consistent (GHSA-v2vv-7wq3-8w2j).
-          if (/^(javascript|data|vbscript|file|about):/i.test(href)) {
-            return false;
-          }
-
-          window.open(href, target);
-
+        // Defence-in-depth: link.href is the browser-resolved URL (whitespace
+        // already stripped by the browser's WHATWG URL parser), so a protocol
+        // check here is sufficient to catch any dangerous URI that slipped past
+        // the editor's parse/render-time guards. Matches the blocked-scheme list
+        // in isValidHttpUrl (javascript:, data:, vbscript:, file:, about:)
+        // to keep the policy consistent (GHSA-v2vv-7wq3-8w2j).
+        if (/^(javascript|data|vbscript|file|about):/i.test(href)) {
+          event.preventDefault();
           return true;
         }
 
-        return false;
+        if (!view.editable) {
+          return false;
+        }
+
+        window.open(href, target);
+
+        return true;
       },
     },
   });

--- a/packages/editor/src/core/extensions/custom-link/helpers/clickHandler.ts
+++ b/packages/editor/src/core/extensions/custom-link/helpers/clickHandler.ts
@@ -21,6 +21,10 @@ export function clickHandler(options: ClickHandlerOptions): Plugin {
           return false;
         }
 
+        if (!view.editable) {
+          return false;
+        }
+
         let a = event.target as HTMLElement;
         const els: HTMLElement[] = [];
 


### PR DESCRIPTION
### Description
Fixes duplicate tabs opening when left-clicking links in read-only comments and work-item descriptions.

The custom link click handler previously called `window.open()` even when the editor was read-only. In that mode, the browser also followed the rendered anchor's native navigation, causing the same link to open twice. The handler now returns early for non-editable views, allowing the browser to handle read-only links natively while preserving the existing programmatic behavior in editable views.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
Not applicable.

### Test Scenarios
- Verified that the custom click handler returns without calling `window.open()` when the editor is read-only, leaving navigation to the native anchor behavior.
- Verified that the focused regression test fails before the fix and passes after it.
- Ran formatting and lint checks against the changed code.

### References
Fixes #9386


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved link-click handling to reliably identify the clicked link and only process it when the link is within the editor’s active content area.
  * Prevented link clicks from being processed when the editor is in a non-editable state, avoiding unintended opening behavior.
  * Stopped navigation/opening for unsafe URL schemes (such as `javascript:`, `data:`, `vbscript:`, `file:`, or `about:`) to reduce the risk of unintended actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->