### PR TITLE
[WEB-8333] fix(security): guard undecorated viewset routes with project-membership check

### DIFF
--- a/apps/api/plane/app/views/intake/base.py
+++ b/apps/api/plane/app/views/intake/base.py
@@ -80,6 +80,23 @@ class IntakeViewSet(BaseViewSet):
         serializer.save(project_id=self.kwargs.get("project_id"))
 
     @allow_permission([ROLE.ADMIN, ROLE.MEMBER])
+    def retrieve(self, request, slug, project_id, pk):
+        # Guard the routed retrieve action with the project-membership check.
+        # Without this handler the action falls through to the stock DRF
+        # ModelViewSet.retrieve under bare IsAuthenticated, allowing any
+        # authenticated user to read an intake in a project they don't belong to.
+        return super().retrieve(request, slug=slug, project_id=project_id, pk=pk)
+
+    @allow_permission([ROLE.ADMIN, ROLE.MEMBER])
+    def partial_update(self, request, slug, project_id, pk):
+        # Guard the routed partial_update action with the project-membership
+        # check. Without this handler the action falls through to the stock
+        # DRF ModelViewSet.partial_update under bare IsAuthenticated, allowing
+        # any authenticated user to modify an intake in a project they don't
+        # belong to.
+        return super().partial_update(request, slug=slug, project_id=project_id, pk=pk)
+
+    @allow_permission([ROLE.ADMIN, ROLE.MEMBER])
     def destroy(self, request, slug, project_id, pk):
         intake = Intake.objects.filter(workspace__slug=slug, project_id=project_id, pk=pk).first()
         # Handle default intake delete

--- a/apps/api/plane/app/views/issue/base.py
+++ b/apps/api/plane/app/views/issue/base.py
@@ -713,6 +713,15 @@ class IssueViewSet(BaseViewSet):
             return Response(status=status.HTTP_204_NO_CONTENT)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
+    @allow_permission(allowed_roles=[ROLE.ADMIN, ROLE.MEMBER], creator=True, model=Issue)
+    def update(self, request, slug, project_id, pk=None):
+        # A full PUT-replace is not a meaningful operation for issues; the
+        # client only ever issues PATCH updates. Route PUT through the same
+        # authorized partial-update path so this routed action is guarded by
+        # the project-membership check instead of falling through to the
+        # stock DRF ModelViewSet.update under bare IsAuthenticated.
+        return self.partial_update(request, slug=slug, project_id=project_id, pk=pk)
+
     @allow_permission([ROLE.ADMIN], creator=True, model=Issue)
     def destroy(self, request, slug, project_id, pk=None):
         issue = Issue.objects.get(workspace__slug=slug, project_id=project_id, pk=pk)

--- a/apps/api/plane/app/views/issue/base.py
+++ b/apps/api/plane/app/views/issue/base.py
@@ -717,10 +717,15 @@ class IssueViewSet(BaseViewSet):
     def update(self, request, slug, project_id, pk=None):
         # A full PUT-replace is not a meaningful operation for issues; the
         # client only ever issues PATCH updates. Route PUT through the same
-        # authorized partial-update path so this routed action is guarded by
-        # the project-membership check instead of falling through to the
-        # stock DRF ModelViewSet.update under bare IsAuthenticated.
-        return self.partial_update(request, slug=slug, project_id=project_id, pk=pk)
+        # partial-update logic so this routed action is guarded by the
+        # project-membership check instead of falling through to the stock DRF
+        # ModelViewSet.update under bare IsAuthenticated. Call partial_update's
+        # *undecorated* implementation (__wrapped__) since this method's own
+        # decorator has already authorized the request — avoids running
+        # allow_permission (and its DB lookups) a second time on every PUT.
+        return self.partial_update.__wrapped__(
+            self, request, slug=slug, project_id=project_id, pk=pk
+        )
 
     @allow_permission([ROLE.ADMIN], creator=True, model=Issue)
     def destroy(self, request, slug, project_id, pk=None):

--- a/apps/api/plane/app/views/module/base.py
+++ b/apps/api/plane/app/views/module/base.py
@@ -652,10 +652,15 @@ class ModuleViewSet(BaseViewSet):
     def update(self, request, slug, project_id, pk):
         # A full PUT-replace is not a meaningful operation for modules; the
         # client only ever issues PATCH updates. Route PUT through the same
