### PR TITLE
fix(api): support work item sequence_id filter

### DIFF
--- a/apps/api/plane/api/views/issue.py
+++ b/apps/api/plane/api/views/issue.py
@@ -330,6 +330,7 @@ class IssueListCreateAPIEndpoint(BaseAPIView):
 
         external_id = request.GET.get("external_id")
         external_source = request.GET.get("external_source")
+        sequence_id = request.GET.get("sequence_id")
 
         if external_id and external_source:
             issue = Issue.objects.get(
@@ -342,6 +343,22 @@ class IssueListCreateAPIEndpoint(BaseAPIView):
                 IssueSerializer(issue, fields=self.fields, expand=self.expand).data,
                 status=status.HTTP_200_OK,
             )
+
+        parsed_sequence_id = None
+        if sequence_id:
+            try:
+                parsed_sequence_id = int(sequence_id)
+            except ValueError:
+                return Response(
+                    {"sequence_id": "Must be a positive integer."},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
+            if parsed_sequence_id < 1:
+                return Response(
+                    {"sequence_id": "Must be a positive integer."},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
 
         # Custom ordering for priority and state
         priority_order = ["urgent", "high", "medium", "low", "none"]
@@ -381,6 +398,9 @@ class IssueListCreateAPIEndpoint(BaseAPIView):
         )
 
         total_issue_queryset = Issue.issue_objects.filter(project_id=project_id, workspace__slug=slug)
+        if parsed_sequence_id is not None:
+            issue_queryset = issue_queryset.filter(sequence_id=parsed_sequence_id)
+            total_issue_queryset = total_issue_queryset.filter(sequence_id=parsed_sequence_id)
 
         # Priority Ordering
         if order_by_param == "priority" or order_by_param == "-priority":

--- a/apps/api/plane/tests/contract/api/test_issues.py
+++ b/apps/api/plane/tests/contract/api/test_issues.py
@@ -94,3 +94,65 @@ class TestIssueListOrderByInjection:
             assert response.status_code == status.HTTP_200_OK, (
                 f"order_by={value!r} got {response.status_code}: {response.data!r}"
             )
+
+
+@pytest.mark.contract
+class TestIssueListSequenceFilter:
+    """Regression tests for project-scoped work-item lookup by sequence id.
+
+    Integrations often receive the visible work-item identifier, such as
+    ``TP-2``, rather than the internal UUID. The project work-item list endpoint
+    should support filtering by the numeric sequence portion.
+    """
+
+    def get_url(self, workspace_slug, project_id):
+        return f"/api/v1/workspaces/{workspace_slug}/projects/{project_id}/work-items/"
+
+    @pytest.mark.django_db
+    def test_filters_work_items_by_sequence_id(self, api_key_client, workspace, project, state, create_user):
+        Issue.objects.create(
+            name="First Issue",
+            workspace=workspace,
+            project=project,
+            state=state,
+            created_by=create_user,
+        )
+        second_issue = Issue.objects.create(
+            name="Second Issue",
+            workspace=workspace,
+            project=project,
+            state=state,
+            created_by=create_user,
+        )
+
+        response = api_key_client.get(
+            self.get_url(workspace.slug, project.id),
+            {"sequence_id": second_issue.sequence_id},
+        )
+
+        assert response.status_code == status.HTTP_200_OK, f"Got {response.status_code}: {response.data!r}"
+        assert response.data["total_count"] == 1
+        assert [str(item["id"]) for item in response.data["results"]] == [str(second_issue.id)]
+
+    @pytest.mark.django_db
+    def test_sequence_id_filter_returns_empty_page_for_missing_sequence(
+        self, api_key_client, workspace, project, issue
+    ):
+        response = api_key_client.get(
+            self.get_url(workspace.slug, project.id),
+            {"sequence_id": issue.sequence_id + 100},
+        )
+
+        assert response.status_code == status.HTTP_200_OK, f"Got {response.status_code}: {response.data!r}"
+        assert response.data["total_count"] == 0
+        assert response.data["results"] == []
+
+    @pytest.mark.django_db
+    def test_sequence_id_filter_rejects_invalid_values(self, api_key_client, workspace, project):
+        response = api_key_client.get(
+            self.get_url(workspace.slug, project.id),
+            {"sequence_id": "not-a-number"},
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.data == {"sequence_id": "Must be a positive integer."}


### PR DESCRIPTION
## Summary

- support `sequence_id` on the project-scoped work item list endpoint
- reject invalid or non-positive sequence IDs with a `400` response
- keep paginated `total_count` aligned with the filtered results
- add contract coverage for matching, missing, and invalid sequence IDs

## Why

The API accepted `?sequence_id=` but silently ignored it, so clients could not look up a work item using the numeric portion of its human-readable ID. Applying the filter to both the result and count querysets makes the endpoint useful and keeps pagination metadata correct.

Fixes #9446

## Validation

- `uvx ruff format --check apps/api/plane/api/views/issue.py apps/api/plane/tests/contract/api/test_issues.py`
- `uvx ruff check apps/api/plane/api/views/issue.py apps/api/plane/tests/contract/api/test_issues.py`
- `docker compose -f docker-compose-test.yml run --rm api-tests pytest plane/tests/contract/api/test_issues.py -q` (6 passed)