### PR TITLE
fix(api): return 400 for non-positive per_page instead of 500

### DIFF
--- a/apps/api/plane/tests/contract/api/test_issues.py
+++ b/apps/api/plane/tests/contract/api/test_issues.py
@@ -94,3 +94,50 @@ class TestIssueListOrderByInjection:
             assert response.status_code == status.HTTP_200_OK, (
                 f"order_by={value!r} got {response.status_code}: {response.data!r}"
             )
+
+
+@pytest.mark.contract
+class TestIssueListPerPageValidation:
+    """Regression tests for the work-item list endpoint's ``per_page`` handling:
+    GET /api/v1/workspaces/{slug}/projects/{project_id}/issues/.
+
+    Non-numeric and oversized values already returned a clear 400, but zero and
+    negative values fell through validation and crashed downstream with a 500.
+    They should return a 400 like the other invalid cases.
+    """
+
+    def get_url(self, workspace_slug, project_id):
+        return f"/api/v1/workspaces/{workspace_slug}/projects/{project_id}/issues/"
+
+    @pytest.mark.django_db
+    @pytest.mark.parametrize("per_page", ["0", "-5"])
+    def test_non_positive_per_page_returns_400(self, api_key_client, workspace, project, issue, per_page):
+        """``per_page=0`` and negative values used to raise a 500; now a 400."""
+        url = self.get_url(workspace.slug, project.id)
+        response = api_key_client.get(url, {"per_page": per_page})
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, (
+            f"per_page={per_page!r} got {response.status_code}: {response.data!r}"
+        )
+        assert "positive integer" in str(response.data).lower()
+
+    @pytest.mark.django_db
+    def test_non_numeric_per_page_returns_400(self, api_key_client, workspace, project, issue):
+        url = self.get_url(workspace.slug, project.id)
+        response = api_key_client.get(url, {"per_page": "abc"})
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    @pytest.mark.django_db
+    def test_oversized_per_page_returns_400(self, api_key_client, workspace, project, issue):
+        url = self.get_url(workspace.slug, project.id)
+        response = api_key_client.get(url, {"per_page": "100000"})
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    @pytest.mark.django_db
+    def test_valid_per_page_still_works(self, api_key_client, workspace, project, issue):
+        url = self.get_url(workspace.slug, project.id)
+        response = api_key_client.get(url, {"per_page": "50"})
+
+        assert response.status_code == status.HTTP_200_OK, f"Got {response.status_code}: {response.data!r}"

--- a/apps/api/plane/utils/paginator.py
+++ b/apps/api/plane/utils/paginator.py
@@ -646,6 +646,9 @@ class BasePaginator:
         except ValueError:
             raise ParseError(detail="Invalid per_page parameter.")
 
+        if per_page <= 0:
+            raise ParseError(detail="Invalid per_page value. Must be a positive integer.")
+
         max_per_page = max(max_per_page, default_per_page)
         if per_page > max_per_page:
             raise ParseError(detail=f"Invalid per_page value. Cannot exceed {max_per_page}.")


### PR DESCRIPTION
The work items list endpoint (and every other paginated v1 endpoint) validated per_page for non-numeric and oversized values but not for zero or negative ones. Those fell through get_per_page and crashed downstream in the paginator, surfacing as an unhelpful HTTP 500 that clients retry.

Reject per_page <= 0 in BasePaginator.get_per_page with a 400 ParseError ("Invalid per_page value. Must be a positive integer."), matching the existing non-numeric and too-large validation cases.

Add contract tests covering per_page=0, negative, non-numeric, oversized, and valid values on the work items list endpoint.

Closes #9426

### Description
<!-- Provide a detailed description of the changes in this PR -->

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
<!-- Link related issues if there are any -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for issue list pagination.
  * Invalid, non-numeric, non-positive, or excessively large `per_page` values now return a clear HTTP 400 error.
  * Valid pagination values continue to work as expected.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->