### PR TITLE
[WEB-8291] fix: gate project invitation list/retrieve/destroy to project admins

### DIFF
--- a/apps/api/plane/app/views/project/invite.py
+++ b/apps/api/plane/app/views/project/invite.py
@@ -28,7 +28,6 @@ from plane.db.models import (
     ProjectMember,
     Workspace,
     ProjectMemberInvite,
-    User,
     WorkspaceMember,
     Project,
     ProjectUserProperty,
@@ -52,6 +51,23 @@ class ProjectInvitationsViewset(BaseViewSet):
             .select_related("project")
             .select_related("workspace", "workspace__owner")
         )
+
+    # GHSA-r68c-48rr-m67f: project invitations expose invitee email + raw token
+    # and allow deletion, so every action must be restricted to project admins
+    # (mirroring create). Without these, the default list/retrieve/destroy
+    # inherited only IsAuthenticated, letting any workspace user read/delete
+    # another project's invitations.
+    @allow_permission([ROLE.ADMIN])
+    def list(self, request, slug, project_id):
+        return super().list(request)
+
+    @allow_permission([ROLE.ADMIN])
+    def retrieve(self, request, slug, project_id, pk):
+        return super().retrieve(request)
+
+    @allow_permission([ROLE.ADMIN])
+    def destroy(self, request, slug, project_id, pk):
+        return super().destroy(request)
 
     @allow_permission([ROLE.ADMIN])
     def create(self, request, slug, project_id):

--- a/apps/api/plane/app/views/project/invite.py
+++ b/apps/api/plane/app/views/project/invite.py
@@ -52,11 +52,10 @@ class ProjectInvitationsViewset(BaseViewSet):
             .select_related("workspace", "workspace__owner")
         )
 
-    # GHSA-r68c-48rr-m67f: project invitations expose invitee email + raw token
-    # and allow deletion, so every action must be restricted to project admins
-    # (mirroring create). Without these, the default list/retrieve/destroy
-    # inherited only IsAuthenticated, letting any workspace user read/delete
-    # another project's invitations.
+    # Project invitations expose the invitee email and the raw token, and can be
+    # deleted, so list/retrieve/destroy must be admin-only like create. Without
+    # these decorators they inherit only IsAuthenticated, letting any workspace
+    # user read or delete another project's invitations.
     @allow_permission([ROLE.ADMIN])
     def list(self, request, slug, project_id):
         return super().list(request)
@@ -167,7 +166,7 @@ class UserProjectInvitationsViewset(BaseViewSet):
         # Use the workspace-scoped, network-validated project IDs only.
         # Raw project_ids may contain UUIDs from other workspaces; those are
         # absent from the `projects` queryset and therefore bypass the SECRET
-        # network check above (GHSA-45hc-q4mw-jhxm).
+        # network check above.
         validated_project_ids = [str(p.id) for p in projects]
 
         # If the user was already part of workspace
@@ -222,8 +221,7 @@ class ProjectJoinEndpoint(BaseAPIView):
 
         # Require an authenticated session — the accepting user must be the
         # person who was invited.  Without this check an attacker who knows the