-        # authorized partial-update path so this routed action is guarded by
-        # the project-membership check instead of falling through to the
-        # stock DRF ModelViewSet.update under bare IsAuthenticated.
-        return self.partial_update(request, slug=slug, project_id=project_id, pk=pk)
+        # partial-update logic so this routed action is guarded by the
+        # project-membership check instead of falling through to the stock DRF
+        # ModelViewSet.update under bare IsAuthenticated. Call partial_update's
+        # *undecorated* implementation (__wrapped__) since this method's own
+        # decorator has already authorized the request — avoids running
+        # allow_permission (and its DB lookups) a second time on every PUT.
+        return self.partial_update.__wrapped__(
+            self, request, slug=slug, project_id=project_id, pk=pk
+        )
 
     @allow_permission([ROLE.ADMIN, ROLE.MEMBER])
     def partial_update(self, request, slug, project_id, pk):

--- a/apps/api/plane/app/views/module/base.py
+++ b/apps/api/plane/app/views/module/base.py
@@ -649,6 +649,15 @@ class ModuleViewSet(BaseViewSet):
         return Response(data, status=status.HTTP_200_OK)
 
     @allow_permission([ROLE.ADMIN, ROLE.MEMBER])
+    def update(self, request, slug, project_id, pk):
+        # A full PUT-replace is not a meaningful operation for modules; the
+        # client only ever issues PATCH updates. Route PUT through the same
+        # authorized partial-update path so this routed action is guarded by
+        # the project-membership check instead of falling through to the
+        # stock DRF ModelViewSet.update under bare IsAuthenticated.
+        return self.partial_update(request, slug=slug, project_id=project_id, pk=pk)
+
+    @allow_permission([ROLE.ADMIN, ROLE.MEMBER])
     def partial_update(self, request, slug, project_id, pk):
         module_queryset = self.get_queryset().filter(pk=pk)
 

--- a/apps/api/plane/tests/contract/app/test_undecorated_route_project_scope_app.py
+++ b/apps/api/plane/tests/contract/app/test_undecorated_route_project_scope_app.py
@@ -52,8 +52,10 @@ def _module_detail_url(slug, project_id, pk):
     return f"/api/workspaces/{slug}/projects/{project_id}/modules/{pk}/"
 
 
-def _intake_detail_url(slug, project_id, pk):
-    return f"/api/workspaces/{slug}/projects/{project_id}/intakes/{pk}/"
+def _intake_detail_url(slug, project_id, pk, route="intakes"):
+    # ``intakes`` and the legacy ``inboxes`` alias both route to IntakeViewSet;
+    # tests parameterize ``route`` so the alias cannot regress independently.
+    return f"/api/workspaces/{slug}/projects/{project_id}/{route}/{pk}/"
 
 
 def _make_user(email):
@@ -108,14 +110,30 @@ def state_b(db, workspace, project_b):
 
 
 @pytest.fixture
