### PR TITLE
fix: unescape HTML entities in plain-text email bodies

### DIFF
--- a/apiserver/plane/bgtasks/forgot_password_task.py
+++ b/apiserver/plane/bgtasks/forgot_password_task.py
@@ -1,4 +1,5 @@
 # Python imports
+import html
 import logging
 
 # Third party imports
@@ -43,7 +44,7 @@ def forgot_password(first_name, email, uidb64, token, current_site):
 
         html_content = render_to_string("emails/auth/forgot_password.html", context)
 
-        text_content = strip_tags(html_content)
+        text_content = html.unescape(strip_tags(html_content))
 
         connection = get_connection(
             host=EMAIL_HOST,

--- a/apiserver/plane/bgtasks/magic_link_code_task.py
+++ b/apiserver/plane/bgtasks/magic_link_code_task.py
@@ -1,4 +1,5 @@
 # Python imports
+import html
 import logging
 
 # Third party imports
@@ -33,7 +34,7 @@ def magic_link(email, key, token, current_site):
         context = {"code": token, "email": email}
 
         html_content = render_to_string("emails/auth/magic_signin.html", context)
-        text_content = strip_tags(html_content)
+        text_content = html.unescape(strip_tags(html_content))
 
         connection = get_connection(
             host=EMAIL_HOST,

--- a/apiserver/plane/bgtasks/project_invitation_task.py
+++ b/apiserver/plane/bgtasks/project_invitation_task.py
@@ -1,4 +1,5 @@
 # Python imports
+import html
 import logging
 
 # Third party imports
@@ -41,7 +42,7 @@ def project_invitation(email, project_id, token, current_site, invitor):
             "emails/invitations/project_invitation.html", context
         )
 
-        text_content = strip_tags(html_content)
+        text_content = html.unescape(strip_tags(html_content))
 
         project_member_invite.message = text_content
         project_member_invite.save()

--- a/apiserver/plane/bgtasks/user_activation_email_task.py
+++ b/apiserver/plane/bgtasks/user_activation_email_task.py
@@ -1,4 +1,5 @@
 # Python imports
+import html
 import logging
 
 # Django imports
@@ -27,7 +28,7 @@ def user_activation_email(current_site, user_id):
         # Send email to user
         html_content = render_to_string("emails/user/user_activation.html", context)
 
-        text_content = strip_tags(html_content)
+        text_content = html.unescape(strip_tags(html_content))
         # Configure email connection from the database
         (
             EMAIL_HOST,

--- a/apiserver/plane/bgtasks/user_deactivation_email_task.py
+++ b/apiserver/plane/bgtasks/user_deactivation_email_task.py
@@ -1,4 +1,5 @@
 # Python imports
+import html
 import logging
 
 # Django imports
@@ -27,7 +28,7 @@ def user_deactivation_email(current_site, user_id):
         # Send email to user
         html_content = render_to_string("emails/user/user_deactivation.html", context)
 
-        text_content = strip_tags(html_content)
+        text_content = html.unescape(strip_tags(html_content))
         # Configure email connection from the database
         (
             EMAIL_HOST,

--- a/apiserver/plane/bgtasks/workspace_invitation_task.py
+++ b/apiserver/plane/bgtasks/workspace_invitation_task.py
@@ -1,4 +1,5 @@
 # Python imports
+import html
 import logging
 
 # Third party imports
@@ -55,7 +56,7 @@ def workspace_invitation(email, workspace_id, token, current_site, inviter):
             "emails/invitations/workspace_invitation.html", context
         )
 
-        text_content = strip_tags(html_content)
+        text_content = html.unescape(strip_tags(html_content))
 
         workspace_member_invite.message = text_content
         workspace_member_invite.save()


### PR DESCRIPTION
`django.utils.html.strip_tags()` strips HTML markup but leaves character entities (`&amp;`, `&lt;`, etc.) in the output as literals. In invitation and authentication emails, URLs are rendered inside HTML anchor tags — so `&` in query strings becomes `&amp;` in the HTML source. After stripping tags the entity survives, producing fallback links like:

```
https://app.plane.so/workspace-invitations/?invitation_id=…&amp;slug=…
```

Email clients that display the plain-text part pass this literally to the browser, which sees `amp;slug` and `amp;token` instead of `slug` and `token`. The invitation page never fetches `/api/workspaces/<slug>/invitations/<id>/` and stays on the loading screen indefinitely.

Wrapping the result in `html.unescape()` decodes all entities before the text is stored or sent. Applied consistently across every email background task that follows the same pattern.

Fixes #9497