### PR TITLE
fix: dispatch notifications for comment, link, and delete endpoints in the external API

### DIFF
--- a/apps/api/plane/api/views/issue.py
+++ b/apps/api/plane/api/views/issue.py
@@ -871,6 +871,8 @@ class IssueDetailAPIEndpoint(BaseAPIView):
             project_id=str(project_id),
             current_instance=current_instance,
             epoch=int(timezone.now().timestamp()),
+            notification=True,
+            origin=base_host(request=request, is_app=True),
         )
         return Response(status=status.HTTP_204_NO_CONTENT)
 
@@ -1208,6 +1210,8 @@ class IssueLinkListCreateAPIEndpoint(BaseAPIView):
                 actor_id=str(link.created_by_id),
                 current_instance=None,
                 epoch=int(timezone.now().timestamp()),
+                notification=True,
+                origin=base_host(request=request, is_app=True),
             )
             serializer = IssueLinkSerializer(link)
             return Response(serializer.data, status=status.HTTP_201_CREATED)
@@ -1319,6 +1323,8 @@ class IssueLinkDetailAPIEndpoint(BaseAPIView):
                 project_id=str(project_id),
                 current_instance=current_instance,
                 epoch=int(timezone.now().timestamp()),
+                notification=True,
+                origin=base_host(request=request, is_app=True),
             )
             serializer = IssueLinkSerializer(issue_link)
             return Response(serializer.data, status=status.HTTP_200_OK)
@@ -1352,6 +1358,8 @@ class IssueLinkDetailAPIEndpoint(BaseAPIView):
             project_id=str(project_id),
             current_instance=current_instance,
             epoch=int(timezone.now().timestamp()),
+            notification=True,
+            origin=base_host(request=request, is_app=True),
         )
         issue_link.delete()
         return Response(status=status.HTTP_204_NO_CONTENT)
@@ -1495,6 +1503,8 @@ class IssueCommentListCreateAPIEndpoint(BaseAPIView):
                 project_id=str(self.kwargs.get("project_id")),
                 current_instance=None,
                 epoch=int(timezone.now().timestamp()),
+                notification=True,
+                origin=base_host(request=request, is_app=True),
             )
 
             # Send the model activity
@@ -1635,6 +1645,8 @@ class IssueCommentDetailAPIEndpoint(BaseAPIView):
                 project_id=str(project_id),
                 current_instance=current_instance,
                 epoch=int(timezone.now().timestamp()),
+                notification=True,
+                origin=base_host(request=request, is_app=True),
             )
             # Send the model activity
             model_activity.delay(
@@ -1681,6 +1693,8 @@ class IssueCommentDetailAPIEndpoint(BaseAPIView):
             project_id=str(project_id),
             current_instance=current_instance,
             epoch=int(timezone.now().timestamp()),
+            notification=True,
+            origin=base_host(request=request, is_app=True),
         )
         return Response(status=status.HTTP_204_NO_CONTENT)
 

--- a/apps/api/plane/tests/contract/api/test_issue_notifications.py
+++ b/apps/api/plane/tests/contract/api/test_issue_notifications.py
@@ -133,3 +133,141 @@ class TestIssueNotificationContract:
         kwargs = mock_issue_activity.delay.call_args.kwargs
         assert kwargs["type"] == "issue.activity.updated"
         assert kwargs["notification"] is True
