### PR TITLE
chore: resolve open Dependabot security alerts (axios, brace-expansion, morgan)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -534,7 +534,7 @@ overrides:
   mdast-util-to-hast: 13.2.1
   valibot: 1.2.0
   glob: 11.1.0
-  brace-expansion: 5.0.6
+  brace-expansion: 5.0.7
   nanoid: 3.3.8
   esbuild: 0.28.1
   '@babel/core': 7.29.7
@@ -565,7 +565,7 @@ overrides:
   path-to-regexp: 0.1.13
   defu: 6.1.5
   postcss: 8.5.15
-  axios: 1.16.0
+  axios: 1.18.1
   follow-redirects: 1.16.0
   uuid: 14.0.0
   fast-uri@<3.1.2: '>=3.1.2'
@@ -576,6 +576,7 @@ overrides:
   '@opentelemetry/core': 2.8.0
   '@opentelemetry/resources': 2.8.0
   '@opentelemetry/sdk-trace-base': 2.8.0
+  morgan: 1.11.0
 
 importers:
 
@@ -772,8 +773,8 @@ importers:
         specifier: 'catalog:'
         version: 2.26.2(@tiptap/core@2.26.3(@tiptap/pm@3.6.6))(@tiptap/pm@3.6.6)
       axios:
-        specifier: 1.16.0
-        version: 1.16.0
+        specifier: 1.18.1
+        version: 1.18.1
       compression:
         specifier: 'catalog:'
         version: 1.8.1
@@ -917,8 +918,8 @@ importers:
         specifier: 'catalog:'
         version: 7.15.0(react-router@7.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.8.3)
       axios:
-        specifier: 1.16.0
-        version: 1.16.0
+        specifier: 1.18.1
+        version: 1.18.1
       clsx:
         specifier: 'catalog:'
         version: 2.1.1
@@ -1080,8 +1081,8 @@ importers:
         specifier: 'catalog:'
         version: 8.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       axios:
-        specifier: 1.16.0
-        version: 1.16.0
+        specifier: 1.18.1
+        version: 1.18.1
       clsx:
         specifier: 'catalog:'
         version: 2.1.1
@@ -1648,8 +1649,8 @@ importers:
         specifier: workspace:*
         version: link:../types
       axios:
-        specifier: 1.16.0
-        version: 1.16.0
+        specifier: 1.18.1
+        version: 1.18.1
       file-type:
         specifier: 'catalog:'
         version: 21.3.3
@@ -5447,6 +5448,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+
   agent-install@0.0.5:
     resolution: {integrity: sha512-nHlms9BkP8ZiY79HrwCGiA2DcNaXrAaJrCM/BEqQ7MEsSKyCk+2A76xPGylIfASZSZE0SaU3T0bNSg4rBPIJAQ==}
     hasBin: true
@@ -5592,8 +5597,8 @@ packages:
     peerDependencies:
       postcss: 8.5.15
 
-  axios@1.16.0:
-    resolution: {integrity: sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==}
+  axios@1.18.1:
+    resolution: {integrity: sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==}
 
   babel-dead-code-elimination@1.0.10:
     resolution: {integrity: sha512-DV5bdJZTzZ0zn0DC24v3jD7Mnidh6xhKa4GfKCbq3sfW8kaWhDdZjP3i81geA8T33tdYqWKw4D3fVv0CwEgKVA==}
