### PR TITLE
[WEB-8382][WEB-8383][INFRA-502] fix(security): external-API issue comment + attachment authz

### DIFF
--- a/apps/api/plane/api/views/issue.py
+++ b/apps/api/plane/api/views/issue.py
@@ -1591,6 +1591,7 @@ class IssueCommentDetailAPIEndpoint(BaseAPIView):
                 examples=[ISSUE_COMMENT_EXAMPLE],
             ),
             400: INVALID_REQUEST_RESPONSE,
+            403: FORBIDDEN_RESPONSE,
             404: COMMENT_NOT_FOUND_RESPONSE,
             409: EXTERNAL_ID_EXISTS_RESPONSE,
         },
@@ -1672,6 +1673,7 @@ class IssueCommentDetailAPIEndpoint(BaseAPIView):
         ],
         responses={
             204: OpenApiResponse(description="Work item comment deleted successfully"),
+            403: FORBIDDEN_RESPONSE,
             404: COMMENT_NOT_FOUND_RESPONSE,
         },
     )
@@ -2014,6 +2016,7 @@ class IssueAttachmentListCreateAPIEndpoint(BaseAPIView):
                 examples=[ISSUE_ATTACHMENT_EXAMPLE],
             ),
             400: INVALID_REQUEST_RESPONSE,
+            403: FORBIDDEN_RESPONSE,
             404: ATTACHMENT_NOT_FOUND_RESPONSE,
         },
     )

--- a/apps/api/plane/api/views/issue.py
+++ b/apps/api/plane/api/views/issue.py
@@ -349,7 +349,7 @@ class IssueListCreateAPIEndpoint(BaseAPIView):
 
         # Reject any field not in the allowlist before it reaches .order_by().
         # An unrecognised value is replaced with the safe default, preventing
