### PR TITLE
[INFRA-461] chore: bump nginx to 1.31-alpine in web and admin Dockerfiles

### DIFF
--- a/apps/admin/Dockerfile.admin
+++ b/apps/admin/Dockerfile.admin
@@ -75,7 +75,7 @@ RUN pnpm turbo run build --filter=admin
 
 # =========================================================================== #
 
-FROM nginx:1.29-alpine AS production
+FROM nginx:1.31-alpine AS production
 
 RUN apk update && apk upgrade --no-cache && rm -rf /var/cache/apk/*
 

--- a/apps/web/Dockerfile.web
+++ b/apps/web/Dockerfile.web
@@ -75,7 +75,7 @@ RUN pnpm turbo run build --filter=web
 # *****************************************************************************
 # STAGE 3: Serve with nginx
 # *****************************************************************************
-FROM nginx:1.29-alpine AS production
+FROM nginx:1.31-alpine AS production
 
 RUN apk update && apk upgrade --no-cache && rm -rf /var/cache/apk/*
 


### PR DESCRIPTION
### Description

Bumps the nginx base image from `1.29-alpine` to `1.31-alpine` in the production stage of the web and admin Dockerfiles.

- `apps/web/Dockerfile.web`
- `apps/admin/Dockerfile.admin`

`nginx:1.31-alpine` is confirmed to exist on Docker Hub.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [x] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)

<!-- Add screenshots here -->

### Test Scenarios

- Build the `web` and `admin` Docker images and verify they start correctly with `nginx:1.31-alpine`.
- Confirm nginx serves the app as expected on the expected ports.

### References

<!-- No linked issues -->

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the production web and admin server images to use a newer Nginx Alpine release.
  * Existing build and serving behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->