### PR TITLE
[WEB-8332] fix(security): block workspace-member mass-assignment

### DIFF
--- a/apps/api/plane/app/views/workspace/member.py
+++ b/apps/api/plane/app/views/workspace/member.py
@@ -88,7 +88,18 @@ class WorkSpaceMemberViewSet(BaseViewSet):
         if "role" in request.data and int(request.data.get("role")) == 5:
             ProjectMember.objects.filter(workspace__slug=slug, member_id=workspace_member.member_id).update(role=5)
 
-        serializer = WorkSpaceMemberSerializer(workspace_member, data=request.data, partial=True)
+        # SECURITY: The only field this endpoint is allowed to mutate is ``role``.
+        # ``WorkSpaceMemberSerializer`` is declared with ``fields = "__all__"`` and
+        # ``DynamicBaseSerializer`` ignores the ``fields=`` kwarg for writes, so
+        # passing ``request.data`` verbatim would let a workspace admin mass-assign
+        # ``workspace`` (relocating a controlled member row into a victim workspace as
+        # an admin — full cross-tenant takeover), ``is_active``, and other columns.
+        # Restrict the writable payload to ``role`` only. See GHSA-f739-39g5-jj49.
+        allowed_data = {}
+        if "role" in request.data:
+            allowed_data["role"] = request.data.get("role")
+
+        serializer = WorkSpaceMemberSerializer(workspace_member, data=allowed_data, partial=True)
 
         if serializer.is_valid():
             serializer.save()

--- a/apps/api/plane/app/views/workspace/member.py
+++ b/apps/api/plane/app/views/workspace/member.py
@@ -96,6 +96,16 @@ class WorkSpaceMemberViewSet(BaseViewSet):
         if "role" in request.data:
             allowed_data["role"] = request.data.get("role")
 
+        # If the payload carried no writable field (e.g. only forbidden keys like
+        # ``workspace``/``is_active``), there is nothing to update. Return the
+        # current member without calling ``save()`` so we don't issue a no-op write
+        # that bumps ``updated_at``/``updated_by`` or runs the guest cascade.
+        if not allowed_data:
+            return Response(
+                WorkSpaceMemberSerializer(workspace_member).data,
+                status=status.HTTP_200_OK,
+            )
+
         serializer = WorkSpaceMemberSerializer(workspace_member, data=allowed_data, partial=True)
 
         if not serializer.is_valid():

--- a/apps/api/plane/app/views/workspace/member.py
+++ b/apps/api/plane/app/views/workspace/member.py
@@ -91,7 +91,7 @@ class WorkSpaceMemberViewSet(BaseViewSet):
         # passing ``request.data`` verbatim would let a workspace admin mass-assign
         # ``workspace`` (relocating a controlled member row into a victim workspace as
         # an admin — full cross-tenant takeover), ``is_active``, and other columns.
-        # Restrict the writable payload to ``role`` only. See GHSA-f739-39g5-jj49.
+        # Restrict the writable payload to ``role`` only.
         allowed_data = {}
         if "role" in request.data:
             allowed_data["role"] = request.data.get("role")

--- a/apps/api/plane/app/views/workspace/member.py
+++ b/apps/api/plane/app/views/workspace/member.py
@@ -3,6 +3,7 @@
 # See the LICENSE file for details.
 
 # Django imports
+from django.db import transaction
 from django.db.models import Count, Q, OuterRef, Subquery, IntegerField
 from django.utils import timezone
 from django.db.models.functions import Coalesce
@@ -84,10 +85,6 @@ class WorkSpaceMemberViewSet(BaseViewSet):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        # If a user is moved to a guest role he can't have any other role in projects
-        if "role" in request.data and int(request.data.get("role")) == 5:
-            ProjectMember.objects.filter(workspace__slug=slug, member_id=workspace_member.member_id).update(role=5)
-
         # SECURITY: The only field this endpoint is allowed to mutate is ``role``.
         # ``WorkSpaceMemberSerializer`` is declared with ``fields = "__all__"`` and
         # ``DynamicBaseSerializer`` ignores the ``fields=`` kwarg for writes, so
