### PR TITLE
[WEB-8372] fix(security): restrict StateViewSet.partial_update to project admins

### DIFF
--- a/apps/api/plane/app/views/state/base.py
+++ b/apps/api/plane/app/views/state/base.py
@@ -62,6 +62,7 @@ class StateViewSet(BaseViewSet):
     # the sibling create/destroy/mark_as_default writes. Previously [ADMIN, MEMBER, GUEST]
     # let a Guest rewrite any state (incl. setting `default`, bypassing the admin-only
     # mark_as_default). See GHSA-4jpp-964m-27cr.
+    @invalidate_cache(path="workspaces/:slug/states/", url_params=True, user=False)
     @allow_permission([ROLE.ADMIN])
     def partial_update(self, request, slug, project_id, pk):
         try:

--- a/apps/api/plane/app/views/state/base.py
+++ b/apps/api/plane/app/views/state/base.py
@@ -58,7 +58,11 @@ class StateViewSet(BaseViewSet):
                     status=status.HTTP_400_BAD_REQUEST,
                 )
 
-    @allow_permission([ROLE.ADMIN, ROLE.MEMBER, ROLE.GUEST])
+    # Editing a workflow state is project configuration — restrict to ADMIN, matching
+    # the sibling create/destroy/mark_as_default writes. Previously [ADMIN, MEMBER, GUEST]
+    # let a Guest rewrite any state (incl. setting `default`, bypassing the admin-only
+    # mark_as_default). See GHSA-4jpp-964m-27cr.
+    @allow_permission([ROLE.ADMIN])
     def partial_update(self, request, slug, project_id, pk):
         try:
             state = State.objects.get(pk=pk, project_id=project_id, workspace__slug=slug)

--- a/apps/api/plane/app/views/state/base.py
+++ b/apps/api/plane/app/views/state/base.py
@@ -61,7 +61,7 @@ class StateViewSet(BaseViewSet):
     # Editing a workflow state is project configuration — restrict to ADMIN, matching
     # the sibling create/destroy/mark_as_default writes. Previously [ADMIN, MEMBER, GUEST]
     # let a Guest rewrite any state (incl. setting `default`, bypassing the admin-only
-    # mark_as_default). See GHSA-4jpp-964m-27cr.
+    # mark_as_default).
     @invalidate_cache(path="workspaces/:slug/states/", url_params=True, user=False)
     @allow_permission([ROLE.ADMIN])
     def partial_update(self, request, slug, project_id, pk):

--- a/apps/api/plane/tests/contract/app/test_state_partial_update_admin_scope_app.py
+++ b/apps/api/plane/tests/contract/app/test_state_partial_update_admin_scope_app.py
@@ -75,13 +75,16 @@ class TestStatePartialUpdateAdminScope:
     def test_member_cannot_patch_state(self, workspace, project, state):
         member_client = _member_of(workspace, project, role=15)
         response = member_client.patch(
-            _state_url(workspace.slug, project.id, state.id), {"name": "Member Renamed"}, format="json"
+            _state_url(workspace.slug, project.id, state.id),
+            {"name": "Member Renamed", "default": True},
+            format="json",
         )
         assert response.status_code == status.HTTP_403_FORBIDDEN, (
             f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
         )
         state.refresh_from_db()
         assert state.name == "Backlog"
+        assert state.default is False
 
     def test_admin_can_patch_state(self, session_client, workspace, project, state):
         """Positive control: a project admin may still edit a state."""

