### PR TITLE
[WEB-8512] feat: add workspace member reactivation command

### DIFF
--- a/apps/api/plane/db/management/commands/reactivate_workspace_member.py
+++ b/apps/api/plane/db/management/commands/reactivate_workspace_member.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+# Django imports
+from django.core.management import BaseCommand, CommandError
+
+# Module imports
+from plane.db.models import User, Workspace, WorkspaceMember
+
+
+class Command(BaseCommand):
+    help = "Reactivate a workspace member given a workspace slug and user email"
+
+    def add_arguments(self, parser):
+        # Positional arguments
+        parser.add_argument("slug", type=str, help="workspace slug")
+        parser.add_argument("email", type=str, help="user email")
+
+    def handle(self, *args, **options):
+        # get the workspace slug and user email from console
+        slug = options.get("slug", False)
+        email = options.get("email", False)
+
+        # raise error if slug is not present
+        if not slug:
+            raise CommandError("Error: Workspace slug is required")
+
+        # raise error if email is not present
+        if not email:
+            raise CommandError("Error: Email is required")
+
+        # filter the user
+        user = User.objects.filter(email=email).first()
+
+        # Raise error if the user is not present
+        if not user:
+            raise CommandError(f"Error: User with {email} does not exists")
+
+        # filter the workspace
+        workspace = Workspace.objects.filter(slug=slug).first()
+
+        # Raise error if the workspace is not present
+        if not workspace:
+            raise CommandError(f"Error: Workspace with slug {slug} does not exists")
+
+        # Find the workspace membership (includes inactive members; soft-deleted are excluded by default manager)
+        workspace_member = WorkspaceMember.objects.filter(workspace=workspace, member=user).first()
+
+        # Raise error if the membership is not present
+        if not workspace_member:
+            raise CommandError(f"Error: User {email} is not a member of workspace {slug}")
+
+        # If already active, report without erroring
+        if workspace_member.is_active:
+            self.stdout.write(
+                self.style.SUCCESS(f"User {email} is already an active member of workspace {slug}")
+            )
+            return
+
+        # Reactivate the membership
+        workspace_member.is_active = True
+        workspace_member.save()
+
+        self.stdout.write(
+            self.style.SUCCESS(f"User {email} reactivated successfully in workspace {slug}")
+        )

--- a/apps/api/plane/db/management/commands/reactivate_workspace_member.py
+++ b/apps/api/plane/db/management/commands/reactivate_workspace_member.py
@@ -6,7 +6,7 @@
 from django.core.management import BaseCommand, CommandError
 
 # Module imports
-from plane.db.models import User, Workspace, WorkspaceMember
+from plane.db.models import ProjectMember, User, Workspace, WorkspaceMember
 
 
 class Command(BaseCommand):
@@ -19,8 +19,12 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         # get the workspace slug and user email from console
-        slug = options.get("slug", False)
-        email = options.get("email", False)
+        slug = options.get("slug") or ""
+        email = options.get("email") or ""
+
+        # normalize before validating; emails are stored lowercased and stripped (User.save)
+        slug = slug.strip()
+        email = email.strip().lower()
 
         # raise error if slug is not present
         if not slug:
@@ -29,9 +33,6 @@ class Command(BaseCommand):
         # raise error if email is not present
         if not email:
             raise CommandError("Error: Email is required")
-
-        # emails are stored lowercased and stripped (User.save)
-        email = email.strip().lower()
 
         # filter the user
         user = User.objects.filter(email=email).first()
@@ -56,16 +57,36 @@ class Command(BaseCommand):
 
         # If already active, report without erroring
         if workspace_member.is_active:
-            self.stdout.write(
-                self.style.SUCCESS(f"User {email} is already an active member of workspace {slug}")
-            )
+            self.stdout.write(self.style.SUCCESS(f"User {email} is already an active member of workspace {slug}"))
             return
 
-        # Reactivate the membership; limit the write so audit fields set by
-        # BaseModel.save (no request user here) are not persisted
+        # Reactivate the membership. update_fields keeps the write to the columns that change, and
+        # disable_auto_set_user stops BaseModel.save from nulling created_by/updated_by when there
+        # is no request user, as is the case in a management command.
         workspace_member.is_active = True
-        workspace_member.save(update_fields=["is_active"])
+        workspace_member.save(update_fields=["is_active", "updated_at"], disable_auto_set_user=True)
 
         self.stdout.write(
-            self.style.SUCCESS(f"User {email} reactivated successfully in workspace {slug}")
+            self.style.SUCCESS(
+                f"User {email} reactivated successfully in workspace {slug} as {workspace_member.get_role_display()}"
+            )
         )
