### PR TITLE
feat(api): add work item archive/unarchive endpoints to the public API

### DIFF
--- a/apps/api/plane/api/urls/work_item.py
+++ b/apps/api/plane/api/urls/work_item.py
@@ -18,6 +18,7 @@ from plane.api.views import (
     WorkspaceIssueAPIEndpoint,
     IssueSearchEndpoint,
     IssueRelationListCreateAPIEndpoint,
+    IssueArchiveUnarchiveAPIEndpoint,
 )
 
 # Deprecated url patterns
@@ -81,6 +82,21 @@ old_url_patterns = [
         "workspaces/<str:slug>/projects/<uuid:project_id>/issues/<uuid:issue_id>/issue-attachments/<uuid:pk>/",
         IssueAttachmentDetailAPIEndpoint.as_view(http_method_names=["get", "patch", "delete"]),
         name="issue-attachment",
+    ),
+    path(
+        "workspaces/<str:slug>/projects/<uuid:project_id>/issues/<uuid:pk>/archive/",
+        IssueArchiveUnarchiveAPIEndpoint.as_view(http_method_names=["post"]),
+        name="issue-archive-unarchive",
+    ),
+    path(
+        "workspaces/<str:slug>/projects/<uuid:project_id>/issues/<uuid:pk>/unarchive/",
+        IssueArchiveUnarchiveAPIEndpoint.as_view(http_method_names=["delete"]),
+        name="issue-archive-unarchive",
+    ),
+    path(
+        "workspaces/<str:slug>/projects/<uuid:project_id>/archived-issues/",
+        IssueArchiveUnarchiveAPIEndpoint.as_view(http_method_names=["get"]),
+        name="issue-archive-unarchive",
     ),
 ]
 
@@ -150,6 +166,21 @@ new_url_patterns = [
         "workspaces/<str:slug>/projects/<uuid:project_id>/work-items/<uuid:issue_id>/relations/",
         IssueRelationListCreateAPIEndpoint.as_view(http_method_names=["get", "post"]),
         name="work-item-relation-list",
+    ),
+    path(
+        "workspaces/<str:slug>/projects/<uuid:project_id>/work-items/<uuid:pk>/archive/",
+        IssueArchiveUnarchiveAPIEndpoint.as_view(http_method_names=["post"]),
+        name="work-item-archive-unarchive",
+    ),
+    path(
+        "workspaces/<str:slug>/projects/<uuid:project_id>/work-items/<uuid:pk>/unarchive/",
+        IssueArchiveUnarchiveAPIEndpoint.as_view(http_method_names=["delete"]),
+        name="work-item-archive-unarchive",
+    ),
+    path(
+        "workspaces/<str:slug>/projects/<uuid:project_id>/archived-work-items/",
+        IssueArchiveUnarchiveAPIEndpoint.as_view(http_method_names=["get"]),
+        name="work-item-archive-unarchive",
     ),
 ]
 

