### PR TITLE
chore: retire departed code owners (apps/live, ox configs)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,5 +4,5 @@ apps/api/           @dheeru0198 @pablohashescobar
 apps/web/           @sriramveeraghanta
 apps/space/         @sriramveeraghanta
 apps/admin/         @sriramveeraghanta
-apps/live/          @Prashant-Surya
+apps/live/          @saivallampati
 deployments/        @mguptahub

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,5 +4,5 @@ apps/api/           @dheeru0198 @pablohashescobar
 apps/web/           @sriramveeraghanta
 apps/space/         @sriramveeraghanta
 apps/admin/         @sriramveeraghanta
-apps/live/          @Palanikannan1437
+apps/live/          @Prashant-Surya
 deployments/        @mguptahub

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
-.oxlintrc.json   @sriramveeraghanta @lifeiscontent
-.oxfmtrc.json   @sriramveeraghanta @lifeiscontent
+.oxlintrc.json   @sriramveeraghanta
+.oxfmtrc.json   @sriramveeraghanta
 apps/api/           @dheeru0198 @pablohashescobar
 apps/web/           @sriramveeraghanta
 apps/space/         @sriramveeraghanta


### PR DESCRIPTION
### Description

Two `CODEOWNERS` entries pointed at people who have left the `makeplane` org. GitHub **silently ignores** an entry whose owner lacks write access — no warning on the file view, no CI failure, no error anywhere. The path just quietly stops requesting a reviewer.

| Path | Was | Now | Effect of the stale entry |
| :--- | :--- | :--- | :--- |
| `apps/live/` | `@Palanikannan1437` | `@saivallampati` | **No effective owner** — changes requested nobody |
| `.oxlintrc.json`, `.oxfmtrc.json` | `@sriramveeraghanta @lifeiscontent` | `@sriramveeraghanta` | Dead token only — `@sriramveeraghanta` still resolved |

`@saivallampati` is an org member and direct collaborator with `write` access, so the replacement entry actually resolves. `@lifeiscontent` is simply dropped: `@sriramveeraghanta` co-owns both ox configs and authored them, so those paths keep a real reviewer and no coverage gap is created. **Every path in the file still has at least one owner with write access** — verified against the org membership and collaborator APIs for all seven remaining owner tokens.

### How this surfaced

While auditing why reviewers appear on release PRs. On #9160 (`release: v1.4.0`, 1506 files changed), `@Palanikannan1437` was auto-requested off just **3 files** under `apps/live/`. He still had write access when that PR opened in May 2026 — he doesn't now, which is how the gap opened without anyone noticing.

### Note on timing

`CODEOWNERS` is read from the PR's **base** branch. This takes effect for PRs targeting `preview` once merged, and for PRs targeting `master` only after the next `preview` → `master` release promotion.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [x] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)

<!-- Add screenshots here -->

### Test Scenarios

1. Open a PR against `preview` touching any file under `apps/live/` — `@saivallampati` should be auto-requested.
2. Open a PR against `preview` touching `.oxlintrc.json` or `.oxfmtrc.json` — `@sriramveeraghanta` should be auto-requested, and `@lifeiscontent` should not appear.
3. Confirm each remaining owner has the access the entry requires (it silently no-ops otherwise):
   ```bash
   for u in sriramveeraghanta dheeru0198 pablohashescobar saivallampati mguptahub; do
     echo -n "$u "
     gh api repos/makeplane/plane/collaborators/$u -i | head -1   # expect 204
   done
   ```
   Note: `collaborators/<user>/permission` returns `read` for *any* user on a public repo — that's the anonymous baseline, not a granted role. Use the `collaborators/<user>` 204/404 check as authoritative.
4. Confirm GitHub reports no syntax warnings on the `CODEOWNERS` file view for this branch.

### References

- Related: #9160 (release PR where the stale owner was auto-requested, which surfaced this)
- [About code owners](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) — see "CODEOWNERS errors" for the write-access requirement


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code ownership assignments for the live application area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->