@@ -101,10 +98,22 @@ class WorkSpaceMemberViewSet(BaseViewSet):
 
         serializer = WorkSpaceMemberSerializer(workspace_member, data=allowed_data, partial=True)
 
-        if serializer.is_valid():
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+        # Validate the role (via the serializer) BEFORE cascading, and do the
+        # cascade + save atomically. Otherwise a bad role (e.g. non-integer) would
+        # 500 on the manual int() cast, and the guest project-role downgrade could
+        # persist even if the member update never succeeds.
+        with transaction.atomic():
+            # If a user is moved to a guest role they can't hold any other project role.
+            if serializer.validated_data.get("role") == 5:
+                ProjectMember.objects.filter(
+                    workspace__slug=slug, member_id=workspace_member.member_id
+                ).update(role=5)
             serializer.save()
-            return Response(serializer.data, status=status.HTTP_200_OK)
-        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+        return Response(serializer.data, status=status.HTTP_200_OK)
 
     @allow_permission(allowed_roles=[ROLE.ADMIN], level="WORKSPACE")
     def destroy(self, request, slug, pk):

--- a/apps/api/plane/tests/contract/app/test_workspace_member_mass_assignment_app.py
+++ b/apps/api/plane/tests/contract/app/test_workspace_member_mass_assignment_app.py
@@ -28,7 +28,7 @@ import pytest
 from rest_framework import status
 from rest_framework.test import APIClient
 
-from plane.db.models import User, Workspace, WorkspaceMember
+from plane.db.models import Project, ProjectMember, User, Workspace, WorkspaceMember
 
 
 def _member_detail_url(slug: str, pk: uuid.UUID) -> str:
@@ -102,6 +102,9 @@ class TestWorkspaceMemberMassAssignment:
         puppet_member.refresh_from_db()
         assert puppet_member.workspace_id == attacker_ws.id
         assert puppet_member.workspace_id != victim_ws.id
+        # ... and the allowed field in the same payload (role) WAS applied, proving
+        # the fix filters the payload rather than rejecting it wholesale.
+        assert puppet_member.role == 20
         # And no new member appeared in the victim workspace.
         assert WorkspaceMember.objects.filter(workspace=victim_ws).count() == victim_members_before
         assert not WorkspaceMember.objects.filter(workspace=victim_ws, member=puppet).exists()
@@ -166,6 +169,16 @@ class TestWorkspaceMemberMassAssignment:
         target = _make_user("bad-role-target@plane.so")
         target_member = _add_member(attacker_ws, target, role=15)
 
