### PR TITLE
[SECUR-242] fix(api): scope bulk-asset associate by uploader, not project_id (regression from #9288)

### DIFF
--- a/apps/api/plane/app/views/asset/v2.py
+++ b/apps/api/plane/app/views/asset/v2.py
@@ -708,8 +708,14 @@ class ProjectBulkAssetEndpoint(BaseAPIView):
         if not asset_ids:
             return Response({"error": "No asset ids provided."}, status=status.HTTP_400_BAD_REQUEST)
 
-        # get the asset id — scope to the project to prevent cross-project IDOR
-        assets = FileAsset.objects.filter(id__in=asset_ids, workspace__slug=slug, project_id=project_id)
+        # Scope to the requester's own uploads in this workspace. This endpoint's job is
+        # to *associate* freshly-uploaded assets with a project/entity, so the assets are
+        # not yet project-scoped at this point (e.g. a cover uploaded during project
+        # creation has project_id=NULL until this call sets it). Filtering by
+        # project_id=project_id here 404s that flow; scoping by created_by still prevents
+        # cross-project/user IDOR (a caller can only touch assets they uploaded, and the
+        # @allow_permission decorator already scopes them to this project).
+        assets = FileAsset.objects.filter(id__in=asset_ids, workspace__slug=slug, created_by=request.user)
 
         # Get the first asset
         asset = assets.first()

--- a/apps/api/plane/app/views/asset/v2.py
+++ b/apps/api/plane/app/views/asset/v2.py
@@ -10,6 +10,7 @@ from django.conf import settings
 from django.http import HttpResponseRedirect
 from django.utils import timezone
 from django.db import IntegrityError
+from django.db.models import Q
 
 # Third party imports
 from rest_framework import status
@@ -708,14 +709,19 @@ class ProjectBulkAssetEndpoint(BaseAPIView):
         if not asset_ids:
             return Response({"error": "No asset ids provided."}, status=status.HTTP_400_BAD_REQUEST)
 
-        # Scope to the requester's own uploads in this workspace. This endpoint's job is
-        # to *associate* freshly-uploaded assets with a project/entity, so the assets are
-        # not yet project-scoped at this point (e.g. a cover uploaded during project
-        # creation has project_id=NULL until this call sets it). Filtering by
-        # project_id=project_id here 404s that flow; scoping by created_by still prevents
-        # cross-project/user IDOR (a caller can only touch assets they uploaded, and the
-        # @allow_permission decorator already scopes them to this project).
-        assets = FileAsset.objects.filter(id__in=asset_ids, workspace__slug=slug, created_by=request.user)
+        # Scope to the requester's own uploads in this workspace, limited to assets that are
+        # either unassociated or already in this project. This endpoint *associates*
+        # freshly-uploaded assets, which are not yet project-scoped (e.g. a cover uploaded
+        # during project creation has project_id=NULL until this call sets it) — so the
+        # earlier project_id=project_id filter 404'd that flow. created_by + the
+        # unassociated-or-same-project bound prevent cross-project/user IDOR (a caller can
+        # only touch their own uploads, cannot move an asset in from another project, and
+        # @allow_permission already scopes them to this project).
+        assets = FileAsset.objects.filter(
+            id__in=asset_ids,
+            workspace__slug=slug,
+            created_by=request.user,
+        ).filter(Q(project_id=project_id) | Q(project_id__isnull=True))
 
         # Get the first asset
         asset = assets.first()


### PR DESCRIPTION
## Problem

**Release-blocking regression in v1.4.0-rc1.** Creating a project from the frontend fails at the "enable features" step:

```
POST /api/assets/v2/workspaces/<slug>/projects/<project_id>/<entity_id>/bulk/
→ 404 {"error": "The requested asset could not be found."}
```

## Root cause

#9288 (WEB-7776, "scope FileAsset queries to prevent cross-project IDOR — Cluster F") added `project_id=project_id` to the lookup in `ProjectBulkAssetEndpoint.post`:

```python
assets = FileAsset.objects.filter(id__in=asset_ids, workspace__slug=slug, project_id=project_id)
```

But this endpoint's job is to **associate** freshly-uploaded assets with a project/entity. A cover/feature asset uploaded during project creation still has `project_id=NULL` at this point — in fact this endpoint is what *sets* it (`assets.update(project_id=project_id)` for `PROJECT_COVER`). Requiring `project_id` to already match means the asset is never found → 404. `master` (v1.3.1) had no such filter, so the flow worked there.

Present in both `preview` and `canary` → ships in v1.4.0 unless patched.

## Fix

Scope by `created_by=request.user` (ownership) instead of `project_id=project_id` (association state):

```python
assets = FileAsset.objects.filter(id__in=asset_ids, workspace__slug=slug, created_by=request.user)
```

This **still closes the IDOR** #9288 targeted — a caller can only touch assets they uploaded, and `@allow_permission([ADMIN, MEMBER, GUEST])` already scopes them to the target project — and it is **stricter than the original master code** (which had no ownership check at all), while allowing a not-yet-associated asset to be linked.

## Testing
- ruff lint + format clean.
- Needs verification on redeploy: project creation → enable-features step should complete (204, not 404). ⚠️ **Cherry-pick to `canary` for v1.4.0-rc2** (the RC is already deployed with the bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved bulk asset association security by restricting selectable assets to those uploaded by the requester within the target workspace.
  - Updated the bulk association behavior to support selecting assets that are either already linked to the project or not yet linked, when the requester has the required workspace access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->