### PR TITLE
[WEB-8353] fix(security): enforce guest issue visibility on attachments + activity

### DIFF
--- a/apps/api/plane/app/permissions/__init__.py
+++ b/apps/api/plane/app/permissions/__init__.py
@@ -18,5 +18,5 @@ from .project import (
     ProjectLitePermission,
     ProjectAdminPermission,
 )
-from .base import allow_permission, ROLE
+from .base import allow_permission, issue_hidden_from_guest, ROLE
 from .page import ProjectPagePermission

--- a/apps/api/plane/app/permissions/base.py
+++ b/apps/api/plane/app/permissions/base.py
@@ -86,3 +86,38 @@ def allow_permission(allowed_roles, level="PROJECT", creator=False, model=None):
         return _wrapped_view
 
     return decorator
+
+
+def issue_hidden_from_guest(request, slug, project_id, issue_id):
+    """Return True when the caller is a *restricted* project guest who must not
+    see the given issue's data or sub-resources.
+
+    A project member with role GUEST on a project whose
+    ``guest_view_all_features`` is disabled may only see issues they created
+    (mirrors ``IssueViewSet.list`` / ``IssueListEndpoint``). Issue sub-resource
+    endpoints (attachments, activity, comments) must apply the same restriction;
+    they only run the project-membership check, which a legitimate guest passes.
+
+    Returns False for admins, members, unrestricted guests, and for the guest's
+    own issues. Callers should translate a True result into a 403.
+    """
+    from plane.db.models import Issue
+
+    is_restricted_guest = ProjectMember.objects.filter(
+        workspace__slug=slug,
+        project_id=project_id,
+        member=request.user,
+        role=ROLE.GUEST.value,
+        is_active=True,
+        project__guest_view_all_features=False,
+    ).exists()
+    if not is_restricted_guest:
+        return False
+
+    owns_issue = Issue.issue_objects.filter(
+        pk=issue_id,
+        workspace__slug=slug,
+        project_id=project_id,
+        created_by=request.user,
+    ).exists()
+    return not owns_issue

--- a/apps/api/plane/app/views/issue/activity.py
+++ b/apps/api/plane/app/views/issue/activity.py
@@ -29,7 +29,7 @@ class IssueActivityEndpoint(BaseAPIView):
     @allow_permission([ROLE.ADMIN, ROLE.MEMBER, ROLE.GUEST])
     def get(self, request, slug, project_id, issue_id):
         # A restricted guest may only see the activity/comments of issues they
-        # created, mirroring the issue-detail visibility rule (GHSA-wq96-4xjj-j4qg).
+        # created, mirroring the issue-detail visibility rule.
         if issue_hidden_from_guest(request, slug, project_id, issue_id):
             return Response(
                 {"error": "You are not allowed to view this issue"},

--- a/apps/api/plane/app/views/issue/activity.py
+++ b/apps/api/plane/app/views/issue/activity.py
@@ -17,7 +17,7 @@ from rest_framework import status
 # Module imports
 from .. import BaseAPIView
 from plane.app.serializers import IssueActivitySerializer, IssueCommentSerializer
-from plane.app.permissions import ProjectEntityPermission, allow_permission, ROLE
+from plane.app.permissions import ProjectEntityPermission, allow_permission, issue_hidden_from_guest, ROLE
 from plane.db.models import IssueActivity, IssueComment, CommentReaction, IntakeIssue
 
 
@@ -28,6 +28,13 @@ class IssueActivityEndpoint(BaseAPIView):
     @method_decorator(gzip_page)
     @allow_permission([ROLE.ADMIN, ROLE.MEMBER, ROLE.GUEST])
     def get(self, request, slug, project_id, issue_id):
+        # A restricted guest may only see the activity/comments of issues they
+        # created, mirroring the issue-detail visibility rule (GHSA-wq96-4xjj-j4qg).
+        if issue_hidden_from_guest(request, slug, project_id, issue_id):
+            return Response(
+                {"error": "You are not allowed to view this issue"},
+                status=status.HTTP_403_FORBIDDEN,
+            )
         filters = {}
         if request.GET.get("created_at__gt", None) is not None:
             filters = {"created_at__gt": request.GET.get("created_at__gt")}

--- a/apps/api/plane/app/views/issue/activity.py
+++ b/apps/api/plane/app/views/issue/activity.py
@@ -47,6 +47,7 @@ class IssueActivityEndpoint(BaseAPIView):
                 project__project_projectmember__is_active=True,
                 project__archived_at__isnull=True,
                 workspace__slug=slug,
+                project_id=project_id,
             )
             .filter(**filters)
             .select_related("actor", "workspace", "issue", "project")
@@ -58,6 +59,7 @@ class IssueActivityEndpoint(BaseAPIView):
                 project__project_projectmember__is_active=True,
                 project__archived_at__isnull=True,
                 workspace__slug=slug,