-        # invitee email and obtains the token can hijack the project membership
-        # (GHSA-g36h-p63v-g9c7).
+        # invitee email and obtains the token can hijack the project membership.
         if not request.user.is_authenticated:
             return Response(
                 {"error": "Authentication required to accept project invitation"},

--- a/apps/api/plane/tests/contract/app/test_project_invite_list_scope_app.py
+++ b/apps/api/plane/tests/contract/app/test_project_invite_list_scope_app.py
@@ -1,0 +1,112 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Contract tests for ``ProjectInvitationsViewset`` authorization.
+
+Regression coverage for GHSA-r68c-48rr-m67f (WEB-8291).
+
+The viewset declared no ``permission_classes`` (inheriting ``IsAuthenticated``)
+and only decorated ``create`` with ``@allow_permission([ROLE.ADMIN])``. The
+default ``list`` / ``retrieve`` / ``destroy`` actions were therefore ungated and
+``get_queryset`` was scoped only by URL slug + project_id, so any authenticated
+user could read another project's pending invitations — including invitee
+``email`` and the raw ``token`` — and delete them.
+
+The fix gates every action to project admins (``@allow_permission([ROLE.ADMIN])``).
+"""
+
+from uuid import uuid4
+
+import pytest
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from plane.db.models import Project, ProjectMember, ProjectMemberInvite, User, WorkspaceMember
+
+
+def _invites_url(slug, project_id, pk=None):
+    base = f"/api/workspaces/{slug}/projects/{project_id}/invitations/"
+    return f"{base}{pk}/" if pk else base
+
+
+@pytest.fixture
+def project(db, workspace, create_user):
+    """A project where ``create_user`` (session_client) is an active admin."""
+    project = Project.objects.create(
+        name="Invite Project", identifier="INV", workspace=workspace, created_by=create_user
+    )
+    ProjectMember.objects.create(
+        project=project, member=create_user, workspace=workspace, role=20, is_active=True
+    )
+    return project
+
+
+@pytest.fixture
+def invite(db, workspace, project):
+    """A pending project invitation carrying an email + raw token."""
+    return ProjectMemberInvite.objects.create(
+        project=project,
+        workspace=workspace,
+        email="invitee@plane.so",
+        token="super-secret-token",
+        role=15,
+    )
+
+
+@pytest.fixture
+def outsider_client(db, workspace):
+    """A workspace member who is a member of a *different* project, not ``project``.
+
+    Mirrors the vulnerable scenario: the caller is a legitimate workspace user
+    with project membership elsewhere, but not in the target project.
+    """
+    uid = uuid4().hex[:8]
+    outsider = User.objects.create(email=f"outsider-{uid}@plane.so", username=f"outsider_{uid}")
+    outsider.set_password("test-password")
+    outsider.save()
+    WorkspaceMember.objects.create(workspace=workspace, member=outsider, role=15)
+    other = Project.objects.create(
+        name="Other Project", identifier="OTH", workspace=workspace, created_by=outsider
+    )
+    ProjectMember.objects.create(
+        project=other, member=outsider, workspace=workspace, role=20, is_active=True
+    )
+    client = APIClient()
+    client.force_authenticate(user=outsider)
+    return client
+
+
+@pytest.mark.contract
+class TestProjectInviteListScope:
+    @pytest.mark.django_db
+    def test_non_project_member_cannot_list_invitations(self, outsider_client, workspace, project, invite):
+        response = outsider_client.get(_invites_url(workspace.slug, project.id))
+        assert response.status_code == status.HTTP_403_FORBIDDEN, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+
+    @pytest.mark.django_db
+    def test_non_project_member_cannot_retrieve_invitation(self, outsider_client, workspace, project, invite):
+        response = outsider_client.get(_invites_url(workspace.slug, project.id, pk=invite.id))
+        assert response.status_code == status.HTTP_403_FORBIDDEN, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+
+    @pytest.mark.django_db
+    def test_non_project_member_cannot_delete_invitation(self, outsider_client, workspace, project, invite):
+        response = outsider_client.delete(_invites_url(workspace.slug, project.id, pk=invite.id))
+        assert response.status_code == status.HTTP_403_FORBIDDEN, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+        assert ProjectMemberInvite.objects.filter(pk=invite.id).exists()
+
+    @pytest.mark.django_db
+    def test_project_admin_can_list_invitations(self, session_client, workspace, project, invite):
+        """Positive control: an active project admin can still list invitations."""
+        response = session_client.get(_invites_url(workspace.slug, project.id))
+        assert response.status_code == status.HTTP_200_OK, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+        ids = {str(item["id"]) for item in response.json()}
+        assert str(invite.id) in ids

--- a/apps/api/plane/tests/contract/app/test_project_invite_list_scope_app.py
+++ b/apps/api/plane/tests/contract/app/test_project_invite_list_scope_app.py
@@ -4,7 +4,7 @@
 
 """Contract tests for ``ProjectInvitationsViewset`` authorization.
 
-Regression coverage for GHSA-r68c-48rr-m67f (WEB-8291).
+Regression coverage for WEB-8291.
 
 The viewset declared no ``permission_classes`` (inheriting ``IsAuthenticated``)
 and only decorated ``create`` with ``@allow_permission([ROLE.ADMIN])``. The


### PR DESCRIPTION
## Summary

Fixes the confirmed-vulnerable half of WEB-8291 (HIGH, CWE-862) — the **project-invitation-list authorization bypass**.

`ProjectInvitationsViewset` declared no `permission_classes` (inheriting `IsAuthenticated`) and only decorated `create` with `@allow_permission([ROLE.ADMIN])`. The default `list` / `retrieve` / `destroy` actions were therefore ungated, and `get_queryset` was scoped only by URL `slug` + `project_id` — not by the caller's membership. The serializer (`ProjectMemberInviteSerializer`, `fields="__all__"`) returns `email` and `token`.

**Impact (before fix):** any authenticated user could `GET /api/workspaces/<slug>/projects/<project_id>/invitations/` (and `/<pk>/`) for a project they don't belong to and read every pending invite's raw `token` + invitee `email` (re-exposing what #9305 stripped from the public path), and could `DELETE` arbitrary project invitations.

> The other vector in the advisory — **unauthenticated force-accept** — is already remediated: `ProjectJoinEndpoint.post` enforces token + auth + email-match (#9308) and the public GET uses the token-stripped serializer (#9305).

## Fix

Gate `list` / `retrieve` / `destroy` with `@allow_permission([ROLE.ADMIN])`, matching `create` (project admin, or a workspace-admin who is a project member — the decorator's existing semantics). This mirrors the workspace sibling `WorkspaceInvitationsViewset`, which was already admin-gated (`WorkSpaceAdminPermission`).

Chose the method decorator over a class-level `ProjectAdminPermission` deliberately: a class-level permission would have *tightened* `create` (blocking the workspace-admin-project-member fallback that `@allow_permission` allows), a behavior change. The decorator keeps all four actions consistent.

Also removes a pre-existing unused `User` import in the same file.

## Tests

New contract suite `plane/tests/contract/app/test_project_invite_list_scope_app.py` (**fail-before verified** — the 3 security tests return 200/204 without the fix):
- A workspace user who is a member of a *different* project is rejected with **403** on list / retrieve / delete, and the invitation is left intact.
- Positive control: an active project admin can still list invitations and sees the pending invite.

## Verification
- `ruff check`: clean
- `manage.py check` (test settings): no issues
- `pytest` (new suite): 4/4 green; fail-before verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted project invitation listing, viewing, and deletion to project administrators.
  * Prevented unauthorized workspace users from accessing invitations belonging to other projects.
  * Confirmed that project administrators can continue managing pending invitations.

* **Tests**
  * Added coverage for authorized and unauthorized invitation access scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
