### PR TITLE
fix: resolve React Doctor errors and restore its PR baseline

### DIFF
--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -53,6 +53,10 @@ jobs:
           # has no merge base, which makes it fall back to listing every
           # pre-existing issue in every changed file.
           fetch-depth: 0
+          # Don't leave the workflow token in .git/config for the third-party
+          # action that runs next. fetch-depth: 0 has already fetched every ref
+          # it needs, and it talks to the API through its own credentials.
+          persist-credentials: false
 
       - uses: millionco/react-doctor@v2
         # Common configuration knobs — uncomment any to override the default.

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -9,13 +9,13 @@ name: React Doctor
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-  # Scans `main` on every push so you get a health-score trend on the
+  # Scans `preview` on every push so you get a health-score trend on the
   # default branch — useful for tracking the overall number commit-by-commit
   # and catching regressions that slipped past PR review. PR-specific steps
   # (the sticky summary comment) are skipped automatically on `push` events.
   # Comment this block out if you only want PR-time scans.
   push:
-    branches: [main]
+    branches: [preview]
 
 permissions:
   # `actions/checkout` needs this to read the repo source.
@@ -47,6 +47,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          # React Doctor diffs the changed files against the merge base so it
+          # only reports what the PR introduces. The default shallow checkout
+          # has no merge base, which makes it fall back to listing every
+          # pre-existing issue in every changed file.
+          fetch-depth: 0
 
       - uses: millionco/react-doctor@v2
         # Common configuration knobs — uncomment any to override the default.