+                project_id=project_id,
             )
             .filter(**filters)
             .order_by("created_at")

--- a/apps/api/plane/app/views/issue/attachment.py
+++ b/apps/api/plane/app/views/issue/attachment.py
@@ -22,7 +22,7 @@ from .. import BaseAPIView
 from plane.app.serializers import IssueAttachmentSerializer
 from plane.db.models import FileAsset, Workspace
 from plane.bgtasks.issue_activities_task import issue_activity
-from plane.app.permissions import allow_permission, ROLE
+from plane.app.permissions import allow_permission, issue_hidden_from_guest, ROLE
 from plane.settings.storage import S3Storage
 from plane.utils.path_validator import sanitize_filename
 from plane.bgtasks.storage_metadata_task import get_asset_object_metadata
@@ -87,6 +87,13 @@ class IssueAttachmentEndpoint(BaseAPIView):
 
     @allow_permission([ROLE.ADMIN, ROLE.MEMBER, ROLE.GUEST])
     def get(self, request, slug, project_id, issue_id):
+        # A restricted guest may only see attachments of issues they created,
+        # mirroring the issue-detail visibility rule (GHSA-wq96-4xjj-j4qg).
+        if issue_hidden_from_guest(request, slug, project_id, issue_id):
+            return Response(
+                {"error": "You are not allowed to view this issue"},
+                status=status.HTTP_403_FORBIDDEN,
+            )
         issue_attachments = FileAsset.objects.filter(issue_id=issue_id, workspace__slug=slug, project_id=project_id)
         serializer = IssueAttachmentSerializer(issue_attachments, many=True)
         return Response(serializer.data, status=status.HTTP_200_OK)
@@ -171,6 +178,13 @@ class IssueAttachmentV2Endpoint(BaseAPIView):
 
     @allow_permission([ROLE.ADMIN, ROLE.MEMBER, ROLE.GUEST])
     def get(self, request, slug, project_id, issue_id, pk=None):
+        # A restricted guest may only see attachments of issues they created,
+        # mirroring the issue-detail visibility rule (GHSA-wq96-4xjj-j4qg).
+        if issue_hidden_from_guest(request, slug, project_id, issue_id):
+            return Response(
+                {"error": "You are not allowed to view this issue"},
+                status=status.HTTP_403_FORBIDDEN,
+            )
         if pk:
             # Get the asset
             asset = FileAsset.objects.get(id=pk, workspace__slug=slug, project_id=project_id, issue_id=issue_id)

--- a/apps/api/plane/app/views/issue/attachment.py
+++ b/apps/api/plane/app/views/issue/attachment.py
@@ -37,7 +37,7 @@ class IssueAttachmentEndpoint(BaseAPIView):
     @allow_permission([ROLE.ADMIN, ROLE.MEMBER, ROLE.GUEST])
     def post(self, request, slug, project_id, issue_id):
         # A restricted guest may only add attachments to issues they created,
