### PR TITLE
[WEB-8289] fix: scope draft-to-issue conversion to the draft owner

### DIFF
--- a/apps/api/plane/app/views/workspace/draft.py
+++ b/apps/api/plane/app/views/workspace/draft.py
@@ -204,7 +204,16 @@ class WorkspaceDraftIssueViewSet(BaseViewSet):
 
     @allow_permission(allowed_roles=[ROLE.ADMIN, ROLE.MEMBER], level="WORKSPACE")
     def create_draft_to_issue(self, request, slug, draft_id):
-        draft_issue = self.get_queryset().filter(pk=draft_id).first()
+        # Drafts are private to their creator; scope the lookup to the owner so a
+        # workspace member cannot convert/steal/delete another user's draft
+        # (GHSA-vfqm-7rh7-84hq). Mirrors retrieve/partial_update.
+        draft_issue = self.get_queryset().filter(pk=draft_id, created_by=request.user).first()
+
+        if not draft_issue:
+            return Response(
+                {"error": "The required object does not exist."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
 
         if not draft_issue.project_id:
             return Response(

--- a/apps/api/plane/app/views/workspace/draft.py
+++ b/apps/api/plane/app/views/workspace/draft.py
@@ -206,7 +206,7 @@ class WorkspaceDraftIssueViewSet(BaseViewSet):
     def create_draft_to_issue(self, request, slug, draft_id):
         # Drafts are private to their creator; scope the lookup to the owner so a
         # workspace member cannot convert/steal/delete another user's draft
-        # (GHSA-vfqm-7rh7-84hq). Mirrors retrieve/partial_update.
+        # Mirrors retrieve/partial_update.
         draft_issue = self.get_queryset().filter(pk=draft_id, created_by=request.user).first()
 
         if not draft_issue:

--- a/apps/api/plane/tests/contract/app/test_draft_to_issue_owner_scope_app.py
+++ b/apps/api/plane/tests/contract/app/test_draft_to_issue_owner_scope_app.py
@@ -1,0 +1,140 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Contract tests for draft-to-issue conversion ownership scoping.
+
+Regression coverage for GHSA-vfqm-7rh7-84hq (WEB-8289).
+
+``WorkspaceDraftIssueViewSet.create_draft_to_issue`` resolved the draft with
+``get_queryset().filter(pk=draft_id)`` — scoped only to the workspace, with no
+``created_by`` check — while the decorator admits any workspace ADMIN/MEMBER.
+Drafts are private to their creator, so any member could convert another user's
+draft to an issue, reassign (steal) its file assets, and delete the draft.
+
+The fix scopes the lookup to ``created_by=request.user`` and 404s otherwise.
+"""
+
+from unittest import mock
+from uuid import uuid4
+
+import pytest
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from plane.db.models import (
+    DraftIssue,
+    FileAsset,
+    Issue,
+    Project,
+    ProjectMember,
+    User,
+    WorkspaceMember,
+)
+
+
+def draft_to_issue_url(slug, draft_id):
+    return f"/api/workspaces/{slug}/draft-to-issue/{draft_id}/"
+
+
+@pytest.fixture(autouse=True)
+def _no_activity(db):
+    """Stub the deferred activity task (broker) and base_host (needs APP_BASE_URL
+    / WEB_URL, unset in the test env) so the conversion path runs cleanly."""
+    with (
+        mock.patch("plane.app.views.workspace.draft.issue_activity"),
+        mock.patch("plane.app.views.workspace.draft.base_host", return_value="http://testserver"),
+        # draft.delete() cascades via a Celery task (soft-delete); stub the broker.
+        mock.patch("plane.db.mixins.soft_delete_related_objects"),
+    ):
+        yield
+
+
+@pytest.fixture
+def owned_draft(db, workspace, create_user):
+    """A draft owned by ``create_user`` (session_client), with a project + asset."""
+    project = Project.objects.create(
+        name="Draft Project", identifier="DRP", workspace=workspace, created_by=create_user
+    )
+    ProjectMember.objects.create(
+        project=project, member=create_user, workspace=workspace, role=20, is_active=True
+    )
+    # BaseModel.save auto-sets created_by from the request user (None under
+    # tests), overwriting a created_by= kwarg — pass created_by_id to save.
+    draft = DraftIssue(name="Private draft", workspace=workspace, project=project)
+    draft.save(created_by_id=create_user.id)
+    asset = FileAsset.objects.create(
+        attributes={"name": "secret.pdf", "type": "application/pdf", "size": 1024},
+        asset=f"{workspace.id}/secret.pdf",
+        size=1024,
+        workspace=workspace,
+        project=project,
+        draft_issue=draft,
+        created_by=create_user,
+        entity_type=FileAsset.EntityTypeContext.DRAFT_ISSUE_DESCRIPTION,
+        is_uploaded=True,
+        storage_metadata={"size": 1024},
+    )
+    return {"project": project, "draft": draft, "asset": asset}
+
+
+@pytest.fixture
+def attacker_client(db, workspace):
+    """A workspace MEMBER (role 15) who does NOT own the draft."""
+    uid = uuid4().hex[:8]
+    user = User.objects.create(email=f"attacker-{uid}@plane.so", username=f"attacker_{uid}")
+    user.set_password("test-password")
+    user.save()
+    WorkspaceMember.objects.create(workspace=workspace, member=user, role=15)
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client
+
+
+@pytest.mark.contract
+class TestDraftToIssueOwnerScope:
+    @pytest.mark.django_db
+    def test_cannot_convert_another_users_draft(self, attacker_client, workspace, owned_draft):
+        draft = owned_draft["draft"]
+        asset = owned_draft["asset"]
+
+        response = attacker_client.post(
+            draft_to_issue_url(workspace.slug, draft.id),
+            {"name": "Hijacked issue"},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+        # Draft not deleted.
+        assert DraftIssue.objects.filter(pk=draft.id).exists()
+        # Asset not stolen — still bound to the draft, not reassigned to an issue.
+        asset.refresh_from_db()
+        assert asset.draft_issue_id == draft.id
+        assert asset.issue_id is None
+        # No issue was created from the victim's draft.
+        assert not Issue.objects.filter(name="Hijacked issue").exists()
+
+    @pytest.mark.django_db
+    def test_owner_can_convert_own_draft(self, session_client, workspace, owned_draft):
+        """Positive control: the draft's creator can still convert it."""
+        draft = owned_draft["draft"]
+        asset = owned_draft["asset"]
+
+        response = session_client.post(
+            draft_to_issue_url(workspace.slug, draft.id),
+            {"name": "Converted issue"},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+        # Draft consumed, issue created, asset migrated to the new issue.
+        assert not DraftIssue.objects.filter(pk=draft.id).exists()
+        issue = Issue.objects.filter(name="Converted issue").first()
+        assert issue is not None
+        asset.refresh_from_db()
+        assert asset.issue_id == issue.id
+        assert asset.draft_issue_id is None

--- a/apps/api/plane/tests/contract/app/test_draft_to_issue_owner_scope_app.py
+++ b/apps/api/plane/tests/contract/app/test_draft_to_issue_owner_scope_app.py
@@ -4,7 +4,7 @@
 
 """Contract tests for draft-to-issue conversion ownership scoping.
 
-Regression coverage for GHSA-vfqm-7rh7-84hq (WEB-8289).
+Regression coverage for WEB-8289.
 
 ``WorkspaceDraftIssueViewSet.create_draft_to_issue`` resolved the draft with
 ``get_queryset().filter(pk=draft_id)`` — scoped only to the workspace, with no

--- a/apps/api/plane/tests/contract/app/test_draft_to_issue_owner_scope_app.py
+++ b/apps/api/plane/tests/contract/app/test_draft_to_issue_owner_scope_app.py
@@ -53,28 +53,28 @@ def _no_activity(db):
 @pytest.fixture
 def owned_draft(db, workspace, create_user):
     """A draft owned by ``create_user`` (session_client), with a project + asset."""
-    project = Project.objects.create(
-        name="Draft Project", identifier="DRP", workspace=workspace, created_by=create_user
-    )
+    # BaseModel.save auto-sets created_by from the request user (None under
+    # tests), overwriting a created_by= kwarg — pass created_by_id to save so the
+    # fixtures' ownership is real rather than silently nulled.
+    project = Project(name="Draft Project", identifier="DRP", workspace=workspace)
+    project.save(created_by_id=create_user.id)
     ProjectMember.objects.create(
         project=project, member=create_user, workspace=workspace, role=20, is_active=True
     )
-    # BaseModel.save auto-sets created_by from the request user (None under
-    # tests), overwriting a created_by= kwarg — pass created_by_id to save.
     draft = DraftIssue(name="Private draft", workspace=workspace, project=project)
     draft.save(created_by_id=create_user.id)
-    asset = FileAsset.objects.create(
+    asset = FileAsset(
         attributes={"name": "secret.pdf", "type": "application/pdf", "size": 1024},
         asset=f"{workspace.id}/secret.pdf",
         size=1024,
         workspace=workspace,
         project=project,
         draft_issue=draft,
-        created_by=create_user,
         entity_type=FileAsset.EntityTypeContext.DRAFT_ISSUE_DESCRIPTION,
         is_uploaded=True,
         storage_metadata={"size": 1024},
     )
+    asset.save(created_by_id=create_user.id)
     return {"project": project, "draft": draft, "asset": asset}
 
 


### PR DESCRIPTION
## Summary

Fixes WEB-8289 (HIGH). `WorkspaceDraftIssueViewSet.create_draft_to_issue` resolved the draft with `get_queryset().filter(pk=draft_id)` — scoped only to the workspace, with **no `created_by` check** — while the decorator admits any workspace ADMIN/MEMBER.

Draft issues are **private to their creator** (the sibling `list` / `retrieve` / `partial_update` methods all filter `created_by=request.user`). So any workspace member could supply another user's `draft_id` and:
- convert that private draft into a real issue,
- **reassign (steal) the draft's file assets** to the new issue (`FileAsset.objects.filter(draft_issue_id=draft_id).update(issue_id=...)`), and
- **delete the victim's draft** (`draft_issue.delete()`).

## Fix

Scope the lookup to the owner and 404 otherwise:

```python
draft_issue = self.get_queryset().filter(pk=draft_id, created_by=request.user).first()
if not draft_issue:
    return Response({"error": "The required object does not exist."}, status=404)
```

This mirrors the exact pattern already used by `retrieve` / `partial_update`. The explicit null guard also removes a latent `AttributeError` on the subsequent `.project_id` access when no draft matches.

## Tests

New contract suite `plane/tests/contract/app/test_draft_to_issue_owner_scope_app.py` (**fail-before verified** — the security test returns 201 without the fix):
- A non-owner member converting another user's draft → **404**, and the draft + its file asset are left intact (not deleted, not reassigned).
- Positive control: the draft's owner can still convert their own draft (201, draft consumed, asset migrated to the new issue).

## Verification
- `ruff check`: clean
- `manage.py check` (test settings): no issues
- `pytest` (new suite): 2/2 green; fail-before verified

## Notes
- **Dedupe:** a second MED report shares this root cause and code path — should be closed as a duplicate of this on release. (Mapping on the ticket.)
- **EE:** EE does not override this endpoint, so this CE fix covers EE deployments too. A distinct, lower-severity owner-scope gap on the EE-only `DraftIssuePropertyValueEndpoint` (draft custom-field values, same-project) is being tracked as a separate follow-up, not part of this advisory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted “draft-to-issue” conversion so only the draft’s owner can convert it.
  * Unauthorized attempts now return **404 Not Found** and do not alter the draft, its attached files, or create an issue.
  * Draft owners can still convert their drafts successfully, including transferring any attached files to the new issue.

* **Tests**
  * Added contract tests covering both unauthorized and authorized draft-to-issue conversion paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
