### PR TITLE
fix: enforce public board voting setting

### DIFF
--- a/apps/api/plane/space/views/issue.py
+++ b/apps/api/plane/space/views/issue.py
@@ -542,6 +542,12 @@ class IssueVotePublicViewSet(BaseViewSet):
 
     def create(self, request, anchor, issue_id):
         project_deploy_board = DeployBoard.objects.get(anchor=anchor, entity_name="project")
+        if not project_deploy_board.is_votes_enabled:
+            return Response(
+                {"error": "Votes are not enabled for this board"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
         issue_vote, _ = IssueVote.objects.get_or_create(
             actor_id=request.user.id,
             project_id=project_deploy_board.project_id,

--- a/apps/api/plane/tests/unit/views/test_issue_vote_public.py
+++ b/apps/api/plane/tests/unit/views/test_issue_vote_public.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+from types import SimpleNamespace
+from unittest.mock import patch
+from uuid import uuid4
+
+import pytest
+from rest_framework import status
+
+from plane.space.views.issue import IssueVotePublicViewSet
+
+
+@pytest.mark.unit
+def test_create_vote_rejects_when_public_board_voting_is_disabled():
+    request = SimpleNamespace(
+        user=SimpleNamespace(id=uuid4()),
+        data={"vote": 1},
+    )
+    view = IssueVotePublicViewSet()
+    board = SimpleNamespace(is_votes_enabled=False)
+
+    with (
+        patch(
+            "plane.space.views.issue.DeployBoard.objects.get",
+            return_value=board,
+        ),
+        patch("plane.space.views.issue.IssueVote.objects.get_or_create") as create_vote,
+    ):
+        response = view.create(request, anchor="public-board", issue_id=uuid4())
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.data == {"error": "Votes are not enabled for this board"}
+    create_vote.assert_not_called()


### PR DESCRIPTION
### Description

Reject public-board vote creation when the board has voting disabled. This applies the same feature-flag enforcement already used by public comments and reactions, before any `IssueVote` is created.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)

Not applicable; this is an API behavior fix.

### Test Scenarios

- `pytest plane/tests/unit/views/test_issue_vote_public.py -vv`
- `ruff check plane/space/views/issue.py plane/tests/unit/views/test_issue_vote_public.py`
- `ruff format --check plane/space/views/issue.py plane/tests/unit/views/test_issue_vote_public.py`

### References

Closes #9500