-def issue_b(db, workspace, project_b, state_b, create_user):
-    return Issue.objects.create(
-        name="Victim Issue",
-        project=project_b,
-        workspace=workspace,
-        state=state_b,
-        created_by=create_user,
+def other_member_b(db, workspace, project_b):
+    """A second active project-B member, distinct from ``create_user``.
+
+    Used as an issue's author so the positive-control PUT is authorized through
+    the ROLE.MEMBER branch of ``allow_permission`` rather than the ``creator=True``
+    short-circuit (which would fire if the caller were also the author).
+    """
+    user = _make_user(f"member-b-{uuid4().hex[:8]}@plane.so")
+    WorkspaceMember.objects.create(workspace=workspace, member=user, role=15, is_active=True)
+    ProjectMember.objects.create(
+        workspace=workspace, project=project_b, member=user, role=15, is_active=True
     )
+    return user
+
+
+@pytest.fixture
+def issue_b(db, workspace, project_b, state_b, other_member_b):
+    # Author is a *different* project member so ``test_member_can_put_issue``
+    # exercises the role-based path, not the creator short-circuit. ``save`` with
+    # ``created_by_id`` sets the author explicitly (BaseModel.save otherwise
+    # overwrites ``created_by`` from the request user, which is None under tests).
+    issue = Issue(name="Victim Issue", project=project_b, workspace=workspace, state=state_b)
+    issue.save(created_by_id=other_member_b.id)
+    return issue
 
 
 @pytest.fixture
@@ -221,44 +239,50 @@ class TestUndecoratedRouteProjectScope:
         assert module_b.name == "Renamed Module"
 
     # ---- IntakeViewSet GET (retrieve) ----------------------------------------------
+    # Both the ``intakes/`` route and the legacy ``inboxes/`` alias are covered so
+    # the alias cannot regress independently.
 
-    def test_non_member_cannot_retrieve_intake(self, attacker_client, workspace, project_b, intake_b):
-        response = attacker_client.get(_intake_detail_url(workspace.slug, project_b.id, intake_b.id))
+    @pytest.mark.parametrize("route", ["intakes", "inboxes"])
+    def test_non_member_cannot_retrieve_intake(self, attacker_client, workspace, project_b, intake_b, route):
+        response = attacker_client.get(_intake_detail_url(workspace.slug, project_b.id, intake_b.id, route))
         assert response.status_code == status.HTTP_403_FORBIDDEN, (
-            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+            f"[{route}] Got {response.status_code}: {getattr(response, 'data', None)!r}"
         )
 
-    def test_member_can_retrieve_intake(self, session_client, workspace, project_b, intake_b):
+    @pytest.mark.parametrize("route", ["intakes", "inboxes"])
+    def test_member_can_retrieve_intake(self, session_client, workspace, project_b, intake_b, route):
         """Positive control: a project-B member may retrieve a project-B intake."""
-        response = session_client.get(_intake_detail_url(workspace.slug, project_b.id, intake_b.id))
+        response = session_client.get(_intake_detail_url(workspace.slug, project_b.id, intake_b.id, route))
         assert response.status_code == status.HTTP_200_OK, (
-            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+            f"[{route}] Got {response.status_code}: {getattr(response, 'data', None)!r}"
         )
         assert str(response.data["id"]) == str(intake_b.id)
 
     # ---- IntakeViewSet PATCH (partial_update) --------------------------------------
 
-    def test_non_member_cannot_patch_intake(self, attacker_client, workspace, project_b, intake_b):
+    @pytest.mark.parametrize("route", ["intakes", "inboxes"])
+    def test_non_member_cannot_patch_intake(self, attacker_client, workspace, project_b, intake_b, route):
         response = attacker_client.patch(
-            _intake_detail_url(workspace.slug, project_b.id, intake_b.id),
+            _intake_detail_url(workspace.slug, project_b.id, intake_b.id, route),
             {"name": "Hacked Intake"},
             format="json",
         )
         assert response.status_code == status.HTTP_403_FORBIDDEN, (
-            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+            f"[{route}] Got {response.status_code}: {getattr(response, 'data', None)!r}"
         )
         intake_b.refresh_from_db()
         assert intake_b.name == "Victim Intake"
 
-    def test_member_can_patch_intake(self, session_client, workspace, project_b, intake_b):
+    @pytest.mark.parametrize("route", ["intakes", "inboxes"])
+    def test_member_can_patch_intake(self, session_client, workspace, project_b, intake_b, route):
         """Positive control: a project-B member may patch a project-B intake."""
         response = session_client.patch(
-            _intake_detail_url(workspace.slug, project_b.id, intake_b.id),
-            {"name": "Renamed Intake"},
+            _intake_detail_url(workspace.slug, project_b.id, intake_b.id, route),
+            {"name": f"Renamed via {route}"},
             format="json",
         )
         assert response.status_code == status.HTTP_200_OK, (
-            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+            f"[{route}] Got {response.status_code}: {getattr(response, 'data', None)!r}"
         )
         intake_b.refresh_from_db()
-        assert intake_b.name == "Renamed Intake"
+        assert intake_b.name == f"Renamed via {route}"

--- a/apps/api/plane/tests/contract/app/test_undecorated_route_project_scope_app.py
+++ b/apps/api/plane/tests/contract/app/test_undecorated_route_project_scope_app.py
@@ -1,0 +1,259 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Contract tests for undecorated fall-through route authorization (WEB-8333).
+
+Regression coverage for GHSA-27v6-jc2m-x99w / GHSA-w83f-hr4p-3qhw (duplicates).
+
+Per-project authorization on the app viewsets lives in the
+``@allow_permission(..., level="PROJECT")`` *method* decorator, not in
+``get_queryset`` (which only filters ``workspace__slug`` + ``project_id`` from the
+URL, with no membership predicate). The project-wide default permission is bare
+``IsAuthenticated`` and there is no ``has_object_permission``. So any routed
+action that lacks the decorator falls through to the stock DRF ``ModelViewSet``
+implementation under ``IsAuthenticated`` only, letting any authenticated user act
+on objects in a project they are not a member of.
+
+Three viewsets had undecorated fall-through routes before the fix:
+
+* ``IssueViewSet``   -> ``PUT`` (``update``) was routed but never defined.
+* ``ModuleViewSet``  -> ``PUT`` (``update``) was routed but never defined.
+* ``IntakeViewSet``  -> ``GET`` (``retrieve``) and ``PATCH`` (``partial_update``)
+  were routed but never defined.
+
+The fix defines each handler and decorates it with the same role set as its
+sibling actions, delegating to the authorized/stock implementation.
+"""
+
+from uuid import uuid4
+
+import pytest
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from plane.db.models import (
+    Intake,
+    Issue,
+    Module,
+    Project,
+    ProjectMember,
+    State,
+    User,
+    WorkspaceMember,
+)
+
+
+def _issue_detail_url(slug, project_id, pk):
+    return f"/api/workspaces/{slug}/projects/{project_id}/issues/{pk}/"
+
+
+def _module_detail_url(slug, project_id, pk):
+    return f"/api/workspaces/{slug}/projects/{project_id}/modules/{pk}/"
+
+
+def _intake_detail_url(slug, project_id, pk):
+    return f"/api/workspaces/{slug}/projects/{project_id}/intakes/{pk}/"
+
+
+def _make_user(email):
+    local_part = email.split("@")[0]
+    user = User.objects.create(email=email, username=local_part, first_name=local_part)
+    user.set_password("test-password")
+    user.save()
+    return user
+
+
+@pytest.fixture
+def project_b(db, workspace, create_user):
+    """The victim project. ``create_user`` (workspace owner) is an active ADMIN member."""
+    project = Project.objects.create(
+        name="Project B",
+        identifier="PB",
+        workspace=workspace,
+        created_by=create_user,
+    )
+    ProjectMember.objects.create(
+        workspace=workspace, project=project, member=create_user, role=20, is_active=True
+    )
+    return project
+
+
+@pytest.fixture
+def project_a(db, workspace, create_user):
+    """A different project the attacker *is* a member of (but not project B)."""
+    return Project.objects.create(
+        name="Project A",
+        identifier="PA",
+        workspace=workspace,
+        created_by=create_user,
+    )
+
+
+@pytest.fixture
+def state_b(db, workspace, project_b):
+    return State.objects.create(
+        name="Backlog",
+        color="#000000",
+        group="backlog",
+        default=True,
+        project=project_b,
+        workspace=workspace,
+    )
+
+
+@pytest.fixture
+def issue_b(db, workspace, project_b, state_b, create_user):
+    return Issue.objects.create(
+        name="Victim Issue",
+        project=project_b,
+        workspace=workspace,
+        state=state_b,
+        created_by=create_user,
+    )
+
+
+@pytest.fixture
+def module_b(db, workspace, project_b):
+    return Module.objects.create(
+        name="Victim Module",
+        project=project_b,
+        workspace=workspace,
+    )
+
+
+@pytest.fixture
+def intake_b(db, workspace, project_b):
+    return Intake.objects.create(
+        name="Victim Intake",
+        project=project_b,
+        workspace=workspace,
+        is_default=True,
+    )
+
+
+@pytest.fixture
+def attacker(db, workspace, project_a):
+    """Workspace MEMBER (role 15) who belongs to project A but NOT project B.
+
+    Deliberately not a workspace ADMIN so the workspace-admin bypass in
+    ``allow_permission`` cannot mask the missing membership check.
+    """
+    user = _make_user(f"attacker-{uuid4().hex[:8]}@plane.so")
+    WorkspaceMember.objects.create(workspace=workspace, member=user, role=15, is_active=True)
+    ProjectMember.objects.create(
+        workspace=workspace, project=project_a, member=user, role=20, is_active=True
+    )
+    return user
+
+
+@pytest.fixture
+def attacker_client(attacker):
+    client = APIClient()
+    client.force_authenticate(user=attacker)
+    return client
+
+
+@pytest.mark.contract
+@pytest.mark.django_db
+class TestUndecoratedRouteProjectScope:
+    """A user who is not a member of project B must not act on project-B objects
+    through the previously-undecorated fall-through routes."""
+
+    # ---- IssueViewSet PUT (update) -------------------------------------------------
+
+    def test_non_member_cannot_put_issue(self, attacker_client, workspace, project_b, issue_b):
+        response = attacker_client.put(
+            _issue_detail_url(workspace.slug, project_b.id, issue_b.id),
+            {"name": "Hacked Issue"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_403_FORBIDDEN, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+        issue_b.refresh_from_db()
+        assert issue_b.name == "Victim Issue"
+
+    def test_member_can_put_issue(self, session_client, workspace, project_b, issue_b):
+        """Positive control: a project-B member may PUT a project-B issue."""
+        response = session_client.put(
+            _issue_detail_url(workspace.slug, project_b.id, issue_b.id),
+            {"name": "Renamed Issue"},
+            format="json",
+        )
+        # PUT is routed through partial_update, which returns 204 on success.
+        assert response.status_code == status.HTTP_204_NO_CONTENT, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+        issue_b.refresh_from_db()
+        assert issue_b.name == "Renamed Issue"
+
+    # ---- ModuleViewSet PUT (update) ------------------------------------------------
+
+    def test_non_member_cannot_put_module(self, attacker_client, workspace, project_b, module_b):
+        response = attacker_client.put(
+            _module_detail_url(workspace.slug, project_b.id, module_b.id),
+            {"name": "Hacked Module"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_403_FORBIDDEN, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+        module_b.refresh_from_db()
+        assert module_b.name == "Victim Module"
+
+    def test_member_can_put_module(self, session_client, workspace, project_b, module_b):
+        """Positive control: a project-B member may PUT a project-B module."""
+        response = session_client.put(
+            _module_detail_url(workspace.slug, project_b.id, module_b.id),
+            {"name": "Renamed Module"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_200_OK, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+        module_b.refresh_from_db()
+        assert module_b.name == "Renamed Module"
+
+    # ---- IntakeViewSet GET (retrieve) ----------------------------------------------
+
+    def test_non_member_cannot_retrieve_intake(self, attacker_client, workspace, project_b, intake_b):
+        response = attacker_client.get(_intake_detail_url(workspace.slug, project_b.id, intake_b.id))
+        assert response.status_code == status.HTTP_403_FORBIDDEN, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+
+    def test_member_can_retrieve_intake(self, session_client, workspace, project_b, intake_b):
+        """Positive control: a project-B member may retrieve a project-B intake."""
+        response = session_client.get(_intake_detail_url(workspace.slug, project_b.id, intake_b.id))
+        assert response.status_code == status.HTTP_200_OK, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+        assert str(response.data["id"]) == str(intake_b.id)
+
+    # ---- IntakeViewSet PATCH (partial_update) --------------------------------------
+
+    def test_non_member_cannot_patch_intake(self, attacker_client, workspace, project_b, intake_b):
+        response = attacker_client.patch(
+            _intake_detail_url(workspace.slug, project_b.id, intake_b.id),
+            {"name": "Hacked Intake"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_403_FORBIDDEN, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+        intake_b.refresh_from_db()
+        assert intake_b.name == "Victim Intake"
+
+    def test_member_can_patch_intake(self, session_client, workspace, project_b, intake_b):
+        """Positive control: a project-B member may patch a project-B intake."""
+        response = session_client.patch(
+            _intake_detail_url(workspace.slug, project_b.id, intake_b.id),
+            {"name": "Renamed Intake"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_200_OK, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+        intake_b.refresh_from_db()
+        assert intake_b.name == "Renamed Intake"

--- a/apps/api/plane/tests/contract/app/test_undecorated_route_project_scope_app.py
+++ b/apps/api/plane/tests/contract/app/test_undecorated_route_project_scope_app.py
@@ -66,7 +66,12 @@ def _make_user(email):
 
 @pytest.fixture
 def project_b(db, workspace, create_user):
-    """The victim project. ``create_user`` (workspace owner) is an active ADMIN member."""
+    """The victim project. ``create_user`` is an active project MEMBER (role 15).
+
+    Deliberately MEMBER, not ADMIN, so the positive-control tests exercise the
+    ROLE.MEMBER branch of @allow_permission on the newly-guarded handlers (admin
+    behavior is covered elsewhere). All the fixed decorators allow [ADMIN, MEMBER].
+    """
     project = Project.objects.create(
         name="Project B",
         identifier="PB",
@@ -74,7 +79,7 @@ def project_b(db, workspace, create_user):
         created_by=create_user,
     )
     ProjectMember.objects.create(
-        workspace=workspace, project=project, member=create_user, role=20, is_active=True
+        workspace=workspace, project=project, member=create_user, role=15, is_active=True
     )
     return project
 

--- a/apps/api/plane/tests/contract/app/test_undecorated_route_project_scope_app.py
+++ b/apps/api/plane/tests/contract/app/test_undecorated_route_project_scope_app.py
@@ -4,7 +4,7 @@
 
 """Contract tests for undecorated fall-through route authorization (WEB-8333).
 
-Regression coverage for GHSA-27v6-jc2m-x99w / GHSA-w83f-hr4p-3qhw (duplicates).
+Regression coverage for WEB-8333.
 
 Per-project authorization on the app viewsets lives in the
 ``@allow_permission(..., level="PROJECT")`` *method* decorator, not in


### PR DESCRIPTION
## Summary

**HIGH** — fixes a cross-project/tenant IDOR (WEB-8333). Confirmed-vulnerable on `origin/preview`.

Per-project authorization in these viewsets lives in the `@allow_permission(..., level="PROJECT")` **method decorator**, not the queryset (`get_queryset` filters only `workspace__slug`+`project_id`, no membership predicate). The project-wide default permission is `IsAuthenticated` only, and there's no `has_object_permission` anywhere — so any routed action **without** the decorator falls through to stock DRF `ModelViewSet` and any authenticated user (even a non-member of the project) can act cross-project.

Undecorated fall-through routes:
- `IssueViewSet.update` (PUT) — no `def update`
- `ModuleViewSet.update` (PUT) — no `def update`
- `IntakeViewSet.retrieve` (GET) + `IntakeViewSet.partial_update` (PATCH) — only list/create/destroy were defined

## Fix

Define + decorate the missing handlers, matching each viewset's sibling role set:

| Viewset | Added | Decorator (matches sibling) |
| :--- | :--- | :--- |
| IssueViewSet | `update` | `@allow_permission([ADMIN, MEMBER], creator=True, model=Issue)` |
| ModuleViewSet | `update` | `@allow_permission([ADMIN, MEMBER])` |
| IntakeViewSet | `retrieve`, `partial_update` | `@allow_permission([ADMIN, MEMBER])` |

**PUT is routed through the authorized `partial_update` path** for Issue/Module — no full-replace semantics exist for these resources (the FE only PATCHes), so this is purely additive authorization, not a behavior change reviewers need to worry about. If a strict full-PUT-replace is ever desired that's a separate behavioral change. Intake `retrieve`/`partial_update` delegate to stock DRF (behavior preserved). Both `intakes/` and legacy `inboxes/` routes map to the same viewset, so both are covered.

## Tests

New `tests/contract/app/test_undecorated_route_project_scope_app.py` — 8 cases (non-member cross-project PUT issue / PUT module / GET intake / PATCH intake → 403; + 4 positive controls). Fail-before verified on the CE docker stack: **4 attack routes returned 200 unpatched → all 8 pass patched**. (Full `contract/app` regression: 109 pass; the 8 failures are pre-existing rate-limit flakes in `test_authentication.py`, unrelated.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened authorization for project-scoped issue, module, and intake endpoints, ensuring only admin and project members can update/retrieve.
  * Prevented unauthorized users from accessing previously misrouted update/retrieve actions, returning **403 Forbidden** instead.

* **Tests**
  * Added contract/regression coverage for PUT/PATCH/GET flows across issue, module, and intake, including intake route aliasing (intakes/inboxes).
  * Verified **403** for non-project members and expected **200/204** plus correct field behavior for authorized project members.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