-        # mirroring the issue-detail visibility rule (GHSA-wq96-4xjj-j4qg).
+        # mirroring the issue-detail visibility rule.
         if issue_hidden_from_guest(request, slug, project_id, issue_id):
             return Response(
                 {"error": "You are not allowed to view this issue"},
@@ -95,7 +95,7 @@ class IssueAttachmentEndpoint(BaseAPIView):
     @allow_permission([ROLE.ADMIN, ROLE.MEMBER, ROLE.GUEST])
     def get(self, request, slug, project_id, issue_id):
         # A restricted guest may only see attachments of issues they created,
-        # mirroring the issue-detail visibility rule (GHSA-wq96-4xjj-j4qg).
+        # mirroring the issue-detail visibility rule.
         if issue_hidden_from_guest(request, slug, project_id, issue_id):
             return Response(
                 {"error": "You are not allowed to view this issue"},
@@ -118,7 +118,7 @@ class IssueAttachmentV2Endpoint(BaseAPIView):
     @allow_permission([ROLE.ADMIN, ROLE.MEMBER, ROLE.GUEST])
     def post(self, request, slug, project_id, issue_id):
         # A restricted guest may only add attachments to issues they created,
-        # mirroring the issue-detail visibility rule (GHSA-wq96-4xjj-j4qg).
+        # mirroring the issue-detail visibility rule.
         if issue_hidden_from_guest(request, slug, project_id, issue_id):
             return Response(
                 {"error": "You are not allowed to view this issue"},
@@ -198,7 +198,7 @@ class IssueAttachmentV2Endpoint(BaseAPIView):
     @allow_permission([ROLE.ADMIN, ROLE.MEMBER, ROLE.GUEST])
     def get(self, request, slug, project_id, issue_id, pk=None):
         # A restricted guest may only see attachments of issues they created,
-        # mirroring the issue-detail visibility rule (GHSA-wq96-4xjj-j4qg).
+        # mirroring the issue-detail visibility rule.
         if issue_hidden_from_guest(request, slug, project_id, issue_id):
             return Response(
                 {"error": "You are not allowed to view this issue"},
@@ -238,7 +238,7 @@ class IssueAttachmentV2Endpoint(BaseAPIView):
     @allow_permission([ROLE.ADMIN, ROLE.MEMBER, ROLE.GUEST])
     def patch(self, request, slug, project_id, issue_id, pk):
         # A restricted guest may only touch attachments of issues they created,
-        # mirroring the issue-detail visibility rule (GHSA-wq96-4xjj-j4qg).
+        # mirroring the issue-detail visibility rule.
         if issue_hidden_from_guest(request, slug, project_id, issue_id):
             return Response(
                 {"error": "You are not allowed to view this issue"},
@@ -264,7 +264,7 @@ class IssueAttachmentV2Endpoint(BaseAPIView):
             )
 
             # Update the attachment — do NOT overwrite created_by; it is set at
-            # creation time and must not be reassigned (GHSA-5mxw-g5mw-3v3w).
+            # creation time and must not be reassigned.
             issue_attachment.is_uploaded = True
 
         # Get the storage metadata

--- a/apps/api/plane/app/views/issue/attachment.py
+++ b/apps/api/plane/app/views/issue/attachment.py
@@ -36,6 +36,13 @@ class IssueAttachmentEndpoint(BaseAPIView):
 
     @allow_permission([ROLE.ADMIN, ROLE.MEMBER, ROLE.GUEST])
     def post(self, request, slug, project_id, issue_id):
+        # A restricted guest may only add attachments to issues they created,
+        # mirroring the issue-detail visibility rule (GHSA-wq96-4xjj-j4qg).
+        if issue_hidden_from_guest(request, slug, project_id, issue_id):
+            return Response(
+                {"error": "You are not allowed to view this issue"},
+                status=status.HTTP_403_FORBIDDEN,
+            )
         serializer = IssueAttachmentSerializer(data=request.data)
         workspace = Workspace.objects.get(slug=slug)
         if serializer.is_valid():
@@ -94,7 +101,12 @@ class IssueAttachmentEndpoint(BaseAPIView):
                 {"error": "You are not allowed to view this issue"},
                 status=status.HTTP_403_FORBIDDEN,
             )
-        issue_attachments = FileAsset.objects.filter(issue_id=issue_id, workspace__slug=slug, project_id=project_id)
+        issue_attachments = FileAsset.objects.filter(
+            issue_id=issue_id,
+            entity_type=FileAsset.EntityTypeContext.ISSUE_ATTACHMENT,
+            workspace__slug=slug,
+            project_id=project_id,
+        )
         serializer = IssueAttachmentSerializer(issue_attachments, many=True)
         return Response(serializer.data, status=status.HTTP_200_OK)
 
@@ -105,6 +117,13 @@ class IssueAttachmentV2Endpoint(BaseAPIView):
 
     @allow_permission([ROLE.ADMIN, ROLE.MEMBER, ROLE.GUEST])
     def post(self, request, slug, project_id, issue_id):
+        # A restricted guest may only add attachments to issues they created,
+        # mirroring the issue-detail visibility rule (GHSA-wq96-4xjj-j4qg).
+        if issue_hidden_from_guest(request, slug, project_id, issue_id):
+            return Response(
+                {"error": "You are not allowed to view this issue"},
+                status=status.HTTP_403_FORBIDDEN,
+            )
         name = sanitize_filename(request.data.get("name")) or "unnamed"
         type = request.data.get("type", False)
         size = int(request.data.get("size", settings.FILE_SIZE_LIMIT))
@@ -218,6 +237,13 @@ class IssueAttachmentV2Endpoint(BaseAPIView):
 
     @allow_permission([ROLE.ADMIN, ROLE.MEMBER, ROLE.GUEST])
     def patch(self, request, slug, project_id, issue_id, pk):
+        # A restricted guest may only touch attachments of issues they created,
+        # mirroring the issue-detail visibility rule (GHSA-wq96-4xjj-j4qg).
+        if issue_hidden_from_guest(request, slug, project_id, issue_id):
+            return Response(
+                {"error": "You are not allowed to view this issue"},
+                status=status.HTTP_403_FORBIDDEN,
+            )
         issue_attachment = FileAsset.objects.get(
             pk=pk, workspace__slug=slug, project_id=project_id, issue_id=issue_id
         )

--- a/apps/api/plane/app/views/issue/comment.py
+++ b/apps/api/plane/app/views/issue/comment.py
@@ -18,7 +18,7 @@ from rest_framework import status
 # Module imports
 from .. import BaseViewSet
 from plane.app.serializers import IssueCommentSerializer, CommentReactionSerializer
-from plane.app.permissions import allow_permission, ROLE
+from plane.app.permissions import allow_permission, issue_hidden_from_guest, ROLE
 from plane.db.models import IssueComment, ProjectMember, CommentReaction, Project, Issue
 from plane.bgtasks.issue_activities_task import issue_activity
 from plane.utils.host import base_host
@@ -59,6 +59,28 @@ class IssueCommentViewSet(BaseViewSet):
             )
             .distinct()
         )
+
+    @allow_permission([ROLE.ADMIN, ROLE.MEMBER, ROLE.GUEST])
+    def list(self, request, slug, project_id, issue_id):
+        # A restricted guest may only see the comments of issues they created,
+        # mirroring the issue-detail visibility rule.
+        if issue_hidden_from_guest(request, slug, project_id, issue_id):
+            return Response(
+                {"error": "You are not allowed to view this issue"},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+        return super().list(request, slug, project_id, issue_id)
+
+    @allow_permission([ROLE.ADMIN, ROLE.MEMBER, ROLE.GUEST])
+    def retrieve(self, request, slug, project_id, issue_id, pk):
+        # A restricted guest may only see the comments of issues they created,
+        # mirroring the issue-detail visibility rule.
+        if issue_hidden_from_guest(request, slug, project_id, issue_id):
+            return Response(
+                {"error": "You are not allowed to view this issue"},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+        return super().retrieve(request, slug, project_id, issue_id, pk)
 
     @allow_permission([ROLE.ADMIN, ROLE.MEMBER, ROLE.GUEST])
     def create(self, request, slug, project_id, issue_id):
@@ -182,6 +204,19 @@ class CommentReactionViewSet(BaseViewSet):
 
     @allow_permission([ROLE.ADMIN, ROLE.MEMBER, ROLE.GUEST])
     def create(self, request, slug, project_id, comment_id):
+        # A restricted guest may only react to comments on issues they created,
+        # mirroring the issue-detail visibility rule. Comment reactions are
+        # keyed by comment_id, so resolve the parent issue first.
+        issue_id = (
+            IssueComment.objects.filter(pk=comment_id, workspace__slug=slug, project_id=project_id)
+            .values_list("issue_id", flat=True)
+            .first()
+        )
+        if issue_id and issue_hidden_from_guest(request, slug, project_id, issue_id):
+            return Response(
+                {"error": "You are not allowed to view this issue"},
+                status=status.HTTP_403_FORBIDDEN,
+            )
         try:
             serializer = CommentReactionSerializer(data=request.data)
             if serializer.is_valid():
@@ -211,6 +246,19 @@ class CommentReactionViewSet(BaseViewSet):
 
     @allow_permission([ROLE.ADMIN, ROLE.MEMBER, ROLE.GUEST])
     def destroy(self, request, slug, project_id, comment_id, reaction_code):
+        # A restricted guest may only react to comments on issues they created,
+        # mirroring the issue-detail visibility rule. Comment reactions are
+        # keyed by comment_id, so resolve the parent issue first.
+        issue_id = (
+            IssueComment.objects.filter(pk=comment_id, workspace__slug=slug, project_id=project_id)
+            .values_list("issue_id", flat=True)
+            .first()
+        )
+        if issue_id and issue_hidden_from_guest(request, slug, project_id, issue_id):
+            return Response(
+                {"error": "You are not allowed to view this issue"},
+                status=status.HTTP_403_FORBIDDEN,
+            )
         comment_reaction = CommentReaction.objects.get(
             workspace__slug=slug,
             project_id=project_id,

--- a/apps/api/plane/tests/contract/app/test_guest_issue_subresource_scope_app.py
+++ b/apps/api/plane/tests/contract/app/test_guest_issue_subresource_scope_app.py
@@ -4,7 +4,7 @@
 
 """Contract tests for guest visibility on issue sub-resources.
 
-Regression coverage for GHSA-wq96-4xjj-j4qg. On a project with
+On a project with
 ``guest_view_all_features=False`` the issue-detail endpoint correctly 403s a
 GUEST for issues they did not create, but the issue *sub-resource* endpoints did
 not replicate that restriction:

--- a/apps/api/plane/tests/contract/app/test_guest_issue_subresource_scope_app.py
+++ b/apps/api/plane/tests/contract/app/test_guest_issue_subresource_scope_app.py
@@ -67,7 +67,8 @@ def _make_attachment(issue, project, workspace):
 
 @pytest.fixture
 def project(db, workspace, create_user):
-    """A project with guest_view_all_features defaulting to False; owner is a member."""
+    """A project with guest_view_all_features defaulting to False; the owner
+    (``create_user``) is an active project ADMIN (role 20)."""
     project = Project.objects.create(
         name="Scoped Project", identifier="SP", workspace=workspace, created_by=create_user
     )
@@ -129,8 +130,30 @@ class TestGuestIssueSubresourceScope:
         )
 
     def test_guest_blocked_v2_attachments(self, guest_client, workspace, project, foreign_issue):
-        response = guest_client.get(
-            V2_ATTACH_URL.format(slug=workspace.slug, project_id=project.id, issue_id=foreign_issue.id)
+        base = V2_ATTACH_URL.format(slug=workspace.slug, project_id=project.id, issue_id=foreign_issue.id)
+        # Collection endpoint.
+        response = guest_client.get(base)
+        assert response.status_code == status.HTTP_403_FORBIDDEN, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+        # Single-attachment endpoint — the highest-risk path (returns a presigned
+        # download redirect); must also be blocked.
+        asset = FileAsset.objects.filter(
+            issue_id=foreign_issue.id,
+            entity_type=FileAsset.EntityTypeContext.ISSUE_ATTACHMENT,
+        ).first()
+        response_pk = guest_client.get(f"{base}{asset.id}/")
+        assert response_pk.status_code == status.HTTP_403_FORBIDDEN, (
+            f"Single-attachment leak: {response_pk.status_code} {getattr(response_pk, 'data', None)!r}"
+        )
+
+    def test_guest_cannot_post_attachment_to_foreign_issue(self, guest_client, workspace, project, foreign_issue):
+        """The visibility rule covers writes too: a restricted guest cannot add an
+        attachment to an issue they are not allowed to view."""
+        response = guest_client.post(
+            V2_ATTACH_URL.format(slug=workspace.slug, project_id=project.id, issue_id=foreign_issue.id),
+            {"name": "evil.pdf", "type": "application/pdf", "size": 100},
+            format="json",
         )
         assert response.status_code == status.HTTP_403_FORBIDDEN, (
             f"Got {response.status_code}: {getattr(response, 'data', None)!r}"

--- a/apps/api/plane/tests/contract/app/test_guest_issue_subresource_scope_app.py
+++ b/apps/api/plane/tests/contract/app/test_guest_issue_subresource_scope_app.py
@@ -12,6 +12,8 @@ not replicate that restriction:
 * ``IssueAttachmentEndpoint.get``   (v1 ``.../issue-attachments/``)
 * ``IssueAttachmentV2Endpoint.get`` (v2 ``/assets/v2/.../attachments/``)
 * ``IssueActivityEndpoint.get``     (``.../history/``)
+* ``IssueCommentViewSet.list``/``.retrieve`` (``.../comments/``)
+* ``CommentReactionViewSet.create``/``.destroy`` (``.../comments/<id>/reactions/``)
 
 Each is decorated ``@allow_permission([ADMIN, MEMBER, GUEST])`` and queried by
 ``issue_id`` only, so a restricted guest who is a legitimate project member could
@@ -33,6 +35,7 @@ from rest_framework.test import APIClient
 from plane.db.models import (
     FileAsset,
     Issue,
+    IssueComment,
     Project,
     ProjectMember,
     User,
@@ -42,6 +45,10 @@ from plane.db.models import (
 V1_ATTACH_URL = "/api/workspaces/{slug}/projects/{project_id}/issues/{issue_id}/issue-attachments/"
 V2_ATTACH_URL = "/api/assets/v2/workspaces/{slug}/projects/{project_id}/issues/{issue_id}/attachments/"
 HISTORY_URL = "/api/workspaces/{slug}/projects/{project_id}/issues/{issue_id}/history/"
+COMMENT_LIST_URL = "/api/workspaces/{slug}/projects/{project_id}/issues/{issue_id}/comments/"
+COMMENT_DETAIL_URL = "/api/workspaces/{slug}/projects/{project_id}/issues/{issue_id}/comments/{pk}/"
+REACTION_URL = "/api/workspaces/{slug}/projects/{project_id}/comments/{comment_id}/reactions/"
+REACTION_DETAIL_URL = "/api/workspaces/{slug}/projects/{project_id}/comments/{comment_id}/reactions/{reaction_code}/"
 
 
 def _make_issue(name, project, workspace, author):
@@ -50,6 +57,12 @@ def _make_issue(name, project, workspace, author):
     issue = Issue(name=name, project=project, workspace=workspace)
     issue.save(created_by_id=author.id)
     return issue
+
+
+def _make_comment(issue, project, workspace, actor):
+    return IssueComment.objects.create(
+        issue=issue, project=project, actor=actor, comment_html="<p>secret comment</p>"
+    )
 
 
 def _make_attachment(issue, project, workspace):
@@ -114,6 +127,18 @@ def foreign_issue(db, workspace, project, create_user):
     return issue
 
 
+@pytest.fixture
+def own_issue_comment(db, workspace, project, own_issue, guest):
+    """A comment on the guest's own issue."""
+    return _make_comment(own_issue, project, workspace, guest)
+
+
+@pytest.fixture
+def foreign_issue_comment(db, workspace, project, foreign_issue, create_user):
+    """A comment on an issue authored by someone other than the guest."""
+    return _make_comment(foreign_issue, project, workspace, create_user)
+
+
 @pytest.mark.contract
 @pytest.mark.django_db
 class TestGuestIssueSubresourceScope:
@@ -167,6 +192,56 @@ class TestGuestIssueSubresourceScope:
             f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
         )
 
+    def test_guest_blocked_comments_list(self, guest_client, workspace, project, foreign_issue, foreign_issue_comment):
+        response = guest_client.get(
+            COMMENT_LIST_URL.format(slug=workspace.slug, project_id=project.id, issue_id=foreign_issue.id)
+        )
+        assert response.status_code == status.HTTP_403_FORBIDDEN, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+
+    def test_guest_blocked_comment_retrieve(
+        self, guest_client, workspace, project, foreign_issue, foreign_issue_comment
+    ):
+        response = guest_client.get(
+            COMMENT_DETAIL_URL.format(
+                slug=workspace.slug,
+                project_id=project.id,
+                issue_id=foreign_issue.id,
+                pk=foreign_issue_comment.id,
+            )
+        )
+        assert response.status_code == status.HTTP_403_FORBIDDEN, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+
+    def test_guest_blocked_comment_reaction_create(
+        self, guest_client, workspace, project, foreign_issue, foreign_issue_comment
+    ):
+        response = guest_client.post(
+            REACTION_URL.format(slug=workspace.slug, project_id=project.id, comment_id=foreign_issue_comment.id),
+            {"reaction": "like"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_403_FORBIDDEN, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+
+    def test_guest_blocked_comment_reaction_destroy(
+        self, guest_client, workspace, project, foreign_issue, foreign_issue_comment
+    ):
+        response = guest_client.delete(
+            REACTION_DETAIL_URL.format(
+                slug=workspace.slug,
+                project_id=project.id,
+                comment_id=foreign_issue_comment.id,
+                reaction_code="like",
+            )
+        )
+        assert response.status_code == status.HTTP_403_FORBIDDEN, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+
     # ---- the guest still sees their OWN issue's sub-resources ----------------
 
     def test_guest_allowed_own_issue_attachments(self, guest_client, workspace, project, own_issue):
@@ -178,7 +253,65 @@ class TestGuestIssueSubresourceScope:
         )
         assert len(response.data) == 1, f"Guest should see their own attachment: {response.data!r}"
 
+    def test_guest_allowed_own_issue_comments_list(
+        self, guest_client, workspace, project, own_issue, own_issue_comment
+    ):
+        response = guest_client.get(
+            COMMENT_LIST_URL.format(slug=workspace.slug, project_id=project.id, issue_id=own_issue.id)
+        )
+        assert response.status_code == status.HTTP_200_OK, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+        assert len(response.data) == 1, f"Guest should see their own comment: {response.data!r}"
+
+    def test_guest_allowed_own_issue_comment_retrieve(
+        self, guest_client, workspace, project, own_issue, own_issue_comment
+    ):
+        response = guest_client.get(
+            COMMENT_DETAIL_URL.format(
+                slug=workspace.slug, project_id=project.id, issue_id=own_issue.id, pk=own_issue_comment.id
+            )
+        )
+        assert response.status_code == status.HTTP_200_OK, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+
+    def test_guest_allowed_own_issue_comment_reaction_create(
+        self, guest_client, workspace, project, own_issue, own_issue_comment
+    ):
+        response = guest_client.post(
+            REACTION_URL.format(slug=workspace.slug, project_id=project.id, comment_id=own_issue_comment.id),
+            {"reaction": "like"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_201_CREATED, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+
     # ---- positive controls: members and unrestricted guests unaffected -------
+
+    def test_member_reads_foreign_issue_comments(
+        self, session_client, workspace, project, foreign_issue, foreign_issue_comment
+    ):
+        """A full project member still reads any issue's comments."""
+        response = session_client.get(
+            COMMENT_LIST_URL.format(slug=workspace.slug, project_id=project.id, issue_id=foreign_issue.id)
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data) == 1
+
+    def test_unrestricted_guest_reads_foreign_issue_comments(
+        self, guest_client, workspace, project, foreign_issue, foreign_issue_comment
+    ):
+        """When guest_view_all_features is enabled, the guest sees all comments."""
+        project.guest_view_all_features = True
+        project.save(update_fields=["guest_view_all_features"])
+
+        response = guest_client.get(
+            COMMENT_LIST_URL.format(slug=workspace.slug, project_id=project.id, issue_id=foreign_issue.id)
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data) == 1
 
     def test_member_reads_foreign_issue_attachments(self, session_client, workspace, project, foreign_issue):
         """A full project member still reads any issue's attachments."""

--- a/apps/api/plane/tests/contract/app/test_guest_issue_subresource_scope_app.py
+++ b/apps/api/plane/tests/contract/app/test_guest_issue_subresource_scope_app.py
@@ -1,0 +1,179 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Contract tests for guest visibility on issue sub-resources.
+
+Regression coverage for GHSA-wq96-4xjj-j4qg. On a project with
+``guest_view_all_features=False`` the issue-detail endpoint correctly 403s a
+GUEST for issues they did not create, but the issue *sub-resource* endpoints did
+not replicate that restriction:
+
+* ``IssueAttachmentEndpoint.get``   (v1 ``.../issue-attachments/``)
+* ``IssueAttachmentV2Endpoint.get`` (v2 ``/assets/v2/.../attachments/``)
+* ``IssueActivityEndpoint.get``     (``.../history/``)
+
+Each is decorated ``@allow_permission([ADMIN, MEMBER, GUEST])`` and queried by
+``issue_id`` only, so a restricted guest who is a legitimate project member could
+list attachment metadata / download URLs and read activity + comments of issues
+they are not allowed to view.
+
+The fix routes each through ``issue_hidden_from_guest`` and returns 403 for a
+restricted guest on an issue they did not author — mirroring the issue-detail
+rule — while leaving admins, members, unrestricted guests, and the guest's own
+issues unaffected.
+"""
+
+from uuid import uuid4
+
+import pytest
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from plane.db.models import (
+    FileAsset,
+    Issue,
+    Project,
+    ProjectMember,
+    User,
+    WorkspaceMember,
+)
+
+V1_ATTACH_URL = "/api/workspaces/{slug}/projects/{project_id}/issues/{issue_id}/issue-attachments/"
+V2_ATTACH_URL = "/api/assets/v2/workspaces/{slug}/projects/{project_id}/issues/{issue_id}/attachments/"
+HISTORY_URL = "/api/workspaces/{slug}/projects/{project_id}/issues/{issue_id}/history/"
+
+
+def _make_issue(name, project, workspace, author):
+    """Create an issue with a deterministic ``created_by`` (BaseModel.save
+    otherwise nulls it under tests)."""
+    issue = Issue(name=name, project=project, workspace=workspace)
+    issue.save(created_by_id=author.id)
+    return issue
+
+
+def _make_attachment(issue, project, workspace):
+    return FileAsset.objects.create(
+        attributes={"name": "secret.pdf", "type": "application/pdf", "size": 100},
+        asset=f"{workspace.id}/{uuid4().hex}-secret.pdf",
+        size=100,
+        workspace=workspace,
+        project=project,
+        issue_id=issue.id,
+        entity_type=FileAsset.EntityTypeContext.ISSUE_ATTACHMENT,
+        is_uploaded=True,
+    )
+
+
+@pytest.fixture
+def project(db, workspace, create_user):
+    """A project with guest_view_all_features defaulting to False; owner is a member."""
+    project = Project.objects.create(
+        name="Scoped Project", identifier="SP", workspace=workspace, created_by=create_user
+    )
+    ProjectMember.objects.create(project=project, member=create_user, workspace=workspace, role=20)
+    return project
+
+
+@pytest.fixture
+def guest(db, workspace, project):
+    """An active project GUEST (role 5)."""
+    user = User.objects.create(
+        email=f"guest-{uuid4().hex[:8]}@plane.so",
+        username=f"guest_{uuid4().hex[:8]}",
+        first_name="Guest",
+    )
+    user.set_password("test-password")
+    user.save()
+    WorkspaceMember.objects.create(workspace=workspace, member=user, role=5)
+    ProjectMember.objects.create(project=project, member=user, workspace=workspace, role=5)
+    return user
+
+
+@pytest.fixture
+def guest_client(guest):
+    client = APIClient()
+    client.force_authenticate(user=guest)
+    return client
+
+
+@pytest.fixture
+def own_issue(db, workspace, project, guest):
+    """An issue authored by the guest, with an attachment."""
+    issue = _make_issue("Guest's own issue", project, workspace, guest)
+    _make_attachment(issue, project, workspace)
+    return issue
+
+
+@pytest.fixture
+def foreign_issue(db, workspace, project, create_user):
+    """An issue authored by someone other than the guest, with an attachment."""
+    issue = _make_issue("Someone else's issue", project, workspace, create_user)
+    _make_attachment(issue, project, workspace)
+    return issue
+
+
+@pytest.mark.contract
+@pytest.mark.django_db
+class TestGuestIssueSubresourceScope:
+    """A restricted guest must not read sub-resources of issues they can't view."""
+
+    # ---- restricted guest is blocked on a foreign issue ----------------------
+
+    def test_guest_blocked_v1_attachments(self, guest_client, workspace, project, foreign_issue):
+        response = guest_client.get(
+            V1_ATTACH_URL.format(slug=workspace.slug, project_id=project.id, issue_id=foreign_issue.id)
+        )
+        assert response.status_code == status.HTTP_403_FORBIDDEN, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+
+    def test_guest_blocked_v2_attachments(self, guest_client, workspace, project, foreign_issue):
+        response = guest_client.get(
+            V2_ATTACH_URL.format(slug=workspace.slug, project_id=project.id, issue_id=foreign_issue.id)
+        )
+        assert response.status_code == status.HTTP_403_FORBIDDEN, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+
+    def test_guest_blocked_activity(self, guest_client, workspace, project, foreign_issue):
+        response = guest_client.get(
+            HISTORY_URL.format(slug=workspace.slug, project_id=project.id, issue_id=foreign_issue.id)
+        )
+        assert response.status_code == status.HTTP_403_FORBIDDEN, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+
+    # ---- the guest still sees their OWN issue's sub-resources ----------------
+
+    def test_guest_allowed_own_issue_attachments(self, guest_client, workspace, project, own_issue):
+        response = guest_client.get(
+            V2_ATTACH_URL.format(slug=workspace.slug, project_id=project.id, issue_id=own_issue.id)
+        )
+        assert response.status_code == status.HTTP_200_OK, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+        assert len(response.data) == 1, f"Guest should see their own attachment: {response.data!r}"
+
+    # ---- positive controls: members and unrestricted guests unaffected -------
+
+    def test_member_reads_foreign_issue_attachments(self, session_client, workspace, project, foreign_issue):
+        """A full project member still reads any issue's attachments."""
+        response = session_client.get(
+            V2_ATTACH_URL.format(slug=workspace.slug, project_id=project.id, issue_id=foreign_issue.id)
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data) == 1
+
+    def test_unrestricted_guest_reads_foreign_issue_attachments(
+        self, guest_client, workspace, project, foreign_issue
+    ):
+        """When guest_view_all_features is enabled, the guest sees all attachments."""
+        project.guest_view_all_features = True
+        project.save(update_fields=["guest_view_all_features"])
+
+        response = guest_client.get(
+            V2_ATTACH_URL.format(slug=workspace.slug, project_id=project.id, issue_id=foreign_issue.id)
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data) == 1


### PR DESCRIPTION
## Summary
On a project with `guest_view_all_features=False`, the issue-detail endpoint correctly returns **403** to a GUEST for issues they did not author — but the issue *sub-resource* endpoints did not replicate that rule. Each is decorated `@allow_permission([ADMIN, MEMBER, GUEST])` and queried by `issue_id` only, so a restricted guest (a legitimate project member) could read data for issues they cannot view.

Fixes WEB-8353 (CWE-863). Confirmed vulnerable against `origin/preview` @ `a8e53b6ac7` by reading the canonical code.

## Affected endpoints
- `IssueAttachmentEndpoint.get` — v1 `.../issues/<id>/issue-attachments/`
- `IssueAttachmentV2Endpoint.get` — v2 `/assets/v2/.../issues/<id>/attachments/` (list **and** single-asset download redirect)
- `IssueActivityEndpoint.get` — `.../issues/<id>/history/` (activity **and** comments)

A guest could obtain attachment metadata + download URLs, and read the activity/comment stream, for any issue in the project — including issues explicitly hidden from them by `guest_view_all_features=False`.

## Fix
New shared helper `issue_hidden_from_guest(request, slug, project_id, issue_id)` in `plane.app.permissions` returns `True` when the caller is a **restricted project guest** (role GUEST, `guest_view_all_features=False`) who did **not** author the issue — mirroring the scope `IssueViewSet.list` / `IssueListEndpoint` already apply. Each endpoint returns **403** in that case.

Unaffected: admins, members, unrestricted guests (`guest_view_all_features=True`), and the guest's own issues.

Centralizing the check (as the reporter suggested) means future issue sub-resources can reuse it.

## Tests
`apps/api/plane/tests/contract/app/test_guest_issue_subresource_scope_app.py` — 6 contract tests:
- restricted guest blocked on a foreign issue: v1 attachments (403), v2 attachments (403), activity (403)
- restricted guest still sees their **own** issue's attachments (200)
- positive controls: full member reads foreign-issue attachments (200); unrestricted guest (`guest_view_all_features=True`) reads them (200)

**Fail-before verified**: with the fix reverted, the 3 block tests fail and the 3 positive controls pass; with the fix all 6 pass. `ruff` + `manage.py check` clean.

## EE
plane-ee vendors its own copy of the CE backend; an EE port will be assessed separately under Epic WEB-8293.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted project guests can no longer view activity, comments, reactions, or attachments for issues created by others when guest access is limited.
  * Added consistent 403 responses for unauthorized access to issue sub-resources.
  * Improved project scoping to prevent cross-project data exposure.
  * Guests retain access to their own issue content, while members and unrestricted guests retain appropriate access.

* **Tests**
  * Added contract coverage for restricted, authorized, and unrestricted guest access to issue comments, reactions, attachments, and history.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
