### PR TITLE
fix: register logger_task and webhook_task in CELERY_IMPORTS

### DIFF
--- a/apps/api/plane/settings/common.py
+++ b/apps/api/plane/settings/common.py
@@ -348,6 +348,9 @@ CELERY_IMPORTS = (
     # issue version tasks
     "plane.bgtasks.issue_version_sync",
     "plane.bgtasks.issue_description_version_sync",
+    # request/event tasks enqueued by API middleware and webhooks
+    "plane.bgtasks.logger_task",
+    "plane.bgtasks.webhook_task",
 )
 
 FILE_SIZE_LIMIT = int(os.environ.get("FILE_SIZE_LIMIT", 5242880))


### PR DESCRIPTION
Description

Registers Celery background tasks that the API enqueues but the worker never loaded, so those jobs were silently dropped.

APITokenLogMiddleware queues plane.bgtasks.logger_task.process_logs on API requests. The task module existed, but it was missing from CELERY_IMPORTS in plane/settings/common.py, so the worker never registered it and logged:

Received unregistered task of type 'plane.bgtasks.logger_task.process_logs'
KeyError: 'plane.bgtasks.logger_task.process_logs'

That broke API activity / audit logging and produced noisy worker errors. The same pattern applies to webhook_task (only registered via fragile transitive imports), so both modules are listed explicitly.

Change: add to CELERY_IMPORTS:
• plane.bgtasks.logger_task
• plane.bgtasks.webhook_task

Type of Change
• [x] Bug fix (non-breaking change which fixes an issue)
• [ ] Feature (non-breaking change which adds functionality)
• [ ] Improvement (change that would cause existing functionality to not work as expected)
• [ ] Code refactoring
• [ ] Performance improvements
• [ ] Documentation update

Test Scenarios
• Restart the Celery worker after deploy and confirm it starts without import errors
• Hit any authenticated API endpoint that goes through APITokenLogMiddleware
• Confirm worker logs no longer show unregistered process_logs tasks
• Confirm process_logs tasks are consumed (or API activity logs are written as expected)
• Optionally trigger a webhook delivery and confirm webhook tasks still run

References
• Fixes #9357
• Fixes #8928

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved background processing reliability for logging and webhook-related tasks.
  * Ensured these tasks are properly registered and available for execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->