### PR TITLE
fix(web): trailing slash on workspace notification list API

### DIFF
--- a/apps/web/core/services/workspace-notification.service.ts
+++ b/apps/web/core/services/workspace-notification.service.ts
@@ -36,7 +36,7 @@ export class WorkspaceNotificationService extends APIService {
     params: TNotificationPaginatedInfoQueryParams
   ): Promise<TNotificationPaginatedInfo | undefined> {
     try {
-      const { data } = await this.get(`/api/workspaces/${workspaceSlug}/users/notifications`, {
+      const { data } = await this.get(`/api/workspaces/${workspaceSlug}/users/notifications/`, {
         params,
       });
       return data || undefined;

--- a/packages/services/src/workspace/notification.service.ts
+++ b/packages/services/src/workspace/notification.service.ts
@@ -42,7 +42,7 @@ export class WorkspaceNotificationService extends APIService {
     workspaceSlug: string,
     params: TNotificationPaginatedInfoQueryParams
   ): Promise<TNotificationPaginatedInfo | undefined> {
-    return this.get(`/api/workspaces/${workspaceSlug}/users/notifications`, { params })
+    return this.get(`/api/workspaces/${workspaceSlug}/users/notifications/`, { params })
       .then((response) => response?.data)
       .catch((error) => {
         throw error?.response?.data;


### PR DESCRIPTION
## Summary
- `WorkspaceNotificationService.list()` / `fetchNotifications()` called `/users/notifications` **without** a trailing slash.
- Backend only registers `.../users/notifications/` (Django).
- Unread count (`.../unread/`) worked; the inbox **list** 404'd (often surfaces as **500** behind Traefik on self-hosted).
- Every sibling method already used a trailing slash.

## Changes
- `packages/services/src/workspace/notification.service.ts` — append `/` on `list()`
- `apps/web/core/services/workspace-notification.service.ts` — same for `fetchNotifications()`

## Fixes
Closes #9489

## Test plan
- [ ] Open workspace inbox with existing notifications
- [ ] Network: `GET /api/workspaces/{slug}/users/notifications/?…` → **200** with `results`
- [ ] Badge unread count still works
- [ ] Self-hosted + Traefik no longer shows 500 for the list call

## Notes
Confirmed still present on **v1.3.1**, **v1.4.0**, and `preview` HEAD before this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when loading workspace notifications by correcting the notification listing endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->