### PR TITLE
fix: coerce is_telemetry_enabled form values on instance admin signup

### DIFF
--- a/apps/api/plane/license/api/views/admin.py
+++ b/apps/api/plane/license/api/views/admin.py
@@ -126,7 +126,18 @@ class InstanceAdminSignUpEndpoint(View):
         first_name = request.POST.get("first_name", False)
         last_name = request.POST.get("last_name", "")
         company_name = request.POST.get("company_name", "")
-        is_telemetry_enabled = request.POST.get("is_telemetry_enabled", True)
+        # Form posts may send "true"/"false" strings; coerce to a real bool so
+        # assignment to Instance.is_telemetry_enabled does not 500 on save.
+        is_telemetry_enabled_raw = request.POST.get("is_telemetry_enabled", True)
+        if isinstance(is_telemetry_enabled_raw, bool):
+            is_telemetry_enabled = is_telemetry_enabled_raw
+        else:
+            is_telemetry_enabled = str(is_telemetry_enabled_raw).strip().lower() in {
+                "1",
+                "true",
+                "yes",
+                "on",
+            }
 
         # return error if the email and password is not present
         if not email or not password or not first_name:


### PR DESCRIPTION
Description

Fixes instance admin first-run signup when is_telemetry_enabled is posted as a form string.

POST /api/instances/admins/sign-up/ reads telemetry from the form:

is_telemetry_enabled = request.POST.get("is_telemetry_enabled", True)

When the field is omitted, the default is a real bool. When the form sends is_telemetry_enabled=false / true, Django returns a string. That string was assigned to Instance.is_telemetry_enabled (BooleanField) and instance.save() could 500.

Because the handler creates the user and InstanceAdmin before that save, a failure left the instance half-configured:

• user + instance admin created
• instances.is_setup_done never set
• retry → ADMIN_ALREADY_EXIST
• normal login → INSTANCE_NOT_CONFIGURED
• no UI/API recovery without a manual DB update

Change: coerce form values to a real boolean before assignment:

• already a bool → keep as-is
• otherwise treat truthy strings as true: 1, true, yes, on (case-insensitive)
• everything else (including "false") → False

User/admin/instance writes already run inside transaction.atomic(), so a later failure no longer strands a partial admin signup the same way.

Type of Change
• [x] Bug fix (non-breaking change which fixes an issue)
• [ ] Feature (non-breaking change which adds functionality)
• [ ] Improvement (change that would cause existing functionality to not work as expected)
• [ ] Code refactoring
• [ ] Performance improvements
• [ ] Documentation update

Screenshots and Media (if applicable)
N/A — backend auth/bootstrap only.

Test Scenarios
• Fresh instance (no admin, is_setup_done false)
• Sign up with is_telemetry_enabled=false (form-encoded) → 200 redirect, setup completes, can sign in
• Fresh instance again: omit is_telemetry_enabled → defaults to enabled, setup completes
• Sign up with is_telemetry_enabled=true / True / 1 → telemetry stays enabled
• Confirm instances.is_setup_done is true and is_telemetry_enabled matches the intended value
• Confirm a second signup still returns ADMIN_ALREADY_EXIST (guard unchanged)

References
• Fixes #9370
• Related: #8828 (same endpoint / telemetry form string pattern)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of the telemetry setting during instance setup.
  * Ensures telemetry preferences are consistently interpreted and saved as true or false values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->