### PR TITLE
[WEB-8477] fix: created_at/updated_at filters return no work items

### DIFF
--- a/apps/api/plane/tests/unit/utils/test_issue_datetime_filters.py
+++ b/apps/api/plane/tests/unit/utils/test_issue_datetime_filters.py
@@ -1,0 +1,105 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Regression tests for created_at / updated_at rich-filter lookups (WEB-8477 Bug 5).
+
+``created_at`` and ``updated_at`` are DateTimeFields, but the UI sends a bare calendar
+date. With the default ``exact`` / ``range`` lookups django-filter coerced those dates to
+midnight, so:
+
+* ``created_at__exact=<date>`` matched only rows stamped exactly 00:00:00 -> always empty.
+* ``created_at__range=<a>,<b>`` capped the upper bound at ``b`` 00:00:00 -> silently
+  dropped every row created during the final day of the range.
+
+Both surfaced as "filter returns no work items". The filters now compare the date
+component (``date`` / ``date__range``) so a calendar date means the whole day.
+"""
+
+import datetime
+
+import pytest
+
+from plane.db.models import Issue, Project, ProjectMember
+from plane.utils.filters.filterset import IssueFilterSet
+
+
+@pytest.fixture
+def project(db, workspace, create_user):
+    project = Project.objects.create(
+        name="Filter Project",
+        identifier="FP",
+        workspace=workspace,
+        created_by=create_user,
+    )
+    ProjectMember.objects.create(project=project, member=create_user, role=20, is_active=True)
+    return project
+
+
+def _issue_at(project, create_user, name, created, updated):
+    """Create an issue then force created_at/updated_at (both are auto-managed)."""
+    issue = Issue.objects.create(name=name, project=project, workspace=project.workspace, created_by=create_user)
+    Issue.objects.filter(pk=issue.pk).update(created_at=created, updated_at=updated)
+    issue.refresh_from_db()
+    return issue
+
+
+@pytest.fixture
+def issues(db, project, create_user):
+    tz = datetime.timezone.utc
+    return {
+        # created mid-day, NOT at midnight — the case `exact` used to miss
+        "midday": _issue_at(
+            project,
+            create_user,
+            "midday",
+            datetime.datetime(2026, 7, 30, 13, 45, tzinfo=tz),
+            datetime.datetime(2026, 7, 30, 13, 45, tzinfo=tz),
+        ),
+        # created on an earlier day, but updated on 2026-07-30
+        "old": _issue_at(
+            project,
+            create_user,
+            "old",
+            datetime.datetime(2020, 1, 1, 9, 0, tzinfo=tz),
+            datetime.datetime(2026, 7, 30, 10, 0, tzinfo=tz),
+        ),
+    }
+
+
+def _filter(project, data):
+    qs = Issue.objects.filter(project=project)
+    fs = IssueFilterSet(data=data, queryset=qs)
+    assert fs.is_valid(), fs.errors
+    return set(fs.qs.values_list("name", flat=True))
+
+
+@pytest.mark.unit
+class TestCreatedAtFilter:
+    def test_exact_matches_whole_day_not_just_midnight(self, project, issues):
+        # Previously returned nothing because 13:45 != 00:00:00.
+        assert _filter(project, {"created_at__exact": "2026-07-30"}) == {"midday"}
+
+    def test_exact_excludes_other_days(self, project, issues):
+        assert _filter(project, {"created_at__exact": "2020-01-01"}) == {"old"}
+        assert _filter(project, {"created_at__exact": "2019-05-05"}) == set()
+
+    def test_range_includes_the_final_day(self, project, issues):
+        # Previously returned nothing: the upper bound became 2026-07-30 00:00:00.
+        assert _filter(project, {"created_at__range": "2026-07-28,2026-07-30"}) == {"midday"}
+
+    def test_single_day_range(self, project, issues):
+        assert _filter(project, {"created_at__range": "2026-07-30,2026-07-30"}) == {"midday"}
+
+    def test_range_excludes_outside_days(self, project, issues):
+        assert _filter(project, {"created_at__range": "2019-01-01,2019-12-31"}) == set()
+
+
+@pytest.mark.unit
+class TestUpdatedAtFilter:
+    def test_exact_uses_updated_at_not_created_at(self, project, issues):
+        # "old" was created in 2020 but updated on 2026-07-30, so it must be included.
+        assert _filter(project, {"updated_at__exact": "2026-07-30"}) == {"midday", "old"}
+
+    def test_range_includes_the_final_day(self, project, issues):
+        assert _filter(project, {"updated_at__range": "2026-07-28,2026-07-30"}) == {"midday", "old"}

--- a/apps/api/plane/utils/filters/filterset.py
+++ b/apps/api/plane/utils/filters/filterset.py
@@ -19,6 +19,17 @@ class CharInFilter(filters.BaseInFilter, filters.CharFilter):
     pass
 
 
+class DateCSVRangeFilter(filters.BaseCSVFilter, filters.DateFilter):
+    """Comma-separated date range ("YYYY-MM-DD,YYYY-MM-DD") for DateTimeField columns.
+
+    Parses the CSV value the UI sends into a list of dates so it can be paired with a
+    ``date__range`` lookup — comparing the date component, which makes both bounds
+    inclusive whole days.
+    """
+
+    pass
+
+
 class BaseFilterSet(FilterSet):
     @classmethod
     def get_filters(cls):
@@ -156,6 +167,26 @@ class IssueFilterSet(BaseFilterSet):
 
     subscriber_id = filters.UUIDFilter(method="filter_subscriber_id")
     subscriber_id__in = UUIDInFilter(method="filter_subscriber_id_in", lookup_expr="in")
+
+    # created_at / updated_at are DateTimeFields, but the UI sends a bare calendar
+    # date (yyyy-MM-dd, e.g. {"created_at__exact": "2026-07-30"}). An `exact` lookup
+    # coerces that to midnight, so the filter only matched rows stamped exactly
+    # 00:00:00 and silently returned an empty list. Compare the date component
+    # instead so "created on <date>" means the whole day.
+    # NOTE: `__date` is evaluated in the active timezone, which TimezoneMixin sets
+    # from the user's profile (user_timezone) — not the browser's timezone. A user
+    # whose profile timezone differs from their browser can still see off-by-one-day
+    # results; that mismatch is tracked separately.
+    # The same applies to ranges: the UI sends "YYYY-MM-DD,YYYY-MM-DD", and a plain
+    # `range` on a DateTimeField turns the upper bound into that day's midnight, which
+    # silently dropped every row created during the final day of the range.
+    created_at = filters.DateFilter(field_name="created_at", lookup_expr="date")
+    created_at__exact = filters.DateFilter(field_name="created_at", lookup_expr="date")
+    created_at__range = DateCSVRangeFilter(field_name="created_at", lookup_expr="date__range")
+
+    updated_at = filters.DateFilter(field_name="updated_at", lookup_expr="date")
+    updated_at__exact = filters.DateFilter(field_name="updated_at", lookup_expr="date")
+    updated_at__range = DateCSVRangeFilter(field_name="updated_at", lookup_expr="date__range")
 
     class Meta:
         model = Issue


### PR DESCRIPTION
## Problem (WEB-8477, Bug 5)

Filtering the work item list by a creation/update date returns **no work items**.

`created_at` / `updated_at` are **DateTimeFields**, but the UI sends a bare calendar date, and the filterset only exposed `exact` and `range` lookups. Both are wrong for a datetime column:

| Request the UI sends | What the ORM did | Result |
|---|---|---|
| `{"created_at__exact":"2026-07-30"}` | coerced to `2026-07-30 00:00:00` | matched only rows stamped exactly midnight → **always empty** |
| `{"created_at__range":"2026-07-28,2026-07-30"}` | upper bound capped at `2026-07-30 00:00:00` | **silently dropped everything created during the final day** (only "worked" if you overshot the end date by a day) |

Reproduced from the bug report's exact query strings on a local `canary` build — both returned `total_count: 0` with 4 matching work items present.

## Fix

Compare the **date component** instead, so a calendar date means the whole day and both range bounds are inclusive:

- `created_at` / `created_at__exact` → `lookup_expr="date"`
- `created_at__range` → `lookup_expr="date__range"` via a new `DateCSVRangeFilter` (`BaseCSVFilter` + `DateFilter`) that parses the UI's `"a,b"` CSV value
- same for `updated_at`

**The UI's existing query format is unchanged** — no frontend change needed.

## Verification (local canary build, Django 5.2.15)

| Query | Before | After |
|---|---|---|
| `created_at__exact=2026-07-30` | 0 | **4** ✅ |
| `created_at__range=2026-07-28,2026-07-30` (report's case) | 0 | **4** ✅ |
| `created_at__range=2026-07-30,2026-07-30` | 0 | **4** ✅ |
| `created_at__exact=2020-01-01` (backdated row) | 0 | **1** ✅ |
| `created_at__range=2019-01-01,2019-12-31` | 0 | **0** ✅ (negative control) |
| `updated_at__exact=2026-07-30` | 0 | **5** ✅ (incl. a row created in 2020 but updated today) |

Adds `plane/tests/unit/utils/test_issue_datetime_filters.py` (7 tests). **6 of the 7 fail without this change** (verified by reverting the fix); the 7th is a negative control that passes either way. `ruff check` + `format` clean.

## Scope notes

- **Pre-existing, not a v1.4.0 regression** — `filterset.py` is byte-identical on `master` (v1.3.1).
- **Not covered by** #9512 (Django 5 mixed-type `FieldError`, which fixes WEB-8477 Bugs 2 & 3) or #9323 (the legacy `issue_filters.py` `updated_at`→`created_at` copy-paste bug). This is a third, independent cause.
- ⚠️ **Known remaining issue, deliberately not fixed here:** `__date` is evaluated in the *active* timezone, which `TimezoneMixin` takes from the user's profile (`user_timezone`) rather than the browser's timezone. A user whose profile timezone differs from their browser can still see off-by-one-day results (verified: same data returns different rows for `user_timezone=UTC` vs `Asia/Kolkata`). Needs a product decision on which timezone is authoritative, so it's tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved issue date filtering for creation and update dates.
  - Exact-date filters now include all issues from the selected calendar day, regardless of time.
  - Date-range filters now include the full final day and exclude issues outside the selected range.
  - Added regression coverage to ensure consistent filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->