--- a/apps/api/plane/api/views/__init__.py
+++ b/apps/api/plane/api/views/__init__.py
@@ -31,6 +31,7 @@ from .issue import (
     IssueAttachmentDetailAPIEndpoint,
     IssueSearchEndpoint,
     IssueRelationListCreateAPIEndpoint,
+    IssueArchiveUnarchiveAPIEndpoint,
 )
 
 from .cycle import (

--- a/apps/api/plane/api/views/issue.py
+++ b/apps/api/plane/api/views/issue.py
@@ -144,6 +144,9 @@ from plane.utils.openapi import (
     WORK_ITEM_NOT_FOUND_RESPONSE,
     ISSUE_NOT_FOUND_RESPONSE,
     PROJECT_NOT_FOUND_RESPONSE,
+    ARCHIVED_RESPONSE,
+    UNARCHIVED_RESPONSE,
+    CANNOT_ARCHIVE_RESPONSE,
     EXTERNAL_ID_EXISTS_RESPONSE,
     DELETED_RESPONSE,
     ADMIN_ONLY_RESPONSE,
@@ -872,6 +875,153 @@ class IssueDetailAPIEndpoint(BaseAPIView):
             current_instance=current_instance,
             epoch=int(timezone.now().timestamp()),
         )
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+class IssueArchiveUnarchiveAPIEndpoint(BaseAPIView):
+    """Archive, unarchive and list archived work items.
+
+    Mirrors the application behaviour (and the published Python SDK
+    contract): only work items whose state group is `completed` or
+    `cancelled` can be archived; archived work items disappear from active
+    work item lists until unarchived.
+    """
+
+    model = Issue
+    webhook_event = "issue"
+    permission_classes = [ProjectEntityPermission]
+    serializer_class = IssueSerializer
+    use_read_replica = True
+
+    def get_queryset(self):
+        return (
+            Issue.objects.filter(workspace__slug=self.kwargs.get("slug"))
+            .filter(project_id=self.kwargs.get("project_id"))
+            .filter(archived_at__isnull=False)
+            .filter(
+                project__project_projectmember__member=self.request.user,
+                project__project_projectmember__is_active=True,
+            )
+            .annotate(
+                sub_issues_count=Issue.issue_objects.filter(parent=OuterRef("id"))
+                .order_by()
+                .annotate(count=Func(F("id"), function="Count"))
+                .values("count")
+            )
+            .select_related("project")
+            .select_related("workspace")
+            .select_related("state")
+            .select_related("parent")
+            .prefetch_related("assignees")
+            .prefetch_related("labels")
+            .order_by("-archived_at")
+        ).distinct()
+
+    @work_item_docs(
+        operation_id="list_archived_work_items",
+        summary="List archived work items",
+        description="Retrieve a paginated list of archived work items in a project.",
+        parameters=[
+            CURSOR_PARAMETER,
+            PER_PAGE_PARAMETER,
+            FIELDS_PARAMETER,
+            EXPAND_PARAMETER,
+        ],
+        responses={
+            200: create_paginated_response(
+                IssueSerializer,
+                "PaginatedArchivedWorkItemResponse",
+                "Paginated list of archived work items",
+                "Paginated Archived Work Items",
+            ),
+            404: PROJECT_NOT_FOUND_RESPONSE,
+        },
+    )
+    def get(self, request, slug, project_id):
+        """List archived work items
+
+        Retrieve a paginated list of archived work items in a project,
+        most recently archived first.
+        """
+        return self.paginate(
+            request=request,
+            queryset=self.get_queryset(),
+            on_results=lambda issues: IssueSerializer(
+                issues, many=True, fields=self.fields, expand=self.expand
+            ).data,
+        )
+
+    @work_item_docs(
+        operation_id="archive_work_item",
+        summary="Archive work item",
+        description="Archive a work item. Only work items in a completed or cancelled state group can be archived.",  # noqa: E501
+        responses={
+            200: ARCHIVED_RESPONSE,
+            400: CANNOT_ARCHIVE_RESPONSE,
+            404: WORK_ITEM_NOT_FOUND_RESPONSE,
+        },
+    )
+    def post(self, request, slug, project_id, pk):
+        """Archive work item
+
+        Archive a work item that is in a completed or cancelled state group.
+        Archived work items no longer appear in active work item lists.
+        """
+        issue = Issue.issue_objects.get(workspace__slug=slug, project_id=project_id, pk=pk)
+        if issue.state.group not in ["completed", "cancelled"]:
+            return Response(
+                {"error": "Can only archive completed or cancelled state group issue"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        issue_activity.delay(
+            type="issue.activity.updated",
+            requested_data=json.dumps({"archived_at": str(timezone.now().date()), "automation": False}),
+            actor_id=str(request.user.id),
+            issue_id=str(issue.id),
+            project_id=str(project_id),
+            current_instance=json.dumps(IssueSerializer(issue).data, cls=DjangoJSONEncoder),
+            epoch=int(timezone.now().timestamp()),
+            notification=True,
+            origin=base_host(request=request, is_app=True),
+        )
+        issue.archived_at = timezone.now().date()
+        issue.save()
+        return Response({"archived_at": str(issue.archived_at)}, status=status.HTTP_200_OK)
+
+    @work_item_docs(
+        operation_id="unarchive_work_item",
+        summary="Unarchive work item",
+        description="Restore an archived work item to active status.",
+        responses={
+            204: UNARCHIVED_RESPONSE,
+            404: WORK_ITEM_NOT_FOUND_RESPONSE,
+        },
+    )
+    def delete(self, request, slug, project_id, pk):
+        """Unarchive work item
+
+        Restore an archived work item to active status. The work item will
+        reappear in active work item lists.
+        """
+        issue = Issue.objects.get(
+            workspace__slug=slug,
+            project_id=project_id,
+            archived_at__isnull=False,
+            pk=pk,
+        )
+        issue_activity.delay(
+            type="issue.activity.updated",
+            requested_data=json.dumps({"archived_at": None}),
+            actor_id=str(request.user.id),
+            issue_id=str(issue.id),
+            project_id=str(project_id),
+            current_instance=json.dumps(IssueSerializer(issue).data, cls=DjangoJSONEncoder),
+            epoch=int(timezone.now().timestamp()),
+            notification=True,
+            origin=base_host(request=request, is_app=True),
+        )
+        issue.archived_at = None
+        issue.save()
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 

--- a/apps/api/plane/api/views/issue.py
+++ b/apps/api/plane/api/views/issue.py
@@ -951,6 +951,19 @@ class IssueArchiveUnarchiveAPIEndpoint(BaseAPIView):
             ).data,
         )
 
+    def _record_archive_activity(self, request, project_id, issue, requested_data):
+        issue_activity.delay(
+            type="issue.activity.updated",
+            requested_data=json.dumps(requested_data),
+            actor_id=str(request.user.id),
+            issue_id=str(issue.id),
+            project_id=str(project_id),
+            current_instance=json.dumps(IssueSerializer(issue).data, cls=DjangoJSONEncoder),
+            epoch=int(timezone.now().timestamp()),
+            notification=True,
+            origin=base_host(request=request, is_app=True),
+        )
+
     @work_item_docs(
         operation_id="archive_work_item",
         summary="Archive work item",
@@ -973,16 +986,11 @@ class IssueArchiveUnarchiveAPIEndpoint(BaseAPIView):
                 {"error": "Can only archive completed or cancelled state group issue"},
                 status=status.HTTP_400_BAD_REQUEST,
             )
-        issue_activity.delay(
-            type="issue.activity.updated",
-            requested_data=json.dumps({"archived_at": str(timezone.now().date()), "automation": False}),
-            actor_id=str(request.user.id),
-            issue_id=str(issue.id),
-            project_id=str(project_id),
-            current_instance=json.dumps(IssueSerializer(issue).data, cls=DjangoJSONEncoder),
-            epoch=int(timezone.now().timestamp()),
-            notification=True,
-            origin=base_host(request=request, is_app=True),
+        self._record_archive_activity(
+            request,
+            project_id,
+            issue,
+            {"archived_at": str(timezone.now().date()), "automation": False},
         )
         issue.archived_at = timezone.now().date()
         issue.save()
@@ -1009,16 +1017,11 @@ class IssueArchiveUnarchiveAPIEndpoint(BaseAPIView):
             archived_at__isnull=False,
             pk=pk,
         )
-        issue_activity.delay(
-            type="issue.activity.updated",
-            requested_data=json.dumps({"archived_at": None}),
-            actor_id=str(request.user.id),
-            issue_id=str(issue.id),
-            project_id=str(project_id),
-            current_instance=json.dumps(IssueSerializer(issue).data, cls=DjangoJSONEncoder),
-            epoch=int(timezone.now().timestamp()),
-            notification=True,
-            origin=base_host(request=request, is_app=True),
+        self._record_archive_activity(
+            request,
+            project_id,
+            issue,
+            {"archived_at": None},
         )
         issue.archived_at = None
         issue.save()

--- a/apps/api/plane/tests/contract/api/test_issues_archive.py
+++ b/apps/api/plane/tests/contract/api/test_issues_archive.py
@@ -1,0 +1,160 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+import pytest
+from rest_framework import status
+
+from plane.db.models import Issue, Project, ProjectMember, State
+
+
+@pytest.fixture
+def project(db, workspace, create_user):
+    """Create a test project with the requesting user as an active member."""
+    project = Project.objects.create(
+        name="Test Project",
+        identifier="TP",
+        workspace=workspace,
+        created_by=create_user,
+    )
+    ProjectMember.objects.create(
+        project=project,
+        member=create_user,
+        role=20,  # Admin
+        is_active=True,
+    )
+    return project
+
+
+@pytest.fixture
+def backlog_state(db, workspace, project):
+    return State.objects.create(
+        name="Todo",
+        project=project,
+        workspace=workspace,
+        group="backlog",
+        default=True,
+    )
+
+
+@pytest.fixture
+def completed_state(db, workspace, project):
+    return State.objects.create(
+        name="Done",
+        project=project,
+        workspace=workspace,
+        group="completed",
+    )
+
+
+@pytest.fixture
+def completed_issue(db, workspace, project, completed_state, create_user):
+    return Issue.objects.create(
+        name="Completed Issue",
+        workspace=workspace,
+        project=project,
+        state=completed_state,
+        created_by=create_user,
+    )
+
+
+@pytest.fixture
+def backlog_issue(db, workspace, project, backlog_state, create_user):
+    return Issue.objects.create(
+        name="Backlog Issue",
+        workspace=workspace,
+        project=project,
+        state=backlog_state,
+        created_by=create_user,
+    )
+
+
+@pytest.mark.contract
+class TestIssueArchiveUnarchiveAPIEndpoint:
+    """Contract tests for work item archive / unarchive / archived list.
+
+    POST   /api/v1/workspaces/{slug}/projects/{project_id}/work-items/{pk}/archive/
+    DELETE /api/v1/workspaces/{slug}/projects/{project_id}/work-items/{pk}/unarchive/
+    GET    /api/v1/workspaces/{slug}/projects/{project_id}/archived-work-items/
+
+    (plus the deprecated /issues/-prefixed aliases)
+    """
+
+    def archive_url(self, slug, project_id, pk, prefix="work-items"):
+        return f"/api/v1/workspaces/{slug}/projects/{project_id}/{prefix}/{pk}/archive/"
+
+    def unarchive_url(self, slug, project_id, pk, prefix="work-items"):
+        return f"/api/v1/workspaces/{slug}/projects/{project_id}/{prefix}/{pk}/unarchive/"
+
+    def archived_list_url(self, slug, project_id, prefix="archived-work-items"):
+        return f"/api/v1/workspaces/{slug}/projects/{project_id}/{prefix}/"
+
+    def test_archive_completed_issue(self, api_key_client, workspace, project, completed_issue):
+        url = self.archive_url(workspace.slug, project.id, completed_issue.id)
+        response = api_key_client.post(url, {}, format="json")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data.get("archived_at")
+        completed_issue.refresh_from_db()
+        assert completed_issue.archived_at is not None
+
+    def test_archive_requires_terminal_state_group(self, api_key_client, workspace, project, backlog_issue):
+        url = self.archive_url(workspace.slug, project.id, backlog_issue.id)
+        response = api_key_client.post(url, {}, format="json")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        backlog_issue.refresh_from_db()
+        assert backlog_issue.archived_at is None
+
+    def test_archive_nonexistent_issue_returns_404(self, api_key_client, workspace, project):
+        url = self.archive_url(workspace.slug, project.id, "00000000-0000-0000-0000-000000000000")
+        response = api_key_client.post(url, {}, format="json")
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_archived_issue_leaves_active_list_and_shows_in_archived_list(
+        self, api_key_client, workspace, project, completed_issue
+    ):
+        archive = self.archive_url(workspace.slug, project.id, completed_issue.id)
+        assert api_key_client.post(archive, {}, format="json").status_code == status.HTTP_200_OK
+
+        active = api_key_client.get(
+            f"/api/v1/workspaces/{workspace.slug}/projects/{project.id}/work-items/"
+        )
+        assert active.status_code == status.HTTP_200_OK
+        assert str(completed_issue.id) not in [str(i["id"]) for i in active.data["results"]]
+
+        archived = api_key_client.get(self.archived_list_url(workspace.slug, project.id))
+        assert archived.status_code == status.HTTP_200_OK
+        assert str(completed_issue.id) in [str(i["id"]) for i in archived.data["results"]]
+
+    def test_archive_already_archived_returns_404(self, api_key_client, workspace, project, completed_issue):
+        url = self.archive_url(workspace.slug, project.id, completed_issue.id)
+        assert api_key_client.post(url, {}, format="json").status_code == status.HTTP_200_OK
+        # Issue.issue_objects excludes archived issues, so a second archive is a 404.
+        assert api_key_client.post(url, {}, format="json").status_code == status.HTTP_404_NOT_FOUND
+
+    def test_unarchive_restores_issue(self, api_key_client, workspace, project, completed_issue):
+        archive = self.archive_url(workspace.slug, project.id, completed_issue.id)
+        assert api_key_client.post(archive, {}, format="json").status_code == status.HTTP_200_OK
+
+        unarchive = self.unarchive_url(workspace.slug, project.id, completed_issue.id)
+        response = api_key_client.delete(unarchive)
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        completed_issue.refresh_from_db()
+        assert completed_issue.archived_at is None
+
+    def test_unarchive_active_issue_returns_404(self, api_key_client, workspace, project, completed_issue):
+        url = self.unarchive_url(workspace.slug, project.id, completed_issue.id)
+        response = api_key_client.delete(url)
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_deprecated_issues_prefix_aliases(self, api_key_client, workspace, project, completed_issue):
+        url = self.archive_url(workspace.slug, project.id, completed_issue.id, prefix="issues")
+        assert api_key_client.post(url, {}, format="json").status_code == status.HTTP_200_OK
+
+        archived = api_key_client.get(
+            self.archived_list_url(workspace.slug, project.id, prefix="archived-issues")
+        )
+        assert archived.status_code == status.HTTP_200_OK
+        assert str(completed_issue.id) in [str(i["id"]) for i in archived.data["results"]]
+
+        unarchive = self.unarchive_url(workspace.slug, project.id, completed_issue.id, prefix="issues")
+        assert api_key_client.delete(unarchive).status_code == status.HTTP_204_NO_CONTENT


### PR DESCRIPTION
### Description

Closes #9452

The official [plane-python-sdk](https://github.com/makeplane/plane-python-sdk) publishes `work_items.archive()` / `unarchive()` / `list_archived()`, and [plane-mcp-server](https://github.com/makeplane/plane-mcp-server) exposes `manage_work_item_archive` / `list_archived_work_items` on top of them - but the public API has no matching routes (only cycles and modules have archive endpoints). Calling the official toolchain against a self-hosted instance returns HTTP 404. The feature exists server-side in the internal app API (used by the web UI), so this is purely a public API surface gap.

### Changes

New `IssueArchiveUnarchiveAPIEndpoint` in `apps/api/plane/api/views/issue.py`, mirroring:

- the existing `CycleArchiveUnarchiveAPIEndpoint` structure (URL/verb layout, permissions `ProjectEntityPermission`, OpenAPI decorators with the existing `ARCHIVED_RESPONSE` / `CANNOT_ARCHIVE_RESPONSE` / `UNARCHIVED_RESPONSE` constants), and
- the internal app archive semantics (`apps/api/plane/app/views/issue/archive.py`): only work items whose state group is `completed` or `cancelled` can be archived (400 otherwise); `issue_activity` is emitted on archive and unarchive; archive returns `{"archived_at": ...}` (200), unarchive returns 204.

Routes (registered in both URL families of `urls/work_item.py`, matching the paths already published by the SDK):

| Verb | Path (new family) | Deprecated alias |
|---|---|---|
| POST | `.../work-items/<pk>/archive/` | `.../issues/<pk>/archive/` |
| DELETE | `.../work-items/<pk>/unarchive/` | `.../issues/<pk>/unarchive/` |
| GET | `.../archived-work-items/` | `.../archived-issues/` |

The archived list is paginated with the standard `self.paginate(...)` helper and excludes nothing beyond the usual project-membership scoping; `Issue.issue_objects` (which excludes archived) keeps archived items out of the active list endpoints, so a second archive of the same work item is a 404 by design.

### Tests

New contract tests in `apps/api/plane/tests/contract/api/test_issues_archive.py`:

- archive a completed-state work item -> 200, `archived_at` set
- archive a backlog-state work item -> 400, untouched
- archive nonexistent / already-archived -> 404
- archived item leaves the active list and appears in `archived-work-items`
- unarchive -> 204, item restored to active list
- unarchive of a non-archived item -> 404
- deprecated `/issues/` + `/archived-issues/` aliases work

`ruff check` passes on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added work-item archiving for completed or cancelled issues, plus unarchiving support.
  * Added archived work items listing with pagination.
  * Archived items are removed from active listings and return to active after unarchiving.
  * Added legacy URL prefix aliases for archive/unarchive/list for backward compatibility.
* **Bug Fixes**
  * Prevent archiving unless the issue is in a completed or cancelled state.
* **Tests**
  * Added contract tests covering success, validation failures, not-found cases, state transitions, and legacy route behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->