### PR TITLE
fix: make LOG_DIR creation race-safe with exist_ok=True

### DIFF
--- a/apps/api/plane/settings/local.py
+++ b/apps/api/plane/settings/local.py
@@ -34,8 +34,7 @@ MEDIA_ROOT = os.path.join(BASE_DIR, "uploads")  # noqa
 
 LOG_DIR = os.path.join(BASE_DIR, "logs")  # noqa
 
-if not os.path.exists(LOG_DIR):
-    os.makedirs(LOG_DIR)
+os.makedirs(LOG_DIR, exist_ok=True)
 
 LOGGING = {
     "version": 1,

--- a/apps/api/plane/settings/production.py
+++ b/apps/api/plane/settings/production.py
@@ -24,8 +24,7 @@ SCOUT_NAME = "Plane"
 
 LOG_DIR = os.path.join(BASE_DIR, "logs")  # noqa
 
-if not os.path.exists(LOG_DIR):
-    os.makedirs(LOG_DIR)
+os.makedirs(LOG_DIR, exist_ok=True)
 
 # Logging configuration
 LOGGING = {


### PR DESCRIPTION
Description

Makes log directory creation race-safe during concurrent local Docker Compose startups.

On a clean boot, multiple backend containers (API, migrator, worker, beat) can all try to create plane/logs at the same time. The old pattern:

if not os.path.exists(LOG_DIR):
    os.makedirs(LOG_DIR)

is not atomic, so one process can create the directory between another’s existence check and makedirs, causing:

FileExistsError: [Errno 17] File exists: '/code/plane/logs'

That can crash containers and leave the UI stuck loading—especially on multi-core hosts or Windows/WSL2 where the race window is wider.

Change: use a single race-safe call in both local and production settings:

os.makedirs(LOG_DIR, exist_ok=True)

Type of Change
• [x] Bug fix (non-breaking change which fixes an issue)
• [ ] Feature (non-breaking change which adds functionality)
• [ ] Improvement (change that would cause existing functionality to not work as expected)
• [ ] Code refactoring
• [ ] Performance improvements
• [ ] Documentation update

Screenshots and Media (if applicable)
N/A — backend settings only.

Test Scenarios
• Remove or clear the local apps/api/plane/logs directory (or start from a clean volume)
• Run docker compose -f docker-compose-local.yml up --build so api/migrator/worker start together
• Confirm containers start without FileExistsError in migrator/api logs
• Confirm the logs directory is created and services continue past settings import
• Re-run with an existing logs directory and confirm startup still succeeds (no-op path)

References
• Fixes #9352

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when creating the application’s logging directory.
  * Prevented potential errors caused by concurrent or repeated directory creation in local and production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->