### PR TITLE
chore: align apps/api pyproject.toml version with monorepo 1.3.1

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "Plane"
-version = "0.24.0"
+version = "1.3.1"
 description = "Open-source project management that unlocks customer value"
 
 [tool.ruff]


### PR DESCRIPTION
apps/api/pyproject.toml was still reporting 0.24.0 while package manifests across the monorepo ship 1.3.1.

Fixes #9355

### Description
<!-- Provide a detailed description of the changes in this PR -->

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
<!-- Link related issues if there are any -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to 1.3.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->