+        # Seed a non-guest project-role for the same member. The guest cascade
+        # (role == 5 -> downgrade every ProjectMember to guest) must not run when
+        # the workspace-member update fails validation, so this must stay at 15.
+        project = Project.objects.create(
+            name="Cascade Project", identifier="CP", workspace=attacker_ws, created_by=attacker
+        )
+        project_member = ProjectMember.objects.create(
+            workspace=attacker_ws, project=project, member=target, role=15, is_active=True
+        )
+
         client = APIClient()
         client.force_authenticate(user=attacker)
         response = client.patch(
@@ -177,3 +190,5 @@ class TestWorkspaceMemberMassAssignment:
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         target_member.refresh_from_db()
         assert target_member.role == 15
+        project_member.refresh_from_db()
+        assert project_member.role == 15, "Guest cascade ran despite the invalid update"

--- a/apps/api/plane/tests/contract/app/test_workspace_member_mass_assignment_app.py
+++ b/apps/api/plane/tests/contract/app/test_workspace_member_mass_assignment_app.py
@@ -110,10 +110,12 @@ class TestWorkspaceMemberMassAssignment:
         assert not WorkspaceMember.objects.filter(workspace=victim_ws, member=puppet).exists()
 
     def test_patch_is_active_false_does_not_deactivate(self, attacker_workspace):
-        """``is_active`` must not be assignable through this endpoint."""
+        """``is_active`` must not be assignable through this endpoint, and a payload
+        with no writable field must be a no-op (no phantom write)."""
         attacker_ws, attacker = attacker_workspace
         target = _make_user("active-target@plane.so")
         target_member = _add_member(attacker_ws, target, role=15)
+        original_updated_at = target_member.updated_at
 
         client = APIClient()
         client.force_authenticate(user=attacker)
@@ -126,6 +128,10 @@ class TestWorkspaceMemberMassAssignment:
         assert response.status_code == status.HTTP_200_OK
         target_member.refresh_from_db()
         assert target_member.is_active is True
+        # No writable field was supplied, so the row must not have been re-saved.
+        assert target_member.updated_at == original_updated_at, (
+            "A forbidden-only payload triggered a no-op write"
+        )
 
     def test_legitimate_role_update_still_works(self, attacker_workspace):
         """Positive control: the intended ``role`` update still functions."""

--- a/apps/api/plane/tests/contract/app/test_workspace_member_mass_assignment_app.py
+++ b/apps/api/plane/tests/contract/app/test_workspace_member_mass_assignment_app.py
@@ -158,3 +158,22 @@ class TestWorkspaceMemberMassAssignment:
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         own_member.refresh_from_db()
         assert own_member.role == 20
+
+    def test_non_integer_role_is_400_not_500(self, attacker_workspace):
+        """A non-integer role must be a validation error (400), not a 500 — and
+        the guest project-role cascade must not run when the update is invalid."""
+        attacker_ws, attacker = attacker_workspace
+        target = _make_user("bad-role-target@plane.so")
+        target_member = _add_member(attacker_ws, target, role=15)
+
+        client = APIClient()
+        client.force_authenticate(user=attacker)
+        response = client.patch(
+            _member_detail_url(attacker_ws.slug, target_member.id),
+            {"role": "not-a-number"},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        target_member.refresh_from_db()
+        assert target_member.role == 15

--- a/apps/api/plane/tests/contract/app/test_workspace_member_mass_assignment_app.py
+++ b/apps/api/plane/tests/contract/app/test_workspace_member_mass_assignment_app.py
@@ -3,7 +3,7 @@
 # See the LICENSE file for details.
 
 """
-Regression tests for GHSA-f739-39g5-jj49 (WEB-8332).
+Regression tests for WEB-8332.
 
 ``WorkSpaceMemberViewSet.partial_update`` is only meant to update a member's
 ``role``. Before the fix it passed ``request.data`` verbatim to

--- a/apps/api/plane/tests/contract/app/test_workspace_member_mass_assignment_app.py
+++ b/apps/api/plane/tests/contract/app/test_workspace_member_mass_assignment_app.py
@@ -1,0 +1,160 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""
+Regression tests for GHSA-f739-39g5-jj49 (WEB-8332).
+
+``WorkSpaceMemberViewSet.partial_update`` is only meant to update a member's
+``role``. Before the fix it passed ``request.data`` verbatim to
+``WorkSpaceMemberSerializer`` (declared ``fields = "__all__"`` with only the
+nested ``member`` read-only). ``DynamicBaseSerializer`` ignores the ``fields=``
+kwarg for writes, so ``workspace`` (FK), ``is_active`` and other columns were
+mass-assignable.
+
+An admin of an attacker-owned workspace could therefore PATCH a controlled
+member row setting ``workspace`` = victim-workspace UUID and ``role`` = 20,
+relocating a controlled account into the victim workspace as an admin with no
+invitation — a full cross-tenant takeover. The ``@allow_permission(level=
+"WORKSPACE")`` decorator authorizes against the URL slug and does NOT prevent
+the write from moving the row to a different workspace.
+
+The fix restricts the writable payload to ``role`` only.
+"""
+
+import uuid
+
+import pytest
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from plane.db.models import User, Workspace, WorkspaceMember
+
+
+def _member_detail_url(slug: str, pk: uuid.UUID) -> str:
+    return f"/api/workspaces/{slug}/members/{pk}/"
+
+
+def _make_user(email: str) -> User:
+    local_part = email.split("@")[0]
+    user = User.objects.create(email=email, username=local_part, first_name=local_part)
+    user.set_password("test-password")
+    user.save()
+    return user
+
+
+def _make_workspace(name: str, slug: str, owner: User) -> Workspace:
+    workspace = Workspace.objects.create(name=name, slug=slug, owner=owner)
+    WorkspaceMember.objects.create(workspace=workspace, member=owner, role=20, is_active=True)
+    return workspace
+
+
+def _add_member(workspace: Workspace, user: User, *, role: int) -> WorkspaceMember:
+    return WorkspaceMember.objects.create(
+        workspace=workspace, member=user, role=role, is_active=True
+    )
+
+
+@pytest.fixture
+def attacker_workspace(db):
+    """A workspace fully controlled by the attacker (they are the admin/owner)."""
+    attacker = _make_user("ws-attacker@plane.so")
+    workspace = _make_workspace("Attacker Workspace", "attacker-ws", attacker)
+    return workspace, attacker
+
+
+@pytest.fixture
+def victim_workspace(db):
+    """An unrelated workspace the attacker has no membership in."""
+    victim_owner = _make_user("ws-victim-owner@plane.so")
+    workspace = _make_workspace("Victim Workspace", "victim-ws", victim_owner)
+    return workspace, victim_owner
+
+
+@pytest.mark.contract
+@pytest.mark.django_db
+class TestWorkspaceMemberMassAssignment:
+    def test_admin_cannot_move_member_to_another_workspace(self, attacker_workspace, victim_workspace):
+        """
+        Core takeover vector: a workspace admin must not be able to relocate a
+        member row into another workspace via the ``workspace`` FK.
+        """
+        attacker_ws, attacker = attacker_workspace
+        victim_ws, _ = victim_workspace
+
+        # A puppet account the attacker controls, sitting in the attacker workspace.
+        puppet = _make_user("puppet@plane.so")
+        puppet_member = _add_member(attacker_ws, puppet, role=15)
+
+        victim_members_before = WorkspaceMember.objects.filter(workspace=victim_ws).count()
+
+        client = APIClient()
+        client.force_authenticate(user=attacker)
+        response = client.patch(
+            _member_detail_url(attacker_ws.slug, puppet_member.id),
+            {"workspace": str(victim_ws.id), "role": 20},
+            format="json",
+        )
+
+        # The request itself succeeds (admin updating a role is legitimate) ...
+        assert response.status_code == status.HTTP_200_OK
+        # ... but the member row must NOT have moved to the victim workspace.
+        puppet_member.refresh_from_db()
+        assert puppet_member.workspace_id == attacker_ws.id
+        assert puppet_member.workspace_id != victim_ws.id
+        # And no new member appeared in the victim workspace.
+        assert WorkspaceMember.objects.filter(workspace=victim_ws).count() == victim_members_before
+        assert not WorkspaceMember.objects.filter(workspace=victim_ws, member=puppet).exists()
+
+    def test_patch_is_active_false_does_not_deactivate(self, attacker_workspace):
+        """``is_active`` must not be assignable through this endpoint."""
+        attacker_ws, attacker = attacker_workspace
+        target = _make_user("active-target@plane.so")
+        target_member = _add_member(attacker_ws, target, role=15)
+
+        client = APIClient()
+        client.force_authenticate(user=attacker)
+        response = client.patch(
+            _member_detail_url(attacker_ws.slug, target_member.id),
+            {"is_active": False},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        target_member.refresh_from_db()
+        assert target_member.is_active is True
+
+    def test_legitimate_role_update_still_works(self, attacker_workspace):
+        """Positive control: the intended ``role`` update still functions."""
+        attacker_ws, attacker = attacker_workspace
+        target = _make_user("role-target@plane.so")
+        target_member = _add_member(attacker_ws, target, role=15)
+
+        client = APIClient()
+        client.force_authenticate(user=attacker)
+        response = client.patch(
+            _member_detail_url(attacker_ws.slug, target_member.id),
+            {"role": 5},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        target_member.refresh_from_db()
+        assert target_member.role == 5
+
+    def test_self_role_update_still_forbidden(self, attacker_workspace):
+        """Positive control: the self-role-update guard is preserved."""
+        attacker_ws, attacker = attacker_workspace
+        own_member = WorkspaceMember.objects.get(workspace=attacker_ws, member=attacker)
+
+        client = APIClient()
+        client.force_authenticate(user=attacker)
+        response = client.patch(
+            _member_detail_url(attacker_ws.slug, own_member.id),
+            {"role": 5},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        own_member.refresh_from_db()
+        assert own_member.role == 20


### PR DESCRIPTION
## Summary

**CRITICAL** — fixes a cross-tenant workspace takeover (WEB-8332). Confirmed-vulnerable on `origin/preview`.

`WorkSpaceMemberViewSet.partial_update` passed `request.data` straight into `WorkSpaceMemberSerializer` (`fields = "__all__"`, only nested `member` read-only). `workspace`, `role`, and `is_active` were therefore mass-assignable. An admin of an attacker-owned workspace could PATCH a member row setting `workspace`=victim-workspace UUID and `role`=20 → relocate a controlled account into the victim workspace as an admin with no invitation. Since all authorization derives from `WorkspaceMember(workspace, member, role, is_active)` rows, this is a full cross-tenant takeover. `@allow_permission([ADMIN], level="WORKSPACE")` authorizes against the URL slug but does not stop the write from moving the row elsewhere.

## Fix

The endpoint's only legitimate mutation is `role`, so the writable payload is restricted to `{"role": ...}` in the view:

```python
allowed_data = {}
if "role" in request.data:
    allowed_data["role"] = request.data.get("role")
serializer = WorkSpaceMemberSerializer(workspace_member, data=allowed_data, partial=True)
```

**Why not `fields=("id","member","role")`?** `DynamicBaseSerializer.__init__` pops the `fields=` kwarg and immediately overwrites it with `self.expand` (`serializers/base.py`), so `fields=` never restricts writes *or* output. The view-level allowlist is the reliable fix and is the only write path through this serializer (list/retrieve are read-only), so no other consumer is affected. The self-role-update guard and guest role-cascade are preserved; `is_active` is only changed via `destroy()`.

## Tests

New `tests/contract/app/test_workspace_member_mass_assignment_app.py` — 4 cases (cross-workspace move blocked; `is_active=false` no-ops; legitimate role update works; self-update still 400). Fail-before verified on the CE docker test stack: **2 attack tests failed unpatched → 4 pass patched**; 12/12 in a regression run with sibling member/authz suites.

## Related finding (separate ticket — NOT in this PR)

The root cause exposed a latent bug: `DynamicBaseSerializer`'s `fields=` kwarg is discarded (`base.py`: `fields = self.expand`), so every caller that passes `fields=(...)` expecting to **limit output** (e.g. `list`/`retrieve` here) actually returns all model columns. That's an app-wide over-disclosure surface needing its own scoped audit + FE-compat check — filed separately; deliberately not touched here (changing `base.py` would enforce output filtering app-wide and likely break the frontend).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Workspace member `PATCH` is now restricted to `role`-only updates, preventing unauthorized changes to other fields (including workspace association and deactivation).
  - Attempts to move a member to another workspace via `PATCH` are blocked, and related role effects no longer impact unrelated membership.
  - Non-integer `role` inputs now return a client error without cascading guest-role behavior.

- **Tests**
  - Added contract regression coverage for mass-assignment prevention, ignored deactivation attempts, valid role updates, self-role restrictions, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
