### PR TITLE
docs: document DATABASE_URL, PORT, and REDIS_URL in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,28 @@ chmod +x setup.sh
 ./setup.sh
 ```
 
+`setup.sh` copies each service’s `.env.example` to `.env` (root, `apps/api`, `apps/web`, `apps/admin`, `apps/space`, `apps/live`) and generates a Django `SECRET_KEY` for the API. Review those files if you need custom values; the defaults work with the local Docker Compose stack.
+
+#### Environment variables
+
+If these are missing or wrong, the API and supporting services fail to connect on first run. Defaults come from `apps/api/.env.example` and `apps/live/.env.example` (copied by `setup.sh`):
+
+| Variable | Where | Purpose | Local Docker default |
+| -------- | ----- | ------- | -------------------- |
+| `DATABASE_URL` | `apps/api/.env` | Postgres connection for the Django API | `postgresql://plane:plane@plane-db:5432/plane` |
+| `REDIS_URL` | `apps/api/.env`, `apps/live/.env` | Redis/Valkey for cache, sessions, and realtime | API: `redis://plane-redis:6379/` · Live: `redis://localhost:6379/` |
+| `PORT` | `apps/live/.env` | Port the live (collab) server listens on | `3100` |
+
+Related values used to build those URLs (also in `apps/api/.env.example`): `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_HOST`, `POSTGRES_PORT`, `POSTGRES_DB`, `REDIS_HOST`, `REDIS_PORT`.
+
+Local app ports after a successful start:
+
+- Web: [http://localhost:3000](http://localhost:3000)
+- Admin (God mode): [http://localhost:3001](http://localhost:3001)
+- Space: [http://localhost:3002](http://localhost:3002)
+- Live: [http://localhost:3100](http://localhost:3100)
+- API: [http://localhost:8000](http://localhost:8000)
+
 3. Start the containers
 
 ```bash


### PR DESCRIPTION
### Description

Documents the required environment variables that new contributors need after `setup.sh`, so first-time local setup is less likely to fail with unclear connection errors.

- Explain that `setup.sh` copies each service `.env.example` → `.env` and generates the API `SECRET_KEY`
- Document `DATABASE_URL`, `REDIS_URL`, and `PORT` with locations and defaults taken from `apps/api/.env.example` and `apps/live/.env.example` (aligned with the local Docker Compose stack)
- List related Postgres/Redis building-block vars and local service ports (web, admin, space, live, API)

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [x] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots here -->

### Test Scenarios
- Open `CONTRIBUTING.md` and confirm the Environment variables section appears after the `setup.sh` step
- Cross-check table defaults against `apps/api/.env.example` and `apps/live/.env.example`
- Confirm listed local ports match the documented web/admin/space/live/API URLs

### References
- Fixes #9302

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded project setup instructions with details about environment configuration.
  * Documented key environment variables and their default local values.
  * Added local application port information for Web, Admin, Space, Live, and API services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->