### PR TITLE
test(space): pin 404 contract for public board routes with unknown anchor

### DIFF
--- a/apps/api/plane/tests/contract/space/__init__.py
+++ b/apps/api/plane/tests/contract/space/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.

--- a/apps/api/plane/tests/contract/space/test_public_board_unknown_anchor_space.py
+++ b/apps/api/plane/tests/contract/space/test_public_board_unknown_anchor_space.py
@@ -1,0 +1,107 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Contract tests for public board routes reached with an unknown ``anchor``.
+
+Every public Space route resolves its board with ``DeployBoard.objects.get(anchor=...)``
+and none of the write methods wrap that call in ``try/except``. The 404 they return
+today is produced further out, by the ``ObjectDoesNotExist`` branch of
+``handle_exception()`` on the shared ``BaseAPIView`` / ``BaseViewSet``, since
+``DeployBoard.DoesNotExist`` subclasses ``ObjectDoesNotExist``.
+
+That makes the status code load-bearing on a base class several layers removed from
+the views that depend on it, so these tests pin the contract: an anchor that was
+never published, or whose board has since been unpublished, answers 404 and not 500.
+
+These tests deliberately assert only on the status code. The response body
+(``{"error": "The required object does not exist."}``) is a shared base-class string,
+not a per-view contract.
+
+Related: https://github.com/makeplane/plane/issues/9499
+"""
+
+from uuid import uuid4
+
+import pytest
+from rest_framework import status
+
+UNKNOWN_ANCHOR = "this-anchor-was-never-published"
+
+
+@pytest.fixture
+def issue_id():
+    return uuid4()
+
+
+@pytest.fixture
+def comment_id():
+    return uuid4()
+
+
+@pytest.mark.contract
+@pytest.mark.django_db
+class TestPublicBoardUnknownAnchor:
+    """Public board routes answer 404 when no DeployBoard matches the anchor."""
+
+    def test_issue_retrieve(self, session_client, issue_id):
+        response = session_client.get(f"/api/public/anchor/{UNKNOWN_ANCHOR}/issues/{issue_id}/")
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_comment_create(self, session_client, issue_id):
+        response = session_client.post(
+            f"/api/public/anchor/{UNKNOWN_ANCHOR}/issues/{issue_id}/comments/",
+            {"comment_html": "<p>hello</p>"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_comment_partial_update(self, session_client, issue_id, comment_id):
+        response = session_client.patch(
+            f"/api/public/anchor/{UNKNOWN_ANCHOR}/issues/{issue_id}/comments/{comment_id}/",
+            {"comment_html": "<p>edited</p>"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_comment_destroy(self, session_client, issue_id, comment_id):
+        response = session_client.delete(
+            f"/api/public/anchor/{UNKNOWN_ANCHOR}/issues/{issue_id}/comments/{comment_id}/"
+        )
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_issue_reaction_create(self, session_client, issue_id):
+        response = session_client.post(
+            f"/api/public/anchor/{UNKNOWN_ANCHOR}/issues/{issue_id}/reactions/",
+            {"reaction": "128077"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_issue_reaction_destroy(self, session_client, issue_id):
+        response = session_client.delete(f"/api/public/anchor/{UNKNOWN_ANCHOR}/issues/{issue_id}/reactions/128077/")
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_comment_reaction_create(self, session_client, comment_id):
+        response = session_client.post(
+            f"/api/public/anchor/{UNKNOWN_ANCHOR}/comments/{comment_id}/reactions/",
+            {"reaction": "128077"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_comment_reaction_destroy(self, session_client, comment_id):
+        response = session_client.delete(f"/api/public/anchor/{UNKNOWN_ANCHOR}/comments/{comment_id}/reactions/128077/")
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_vote_create(self, session_client, issue_id):
+        response = session_client.post(
+            f"/api/public/anchor/{UNKNOWN_ANCHOR}/issues/{issue_id}/votes/",
+            {"vote": 1},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_vote_destroy(self, session_client, issue_id):
+        response = session_client.delete(f"/api/public/anchor/{UNKNOWN_ANCHOR}/issues/{issue_id}/votes/")
+        assert response.status_code == status.HTTP_404_NOT_FOUND


### PR DESCRIPTION
### Description

Investigating #9499 turned up something worth reporting before any code change: **the HTTP 500 described in that issue does not reproduce.** All the routes it names already answer `404`.

The reason is that `DeployBoard.DoesNotExist` subclasses `ObjectDoesNotExist`, and both shared base views in `plane/space/views/base.py` map that to a 404 inside `handle_exception()`:

```python
if isinstance(e, ObjectDoesNotExist):
    return Response(
        {"error": "The required object does not exist."},
        status=status.HTTP_404_NOT_FOUND,
    )
```

Since `BaseAPIView.dispatch` / `BaseViewSet.dispatch` route handler exceptions into that method, the unguarded `DeployBoard.objects.get(anchor=...)` calls in `create()` / `partial_update()` / `destroy()` already surface as 404. That branch also returns *before* `log_exception(e)`, so there is no error-log noise either — both impacts claimed in the issue are absent.

So this PR does not add the nine `try/except` blocks the issue proposes. Two reasons:

1. They would not change any status code, and swapping the body for `{"error": "Project board not found."}` would be a breaking change to a response that is already shipped.
2. #9498 is open against the same methods in the same file, so editing them here would only create conflicts.

What is genuinely missing is coverage. The correct status code currently depends on a base class several layers removed from the views that rely on it, and nothing pins that relationship — a future refactor of `handle_exception()` could turn every public board route into a 500 with no test failing. This PR adds that regression coverage for all ten routes.

The tests assert only on the status code, since the response body is a shared base-class string rather than a per-view contract. They also do not touch `plane/space/views/issue.py`, so they do not conflict with #9498, and I confirmed they still pass against that PR's added guards (its `_issue_belongs_to_board` checks run *after* the board lookup, so an unknown anchor still short-circuits first).

### Type of Change

- [x] Code refactoring <!-- test-only change; no runtime behavior is modified -->

### Test Scenarios

Verified locally against Postgres with `DJANGO_SETTINGS_MODULE=plane.settings.test`:

```
pytest plane/tests/contract/space/
10 passed
```

All ten routes were probed with an anchor that has no `DeployBoard`, under both `DEBUG=True` and `DEBUG=False` (DRF's `raise_uncaught_exception` branches on `settings.DEBUG`, so both paths matter). Every one returned `404` with `{"error": "The required object does not exist."}`, confirming the response comes from the base-class handler and not from URL resolution. `caplog` recorded **0** ERROR-level records across all ten.

Full suite, and the reason the numbers are not clean:

```
pytest plane/tests/            50 failed, 455 passed
pytest plane/tests/ --ignore=plane/tests/contract/space    50 failed, 445 passed
```

The 50 failures are pre-existing and unrelated — they need a Celery broker (`kombu.exceptions.OperationalError: [Errno 61] Connection refused`), which my environment does not run. The failure count is identical with and without this PR's files, and the diff adds only new test files, so nothing here caused them. The new tests do not require the broker, because the board lookup short-circuits before any `issue_activity.delay()` call.

Lint, matching what CI runs:

```
ruff check apps/api/plane/tests/contract/space/    All checks passed!
```

`ruff check apps/api` reports 3 pre-existing `F401` findings in `app/views/issue/sub_issue.py` and `app/views/project/invite.py`, untouched by this PR and auto-fixed by CI's `--fix`.

### References

Related to #9499 — please read this PR as evidence that the issue can be closed as not reproducible, rather than as a fix for it. Adjacent to #9498, but with no overlapping lines.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Public Space board actions now consistently return a 404 response when accessed with an unknown anchor, instead of an internal server error.

* **Tests**
  * Added coverage for issue, comment, reaction, and voting operations using invalid anchors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->