+
+        # Removing a member also deactivates their project memberships, which this command leaves alone
+        inactive_projects = ProjectMember.objects.filter(workspace=workspace, member=user, is_active=False).count()
+        if inactive_projects:
+            self.stdout.write(
+                self.style.WARNING(
+                    f"Note: {inactive_projects} project membership(s) remain inactive; "
+                    "removing a member also deactivates their project memberships"
+                )
+            )
+
+        # A member removed by deactivating their account also has an inactive user record
+        if not user.is_active:
+            self.stdout.write(
+                self.style.WARNING(
+                    f"Note: the account for {email} is deactivated and cannot sign in. "
+                    f"Run 'python manage.py activate_user {email}' to activate it."
+                )
+            )

--- a/apps/api/plane/db/management/commands/reactivate_workspace_member.py
+++ b/apps/api/plane/db/management/commands/reactivate_workspace_member.py
@@ -30,19 +30,22 @@ class Command(BaseCommand):
         if not email:
             raise CommandError("Error: Email is required")
 
+        # emails are stored lowercased and stripped (User.save)
+        email = email.strip().lower()
+
         # filter the user
         user = User.objects.filter(email=email).first()
 
         # Raise error if the user is not present
         if not user:
-            raise CommandError(f"Error: User with {email} does not exists")
+            raise CommandError(f"Error: User with {email} does not exist")
 
         # filter the workspace
         workspace = Workspace.objects.filter(slug=slug).first()
 
         # Raise error if the workspace is not present
         if not workspace:
-            raise CommandError(f"Error: Workspace with slug {slug} does not exists")
+            raise CommandError(f"Error: Workspace with slug {slug} does not exist")
 
         # Find the workspace membership (includes inactive members; soft-deleted are excluded by default manager)
         workspace_member = WorkspaceMember.objects.filter(workspace=workspace, member=user).first()
@@ -58,9 +61,10 @@ class Command(BaseCommand):
             )
             return
 
-        # Reactivate the membership
+        # Reactivate the membership; limit the write so audit fields set by
+        # BaseModel.save (no request user here) are not persisted
         workspace_member.is_active = True
-        workspace_member.save()
+        workspace_member.save(update_fields=["is_active"])
 
         self.stdout.write(
             self.style.SUCCESS(f"User {email} reactivated successfully in workspace {slug}")


### PR DESCRIPTION
### Description

Adds a Django management command `reactivate_workspace_member` that restores a deactivated workspace member from the instance side, given a workspace slug and the user's email:

```
python manage.py reactivate_workspace_member <workspace-slug> <user@email.com>
```

When a member is removed from (or leaves) a workspace, their `WorkspaceMember` row is set to `is_active=False` and there is no admin-facing way to reverse an accidental removal — re-inviting is the only path. This command flips the membership back to active:

- Looks up the user by email and the workspace by slug, raising `CommandError` if either is missing
- Finds the `WorkspaceMember` row via the default manager (inactive rows included, soft-deleted rows excluded) and errors if the user was never a member
- If the membership is already active, reports that and exits cleanly without erroring
- Otherwise sets `is_active=True` and saves — the `role` field is untouched by deactivation, so the member returns with exactly the workspace role they had before removal

Note: project memberships are intentionally not restored. Removal deactivates all of the user's `ProjectMember` rows in the workspace; reversing that is left to a possible follow-up (e.g. a `--with-projects` flag). The command follows the conventions of the existing commands in `plane/db/management/commands/` (e.g. `activate_user.py`).

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)

<!-- Add screenshots here -->

### Test Scenarios

- Remove a member from a workspace, then run `python manage.py reactivate_workspace_member <slug> <email>` and verify the member regains workspace access with their previous role
- Run the command for an already-active member and verify it reports success without erroring
- Run with a non-existent email, a non-existent workspace slug, and an email that was never a member of the workspace — each should fail with a clear `CommandError`
- Verify the reactivated member's project memberships remain inactive (expected: they must be re-added to projects individually)

### References

- [WEB-8512](https://app.plane.so/plane/browse/WEB-8512/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an administrative command to reactivate inactive workspace memberships using a workspace slug and user email.
  * Added input validation, email normalization, and clear status messages for missing or invalid workspace, user, or membership details.
  * Existing active memberships are detected and left unchanged.
  * Successfully reactivated memberships are saved for continued workspace access.
  * Added warnings for inactive project memberships and deactivated user accounts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->