--- a/apps/api/plane/tests/contract/app/test_state_partial_update_admin_scope_app.py
+++ b/apps/api/plane/tests/contract/app/test_state_partial_update_admin_scope_app.py
@@ -4,7 +4,7 @@
 
 """Contract tests for StateViewSet.partial_update authorization.
 
-Regression coverage for GHSA-4jpp-964m-27cr. Editing a workflow state is project
+Editing a workflow state is project
 configuration — its sibling writes (create, destroy, mark_as_default) are all
 ``@allow_permission([ROLE.ADMIN])``. ``partial_update`` was the outlier at
 ``[ADMIN, MEMBER, GUEST]``, so any project Guest could rewrite any state

--- a/apps/api/plane/tests/contract/app/test_state_partial_update_admin_scope_app.py
+++ b/apps/api/plane/tests/contract/app/test_state_partial_update_admin_scope_app.py
@@ -1,0 +1,95 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Contract tests for StateViewSet.partial_update authorization.
+
+Regression coverage for GHSA-4jpp-964m-27cr. Editing a workflow state is project
+configuration — its sibling writes (create, destroy, mark_as_default) are all
+``@allow_permission([ROLE.ADMIN])``. ``partial_update`` was the outlier at
+``[ADMIN, MEMBER, GUEST]``, so any project Guest could rewrite any state
+(name/color/group/description/sequence/order) and set it as the project default,
+functionally bypassing the admin-only ``mark_as_default``.
+
+The fix restricts ``partial_update`` to ADMIN.
+"""
+
+from uuid import uuid4
+
+import pytest
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from plane.db.models import Project, ProjectMember, State, User, WorkspaceMember
+
+
+def _state_url(slug, project_id, pk):
+    return f"/api/workspaces/{slug}/projects/{project_id}/states/{pk}/"
+
+
+def _member_of(workspace, project, *, role):
+    unique = uuid4().hex[:8]
+    user = User.objects.create(email=f"state-{role}-{unique}@plane.so", username=f"state_{role}_{unique}")
+    user.set_password("test-password")
+    user.save()
+    WorkspaceMember.objects.create(workspace=workspace, member=user, role=role, is_active=True)
+    ProjectMember.objects.create(project=project, member=user, workspace=workspace, role=role, is_active=True)
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client
+
+
+@pytest.fixture
+def project(db, workspace, create_user):
+    project = Project.objects.create(
+        name="State Project", identifier="ST", workspace=workspace, created_by=create_user
+    )
+    ProjectMember.objects.create(project=project, member=create_user, workspace=workspace, role=20, is_active=True)
+    return project
+
+
+@pytest.fixture
+def state(db, workspace, project):
+    return State.objects.create(
+        name="Backlog", color="#60646C", group="backlog", default=False, project=project, workspace=workspace
+    )
+
+
+@pytest.mark.contract
+@pytest.mark.django_db
+class TestStatePartialUpdateAdminScope:
+    """Editing a workflow state must be ADMIN-only (matches create/destroy/default)."""
+
+    def test_guest_cannot_patch_state(self, workspace, project, state):
+        guest_client = _member_of(workspace, project, role=5)
+        response = guest_client.patch(
+            _state_url(workspace.slug, project.id, state.id), {"name": "Guest Renamed", "default": True}, format="json"
+        )
+        assert response.status_code == status.HTTP_403_FORBIDDEN, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+        state.refresh_from_db()
+        assert state.name == "Backlog"
+        assert state.default is False
+
+    def test_member_cannot_patch_state(self, workspace, project, state):
+        member_client = _member_of(workspace, project, role=15)
+        response = member_client.patch(
+            _state_url(workspace.slug, project.id, state.id), {"name": "Member Renamed"}, format="json"
+        )
+        assert response.status_code == status.HTTP_403_FORBIDDEN, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+        state.refresh_from_db()
+        assert state.name == "Backlog"
+
+    def test_admin_can_patch_state(self, session_client, workspace, project, state):
+        """Positive control: a project admin may still edit a state."""
+        response = session_client.patch(
+            _state_url(workspace.slug, project.id, state.id), {"name": "Admin Renamed"}, format="json"
+        )
+        assert response.status_code == status.HTTP_200_OK, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+        state.refresh_from_db()
+        assert state.name == "Admin Renamed"


### PR DESCRIPTION
## Summary
`StateViewSet.partial_update` (`apps/api/plane/app/views/state/base.py`) was decorated `@allow_permission([ROLE.ADMIN, ROLE.MEMBER, ROLE.GUEST])`, while every sibling write on the viewset — `create`, `destroy`, `mark_as_default` — is `@allow_permission([ROLE.ADMIN])`. `StateSerializer` exposes `name`, `color`, `group`, `default`, `description`, `sequence`, `order` as writable, so any project **Guest** could rewrite any workflow state and set it as the project **default** — a functional bypass of the admin-only `mark_as_default`.

Fixes WEB-8372 (CWE-862). Confirmed vulnerable against `origin/preview` @ `a8e53b6ac7`.

## Fix
Tighten `partial_update` to `@allow_permission([ROLE.ADMIN])`, matching the other state writes.

## Tests
`test_state_partial_update_admin_scope_app.py` — guest PATCH → 403 (state + default unchanged), member PATCH → 403, admin PATCH → 200. **Fail-before verified** (guest & member could edit without the fix); ruff clean.

## EE
plane-ee vendors its own copy; EE port to be assessed under Epic WEB-8293 (EE StateViewSet uses the `@can` engine — likely already gated, will confirm separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted workflow state editing to project administrators only.
  * Members and guests can no longer modify workflow state details, including names and defaults.
  * Unauthorized update attempts are blocked, preserving existing workflow states.

* **Tests**
  * Added coverage confirming authorization behavior for guests, members, and administrators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