@@ -5650,8 +5655,8 @@ packages:
     resolution: {integrity: sha512-j//dBVuyacJbvW+tvZ9HuH03fZ46QcaKvvhZickZqtB271DxJ7SNRSNxrV/dZX0085m7hISRZWbzWlJvx/rHSg==}
     engines: {node: '>=14.16'}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -6811,10 +6816,6 @@ packages:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
 
-  hasown@2.0.2:
-    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
-    engines: {node: '>= 0.4'}
-
   hasown@2.0.4:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
@@ -6936,6 +6937,10 @@ packages:
   http-errors@2.0.0:
     resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
     engines: {node: '>= 0.8'}
+
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
 
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
@@ -7875,8 +7880,8 @@ packages:
   module-details-from-path@1.0.4:
     resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
 
-  morgan@1.10.1:
-    resolution: {integrity: sha512-223dMRJtI/l25dJKWpgij2cMtywuG/WiUKXdvwfbhGKBhy1puASqXwFzmWZ7+K73vUPoR7SS2Qz2cI/g9MKw0A==}
+  morgan@1.11.0:
+    resolution: {integrity: sha512-zSkVu3t18r39pw4ixfBKvfZi3y2UOqr7d4WYwcj3m8nXpEQK4rPO6GLzs/CExoRgmX3y9EjmmcXqv6jq0SK46g==}
     engines: {node: '>= 0.8.0'}
 
   motion-dom@12.23.12:
@@ -8002,10 +8007,6 @@ packages:
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
-
-  on-finished@2.3.0:
-    resolution: {integrity: sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==}
-    engines: {node: '>= 0.8'}
 
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
@@ -11754,7 +11755,7 @@ snapshots:
       compression: 1.8.1
       express: 4.22.0
       get-port: 5.1.1
-      morgan: 1.10.1
+      morgan: 1.11.0
       react-router: 7.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       source-map-support: 0.5.21
     transitivePeerDependencies:
@@ -13061,6 +13062,12 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   agent-install@0.0.5:
     dependencies:
       '@iarna/toml': 2.2.5
@@ -13196,13 +13203,15 @@ snapshots:
       postcss: 8.5.15
       postcss-value-parser: 4.2.0
 
-  axios@1.16.0:
+  axios@1.18.1:
     dependencies:
       follow-redirects: 1.16.0
       form-data: 4.0.6
+      https-proxy-agent: 5.0.1
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
+      - supports-color
 
   babel-dead-code-elimination@1.0.10:
     dependencies:
@@ -13271,7 +13280,7 @@ snapshots:
       widest-line: 4.0.1
       wrap-ansi: 8.1.0
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.7:
     dependencies:
       balanced-match: 4.0.4
 
@@ -13972,7 +13981,7 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.2
+      hasown: 2.0.4
 
   esbuild@0.28.1:
     optionalDependencies:
@@ -14413,7 +14422,7 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       math-intrinsics: 1.1.0
 
   get-nonce@1.0.1: {}
@@ -14473,10 +14482,6 @@ snapshots:
   has-tostringtag@1.0.2:
     dependencies:
       has-symbols: 1.1.0
-
-  hasown@2.0.2:
-    dependencies:
-      function-bind: 1.1.2
 
   hasown@2.0.4:
     dependencies:
@@ -14670,6 +14675,13 @@ snapshots:
       statuses: 2.0.1
       toidentifier: 1.0.1
 
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   human-signals@2.1.0: {}
 
   husky@9.1.7: {}
@@ -14788,7 +14800,7 @@ snapshots:
 
   is-core-module@2.16.1:
     dependencies:
-      hasown: 2.0.2
+      hasown: 2.0.4
 
   is-date-object@1.1.0:
     dependencies:
@@ -14834,7 +14846,7 @@ snapshots:
       call-bound: 1.0.4
       gopd: 1.2.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.2
+      hasown: 2.0.4
 
   is-stream@2.0.1: {}
 
@@ -15734,11 +15746,11 @@ snapshots:
 
   minimatch@10.2.3:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.7
 
   minimatch@3.1.4:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.7
 
   minimist@1.2.8: {}
 
@@ -15768,12 +15780,12 @@ snapshots:
 
   module-details-from-path@1.0.4: {}
 
-  morgan@1.10.1:
+  morgan@1.11.0:
     dependencies:
       basic-auth: 2.0.1
       debug: 2.6.9
       depd: 2.0.0
-      on-finished: 2.3.0
+      on-finished: 2.4.1
       on-headers: 1.1.0
     transitivePeerDependencies:
       - supports-color
@@ -15894,10 +15906,6 @@ snapshots:
   objectorarray@1.0.5: {}
 
   obug@2.1.1: {}
-
-  on-finished@2.3.0:
-    dependencies:
-      ee-first: 1.1.1
 
   on-finished@2.4.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -91,7 +91,7 @@ catalog:
   "@vitest/coverage-v8": "^4.1.8"
   "ast-types": "0.14.2"
   "autoprefixer": "^10.4.19"
-  "axios": "1.16.0"
+  "axios": "1.18.1"
   "buffer": "^6.0.3"
   "chroma-js": "^3.2.0"
   "class-variance-authority": "0.7.1"
@@ -195,7 +195,7 @@ overrides:
   mdast-util-to-hast: 13.2.1
   valibot: 1.2.0
   glob: 11.1.0
-  brace-expansion: 5.0.6
+  brace-expansion: 5.0.7
   nanoid: 3.3.8
   esbuild: 0.28.1
   "@babel/core": 7.29.7
@@ -237,6 +237,7 @@ overrides:
   "@opentelemetry/core": 2.8.0
   "@opentelemetry/resources": 2.8.0
   "@opentelemetry/sdk-trace-base": 2.8.0
+  morgan: 1.11.0
 
 allowBuilds:
   "@parcel/watcher": true


### PR DESCRIPTION
### Description

Closes all **7 open Dependabot security alerts** on the repo by bumping three pins in `pnpm-workspace.yaml`. Only axios had an automated PR (#9447); `brace-expansion` and `morgan` had none, so they were quietly sitting unpatched.

| Package | Change | Alerts closed |
|---|---|---|
| `axios` | catalog `1.16.0` → `1.18.1` | 5 (1 high, 4 moderate) |
| `brace-expansion` | override `5.0.6` → `5.0.7` | 1 high |
| `morgan` | **new** override → `1.11.0` | 1 moderate |

**Advisories resolved**

- `axios` — GHSA-gcfj-64vw-6mp9 (high, Node HTTP adapter can use an inherited proxy after interceptor config cloning), GHSA-hcpx-6fm6-wx23 (form serializer `maxDepth` bypass via `{}` metatoken), GHSA-mwf2-3pr3-8698 (HTTP/2 streamed uploads bypass `maxBodyLength`), GHSA-f4gw-2p7v-4548 (`NO_PROXY` bypass for `0.0.0.0` local addresses), GHSA-xj6q-8x83-jv6g (prototype pollution — auth subfields can inject Basic auth)
- `brace-expansion` — GHSA-3jxr-9vmj-r5cp (high, DoS via exponential-time expansion of consecutive non-expanding `{}` groups)
- `morgan` — GHSA-4vj7-5mj6-jm8m (log forging via unneutralized control characters in `:remote-user`)

**Implementation notes**

- **axios is pinned to 1.18.1, not the 1.18.0 Dependabot proposed.** 1.18.1 is a pure bugfix release on top of 1.18.0 with an identical dependency set, and additionally fixes runtime crashes, type-definition mismatches, and `AxiosError#cause` circular-JSON serialisation failures. It satisfies all five advisories, so there was no reason to land the strictly worse version.
- **`morgan` needed a new override rather than a direct bump** — it is not a direct dependency anywhere in the workspace. It arrives transitively through `@react-router/serve@7.15.0`, so an override is the only lever available without waiting upstream.
- **This PR supersedes #9447.** That PR bumps axios to 1.18.0 only. Once this merges, Dependabot will auto-close it since the underlying alerts resolve.

The lockfile resolves to exactly one copy of each package — no vulnerable duplicates remain:

```
axios@1.18.1
brace-expansion@5.0.7
morgan@1.11.0
```

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)

<!-- Add screenshots here -->

N/A — dependency-only change, no user-facing UI surface.

### Test Scenarios

Verified locally against the new lockfile:

- [x] `pnpm check:types` — 28/28 tasks pass
- [x] `pnpm check:lint` — 16/16 tasks pass
- [x] `pnpm build` — 16/16 tasks pass
- [x] Lockfile contains a single, patched version of each of the three packages

Worth exercising in review, since axios 1.17/1.18 changed runtime behaviour:

- Any flow issuing an authenticated API request — 1.18.0 strips caller-specified sensitive headers on **cross-origin** redirects. Same-origin Basic auth on redirects is preserved.
- File/attachment upload paths (`FormData` multipart) — `maxDepth` handling and the metatoken fix changed serialisation of deeply nested payloads.
- Any request relying on `validateStatus: undefined` — 1.18.0 adds `transitional.validateStatusUndefinedResolves`; `validateStatus: null` remains the explicit "accept every status" form.
- Requests built from hand-assembled base URLs — malformed `http:`/`https:` URLs that omit `//` now reject with `ERR_INVALID_URL` instead of being coerced.
- `apps/admin` request logging via `@react-router/serve` — confirm morgan output is unchanged aside from control-character neutralisation in `:remote-user`.

### References

- Dependabot alerts: https://github.com/makeplane/plane/security/dependabot
- Supersedes #9447

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated underlying components to newer versions for improved maintenance and compatibility.
  * Added a version constraint to ensure consistent behavior across supported environments.
  * No user-facing feature or interface changes are included in this update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->