+
+
+@pytest.fixture
+def create_comment(db, project, workspace, create_user, create_issue):
+    """Create an existing comment to update/delete in tests."""
+    from plane.db.models import IssueComment
+
+    return IssueComment.objects.create(
+        comment_html="<p>Existing comment</p>",
+        issue=create_issue,
+        project=project,
+        workspace=workspace,
+        actor=create_user,
+        created_by=create_user,
+    )
+
+
+@pytest.fixture
+def create_link(db, project, workspace, create_user, create_issue):
+    """Create an existing link to update/delete in tests."""
+    from plane.db.models import IssueLink
+
+    return IssueLink.objects.create(
+        url="https://example.com/existing",
+        issue=create_issue,
+        project=project,
+        workspace=workspace,
+        created_by=create_user,
+    )
+
+
+@pytest.mark.contract
+class TestCommentLinkDeleteNotificationContract:
+    """
+    Contract: comment create/update/delete, link create/update/delete, and work
+    item delete through the external REST API (``/api/v1/...``) must trigger
+    notifications, i.e. ``issue_activity`` is dispatched with ``notification=True``
+    the same way the web app views do. Complements makeplane/plane#9306 (which
+    covered issue create/update) and covers makeplane/plane#7846.
+    """
+
+    def get_issue_url(self, workspace_slug, project_id, issue_id):
+        return f"/api/v1/workspaces/{workspace_slug}/projects/{project_id}/issues/{issue_id}/"
+
+    def get_comments_url(self, workspace_slug, project_id, issue_id, pk=None):
+        base = f"/api/v1/workspaces/{workspace_slug}/projects/{project_id}/issues/{issue_id}/comments/"
+        return f"{base}{pk}/" if pk else base
+
+    def get_links_url(self, workspace_slug, project_id, issue_id, pk=None):
+        base = f"/api/v1/workspaces/{workspace_slug}/projects/{project_id}/issues/{issue_id}/links/"
+        return f"{base}{pk}/" if pk else base
+
+    def assert_notifying_activity(self, mock_issue_activity, activity_type):
+        mock_issue_activity.delay.assert_called_once()
+        kwargs = mock_issue_activity.delay.call_args.kwargs
+        assert kwargs["type"] == activity_type
+        assert kwargs["notification"] is True
+
+    @pytest.mark.django_db
+    def test_create_comment_triggers_notification(self, api_key_client, workspace, project, create_issue):
+        """Creating a comment via the external API dispatches a notifying activity."""
+        url = self.get_comments_url(workspace.slug, project.id, create_issue.id)
+
+        with patch("plane.api.views.issue.issue_activity") as mock_issue_activity:
+            response = api_key_client.post(url, {"comment_html": "<p>New comment</p>"}, format="json")
+
+        assert response.status_code == status.HTTP_201_CREATED
+        self.assert_notifying_activity(mock_issue_activity, "comment.activity.created")
+
+    @pytest.mark.django_db
+    def test_update_comment_triggers_notification(
+        self, api_key_client, workspace, project, create_issue, create_comment
+    ):
+        """Updating a comment via the external API dispatches a notifying activity."""
+        url = self.get_comments_url(workspace.slug, project.id, create_issue.id, create_comment.id)
+
+        with patch("plane.api.views.issue.issue_activity") as mock_issue_activity:
+            response = api_key_client.patch(url, {"comment_html": "<p>Edited comment</p>"}, format="json")
+
+        assert response.status_code == status.HTTP_200_OK
+        self.assert_notifying_activity(mock_issue_activity, "comment.activity.updated")
+
+    @pytest.mark.django_db
+    def test_delete_comment_triggers_notification(
+        self, api_key_client, workspace, project, create_issue, create_comment
+    ):
+        """Deleting a comment via the external API dispatches a notifying activity."""
+        url = self.get_comments_url(workspace.slug, project.id, create_issue.id, create_comment.id)
+
+        with patch("plane.api.views.issue.issue_activity") as mock_issue_activity:
+            response = api_key_client.delete(url)
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        self.assert_notifying_activity(mock_issue_activity, "comment.activity.deleted")
+
+    @pytest.mark.django_db
+    def test_create_link_triggers_notification(self, api_key_client, workspace, project, create_issue):
+        """Creating a link via the external API dispatches a notifying activity."""
+        url = self.get_links_url(workspace.slug, project.id, create_issue.id)
+
+        with patch("plane.api.views.issue.issue_activity") as mock_issue_activity:
+            response = api_key_client.post(url, {"url": "https://example.com/new"}, format="json")
+
+        assert response.status_code == status.HTTP_201_CREATED
+        self.assert_notifying_activity(mock_issue_activity, "link.activity.created")
+
+    @pytest.mark.django_db
+    def test_update_link_triggers_notification(self, api_key_client, workspace, project, create_issue, create_link):
+        """Updating a link via the external API dispatches a notifying activity."""
+        url = self.get_links_url(workspace.slug, project.id, create_issue.id, create_link.id)
+
+        with patch("plane.api.views.issue.issue_activity") as mock_issue_activity:
+            response = api_key_client.patch(url, {"url": "https://example.com/edited"}, format="json")
+
+        assert response.status_code == status.HTTP_200_OK
+        self.assert_notifying_activity(mock_issue_activity, "link.activity.updated")
+
+    @pytest.mark.django_db
+    def test_delete_link_triggers_notification(self, api_key_client, workspace, project, create_issue, create_link):
+        """Deleting a link via the external API dispatches a notifying activity."""
+        url = self.get_links_url(workspace.slug, project.id, create_issue.id, create_link.id)
+
+        with patch("plane.api.views.issue.issue_activity") as mock_issue_activity:
+            response = api_key_client.delete(url)
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        self.assert_notifying_activity(mock_issue_activity, "link.activity.deleted")
+
+    @pytest.mark.django_db
+    def test_delete_issue_triggers_notification(self, api_key_client, workspace, project, create_issue):
+        """Deleting a work item via the external API dispatches a notifying activity."""
+        url = self.get_issue_url(workspace.slug, project.id, create_issue.id)
+
+        with patch("plane.api.views.issue.issue_activity") as mock_issue_activity:
+            response = api_key_client.delete(url)
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        self.assert_notifying_activity(mock_issue_activity, "issue.activity.deleted")


### PR DESCRIPTION
### Description

Comment create/update/delete, link create/update/delete, and work item delete through the external REST API (`/api/v1/...`) create activities but never notify assignees and subscribers — neither in-app nor by email. `issue_activity` is dispatched without `notification=True` (the parameter defaults to `False` in `apps/api/plane/bgtasks/issue_activities_task.py`), so `notifications.delay(...)` never runs. The web app views (`apps/api/plane/app/views/issue/base.py`, `comment.py`, `link.py`) pass `notification=True` and `origin` for the same actions, and in the same external API file the attachment and relation endpoints already pass it.

This PR passes `notification=True` and `origin=base_host(request=request, is_app=True)` on the remaining seven `issue_activity.delay(...)` calls in `apps/api/plane/api/views/issue.py` (comment create/update/delete, link create/update/delete, work item delete), mirroring the web app views. It complements #9307, which fixed issue create/update in the same file.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

### Test Scenarios

Contract tests added to `plane/tests/contract/api/test_issue_notifications.py` following the conventions introduced there: one test per endpoint asserting that the dispatched activity carries `notification=True` (7 new tests). Ran the full file against PostgreSQL/Redis/RabbitMQ services: 10 passed. Verified red/green: on the unpatched views exactly the 7 new tests fail. `ruff check` clean.

Also verified end-to-end on a self-hosted v1.3.1 instance carrying this change as a patch: an API-token comment on a subscribed work item produces the in-app notification, the email notification log entry, and the batched email.

### References

Covers #7846. Complements #9306 / #9307.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Issue comments, links, and deletions now generate notifications through the external API.
  * Notifications are triggered when comments or links are created, updated, or deleted.

* **Tests**
  * Added coverage verifying notification events for issue, comment, and link changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->