### PR TITLE
fix: prevent Chrome autofill from filling all invite-member email fields

### DIFF
--- a/apps/web/core/components/onboarding/invite-members.tsx
+++ b/apps/web/core/components/onboarding/invite-members.tsx
@@ -156,7 +156,7 @@ const InviteMemberInput = observer(function InviteMemberInput(props: InviteMembe
               <Input
                 id={`emails.${index}.email`}
                 name={`emails.${index}.email`}
-                type="text"
+                type="email"
                 value={value}
                 onChange={(event) => {
                   emailOnChange(event);
@@ -166,7 +166,7 @@ const InviteMemberInput = observer(function InviteMemberInput(props: InviteMembe
                 hasError={Boolean(errors.emails?.[index]?.email)}
                 placeholder={placeholderEmails[index % placeholderEmails.length]}
                 className="w-full border-strong text-11 placeholder:text-placeholder sm:text-13"
-                autoComplete="off"
+                autoComplete="new-password"
               />
             )}
           />


### PR DESCRIPTION
Chrome ignores `autocomplete="off"` on contact-recognizable fields. When a user selects an email from Chrome's autofill picker, Chrome scans the DOM for other inputs with structurally similar names and fills them all with the same value — so all three `emails.0.email`, `emails.1.email`, `emails.2.email` fields get the same address.

Two changes fix this:

1. `type="text"` → `type="email"` — scopes Chrome's autofill to the focused field only; contact autofill only fills one `type="email"` at a time
2. `autoComplete="off"` → `autoComplete="new-password"` — well-known workaround that Chrome respects, suppresses the contact picker entirely on these fields

Fixes #9462