### PR TITLE
Fix instance admin sign-up with form-encoded telemetry value

### DIFF
--- a/apps/api/plane/license/api/views/admin.py
+++ b/apps/api/plane/license/api/views/admin.py
@@ -126,7 +126,7 @@ class InstanceAdminSignUpEndpoint(View):
         first_name = request.POST.get("first_name", False)
         last_name = request.POST.get("last_name", "")
         company_name = request.POST.get("company_name", "")
-        is_telemetry_enabled = request.POST.get("is_telemetry_enabled", True)
+        is_telemetry_enabled = str(request.POST.get("is_telemetry_enabled", True)).lower() in {"1", "true"}
 
         # return error if the email and password is not present
         if not email or not password or not first_name:

--- a/apps/api/plane/tests/contract/app/test_instance_admin.py
+++ b/apps/api/plane/tests/contract/app/test_instance_admin.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+import uuid
+
+import pytest
+from django.utils import timezone
+
+from plane.db.models import User
+from plane.license.models import Instance, InstanceAdmin
+
+
+@pytest.mark.contract
+class TestInstanceAdminSignUp:
+    """Contract tests for the first-run instance administrator setup."""
+
+    @pytest.mark.django_db
+    @pytest.mark.parametrize(
+        ("form_value", "expected_value"),
+        [("false", False), ("true", True)],
+    )
+    def test_telemetry_form_value_is_coerced_to_boolean(self, client, form_value, expected_value):
+        """Form-encoded telemetry values must not interrupt instance setup."""
+        instance = Instance.objects.create(
+            instance_name="Test Instance",
+            instance_id=str(uuid.uuid4()),
+            current_version="1.0.0",
+            domain="http://localhost:8000",
+            last_checked_at=timezone.now(),
+        )
+        response = client.post(
+            "/api/instances/admins/sign-up/",
+            {
+                "email": "admin@plane.so",
+                "password": "vB9!qZ2@Lm7#Rx4$",
+                "first_name": "Admin",
+                "is_telemetry_enabled": form_value,
+            },
+            follow=False,
+            HTTP_USER_AGENT="Mozilla/5.0",
+        )
+
+        assert response.status_code == 302
+        assert response.url.endswith("/general/")
+
+        instance.refresh_from_db()
+        assert instance.is_setup_done is True
+        assert instance.is_telemetry_enabled is expected_value
+        assert User.objects.filter(email="admin@plane.so").exists()
+        assert InstanceAdmin.objects.filter(instance=instance).exists()

--- a/apps/api/plane/tests/contract/app/test_instance_admin.py
+++ b/apps/api/plane/tests/contract/app/test_instance_admin.py
@@ -18,7 +18,7 @@ class TestInstanceAdminSignUp:
     @pytest.mark.django_db
     @pytest.mark.parametrize(
         ("form_value", "expected_value"),
-        [("false", False), ("true", True)],
+        [("false", False), ("true", True), ("False", False), ("True", True), ("1", True)],
     )
     def test_telemetry_form_value_is_coerced_to_boolean(self, client, form_value, expected_value):
         """Form-encoded telemetry values must not interrupt instance setup."""


### PR DESCRIPTION
### Description
Fixes instance administrator sign-up failing when `is_telemetry_enabled` is submitted as a form-encoded string.

The endpoint now converts supported truthy form values (`"true"` and `"1"`) into a Python boolean before assigning the value to the instance model. This prevents PostgreSQL from rejecting string values for the boolean column and allows the existing atomic setup flow to complete successfully.

A contract test covers both `"true"` and `"false"` form values and verifies that:
- sign-up completes successfully;
- the instance is marked as configured;
- the selected telemetry setting is persisted as a boolean;
- the user and instance administrator records are created.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
Not applicable.

### Test Scenarios
- Submit first-run administrator sign-up with `is_telemetry_enabled=false` and verify setup completes with telemetry disabled.
- Submit first-run administrator sign-up with `is_telemetry_enabled=true` and verify setup completes with telemetry enabled.
- Verify the instance, user, and instance administrator records are created together.

### References
Fixes #9370


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Correctly interpret the first-run administrator “telemetry” preference when submitted as common form values (e.g., `true`, `false`, and `1`), and persist the normalized setting during instance setup.
* **Tests**
  * Added contract coverage for the admin sign-up endpoint to verify telemetry coercion, successful redirect, setup completion, and creation of the administrator account.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->