-        # ORM order_by injection via relational traversal (GHSA-p885-6jpg-cr2p).
+        # ORM order_by injection via relational traversal.
         order_by_param = sanitize_order_by(
             request.GET.get("order_by", "-created_at"),
             ISSUE_ORDER_BY_ALLOWLIST,
@@ -1605,8 +1605,7 @@ class IssueCommentDetailAPIEndpoint(BaseAPIView):
         issue_comment = IssueComment.objects.get(workspace__slug=slug, project_id=project_id, issue_id=issue_id, pk=pk)
         # Only the comment author or a project admin may modify a comment.
         # ProjectLitePermission alone lets any active member (incl. Guest) reach
-        # here, so enforce the same author/admin rule the app applies
-        # (GHSA-h4p4-mwfg-qh82).
+        # here, so enforce the same author/admin rule the app applies.
         if issue_comment.created_by_id != request.user.id and not ProjectMember.objects.filter(
             project_id=project_id, member_id=request.user.id, role=ROLE.ADMIN.value, is_active=True
         ).exists():
@@ -1684,8 +1683,7 @@ class IssueCommentDetailAPIEndpoint(BaseAPIView):
         Records deletion activity for audit purposes.
         """
         issue_comment = IssueComment.objects.get(workspace__slug=slug, project_id=project_id, issue_id=issue_id, pk=pk)
-        # Only the comment author or a project admin may delete a comment
-        # (GHSA-h4p4-mwfg-qh82).
+        # Only the comment author or a project admin may delete a comment.
         if issue_comment.created_by_id != request.user.id and not ProjectMember.objects.filter(
             project_id=project_id, member_id=request.user.id, role=ROLE.ADMIN.value, is_active=True
         ).exists():
@@ -2028,8 +2026,7 @@ class IssueAttachmentListCreateAPIEndpoint(BaseAPIView):
         # This endpoint has no permission_classes beyond IsAuthenticated, and API
         # tokens authenticate globally (not workspace-scoped), so enforce project
         # membership on the issue the same way post() does — otherwise any token
-        # holder could read any issue's attachment metadata cross-tenant
-        # (GHSA-xvc5-m5jf-gvpj).
+        # holder could read any issue's attachment metadata cross-tenant.
         issue = Issue.objects.get(pk=issue_id, workspace__slug=slug, project_id=project_id)
         if not user_has_issue_permission(
             request.user.id,

--- a/apps/api/plane/api/views/issue.py
+++ b/apps/api/plane/api/views/issue.py
@@ -2023,10 +2023,9 @@ class IssueAttachmentListCreateAPIEndpoint(BaseAPIView):
 
         List all attachments for an issue.
         """
-        # This endpoint has no permission_classes beyond IsAuthenticated, and API
-        # tokens authenticate globally (not workspace-scoped), so enforce project
-        # membership on the issue the same way post() does — otherwise any token
-        # holder could read any issue's attachment metadata cross-tenant.
+        # Bare IsAuthenticated here, and API tokens authenticate globally rather
+        # than per workspace, so enforce project membership as post() does --
+        # otherwise any token holder reads any issue's attachment metadata.
         issue = Issue.objects.get(pk=issue_id, workspace__slug=slug, project_id=project_id)
         if not user_has_issue_permission(
             request.user.id,
@@ -2077,20 +2076,34 @@ class IssueAttachmentDetailAPIEndpoint(BaseAPIView):
         Records deletion activity and triggers metadata cleanup.
         """
         issue = Issue.objects.get(pk=issue_id, workspace__slug=slug, project_id=project_id)
-        # if the request user is creator or admin then delete the attachment
-        if not user_has_issue_permission(
+
+        # Bind the asset to the URL work item and to the attachment entity type,
+        # matching the sibling list handler. Resolved before authorizing, so the
+        # check below applies to the object actually being acted on.
+        issue_attachment = FileAsset.objects.get(
+            pk=pk,
+            workspace__slug=slug,
+            project_id=project_id,
+            issue_id=issue_id,
+            entity_type=FileAsset.EntityTypeContext.ISSUE_ATTACHMENT,
+        )
+
+        # Admin or the uploader, as the app surface allows. allow_creator is off
+        # because it compares against the work item's author, not this file's
+        # uploader, so the ownership test is done explicitly below.
+        is_project_admin = user_has_issue_permission(
             request.user.id,
             project_id=project_id,
             issue=issue,
-            allowed_roles=[ROLE.ADMIN.value, ROLE.MEMBER.value, ROLE.GUEST.value],
-            allow_creator=True,
-        ):
+            allowed_roles=[ROLE.ADMIN.value],
+            allow_creator=False,
+        )
+        if not (is_project_admin or issue_attachment.created_by_id == request.user.id):
             return Response(
                 {"error": "You are not allowed to delete this attachment"},
                 status=status.HTTP_403_FORBIDDEN,
             )
 
-        issue_attachment = FileAsset.objects.get(pk=pk, workspace__slug=slug, project_id=project_id)
         issue_attachment.is_deleted = True
         issue_attachment.deleted_at = timezone.now()
         issue_attachment.save()
@@ -2163,8 +2176,16 @@ class IssueAttachmentDetailAPIEndpoint(BaseAPIView):
                 status=status.HTTP_403_FORBIDDEN,
             )
 
-        # Get the asset
-        asset = FileAsset.objects.get(id=pk, workspace__slug=slug, project_id=project_id)
+        # Bind to the URL work item and entity type: scoped to the project alone,
+        # this route issued a presigned URL for any asset in it, page and comment
+        # images included.
+        asset = FileAsset.objects.get(
+            id=pk,
+            workspace__slug=slug,
+            project_id=project_id,
+            issue_id=issue_id,
+            entity_type=FileAsset.EntityTypeContext.ISSUE_ATTACHMENT,
+        )
 
         # Check if the asset is uploaded
         if not asset.is_uploaded:
@@ -2228,7 +2249,14 @@ class IssueAttachmentDetailAPIEndpoint(BaseAPIView):
                 status=status.HTTP_403_FORBIDDEN,
             )
 
-        issue_attachment = FileAsset.objects.get(pk=pk, workspace__slug=slug, project_id=project_id)
+        # Bound as in the delete and retrieve handlers above.
+        issue_attachment = FileAsset.objects.get(
+            pk=pk,
+            workspace__slug=slug,
+            project_id=project_id,
+            issue_id=issue_id,
+            entity_type=FileAsset.EntityTypeContext.ISSUE_ATTACHMENT,
+        )
         serializer = IssueAttachmentSerializer(issue_attachment)
 
         # Send this activity only if the attachment is not uploaded before
@@ -2245,9 +2273,10 @@ class IssueAttachmentDetailAPIEndpoint(BaseAPIView):
                 origin=base_host(request=request, is_app=True),
             )
 
-            # Update the attachment
+            # created_by is deliberately not reassigned: confirming an upload is
+            # not authorship, and rewriting it would hand the caller the
+            # creator-based delete right on someone else's attachment.
             issue_attachment.is_uploaded = True
-            issue_attachment.created_by = request.user
 
         # Get the storage metadata
         if not issue_attachment.storage_metadata:

--- a/apps/api/plane/api/views/issue.py
+++ b/apps/api/plane/api/views/issue.py
@@ -1602,6 +1602,17 @@ class IssueCommentDetailAPIEndpoint(BaseAPIView):
         Validates external ID uniqueness if provided.
         """
         issue_comment = IssueComment.objects.get(workspace__slug=slug, project_id=project_id, issue_id=issue_id, pk=pk)
+        # Only the comment author or a project admin may modify a comment.
+        # ProjectLitePermission alone lets any active member (incl. Guest) reach
+        # here, so enforce the same author/admin rule the app applies
+        # (GHSA-h4p4-mwfg-qh82).
+        if issue_comment.created_by_id != request.user.id and not ProjectMember.objects.filter(
+            project_id=project_id, member_id=request.user.id, role=ROLE.ADMIN.value, is_active=True
+        ).exists():
+            return Response(
+                {"error": "Only the comment author or a project admin can modify this comment."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
         requested_data = json.dumps(self.request.data, cls=DjangoJSONEncoder)
         current_instance = json.dumps(IssueCommentSerializer(issue_comment).data, cls=DjangoJSONEncoder)
 
@@ -1671,6 +1682,15 @@ class IssueCommentDetailAPIEndpoint(BaseAPIView):
         Records deletion activity for audit purposes.
         """
         issue_comment = IssueComment.objects.get(workspace__slug=slug, project_id=project_id, issue_id=issue_id, pk=pk)
+        # Only the comment author or a project admin may delete a comment
+        # (GHSA-h4p4-mwfg-qh82).
+        if issue_comment.created_by_id != request.user.id and not ProjectMember.objects.filter(
+            project_id=project_id, member_id=request.user.id, role=ROLE.ADMIN.value, is_active=True
+        ).exists():
+            return Response(
+                {"error": "Only the comment author or a project admin can delete this comment."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
         current_instance = json.dumps(IssueCommentSerializer(issue_comment).data, cls=DjangoJSONEncoder)
         issue_comment.delete()
         issue_activity.delay(
@@ -2002,6 +2022,23 @@ class IssueAttachmentListCreateAPIEndpoint(BaseAPIView):
 
         List all attachments for an issue.
         """
+        # This endpoint has no permission_classes beyond IsAuthenticated, and API
+        # tokens authenticate globally (not workspace-scoped), so enforce project
+        # membership on the issue the same way post() does — otherwise any token
+        # holder could read any issue's attachment metadata cross-tenant
+        # (GHSA-xvc5-m5jf-gvpj).
+        issue = Issue.objects.get(pk=issue_id, workspace__slug=slug, project_id=project_id)
+        if not user_has_issue_permission(
+            request.user.id,
+            project_id=project_id,
+            issue=issue,
+            allowed_roles=[ROLE.ADMIN.value, ROLE.MEMBER.value, ROLE.GUEST.value],
+            allow_creator=True,
+        ):
+            return Response(
+                {"error": "You are not allowed to view these attachments"},
+                status=status.HTTP_403_FORBIDDEN,
+            )
         # Get all the attachments
         issue_attachments = FileAsset.objects.filter(
             issue_id=issue_id,

--- a/apps/api/plane/tests/contract/api/test_external_api_issue_authz.py
+++ b/apps/api/plane/tests/contract/api/test_external_api_issue_authz.py
@@ -1,0 +1,184 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Contract tests for external-API issue comment + attachment authorization.
+
+Regression coverage for:
+
+* GHSA-h4p4-mwfg-qh82 — ``IssueCommentDetailAPIEndpoint`` (``ProjectLitePermission``,
+  any active member) edited/deleted comments by id with no author/admin check, so
+  a Guest could tamper with anyone's comments.
+* GHSA-xvc5-m5jf-gvpj — ``IssueAttachmentListCreateAPIEndpoint.get`` had no
+  ``permission_classes`` (bare ``IsAuthenticated``) and no membership check, so any
+  API-token holder could list any issue's attachment metadata cross-tenant.
+
+The fixes: comment patch/delete require the comment author or a project admin;
+the attachment GET enforces project membership on the issue (mirroring ``post``).
+"""
+
+from uuid import uuid4
+
+import pytest
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from plane.db.models import (
+    APIToken,
+    FileAsset,
+    Issue,
+    IssueComment,
+    Project,
+    ProjectMember,
+    User,
+    WorkspaceMember,
+)
+
+COMMENT_URL = "/api/v1/workspaces/{slug}/projects/{project_id}/issues/{issue_id}/comments/{pk}/"
+ATTACH_URL = "/api/v1/workspaces/{slug}/projects/{project_id}/issues/{issue_id}/issue-attachments/"
+
+
+def _user(prefix):
+    unique = uuid4().hex[:8]
+    user = User.objects.create(email=f"{prefix}-{unique}@plane.so", username=f"{prefix}_{unique}")
+    user.set_password("test-password")
+    user.save()
+    return user
+
+
+def _token_client(user):
+    token = APIToken.objects.create(user=user, label=f"tok-{uuid4().hex[:6]}", token=f"tok-{uuid4().hex}")
+    client = APIClient()
+    client.credentials(HTTP_X_API_KEY=token.token)
+    return client
+
+
+@pytest.fixture
+def project(db, workspace, create_user):
+    project = Project.objects.create(
+        name="Ext API Project", identifier="EA", workspace=workspace, created_by=create_user
+    )
+    # create_user is the project ADMIN
+    ProjectMember.objects.create(project=project, member=create_user, workspace=workspace, role=20, is_active=True)
+    return project
+
+
+def _project_member(workspace, project, *, role):
+    user = _user(f"role{role}")
+    WorkspaceMember.objects.create(workspace=workspace, member=user, role=role, is_active=True)
+    ProjectMember.objects.create(project=project, member=user, workspace=workspace, role=role, is_active=True)
+    return user
+
+
+@pytest.fixture
+def issue(db, workspace, project, create_user):
+    issue = Issue(name="Issue", project=project, workspace=workspace)
+    issue.save(created_by_id=create_user.id)
+    return issue
+
+
+# --- h4p4: comment tamper -----------------------------------------------------
+
+
+@pytest.fixture
+def author(db, workspace, project):
+    return _project_member(workspace, project, role=15)
+
+
+@pytest.fixture
+def comment(db, workspace, project, issue, author):
+    c = IssueComment(
+        workspace=workspace, project=project, issue=issue, comment_html="<p>original</p>", actor=author
+    )
+    c.save(created_by_id=author.id)
+    return c
+
+
+@pytest.mark.contract
+@pytest.mark.django_db
+class TestExternalApiCommentAuthz:
+    """A Guest / non-author must not edit or delete another user's comment."""
+
+    def test_guest_cannot_patch_comment(self, workspace, project, issue, comment):
+        guest = _project_member(workspace, project, role=5)
+        response = _token_client(guest).patch(
+            COMMENT_URL.format(slug=workspace.slug, project_id=project.id, issue_id=issue.id, pk=comment.id),
+            {"comment_html": "<p>tampered</p>"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_403_FORBIDDEN, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+        comment.refresh_from_db()
+        assert comment.comment_html == "<p>original</p>"
+
+    def test_guest_cannot_delete_comment(self, workspace, project, issue, comment):
+        guest = _project_member(workspace, project, role=5)
+        response = _token_client(guest).delete(
+            COMMENT_URL.format(slug=workspace.slug, project_id=project.id, issue_id=issue.id, pk=comment.id)
+        )
+        assert response.status_code == status.HTTP_403_FORBIDDEN, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+        assert IssueComment.objects.filter(pk=comment.id).exists()
+
+    def test_author_can_patch_own_comment(self, workspace, project, issue, comment, author):
+        response = _token_client(author).patch(
+            COMMENT_URL.format(slug=workspace.slug, project_id=project.id, issue_id=issue.id, pk=comment.id),
+            {"comment_html": "<p>edited by author</p>"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_200_OK, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+
+    def test_admin_can_delete_comment(self, workspace, project, issue, comment, create_user):
+        """Positive control: a project admin may delete another user's comment."""
+        response = _token_client(create_user).delete(
+            COMMENT_URL.format(slug=workspace.slug, project_id=project.id, issue_id=issue.id, pk=comment.id)
+        )
+        assert response.status_code == status.HTTP_204_NO_CONTENT, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+
+
+# --- xvc5: attachment metadata disclosure -------------------------------------
+
+
+@pytest.fixture
+def attachment(db, workspace, project, issue):
+    return FileAsset.objects.create(
+        attributes={"name": "secret.pdf", "type": "application/pdf", "size": 100},
+        asset=f"{workspace.id}/{uuid4().hex}-secret.pdf",
+        size=100,
+        workspace=workspace,
+        project=project,
+        issue_id=issue.id,
+        entity_type=FileAsset.EntityTypeContext.ISSUE_ATTACHMENT,
+        is_uploaded=True,
+    )
+
+
+@pytest.mark.contract
+@pytest.mark.django_db
+class TestExternalApiAttachmentAuthz:
+    """A token holder with no project membership must not read attachment metadata."""
+
+    def test_outsider_cannot_list_attachments(self, workspace, project, issue, attachment):
+        outsider = _user("outsider")  # valid token, NO membership anywhere
+        response = _token_client(outsider).get(
+            ATTACH_URL.format(slug=workspace.slug, project_id=project.id, issue_id=issue.id)
+        )
+        assert response.status_code == status.HTTP_403_FORBIDDEN, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+
+    def test_project_member_can_list_attachments(self, workspace, project, issue, attachment):
+        member = _project_member(workspace, project, role=15)
+        response = _token_client(member).get(
+            ATTACH_URL.format(slug=workspace.slug, project_id=project.id, issue_id=issue.id)
+        )
+        assert response.status_code == status.HTTP_200_OK, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+        assert len(response.data) == 1

--- a/apps/api/plane/tests/contract/api/test_external_api_issue_authz.py
+++ b/apps/api/plane/tests/contract/api/test_external_api_issue_authz.py
@@ -6,10 +6,10 @@
 
 Regression coverage for:
 
-* GHSA-h4p4-mwfg-qh82 — ``IssueCommentDetailAPIEndpoint`` (``ProjectLitePermission``,
+* comment tamper — ``IssueCommentDetailAPIEndpoint`` (``ProjectLitePermission``,
   any active member) edited/deleted comments by id with no author/admin check, so
   a Guest could tamper with anyone's comments.
-* GHSA-xvc5-m5jf-gvpj — ``IssueAttachmentListCreateAPIEndpoint.get`` had no
+* attachment leak — ``IssueAttachmentListCreateAPIEndpoint.get`` had no
   ``permission_classes`` (bare ``IsAuthenticated``) and no membership check, so any
   API-token holder could list any issue's attachment metadata cross-tenant.
 

--- a/apps/api/plane/tests/contract/api/test_external_api_issue_authz.py
+++ b/apps/api/plane/tests/contract/api/test_external_api_issue_authz.py
@@ -182,3 +182,170 @@ class TestExternalApiAttachmentAuthz:
             f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
         )
         assert len(response.data) == 1
+
+
+# --- attachment object binding + ownership transfer ---------------------------
+
+ATTACH_DETAIL_URL = "/api/v1/workspaces/{slug}/projects/{project_id}/issues/{issue_id}/issue-attachments/{pk}/"
+
+
+@pytest.fixture
+def other_issue(db, workspace, project, create_user):
+    """A second work item in the same project, which the attachment does NOT belong to."""
+    issue = Issue(name="Other Issue", project=project, workspace=workspace)
+    issue.save(created_by_id=create_user.id)
+    return issue
+
+
+@pytest.fixture
+def page_image(db, workspace, project, create_user):
+    """A page inline image: same project, no issue, a different entity type."""
+    return FileAsset.objects.create(
+        attributes={"name": "diagram.png", "type": "image/png", "size": 100},
+        asset=f"{workspace.id}/{uuid4().hex}-diagram.png",
+        size=100,
+        workspace=workspace,
+        project=project,
+        created_by=create_user,
+        entity_type=FileAsset.EntityTypeContext.PAGE_DESCRIPTION,
+        is_uploaded=True,
+    )
+
+
+@pytest.mark.contract
+@pytest.mark.django_db
+class TestExternalApiAttachmentObjectBinding:
+    """The permission is checked against the URL work item; the object must match it.
+
+    Resolved by project alone, any asset in it came back -- page and comment
+    images included -- so naming a work item you may act on reached all of them.
+    """
+
+    def test_admin_cannot_delete_attachment_through_a_different_work_item(
+        self, workspace, project, issue, other_issue, attachment, create_user
+    ):
+        # Admin, so the 404 is attributable to the binding, not the role check.
+        response = _token_client(create_user).delete(
+            ATTACH_DETAIL_URL.format(
+                slug=workspace.slug, project_id=project.id, issue_id=other_issue.id, pk=attachment.id
+            )
+        )
+        assert response.status_code == status.HTTP_404_NOT_FOUND, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+        attachment.refresh_from_db()
+        assert attachment.is_deleted is False, "an attachment of another work item was destroyed"
+
+    def test_member_cannot_read_attachment_through_a_different_work_item(
+        self, workspace, project, issue, other_issue, attachment
+    ):
+        # Retrieve is open to any project member, so a member is the right caller.
+        member = _project_member(workspace, project, role=15)
+        response = _token_client(member).get(
+            ATTACH_DETAIL_URL.format(
+                slug=workspace.slug, project_id=project.id, issue_id=other_issue.id, pk=attachment.id
+            )
+        )
+        assert response.status_code == status.HTTP_404_NOT_FOUND, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+
+    def test_page_image_is_not_reachable_through_the_attachment_route(
+        self, workspace, project, issue, page_image, create_user
+    ):
+        """The cross-entity half: a page's inline image is not a work item attachment."""
+        # Admin again, so the refusal is the entity_type binding and not the role.
+        response = _token_client(create_user).delete(
+            ATTACH_DETAIL_URL.format(
+                slug=workspace.slug, project_id=project.id, issue_id=issue.id, pk=page_image.id
+            )
+        )
+        assert response.status_code == status.HTTP_404_NOT_FOUND, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+        page_image.refresh_from_db()
+        assert page_image.is_deleted is False, "a page image was destroyed through the attachment route"
+
+    def test_admin_can_delete_a_correctly_bound_attachment(
+        self, workspace, project, issue, attachment, create_user
+    ):
+        """Positive control: the binding must not break the legitimate path."""
+        response = _token_client(create_user).delete(
+            ATTACH_DETAIL_URL.format(
+                slug=workspace.slug, project_id=project.id, issue_id=issue.id, pk=attachment.id
+            )
+        )
+        assert response.status_code == status.HTTP_204_NO_CONTENT, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+        attachment.refresh_from_db()
+        assert attachment.is_deleted is True
+
+
+@pytest.mark.contract
+@pytest.mark.django_db
+class TestExternalApiAttachmentDeleteRole:
+    """Delete is admin-or-uploader, matching the app surface.
+
+    Listing every role made the filter a no-op, reducing it to any active project
+    member while the handler's own comment claimed "creator or admin".
+    """
+
+    def test_member_who_did_not_upload_cannot_delete(self, workspace, project, issue, attachment):
+        member = _project_member(workspace, project, role=15)
+        response = _token_client(member).delete(
+            ATTACH_DETAIL_URL.format(
+                slug=workspace.slug, project_id=project.id, issue_id=issue.id, pk=attachment.id
+            )
+        )
+        assert response.status_code == status.HTTP_403_FORBIDDEN, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+        attachment.refresh_from_db()
+        assert attachment.is_deleted is False
+
+    def test_uploader_can_delete_own_attachment(self, workspace, project, issue, attachment):
+        uploader = _project_member(workspace, project, role=15)
+        # A queryset update, not save(): BaseModel.save() nulls created_by when no
+        # request is in scope, which is the case in a test.
+        FileAsset.objects.filter(pk=attachment.id).update(created_by=uploader)
+
+        response = _token_client(uploader).delete(
+            ATTACH_DETAIL_URL.format(
+                slug=workspace.slug, project_id=project.id, issue_id=issue.id, pk=attachment.id
+            )
+        )
+        assert response.status_code == status.HTTP_204_NO_CONTENT, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+
+
+@pytest.mark.contract
+@pytest.mark.django_db
+class TestExternalApiAttachmentOwnershipTransfer:
+    """Confirming an upload must not rewrite created_by.
+
+    Whoever confirmed became the recorded uploader, and delete grants the creator
+    a delete right -- so the reassignment handed over someone else's attachment.
+    """
+
+    def test_patch_does_not_transfer_ownership(self, workspace, project, issue, attachment, create_user):
+        # See above: set ownership through the queryset so save() cannot clear it.
+        FileAsset.objects.filter(pk=attachment.id).update(is_uploaded=False, created_by=create_user)
+        attachment.refresh_from_db()
+
+        member = _project_member(workspace, project, role=15)
+        response = _token_client(member).patch(
+            ATTACH_DETAIL_URL.format(
+                slug=workspace.slug, project_id=project.id, issue_id=issue.id, pk=attachment.id
+            ),
+            {"is_uploaded": True},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+        attachment.refresh_from_db()
+        assert attachment.is_uploaded is True, "the upload confirmation itself must still work"
+        assert attachment.created_by_id == create_user.id, "created_by was transferred to the caller"


### PR DESCRIPTION
## Summary
Two authorization gaps in the **external API** (`apps/api/plane/api/views/issue.py`), both confirmed vulnerable against `origin/preview` @ `a8e53b6ac7`:

### Comment tampering (WEB-8382)
`IssueCommentDetailAPIEndpoint` is guarded by `ProjectLitePermission` (any active project member, incl. Guest) and edited/deleted comments by id with **no author/admin check**. A Guest could modify or delete any other user's comments — including an admin's. The web app restricts this to the comment's creator or a project admin; the external API dropped both checks.

### Cross-tenant attachment metadata disclosure (WEB-8383)
`IssueAttachmentListCreateAPIEndpoint.get` sets **no `permission_classes`** (inherits bare `IsAuthenticated`) and does **no membership check**, while its `post` calls `user_has_issue_permission`. Because API tokens authenticate globally (not workspace-scoped), any token holder could list **any** issue's attachment metadata (filenames, sizes, S3 keys, uploader) across tenants.

## Fix
- **Comment** `patch`/`delete`: require `created_by == request.user` **or** project admin (`ProjectMember role=ADMIN`), else 403.
- **Attachment** `get`: load the issue scoped to the URL workspace/project and enforce `user_has_issue_permission([ADMIN, MEMBER, GUEST], allow_creator=True)`, mirroring `post`.

## Tests
`tests/contract/api/test_external_api_issue_authz.py` — 6 tests: guest cannot patch/delete a comment (403, unchanged), author can patch own + admin can delete (positive); outsider (token, no membership) cannot list attachments (403), project member can (positive). **Fail-before verified**; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted issue comment updates and deletions to comment authors or active project administrators.
  * Prevented unauthorized access to attachment metadata and content across projects or issues.
  * Limited attachment deletion to uploaders or project administrators.
  * Preserved the original uploader when confirming an attachment upload.
  * Prevented unauthorized relational data access through issue list sorting.
  * Added clear permission-denied responses and updated API documentation.

* **Tests**
  * Added coverage for comment and attachment authorization, object binding, cross-issue access, and uploader ownership.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
