### PR TITLE
feat(api): add endpoint to list current user's workspaces

### DIFF
--- a/apps/api/plane/api/urls/user.py
+++ b/apps/api/plane/api/urls/user.py
@@ -4,12 +4,17 @@
 
 from django.urls import path
 
-from plane.api.views import UserEndpoint
+from plane.api.views import UserEndpoint, UserWorkspacesEndpoint
 
 urlpatterns = [
     path(
         "users/me/",
         UserEndpoint.as_view(http_method_names=["get"]),
         name="users",
+    ),
+    path(
+        "users/me/workspaces/",
+        UserWorkspacesEndpoint.as_view(http_method_names=["get"]),
+        name="users-workspaces",
     ),
 ]

--- a/apps/api/plane/api/views/__init__.py
+++ b/apps/api/plane/api/views/__init__.py
@@ -67,7 +67,7 @@ from .intake import (
 
 from .asset import UserAssetEndpoint, UserServerAssetEndpoint, GenericAssetEndpoint
 
-from .user import UserEndpoint
+from .user import UserEndpoint, UserWorkspacesEndpoint
 
 from .invite import WorkspaceInvitationsViewset
 

--- a/apps/api/plane/api/views/user.py
+++ b/apps/api/plane/api/views/user.py
@@ -5,12 +5,12 @@
 # Third party imports
 from rest_framework import status
 from rest_framework.response import Response
-from drf_spectacular.utils import OpenApiResponse
+from drf_spectacular.utils import OpenApiExample, OpenApiResponse
 
 # Module imports
-from plane.api.serializers import UserLiteSerializer
+from plane.api.serializers import UserLiteSerializer, WorkspaceLiteSerializer
 from plane.api.views.base import BaseAPIView
-from plane.db.models import User
+from plane.db.models import User, Workspace, WorkspaceMember
 from plane.utils.openapi.decorators import user_docs
 from plane.utils.openapi import USER_EXAMPLE
 
@@ -38,4 +38,51 @@ class UserEndpoint(BaseAPIView):
         Returns user data based on the current authentication context.
         """
         serializer = UserLiteSerializer(request.user)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+
+class UserWorkspacesEndpoint(BaseAPIView):
+    serializer_class = WorkspaceLiteSerializer
+    model = Workspace
+    use_read_replica = True
+
+    @user_docs(
+        operation_id="list_current_user_workspaces",
+        summary="List current user's workspaces",
+        description=(
+            "List the workspaces the authenticated token can access, returning the id, name, "
+            "and slug of each workspace the user is an active member of. Useful for discovering "
+            "the workspace slug required by other API endpoints."
+        ),
+        responses={
+            200: OpenApiResponse(
+                description="List of workspaces accessible to the current token",
+                response=WorkspaceLiteSerializer(many=True),
+                examples=[
+                    OpenApiExample(
+                        name="Workspaces",
+                        value=[
+                            {
+                                "id": "550e8400-e29b-41d4-a716-446655440000",
+                                "name": "My Workspace",
+                                "slug": "my-workspace",
+                            }
+                        ],
+                    )
+                ],
+            ),
+        },
+    )
+    def get(self, request):
+        """List current user's workspaces
+
+        List the workspaces the authenticated token can access, returning the id, name, and
+        slug of each workspace the user is an active member of. Useful for discovering the
+        workspace slug required by other API endpoints.
+        """
+        workspace_ids = WorkspaceMember.objects.filter(
+            member=request.user, is_active=True
+        ).values_list("workspace_id", flat=True)
+        workspaces = Workspace.objects.filter(id__in=workspace_ids).order_by("name")
+        serializer = WorkspaceLiteSerializer(workspaces, many=True)
         return Response(serializer.data, status=status.HTTP_200_OK)

--- a/apps/api/plane/tests/contract/api/test_user_workspaces.py
+++ b/apps/api/plane/tests/contract/api/test_user_workspaces.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Contract tests for the current user's workspaces endpoint.
+
+GET /api/v1/users/me/workspaces/
+"""
+
+import pytest
+from rest_framework import status
+
+from plane.db.models import Workspace, WorkspaceMember
+
+URL = "/api/v1/users/me/workspaces/"
+
+
+@pytest.fixture
+def other_workspace(db, create_bot_user):
+    """A workspace the requesting user is not a member of."""
+    return Workspace.objects.create(
+        name="Other Workspace",
+        owner=create_bot_user,
+        slug="other-workspace",
+    )
+
+
+@pytest.fixture
+def inactive_workspace(db, create_user, create_bot_user):
+    """A workspace the requesting user's membership has been deactivated on."""
+    workspace = Workspace.objects.create(
+        name="Inactive Workspace",
+        owner=create_bot_user,
+        slug="inactive-workspace",
+    )
+    WorkspaceMember.objects.create(
+        workspace=workspace,
+        member=create_user,
+        role=20,
+        is_active=False,
+    )
+    return workspace
+
+
+@pytest.mark.contract
+class TestUserWorkspaces:
+    @pytest.mark.django_db
+    def test_returns_workspaces_of_the_current_user(self, api_key_client, workspace):
+        response = api_key_client.get(URL)
+        assert response.status_code == status.HTTP_200_OK
+        slugs = {item["slug"] for item in response.data}
+        assert workspace.slug in slugs
+
+    @pytest.mark.django_db
+    def test_returns_only_lite_fields(self, api_key_client, workspace):
+        response = api_key_client.get(URL)
+        assert response.status_code == status.HTTP_200_OK
+        item = response.data[0]
+        assert set(item.keys()) == {"id", "name", "slug"}
+
+    @pytest.mark.django_db
+    def test_excludes_workspaces_the_user_is_not_a_member_of(self, api_key_client, workspace, other_workspace):
+        response = api_key_client.get(URL)
+        assert response.status_code == status.HTTP_200_OK
+        slugs = {item["slug"] for item in response.data}
+        assert other_workspace.slug not in slugs
+
+    @pytest.mark.django_db
+    def test_excludes_inactive_memberships(self, api_key_client, workspace, inactive_workspace):
+        response = api_key_client.get(URL)
+        assert response.status_code == status.HTTP_200_OK
+        slugs = {item["slug"] for item in response.data}
+        assert inactive_workspace.slug not in slugs
+
+    @pytest.mark.django_db
+    def test_requires_authentication(self, api_client, workspace):
+        response = api_client.get(URL)
+        assert response.status_code in (
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        )

--- a/apps/api/plane/tests/contract/api/test_user_workspaces.py
+++ b/apps/api/plane/tests/contract/api/test_user_workspaces.py
@@ -8,6 +8,7 @@ GET /api/v1/users/me/workspaces/
 """
 
 import pytest
+from django.utils import timezone
 from rest_framework import status
 
 from plane.db.models import Workspace, WorkspaceMember
@@ -42,6 +43,26 @@ def inactive_workspace(db, create_user, create_bot_user):
     return workspace
 
 
+@pytest.fixture
+def deleted_workspace(db, create_user, create_bot_user):
+    """A soft deleted workspace the requesting user still has an active membership row on."""
+    workspace = Workspace.objects.create(
+        name="Deleted Workspace",
+        owner=create_bot_user,
+        slug="deleted-workspace",
+    )
+    WorkspaceMember.objects.create(
+        workspace=workspace,
+        member=create_user,
+        role=20,
+        is_active=True,
+    )
+    # Stamp deleted_at directly instead of calling delete(), which queues a Celery
+    # task to soft delete related objects.
+    Workspace.all_objects.filter(id=workspace.id).update(deleted_at=timezone.now())
+    return workspace
+
+
 @pytest.mark.contract
 class TestUserWorkspaces:
     @pytest.mark.django_db
@@ -71,6 +92,13 @@ class TestUserWorkspaces:
         assert response.status_code == status.HTTP_200_OK
         slugs = {item["slug"] for item in response.data}
         assert inactive_workspace.slug not in slugs
+
+    @pytest.mark.django_db
+    def test_excludes_soft_deleted_workspaces(self, api_key_client, workspace, deleted_workspace):
+        response = api_key_client.get(URL)
+        assert response.status_code == status.HTTP_200_OK
+        slugs = {item["slug"] for item in response.data}
+        assert deleted_workspace.slug not in slugs
 
     @pytest.mark.django_db
     def test_requires_authentication(self, api_client, workspace):


### PR DESCRIPTION
### Description

Adds `GET /api/v1/users/me/workspaces/`, returning the `id`, `name`, and `slug` of every workspace the authenticated token's user is an active member of, ordered by name.

Today an API token holder has no way to discover their workspace slug programmatically — `GET /api/v1/users/me/` returns the profile but nothing lists workspaces, while every other v1 endpoint requires the slug in the path. Integrations, scripts, and MCP servers therefore cannot bootstrap from a token alone and the slug has to be read out of the browser address bar by hand.

Implementation notes:

- `UserWorkspacesEndpoint` extends `BaseAPIView`, so it inherits `APIKeyAuthentication` + `IsAuthenticated`; unauthenticated requests are rejected.
- Scoped to `WorkspaceMember` rows with `is_active=True` for `request.user`, so deactivated memberships and workspaces the user does not belong to are never returned.
- Reuses the existing `WorkspaceLiteSerializer` (`id`, `name`, `slug`) — no new serializer, no heavy computed fields.
- Reads go to the read replica (`use_read_replica = True`).
- Documented for OpenAPI via the existing `user_docs` decorator, so it shows up under the **Users** tag in the generated schema.

The response is a plain array rather than the cursor-paginated envelope used by the larger list endpoints, matching the other small-collection endpoints in the v1 API. Happy to switch it to `self.paginate(...)` if maintainers prefer consistency with `projects-lite` and friends — better to settle that before release than after, since it is a breaking response-shape change.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)

N/A — API only.

```console
$ curl -s -H "X-Api-Key: $PLANE_API_KEY" https://api.plane.so/api/v1/users/me/workspaces/
[
  {
    "id": "550e8400-e29b-41d4-a716-446655440000",
    "name": "My Workspace",
    "slug": "my-workspace"
  }
]
```

### Test Scenarios

Contract tests added in `apps/api/plane/tests/contract/api/test_user_workspaces.py`, run via the `docker-compose-test.yml` stack (`docker compose -f docker-compose-test.yml run --rm api-tests pytest plane/tests/contract/api/test_user_workspaces.py`) — 6 passed:

- Returns the workspaces the token's user is an active member of.
- Returns only the lite fields (`id`, `name`, `slug`) and nothing else.
- Excludes workspaces the user is not a member of.
- Excludes workspaces where the user's membership has `is_active=False`.
- Excludes soft deleted workspaces even when an active membership row survives.
- Rejects unauthenticated requests.

Also verified the OpenAPI schema generates cleanly with `ENABLE_DRF_SPECTACULAR=1`: `list_current_user_workspaces` appears under the **Users** tag with the `WorkspaceLite` array response and the shared 401, and no new generator warnings are introduced.

### References

Closes #9427


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `GET /api/v1/users/me/workspaces/` to list the authenticated user’s workspaces.
  * Returns only workspaces where the user has an active membership; ordered by name.
  * Excludes workspaces the user isn’t a member of and omits soft-deleted workspaces; returns lite fields (`id`, `name`, `slug`).
  * Added OpenAPI documentation for the new endpoint.
* **Tests**
  * Added contract tests covering filtering rules, lite fields, soft-delete behavior, and unauthenticated/unauthorized access (401/403).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->