### PR TITLE
fix: handle empty EMAIL_PORT in test-email endpoint (HTTP 500 → 400)

### DIFF
--- a/apps/api/plane/license/api/views/configuration.py
+++ b/apps/api/plane/license/api/views/configuration.py
@@ -104,10 +104,24 @@ class EmailCredentialCheckEndpoint(BaseAPIView):
             EMAIL_FROM,
         ) = get_email_configuration()
 
+        # Guard: EMAIL_PORT may be an empty string when SMTP settings have not
+        # been saved yet (fresh install with SKIP_ENV_VAR=True). Attempting
+        # int("") raises an unhandled ValueError → HTTP 500 (Issue #9472).
+        try:
+            smtp_port = int(EMAIL_PORT)
+        except (ValueError, TypeError):
+            return Response(
+                {
+                    "error": "Email port is not configured. "
+                    "Please save your email settings before sending a test email."
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
         # Configure all the connections
         connection = get_connection(
             host=EMAIL_HOST,
-            port=int(EMAIL_PORT),
+            port=smtp_port,
             username=EMAIL_HOST_USER,
             password=EMAIL_HOST_PASSWORD,
             use_tls=EMAIL_USE_TLS == "1",

--- a/apps/api/tests/test_email_credential_check.py
+++ b/apps/api/tests/test_email_credential_check.py
@@ -1,0 +1,81 @@
+"""
+Regression tests for EmailCredentialCheckEndpoint (Issue #9472).
+
+When EMAIL_PORT is an empty string (SMTP settings not yet saved on a fresh
+Plane install with SKIP_ENV_VAR=True), int("") raised an unhandled
+ValueError that propagated as HTTP 500.  These tests verify the endpoint
+returns HTTP 400 with a descriptive error message instead.
+"""
+import pytest
+from unittest.mock import patch
+from rest_framework.test import APIRequestFactory
+from rest_framework import status
+
+
+@pytest.mark.unit
+class TestEmailCredentialCheckEmptyPort:
+    """Guards around invalid EMAIL_PORT values (Issue #9472)."""
+
+    def setup_method(self):
+        from plane.license.api.views.configuration import EmailCredentialCheckEndpoint
+
+        self.factory = APIRequestFactory()
+        self.view = EmailCredentialCheckEndpoint.as_view()
+
+    def _make_config(self, port):
+        """Return a get_email_configuration()-shaped tuple with *port* as EMAIL_PORT."""
+        return (
+            "smtp.example.com",     # EMAIL_HOST
+            "user@example.com",     # EMAIL_HOST_USER
+            "s3cr3t",               # EMAIL_HOST_PASSWORD
+            port,                   # EMAIL_PORT — value under test
+            "1",                    # EMAIL_USE_TLS
+            "0",                    # EMAIL_USE_SSL
+            "noreply@example.com",  # EMAIL_FROM
+        )
+
+    def _post(self, data):
+        request = self.factory.post(
+            "/api/instances/email-credentials-check/",
+            data,
+            format="json",
+        )
+        return self.view(request)
+
+    # ------------------------------------------------------------------
+    # Regression: empty / None / non-numeric EMAIL_PORT must not 500
+    # ------------------------------------------------------------------
+
+    @patch("plane.license.api.views.configuration.get_email_configuration")
+    def test_returns_400_for_empty_email_port(self, mock_config):
+        """Regression for #9472: int('') must not propagate as HTTP 500."""
+        mock_config.return_value = self._make_config("")
+        response = self._post({"receiver_email": "test@example.com"})
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "error" in response.data
+
+    @patch("plane.license.api.views.configuration.get_email_configuration")
+    def test_returns_400_for_none_email_port(self, mock_config):
+        """EMAIL_PORT of None (missing DB row) must not raise TypeError → HTTP 500."""
+        mock_config.return_value = self._make_config(None)
+        response = self._post({"receiver_email": "test@example.com"})
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "error" in response.data
+
+    @patch("plane.license.api.views.configuration.get_email_configuration")
+    def test_returns_400_for_non_numeric_email_port(self, mock_config):
+        """Non-numeric EMAIL_PORT (corrupt config row) must not cause HTTP 500."""
+        mock_config.return_value = self._make_config("not-a-port")
+        response = self._post({"receiver_email": "test@example.com"})
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "error" in response.data
+
+    # ------------------------------------------------------------------
+    # Pre-existing guard must still pass
+    # ------------------------------------------------------------------
+
+    def test_returns_400_when_receiver_email_is_missing(self):
+        """Pre-existing guard: missing receiver_email still returns 400."""
+        response = self._post({})
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "error" in response.data

--- a/apps/api/tests/test_email_credential_check.py
+++ b/apps/api/tests/test_email_credential_check.py
@@ -53,6 +53,7 @@ class TestEmailCredentialCheckEmptyPort:
         response = self._post({"receiver_email": "test@example.com"})
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert "error" in response.data
+        assert "save your email settings before sending a test email" in response.data["error"].lower()
 
     @patch("plane.license.api.views.configuration.get_email_configuration")
     def test_returns_400_for_none_email_port(self, mock_config):
@@ -61,6 +62,7 @@ class TestEmailCredentialCheckEmptyPort:
         response = self._post({"receiver_email": "test@example.com"})
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert "error" in response.data
+        assert "save your email settings before sending a test email" in response.data["error"].lower()
 
     @patch("plane.license.api.views.configuration.get_email_configuration")
     def test_returns_400_for_non_numeric_email_port(self, mock_config):
@@ -69,6 +71,7 @@ class TestEmailCredentialCheckEmptyPort:
         response = self._post({"receiver_email": "test@example.com"})
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert "error" in response.data
+        assert "save your email settings before sending a test email" in response.data["error"].lower()
 
     # ------------------------------------------------------------------
     # Pre-existing guard must still pass


### PR DESCRIPTION
## Summary

Fixes #9472

### Bug

On a fresh Plane installation with `SKIP_ENV_VAR=True`, the `EMAIL_PORT` row exists in `InstanceConfiguration` with value `""` (empty string) because no SMTP settings have been saved yet.

Clicking **Send Test Email** before saving the form calls `EmailCredentialCheckEndpoint.post()`, which reaches:

```python
connection = get_connection(
    port=int(EMAIL_PORT),   # int("") → ValueError → HTTP 500
    ...
)
```

The unhandled `ValueError` propagates as an opaque HTTP 500, giving the user no indication of what went wrong.

### Root Cause

`get_email_configuration()` reads `EMAIL_PORT` from the DB via `get_configuration_value()`. When `SKIP_ENV_VAR=True` and the row exists with `""`, the function returns `""` instead of falling back to the env-var default (`587`). The call site did not guard against this before attempting `int()`.

### Fix

Wrap the `int(EMAIL_PORT)` conversion in a `try/except (ValueError, TypeError)` block that returns **HTTP 400** with a descriptive message, consistent with every other error branch in this endpoint:

```python
try:
    smtp_port = int(EMAIL_PORT)
except (ValueError, TypeError):
    return Response(
        {
            "error": "Email port is not configured. "
                     "Please save your email settings before sending a test email."
        },
        status=status.HTTP_400_BAD_REQUEST,
    )
```

### Tests

Four pytest unit tests added in `apps/api/tests/test_email_credential_check.py`:

| Test | Scenario |
|---|---|
| `test_returns_400_for_empty_email_port` | `EMAIL_PORT = ""` — the exact regression case |
| `test_returns_400_for_none_email_port` | `EMAIL_PORT = None` — missing DB row |
| `test_returns_400_for_non_numeric_email_port` | `EMAIL_PORT = "not-a-port"` — corrupt value |
| `test_returns_400_when_receiver_email_is_missing` | Pre-existing guard still works |

All tests mock `get_email_configuration` at the call site and assert `HTTP 400` + `"error"` key in the response — no network or DB required.

### Change surface

- `apps/api/plane/license/api/views/configuration.py` — 8-line guard added before `get_connection()`; `port=smtp_port` replaces inline `int()` call
- `apps/api/tests/test_email_credential_check.py` — new regression test file


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Email credential checks now validate the configured email port before attempting an SMTP connection.
  * Invalid or missing port values return a clear HTTP 400 error instead of an internal server error.

* **Tests**
  * Added regression coverage for empty, null, and non-numeric email port configurations.
  * Confirmed requests without a recipient email still return an HTTP 400 with an error message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->