### PR TITLE
[WEB-8477] fix(api): filter "Updated At" by updated_at column, not created_at

### DIFF
--- a/apps/api/plane/tests/unit/utils/test_issue_filters.py
+++ b/apps/api/plane/tests/unit/utils/test_issue_filters.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+import pytest
+
+from plane.utils.issue_filters import filter_updated_at
+
+
+@pytest.mark.unit
+class TestFilterUpdatedAt:
+    """Regression test for the "Updated At" filter bug — the filter was
+    applying to the `created_at` column instead of `updated_at`, so work
+    items updated today but created earlier never showed up under
+    `Updated At -> is -> today`. See issue #9316."""
+
+    def test_get_method_targets_updated_at_column(self):
+        issue_filter = {}
+        params = {"updated_at": "2026-06-26"}
+        filter_updated_at(params, issue_filter, method="GET")
+        # The filter must key on updated_at, not created_at. A bare date goes through
+        # date_filter's single-value branch, which appends a lookup suffix
+        # (updated_at__date__contains), so match on the prefix rather than the exact key.
+        assert any(key.startswith("updated_at__date") for key in issue_filter)
+        assert not any("created_at" in key for key in issue_filter)
+
+    def test_get_method_with_csv_targets_updated_at_column(self):
+        issue_filter = {}
+        params = {"updated_at": "2026-06-25,2026-06-26"}
+        filter_updated_at(params, issue_filter, method="GET")
+        assert all("updated_at" in key for key in issue_filter)
+        assert not any("created_at" in key for key in issue_filter)
+
+    def test_post_method_targets_updated_at_column(self):
+        issue_filter = {}
+        params = {"updated_at": ["2026-06-26"]}
+        filter_updated_at(params, issue_filter, method="POST")
+        assert all("updated_at" in key for key in issue_filter)
+        assert not any("created_at" in key for key in issue_filter)
+
+    def test_get_method_with_prefix_targets_updated_at_column(self):
+        issue_filter = {}
+        params = {"updated_at": "2026-06-26"}
+        filter_updated_at(params, issue_filter, method="GET", prefix="cycle_issue__")
+        keys = list(issue_filter)
+        assert any("cycle_issue__updated_at" in k for k in keys)
+        assert not any("created_at" in k for k in keys)
+
+    def test_empty_get_filter_is_noop(self):
+        issue_filter = {}
+        params = {"updated_at": ""}
+        filter_updated_at(params, issue_filter, method="GET")
+        assert issue_filter == {}

--- a/apps/api/plane/utils/issue_filters.py
+++ b/apps/api/plane/utils/issue_filters.py
@@ -231,14 +231,14 @@ def filter_updated_at(params, issue_filter, method, prefix=""):
         if len(updated_ats) and "" not in updated_ats:
             date_filter(
                 issue_filter=issue_filter,
-                date_term=f"{prefix}created_at__date",
+                date_term=f"{prefix}updated_at__date",
                 queries=updated_ats,
             )
     else:
         if params.get("updated_at", None) and len(params.get("updated_at")):
             date_filter(
                 issue_filter=issue_filter,
-                date_term=f"{prefix}created_at__date",
+                date_term=f"{prefix}updated_at__date",
                 queries=params.get("updated_at", []),
             )
     return issue_filter


### PR DESCRIPTION
> **Re-raise of #9323 by @sanjibani.** That PR is technically ready but cannot merge — its CLA is unsigned. Opening from a covered account so the fix can land. **Credit for the fix and the tests belongs to @sanjibani**; please close #9323 as superseded by this one once merged.

## Problem

`filter_updated_at()` passed `created_at__date` as the date term in **both** its GET and POST branches, so filtering by **"Updated At" actually filtered on the creation date**. Work items updated today but created earlier never appeared under `Updated At → is → today`, and the "Created at" / "Updated at" filters returned identical result sets.

This is the legacy `issue_filters.py` query-param path (pre-existing — present in v1.3.1, not a v1.4.0 regression).

## Fix

```diff
-                date_term=f"{prefix}created_at__date",
+                date_term=f"{prefix}updated_at__date",
```

in both branches of `filter_updated_at()`, plus the unit tests from #9323.

## Adjustments made while porting

Two small issues in the original patch:

1. **`test_get_method_targets_updated_at_column` always failed.** It asserted the exact key `"updated_at__date"`, but `date_filter()`'s single-value branch appends a lookup suffix, producing `updated_at__date__contains`. Changed to match on the key prefix. (Confirmed: a bare date yields `{'updated_at__date__contains': '2026-06-26'}`, while `;after` yields `{'updated_at__date__gte': ...}`.)
2. Added the missing trailing newline to the new test file.

## Verification (local canary build, Django 5.2.15)

With 5 work items — one created `2020-01-01` but updated today, four created today:

| Query | Before | After |
|---|---|---|
| `?updated_at=2026-07-01;after` | 4 ❌ | **5** ✅ (includes the 2020-created row) |
| `?created_at=2026-07-01;after` | 4 | **4** ✅ (unchanged) |

Before the fix both returned 4 (identical sets — the tell-tale symptom). Unit tests: **5 pass**, and **4 of the 5 fail** with the source change reverted. `ruff check` + `format` clean.

## Related

Part of WEB-8477 (canary bug sweep). Complements — does not overlap — the other two fixes:

- **#9512** — Django 5.2 mixed-type `FieldError` (Bugs 1, 2, 3). *Also blocked on an unsigned CLA.*
- **#9513** — rich-filter `created_at`/`updated_at` date lookups (Bug 5). Different code path: this PR fixes the legacy `?updated_at=` query param, #9513 fixes the `filters={"updated_at__exact":...}` rich-filter path. Both are needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the “Updated At” filter so it correctly searches by issue update dates instead of creation dates.
  * Ensured filtering works consistently for single dates, multiple dates, and different request methods.
  * Empty “Updated At” filters now leave existing results unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->