--- a/apps/web/core/components/estimates/points/preview.tsx
+++ b/apps/web/core/components/estimates/points/preview.tsx
@@ -53,8 +53,15 @@ export const EstimatePointItemPreview = observer(function EstimatePointItemPrevi
   const EstimatePointValueRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (!estimatePointEditToggle && !estimatePointDeleteToggle)
-      EstimatePointValueRef?.current?.addEventListener("dblclick", () => setEstimatePointEditToggle(true));
+    const estimatePointValueElement = EstimatePointValueRef.current;
+    if (!estimatePointValueElement || estimatePointEditToggle || estimatePointDeleteToggle) return;
+
+    const handleDoubleClick = () => setEstimatePointEditToggle(true);
+    estimatePointValueElement.addEventListener("dblclick", handleDoubleClick);
+
+    return () => {
+      estimatePointValueElement.removeEventListener("dblclick", handleDoubleClick);
+    };
   }, [estimatePointDeleteToggle, estimatePointEditToggle]);
 
   return (

--- a/apps/web/core/components/issues/header.tsx
+++ b/apps/web/core/components/issues/header.tsx
@@ -55,7 +55,9 @@ export const IssuesHeader = observer(function IssuesHeader() {
   const { allowPermissions } = useUserPermissions();
   const { isMobile } = usePlatformOS();
 
-  const SPACE_APP_URL = (SPACE_BASE_URL.trim() === "" ? window.location.origin : SPACE_BASE_URL) + SPACE_BASE_PATH;
+  const SPACE_APP_URL =
+    (SPACE_BASE_URL.trim() === "" && typeof window !== "undefined" ? window.location.origin : SPACE_BASE_URL) +
+    SPACE_BASE_PATH;
   const publishedURL = `${SPACE_APP_URL}/issues/${currentProjectDetails?.anchor}`;
 
   const issuesCount = getGroupIssueCount(undefined, undefined, false);

--- a/apps/web/core/components/issues/issue-layouts/calendar/issue-block.tsx
+++ b/apps/web/core/components/issues/issue-layouts/calendar/issue-block.tsx
@@ -59,7 +59,7 @@ export const CalendarIssueBlock = observer(
 
     // handlers
     const handleIssuePeekOverview = (peekIssue: TIssue) =>
-      handleRedirection(workspaceSlug.toString(), peekIssue, isMobile);
+      handleRedirection(workspaceSlug?.toString(), peekIssue, isMobile);
 
     useOutsideClickDetector(menuActionRef, () => setIsMenuActive(false));
 

--- a/apps/web/core/components/issues/issue-layouts/calendar/issue-block.tsx
+++ b/apps/web/core/components/issues/issue-layouts/calendar/issue-block.tsx
@@ -58,12 +58,16 @@ export const CalendarIssueBlock = observer(
     const projectIdentifier = getProjectIdentifierById(issue?.project_id);
 
     // handlers
-    const handleIssuePeekOverview = (issue: TIssue) => handleRedirection(workspaceSlug.toString(), issue, isMobile);
+    const handleIssuePeekOverview = (peekIssue: TIssue) =>
+      handleRedirection(workspaceSlug.toString(), peekIssue, isMobile);
 
     useOutsideClickDetector(menuActionRef, () => setIsMenuActive(false));
 
     const customActionButton = (
+      // CustomMenu renders this inside its own <button>, which already carries the
+      // interactive semantics and keyboard handling — this div is presentational.
       <div
+        role="presentation"
         ref={menuActionRef}
         className={`w-full cursor-pointer rounded-sm p-1 text-placeholder hover:bg-layer-1 ${
           isMenuActive ? "bg-layer-1-active text-primary" : "text-secondary"
@@ -75,7 +79,9 @@ export const CalendarIssueBlock = observer(
     );
 
     const isMenuActionRefAboveScreenBottom =
-      menuActionRef?.current && menuActionRef?.current?.getBoundingClientRect().bottom < window.innerHeight - 220;
+      typeof window !== "undefined" &&
+      menuActionRef?.current &&
+      menuActionRef?.current?.getBoundingClientRect().bottom < window.innerHeight - 220;
 
     const placement = isMenuActionRefAboveScreenBottom ? "bottom-end" : "top-end";
 
@@ -136,7 +142,10 @@ export const CalendarIssueBlock = observer(
                     )}
                     <div className="truncate text-13 font-medium md:text-11 md:font-regular">{issue.name}</div>
                   </div>
+                  {/* Wrapper exists only to stop clicks reaching the ControlLink; the
+                      quick-action menu inside carries its own interactive semantics. */}
                   <div
+                    role="presentation"
                     className={cn("size-5 flex-shrink-0", {
                       "hidden group-hover/calendar-block:block": !isMobile,
                       block: isMenuActive,

--- a/apps/web/core/components/pages/editor/editor-body.tsx
+++ b/apps/web/core/components/pages/editor/editor-body.tsx
@@ -44,7 +44,7 @@ import type { TPageInstance } from "@/store/pages/base-page";
 import { PageContentLoader } from "../loaders/page-content-loader";
 import { PageEditorHeaderRoot } from "./header";
 import { PageContentBrowser } from "./summary";
-import { EditorAIMenu } from "./ai";
+import { EditorAIMenu } from "./ai/menu";
 
 export type TEditorBodyConfig = {
   fileHandler: TFileHandler;

--- a/apps/web/core/components/pages/editor/editor-body.tsx
+++ b/apps/web/core/components/pages/editor/editor-body.tsx
@@ -188,6 +188,11 @@ export const PageEditorBody = observer(function PageEditorBody(props: Props) {
   );
 
   const realtimeConfig: TRealtimeConfig | undefined = useMemo(() => {
+    // The collaboration URL is derived from window.location, so it can only be
+    // built on the client. There is no socket to connect to during SSR anyway —
+    // the config is recomputed on hydration.
+    if (typeof window === "undefined") return undefined;
+
     // Construct the WebSocket Collaboration URL
     try {
       const LIVE_SERVER_BASE_URL = LIVE_BASE_URL?.trim() || window.location.origin;

--- a/apps/web/core/hooks/use-keypress.tsx
+++ b/apps/web/core/hooks/use-keypress.tsx
@@ -4,13 +4,21 @@
  * See the LICENSE file for details.
  */
 
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
 const useKeypress = (key: string, callback: (event: KeyboardEvent) => void) => {
+  // Keep the latest callback in a ref so callers can pass an inline arrow
+  // without tearing down and re-adding the document listener every render.
+  const callbackRef = useRef(callback);
+
+  useEffect(() => {
+    callbackRef.current = callback;
+  }, [callback]);
+
   useEffect(() => {
     const handleKeydown = (event: KeyboardEvent) => {
       if (event.key === key) {
-        callback(event);
+        callbackRef.current(event);
       }
     };
 
@@ -19,7 +27,7 @@ const useKeypress = (key: string, callback: (event: KeyboardEvent) => void) => {
     return () => {
       document.removeEventListener("keydown", handleKeydown);
     };
-  }, [key, callback]);
+  }, [key]);
 };
 
 export default useKeypress;


### PR DESCRIPTION
### Description

Resolves the React Doctor findings reported on the v1.4.0 release PR (#9160), where the check surfaced **266 issues across 130 files** (7 errors, 259 warnings, score 67/100).

**Most of that count is a reporting artifact, not new debt.** React Doctor diffs changed files against the merge base so it only reports what a PR introduces. The workflow's `actions/checkout` step used the default shallow clone, so there was no merge base to diff against and the action fell back to listing *every* pre-existing issue in *every* changed file. On a release PR touching ~130 files, that means it reported the accumulated backlog of the whole web app. The action said so itself in a collapsed warning at the bottom of its comment.

Two workflow fixes and the seven genuine errors:

#### `.github/workflows/react-doctor.yml`

- Added `fetch-depth: 0` to the checkout step so the merge-base comparison works and future PRs only see what they actually introduce.
- Changed the `push` trigger from `main` to `preview`. This repo's default branch is `preview`; there is no `main`, so the health-score trend on the default branch has never run.

#### `core/hooks/use-keypress.tsx` — 2 errors, fixed at the source

`callback` sat in the effect's dependency array, but all 10 call sites pass an inline arrow or an unmemoized function. The document `keydown` listener was therefore removed and re-added on every single render of every modal using it. The callback is now latched in a ref and the subscription keys on `key` alone.

This clears `no-effect-with-fresh-deps` at both reported sites — `inbox/modals/create-modal/create-root.tsx:102` and `project/create-project-modal.tsx:64` — without touching either call site, and removes the same churn from the other eight callers.

#### `core/components/estimates/points/preview.tsx` — `effect-needs-cleanup`

The `dblclick` listener was attached with no cleanup, so a fresh anonymous listener accumulated on the same element every time the edit/delete toggles changed. Added the matching `removeEventListener` and hoisted the handler so add and remove reference the same function.

#### Three unguarded browser globals read during render

`issues/header.tsx:58`, `issue-layouts/calendar/issue-block.tsx:78`, and `pages/editor/editor-body.tsx:193,195` read `window.location` / `window.innerHeight` during render. Guarded with `typeof window !== "undefined"`, matching the pattern already used in `issue-detail-quick-actions.tsx`, `workspace-details.tsx`, and the admin auth forms.

To be precise about the impact: `apps/web` sets `ssr: false` in `react-router.config.ts` and ships a client-only bundle, so none of these ever executed on a server and none of them were failing today. The guards satisfy the React Doctor rule and make the components safe to render server-side if that ever changes; they are defensive, not a live bug fix.

### CodeRabbit review

Applied two of four findings:

- **`persist-credentials: false` on checkout** (major). The token otherwise stays in `.git/config` for the third-party `millionco/react-doctor` step that runs next. `fetch-depth: 0` has already fetched every ref the merge-base diff needs and the action authenticates to the API through its own credentials, so nothing depends on the persisted git credential.
- **`workspaceSlug?.toString()`** in `calendar/issue-block`. The parameter is typed `string | undefined` and line 89 of the same file already optional-chains it, so this call site would have thrown on a missing route param.

Declined the two SSR/hydration findings — both are premised on the app server-rendering. It does not: `ssr: false`, client-only bundle, no server render for the first client render to diverge from. Deferring `realtimeConfig` behind a post-mount state flag as suggested would add a render cycle and delay the collaboration socket to fix a mismatch that cannot occur.

#### `issue-layouts/calendar/issue-block.tsx` — pre-existing lint warnings

The repo's `--deny-warnings` pre-commit gate blocks on five warnings that already existed in this file once it is touched. Cleared them: renamed a shadowed `issue` parameter, and marked two wrapper `<div>`s `role="presentation"`. Neither is the interactive element — `CustomMenu` renders the first inside its own `<button type="button">` (`packages/ui/src/dropdowns/custom-menu.tsx:251`), and the second exists only to stop click propagation reaching the surrounding `ControlLink`.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Test Scenarios

- `pnpm turbo run check:types --filter=web` — 11/11 tasks pass.
- `pnpm exec oxlint --deny-warnings` on all changed files — 0 warnings, 0 errors.
- Workflow YAML parses and resolves to the intended structure: `push.branches: ["preview"]`, checkout step `{uses: actions/checkout@v5, with: {fetch-depth: 0}}`.
- The `fetch-depth` change verifies itself: React Doctor's run on this PR should report only this diff rather than the whole backlog.

Not covered by automated checks — worth a look during review:

- Escape-to-close still works on the modals using `useKeypress` (project create, cycle, module, view, webhook, inbox create, issue peek, quick-add).
- The calendar work-item quick-action menu still opens, positions, and closes on outside click.

### References

- Release PR where the check ran: #9160
- The three CodeQL alerts on that same PR are **not** included here — they are already fixed by #9457, which is open against `preview`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved double-click editing for estimate points and prevented stale interactions.
  * Fixed calendar quick actions so clicks don’t unintentionally open the issue.
  * Improved issue page linking and URL building in different browser environments.
  * Prevented server-side rendering errors in the page editor’s AI/realtime setup.
  * Enhanced keyboard shortcut responsiveness across the app.
  * Improved calendar popover positioning and issue preview navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->