### PR TITLE
fix(nginx): add no-cache header for index.html to prevent stale SPA s…

### DIFF
--- a/apps/admin/nginx/nginx.conf
+++ b/apps/admin/nginx/nginx.conf
@@ -26,6 +26,16 @@ http {
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
     add_header X-XSS-Protection "1; mode=block" always;
 
+     location = /god-mode/index.html {
+      root   /usr/share/nginx/html;
+      add_header X-Frame-Options "DENY" always;
+      add_header X-Content-Type-Options "nosniff" always;
+      add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+      add_header X-XSS-Protection "1; mode=block" always;
+      add_header Cache-Control "no-cache, must-revalidate" always;
+      try_files $uri =404;
+    }
+
     location / {
       root   /usr/share/nginx/html;
       index  index.html index.htm;

--- a/apps/web/nginx/nginx.conf
+++ b/apps/web/nginx/nginx.conf
@@ -26,6 +26,19 @@ http {
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
     add_header X-XSS-Protection "1; mode=block" always;
 
+    # index.html is not content-hashed like /assets/*, so it must never be
+    # cached long-term. Safari/iOS's aggressive heuristic caching can otherwise
+    # keep serving a stale shell indefinitely, even after a fix is deployed.
+    location = /index.html {
+      root   /usr/share/nginx/html;
+      add_header X-Frame-Options "DENY" always;
+      add_header X-Content-Type-Options "nosniff" always;
+      add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+      add_header X-XSS-Protection "1; mode=block" always;
+      add_header Cache-Control "no-cache, must-revalidate" always;
+      try_files $uri =404;
+    }
+
     location / {
       root   /usr/share/nginx/html;
       index  index.html index.htm;
@@ -33,4 +46,3 @@ http {
     }
   }
 }
-


### PR DESCRIPTION
### Description
Adds explicit `Cache-Control: no-cache, must-revalidate` headers for `index.html` 
in the web (`apps/web/nginx/nginx.conf`) and admin (`apps/admin/nginx/nginx.conf`) 
nginx configs.

`index.html` is not content-hashed like the files under `/assets/*`, so without an 
explicit cache header, browsers rely on nginx's default heuristic caching. Safari 
in particular applies aggressive heuristic caching to responses without an explicit 
`Cache-Control` header, which can cause it to keep serving a stale `index.html` 
indefinitely — even after a bug fix is deployed to production — until the user 
manually clears site data.

This was flagged as a secondary finding in #9439 (the Safari/iOS 
`requestIdleCallback` crash issue): even once that crash fix ships in a release, 
Safari/iOS users could keep hitting the old broken build because of this caching 
gap.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

### Screenshots and Media (if applicable)
N/A — this is a header-only nginx config change, not a UI change.

### Test Scenarios
- Built the nginx image locally and confirmed `curl -I http://localhost:3000/index.html` 
  returns `Cache-Control: no-cache, must-revalidate`
- Confirmed `/assets/*` static chunks are unaffected and still use their existing 
  caching behavior
- Confirmed existing security headers (`X-Frame-Options`, `X-Content-Type-Options`, 
  `Strict-Transport-Security`, `X-XSS-Protection`) are still present on `index.html` 
  responses
- Verified the app still loads correctly via `try_files` fallback for both 
  `apps/web` and `apps/admin` (`/god-mode/index.html`)

### References
Related to #9439

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application routing so direct and unresolved URLs correctly load the appropriate app shell.
  * Added security headers to key entry pages.
  * Disabled caching for entry pages to ensure users receive the latest application version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->