### PR TITLE
fix(api): stop rendering "None" and raw TipTap in issue-update emails

### DIFF
--- a/apps/api/plane/bgtasks/email_notification_task.py
+++ b/apps/api/plane/bgtasks/email_notification_task.py
@@ -98,6 +98,27 @@ def is_meaningful_activity_value(value):
     return value.strip() not in _EMPTY_ACTIVITY_VALUES
 
 
+def absolute_avatar_url(base_api, avatar_url):
+    """
+    Build an absolute avatar URL for email HTML, or "" for the initials fallback.
+
+    Upstream bug: f\"{base_api}{actor.avatar_url}\" when avatar_url is None becomes
+    \"https://hostNone\", which is truthy in the template so clients show a broken
+    image icon instead of the letter avatar.
+    """
+    if not avatar_url or not is_meaningful_activity_value(str(avatar_url)):
+        return ""
+    url = str(avatar_url).strip()
+    if url.startswith("http://") or url.startswith("https://"):
+        return url
+    if not base_api:
+        return url
+    base = str(base_api).rstrip("/")
+    if not url.startswith("/"):
+        url = f"/{url}"
+    return f"{base}{url}"
+
+
 def create_payload(notification_data):
     # return format {"actor_id":  { "key": { "old_value": [], "new_value": [] } }}
     data = {}
@@ -255,7 +276,7 @@ def send_email_notification(issue_id, notification_data, receiver_id, email_noti
                             {
                                 "actor_comments": comment,
                                 "actor_detail": {
-                                    "avatar_url": f"{base_api}{actor.avatar_url}",
+                                    "avatar_url": absolute_avatar_url(base_api, actor.avatar_url),
                                     "first_name": actor.first_name,
                                     "last_name": actor.last_name,
                                 },
@@ -269,7 +290,7 @@ def send_email_notification(issue_id, notification_data, receiver_id, email_noti
                             {
                                 "actor_comments": mention,
                                 "actor_detail": {
-                                    "avatar_url": f"{base_api}{actor.avatar_url}",
+                                    "avatar_url": absolute_avatar_url(base_api, actor.avatar_url),
                                     "first_name": actor.first_name,
                                     "last_name": actor.last_name,
                                 },
@@ -282,7 +303,7 @@ def send_email_notification(issue_id, notification_data, receiver_id, email_noti
                     template_data.append(
                         {
                             "actor_detail": {
-                                "avatar_url": f"{base_api}{actor.avatar_url}",
+                                "avatar_url": absolute_avatar_url(base_api, actor.avatar_url),
                                 "first_name": actor.first_name,
                                 "last_name": actor.last_name,
                             },

--- a/apps/api/plane/bgtasks/email_notification_task.py
+++ b/apps/api/plane/bgtasks/email_notification_task.py
@@ -84,69 +84,118 @@ def stack_email_notification():
     EmailNotificationLog.objects.filter(pk__in=processed_notifications).update(processed_at=timezone.now())
 
 
+# Values that must never appear as email field/comment content.
+# notification_task uses str(None) → "None" for deleted comments and empty fields.
+_EMPTY_ACTIVITY_VALUES = frozenset({"", "None", "null", "none", "NULL", "NoneType"})
+
+
+def is_meaningful_activity_value(value):
+    """Return True if value is real user-facing content (not None / "None" / blank)."""
+    if value is None:
+        return False
+    if not isinstance(value, str):
+        value = str(value)
+    return value.strip() not in _EMPTY_ACTIVITY_VALUES
+
+
 def create_payload(notification_data):
     # return format {"actor_id":  { "key": { "old_value": [], "new_value": [] } }}
     data = {}
     for actor_id, changes in notification_data.items():
         for change in changes:
             issue_activity = change.get("issue_activity")
-            if issue_activity:  # Ensure issue_activity is not None
-                field = issue_activity.get("field")
-                old_value = str(issue_activity.get("old_value"))
-                new_value = str(issue_activity.get("new_value"))
+            if not issue_activity:
+                continue
 
-                # Append old_value if it's not empty and not already in the list
-                if old_value:
-                    (
-                        data.setdefault(actor_id, {})
-                        .setdefault(field, {})
-                        .setdefault("old_value", [])
-                        .append(old_value)
-                        if old_value not in data.setdefault(actor_id, {}).setdefault(field, {}).get("old_value", [])
-                        else None
-                    )
+            field = issue_activity.get("field")
+            verb = issue_activity.get("verb")
 
-                # Append new_value if it's not empty and not already in the list
-                if new_value:
-                    (
-                        data.setdefault(actor_id, {})
-                        .setdefault(field, {})
-                        .setdefault("new_value", [])
-                        .append(new_value)
-                        if new_value not in data.setdefault(actor_id, {}).setdefault(field, {}).get("new_value", [])
-                        else None
-                    )
+            # Deleted comments leave new_value/old_value as None → str → "None".
+            # Including them produces unprofessional "None" boxes in the Comments section.
+            if verb == "deleted" and field in ("comment", "mention"):
+                continue
 
-                if not data.get("actor_id", {}).get("activity_time", False):
-                    data[actor_id]["activity_time"] = str(
-                        datetime.fromisoformat(issue_activity.get("activity_time").rstrip("Z")).strftime(
-                            "%Y-%m-%d %H:%M:%S"
-                        )
-                    )
+            old_value = issue_activity.get("old_value")
+            new_value = issue_activity.get("new_value")
+            if old_value is not None:
+                old_value = str(old_value)
+            if new_value is not None:
+                new_value = str(new_value)
+
+            # Append old_value if meaningful and not already in the list
+            if is_meaningful_activity_value(old_value):
+                old_list = data.setdefault(actor_id, {}).setdefault(field, {}).setdefault("old_value", [])
+                if old_value not in old_list:
+                    old_list.append(old_value)
+
+            # Append new_value if meaningful and not already in the list
+            if is_meaningful_activity_value(new_value):
+                new_list = data.setdefault(actor_id, {}).setdefault(field, {}).setdefault("new_value", [])
+                if new_value not in new_list:
+                    new_list.append(new_value)
+
+            # activity_time: only set when we have (or will have) payload for this actor
+            activity_time = issue_activity.get("activity_time")
+            if activity_time and actor_id in data and "activity_time" not in data[actor_id]:
+                data[actor_id]["activity_time"] = str(
+                    datetime.fromisoformat(str(activity_time).rstrip("Z")).strftime("%Y-%m-%d %H:%M:%S")
+                )
 
     return data
 
 
+def process_email_html(html_content):
+    """
+    Convert TipTap/editor HTML into email-safe HTML.
+
+    - mention-component → @display_name
+    - image-component → [Image] placeholder (asset UUIDs are not public URLs)
+    - issue-embed-component → [Work item] placeholder
+    """
+    if not is_meaningful_activity_value(html_content):
+        return None
+
+    soup = BeautifulSoup(html_content, "html.parser")
+
+    for mention in soup.find_all("mention-component"):
+        user_id = mention.get("entity_identifier")
+        try:
+            user = User.objects.get(pk=user_id)
+            mention.replace_with(f"@{user.display_name}")
+        except Exception:
+            mention.replace_with("@user")
+
+    for image in soup.find_all("image-component"):
+        image.replace_with("[Image]")
+
+    for embed in soup.find_all("issue-embed-component"):
+        label = embed.get("entity_name") or "Work item"
+        embed.replace_with(f"[{label}]")
+
+    # Drop empty paragraphs left after stripping custom nodes
+    text = str(soup).strip()
+    if not text or not BeautifulSoup(text, "html.parser").get_text(strip=True):
+        # Still allow content that is only images/embeds converted to placeholders
+        if "[Image]" not in text and "[" not in text:
+            return None
+    return text
+
+
 def process_mention(mention_component):
-    soup = BeautifulSoup(mention_component, "html.parser")
-    mentions = soup.find_all("mention-component")
-    for mention in mentions:
-        user_id = mention["entity_identifier"]
-        user = User.objects.get(pk=user_id)
-        user_name = user.display_name
-        highlighted_name = f"@{user_name}"
-        mention.replace_with(highlighted_name)
-    return str(soup)
+    """Backward-compatible alias used by existing call sites / tests."""
+    return process_email_html(mention_component) or ""
 
 
 def process_html_content(content):
+    """Process a list of HTML fragments for email. Drops empty / None / 'None' entries."""
     if content is None:
         return None
     processed_content_list = []
     for html_content in content:
-        processed_content = process_mention(html_content)
-        processed_content_list.append(processed_content)
-    return processed_content_list
+        processed_content = process_email_html(html_content)
+        if is_meaningful_activity_value(processed_content):
+            processed_content_list.append(processed_content)
+    return processed_content_list or None
 
 
 @shared_task
@@ -191,36 +240,45 @@ def send_email_notification(issue_id, notification_data, receiver_id, email_noti
                 total_changes = total_changes + len(changes)
                 comment = changes.pop("comment", False)
                 mention = changes.pop("mention", False)
+                activity_time = changes.pop("activity_time", None)
                 actors_involved.append(actor_id)
+
+                # Comments and mentions both need TipTap HTML converted for email clients.
+                # Previously only mentions were processed, so raw mention-component /
+                # image-component tags and str(None)→"None" deleted-comment residue
+                # rendered as broken form-like boxes (see issue-updates Comments section).
                 if comment:
-                    comments.append(
-                        {
-                            "actor_comments": comment,
-                            "actor_detail": {
-                                "avatar_url": f"{base_api}{actor.avatar_url}",
-                                "first_name": actor.first_name,
-                                "last_name": actor.last_name,
-                            },
-                        }
-                    )
+                    comment["new_value"] = process_html_content(comment.get("new_value"))
+                    comment["old_value"] = process_html_content(comment.get("old_value"))
+                    if comment.get("new_value"):
+                        comments.append(
+                            {
+                                "actor_comments": comment,
+                                "actor_detail": {
+                                    "avatar_url": f"{base_api}{actor.avatar_url}",
+                                    "first_name": actor.first_name,
+                                    "last_name": actor.last_name,
+                                },
+                            }
+                        )
                 if mention:
                     mention["new_value"] = process_html_content(mention.get("new_value"))
                     mention["old_value"] = process_html_content(mention.get("old_value"))
-                    comments.append(
-                        {
-                            "actor_comments": mention,
-                            "actor_detail": {
-                                "avatar_url": f"{base_api}{actor.avatar_url}",
-                                "first_name": actor.first_name,
-                                "last_name": actor.last_name,
-                            },
-                        }
-                    )
-                activity_time = changes.pop("activity_time")
-                # Parse the input string into a datetime object
-                formatted_time = datetime.strptime(activity_time, "%Y-%m-%d %H:%M:%S").strftime("%H:%M %p")
+                    if mention.get("new_value"):
+                        comments.append(
+                            {
+                                "actor_comments": mention,
+                                "actor_detail": {
+                                    "avatar_url": f"{base_api}{actor.avatar_url}",
+                                    "first_name": actor.first_name,
+                                    "last_name": actor.last_name,
+                                },
+                            }
+                        )
 
-                if changes:
+                # Skip property-update block if no real field changes remain
+                if changes and activity_time:
+                    formatted_time = datetime.strptime(activity_time, "%Y-%m-%d %H:%M:%S").strftime("%H:%M %p")
                     template_data.append(
                         {
                             "actor_detail": {
@@ -236,6 +294,16 @@ def send_email_notification(issue_id, notification_data, receiver_id, email_noti
                             "activity_time": str(formatted_time),
                         }
                     )
+
+            # Nothing meaningful to email (e.g. only deleted comments / empty "None" values)
+            if not template_data and not comments:
+                logging.getLogger("plane.worker").info(
+                    "Skipping empty issue-update email for issue %s receiver %s",
+                    issue_id,
+                    receiver_id,
+                )
+                release_lock(lock_id=lock_id)
+                return
 
             summary = "Updates were made to the issue by"
 

--- a/apps/api/plane/bgtasks/notification_task.py
+++ b/apps/api/plane/bgtasks/notification_task.py
@@ -31,6 +31,18 @@ from celery import shared_task
 from bs4 import BeautifulSoup
 
 
+def activity_value_as_str(value):
+    """
+    Serialize activity old/new values for notification / email payloads.
+
+    Avoid str(None) → "None", which was rendered as literal comment text in
+    issue-update emails when comments were deleted (new_value left null).
+    """
+    if value is None:
+        return ""
+    return str(value)
+
+
 # =========== Issue Description Html Parsing and notification Functions ======================
 
 
@@ -178,8 +190,8 @@ def create_mention_notification(project, notification_comment, issue, actor_id, 
                 "verb": str(activity.get("verb")),
                 "field": str(activity.get("field")),
                 "actor": str(activity.get("actor_id")),
-                "new_value": str(activity.get("new_value")),
-                "old_value": str(activity.get("old_value")),
+                "new_value": activity_value_as_str(activity.get("new_value")),
+                "old_value": activity_value_as_str(activity.get("old_value")),
                 "old_identifier": (str(activity.get("old_identifier")) if activity.get("old_identifier") else None),
                 "new_identifier": (str(activity.get("new_identifier")) if activity.get("new_identifier") else None),
             },
@@ -385,8 +397,8 @@ def notifications(
                                     "verb": str(issue_activity.get("verb")),
                                     "field": str(issue_activity.get("field")),
                                     "actor": str(issue_activity.get("actor_id")),
-                                    "new_value": str(issue_activity.get("new_value")),
-                                    "old_value": str(issue_activity.get("old_value")),
+                                    "new_value": activity_value_as_str(issue_activity.get("new_value")),
+                                    "old_value": activity_value_as_str(issue_activity.get("old_value")),
                                     "issue_comment": str(
                                         issue_comment.comment_stripped if issue_comment is not None else ""
                                     ),
@@ -428,8 +440,8 @@ def notifications(
                                         "verb": str(issue_activity.get("verb")),
                                         "field": str(issue_activity.get("field")),
                                         "actor": str(issue_activity.get("actor_id")),
-                                        "new_value": str(issue_activity.get("new_value")),
-                                        "old_value": str(issue_activity.get("old_value")),
+                                        "new_value": activity_value_as_str(issue_activity.get("new_value")),
+                                        "old_value": activity_value_as_str(issue_activity.get("old_value")),
                                         "issue_comment": str(
                                             issue_comment.comment_stripped if issue_comment is not None else ""
                                         ),
@@ -500,8 +512,8 @@ def notifications(
                                             "verb": str(issue_activity.get("verb")),
                                             "field": str("mention"),
                                             "actor": str(issue_activity.get("actor_id")),
-                                            "new_value": str(issue_activity.get("new_value")),
-                                            "old_value": str(issue_activity.get("old_value")),
+                                            "new_value": activity_value_as_str(issue_activity.get("new_value")),
+                                            "old_value": activity_value_as_str(issue_activity.get("old_value")),
                                             "old_identifier": (
                                                 str(issue_activity.get("old_identifier"))
                                                 if issue_activity.get("old_identifier")
@@ -553,8 +565,8 @@ def notifications(
                                         "verb": str(last_activity.verb),
                                         "field": str(last_activity.field),
                                         "actor": str(last_activity.actor_id),
-                                        "new_value": str(last_activity.new_value),
-                                        "old_value": str(last_activity.old_value),
+                                        "new_value": activity_value_as_str(last_activity.new_value),
+                                        "old_value": activity_value_as_str(last_activity.old_value),
                                         "old_identifier": (
                                             str(issue_activity.get("old_identifier"))
                                             if issue_activity.get("old_identifier")
@@ -590,8 +602,8 @@ def notifications(
                                             "verb": str(last_activity.verb),
                                             "field": "mention",
                                             "actor": str(last_activity.actor_id),
-                                            "new_value": str(last_activity.new_value),
-                                            "old_value": str(last_activity.old_value),
+                                            "new_value": activity_value_as_str(last_activity.new_value),
+                                            "old_value": activity_value_as_str(last_activity.old_value),
                                             "old_identifier": (
                                                 str(issue_activity.get("old_identifier"))
                                                 if issue_activity.get("old_identifier")
@@ -639,8 +651,8 @@ def notifications(
                                                 "verb": str(issue_activity.get("verb")),
                                                 "field": str("mention"),
                                                 "actor": str(issue_activity.get("actor_id")),
-                                                "new_value": str(issue_activity.get("new_value")),
-                                                "old_value": str(issue_activity.get("old_value")),
+                                                "new_value": activity_value_as_str(issue_activity.get("new_value")),
+                                                "old_value": activity_value_as_str(issue_activity.get("old_value")),
                                                 "old_identifier": (
                                                     str(issue_activity.get("old_identifier"))
                                                     if issue_activity.get("old_identifier")

--- a/apps/api/plane/tests/unit/bg_tasks/test_email_notification_payload.py
+++ b/apps/api/plane/tests/unit/bg_tasks/test_email_notification_payload.py
@@ -9,6 +9,7 @@ str(None) → "None" values rendered as empty form-like boxes.
 """
 
 from plane.bgtasks.email_notification_task import (
+    absolute_avatar_url,
     create_payload,
     is_meaningful_activity_value,
     process_email_html,
@@ -136,3 +137,24 @@ class TestProcessEmailHtml:
             ]
         )
         assert result == ["<p><strong>UPDATE</strong></p>"]
+
+
+class TestAbsoluteAvatarUrl:
+    def test_none_does_not_become_hostnone(self):
+        # Regression: f"{base}{None}" → "https://plane.darka.ioNone" broken <img>
+        assert absolute_avatar_url("https://plane.darka.io", None) == ""
+        assert absolute_avatar_url("https://plane.darka.io", "") == ""
+        assert absolute_avatar_url("https://plane.darka.io", "None") == ""
+
+    def test_relative_path_prefixed(self):
+        assert (
+            absolute_avatar_url(
+                "https://plane.darka.io",
+                "/api/assets/v2/static/abc/",
+            )
+            == "https://plane.darka.io/api/assets/v2/static/abc/"
+        )
+
+    def test_absolute_unchanged(self):
+        url = "https://cdn.example.com/a.png"
+        assert absolute_avatar_url("https://plane.darka.io", url) == url

--- a/apps/api/plane/tests/unit/bg_tasks/test_email_notification_payload.py
+++ b/apps/api/plane/tests/unit/bg_tasks/test_email_notification_payload.py
@@ -1,0 +1,138 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Unit tests for email notification payload assembly.
+
+Reproduces the broken Comments section where deleted comments and
+str(None) → "None" values rendered as empty form-like boxes.
+"""
+
+from plane.bgtasks.email_notification_task import (
+    create_payload,
+    is_meaningful_activity_value,
+    process_email_html,
+    process_html_content,
+)
+
+
+class TestIsMeaningfulActivityValue:
+    def test_rejects_none_and_none_string(self):
+        assert is_meaningful_activity_value(None) is False
+        assert is_meaningful_activity_value("None") is False
+        assert is_meaningful_activity_value("null") is False
+        assert is_meaningful_activity_value("") is False
+        assert is_meaningful_activity_value("   ") is False
+
+    def test_accepts_real_content(self):
+        assert is_meaningful_activity_value("UPDATE") is True
+        assert is_meaningful_activity_value("<p><strong>UPDATE</strong></p>") is True
+        assert is_meaningful_activity_value("none of the above") is True  # not exact match
+
+
+class TestCreatePayloadFiltersNoneAndDeletedComments:
+    def test_eqa6_regression_deleted_comment_none_string(self):
+        """Exact payload shape from production EQA-6 email at 2026-08-01 13:05 UTC.
+
+        Before fix: new_value = [UPDATE html, "None"] → two broken comment boxes.
+        After fix: only the real created comment remains.
+        """
+        notification_data = {
+            "608cad9a-0fb4-47a3-8b1f-47057f34ca49": [
+                {
+                    "issue_activity": {
+                        "verb": "created",
+                        "field": "comment",
+                        "new_value": (
+                            '<p class="editor-paragraph-block" '
+                            'data-id="c826262e-0789-43b4-900d-af536160231a">'
+                            "<strong>UPDATE</strong></p>"
+                        ),
+                        "old_value": "None",
+                        "activity_time": "2026-08-01T13:03:31.729455Z",
+                    }
+                },
+                {
+                    "issue_activity": {
+                        "verb": "deleted",
+                        "field": "comment",
+                        "new_value": "None",
+                        "old_value": "None",
+                        "activity_time": "2026-08-01T13:03:34.682665Z",
+                    }
+                },
+            ]
+        }
+
+        payload = create_payload(notification_data)
+        actor = payload["608cad9a-0fb4-47a3-8b1f-47057f34ca49"]
+        assert "comment" in actor
+        assert actor["comment"]["new_value"] == [
+            '<p class="editor-paragraph-block" data-id="c826262e-0789-43b4-900d-af536160231a">'
+            "<strong>UPDATE</strong></p>"
+        ]
+        # old_value "None" must not appear
+        assert "old_value" not in actor["comment"] or actor["comment"].get("old_value") == []
+
+    def test_skips_deleted_comment_only_batch(self):
+        notification_data = {
+            "actor-1": [
+                {
+                    "issue_activity": {
+                        "verb": "deleted",
+                        "field": "comment",
+                        "new_value": "None",
+                        "old_value": "None",
+                        "activity_time": "2026-08-01T13:03:34.682665Z",
+                    }
+                }
+            ]
+        }
+        payload = create_payload(notification_data)
+        assert payload == {}
+
+    def test_keeps_real_assignee_change(self):
+        notification_data = {
+            "actor-1": [
+                {
+                    "issue_activity": {
+                        "verb": "updated",
+                        "field": "assignees",
+                        "new_value": "office",
+                        "old_value": "",
+                        "activity_time": "2026-08-01T13:09:28.906563Z",
+                    }
+                }
+            ]
+        }
+        payload = create_payload(notification_data)
+        assert payload["actor-1"]["assignees"]["new_value"] == ["office"]
+        assert "old_value" not in payload["actor-1"]["assignees"]
+
+
+class TestProcessEmailHtml:
+    def test_strips_image_component(self):
+        html = (
+            '<p>See screenshot</p>'
+            '<image-component src="fda9bf23-aedf-4d20-b7fd-d876cbed150e" '
+            'status="uploaded" width="232px"></image-component>'
+        )
+        out = process_email_html(html)
+        assert "image-component" not in out
+        assert "[Image]" in out
+        assert "See screenshot" in out
+
+    def test_rejects_none_string(self):
+        assert process_email_html("None") is None
+        assert process_email_html(None) is None
+
+    def test_process_html_content_filters_list(self):
+        result = process_html_content(
+            [
+                "<p><strong>UPDATE</strong></p>",
+                "None",
+                None,
+                "",
+            ]
+        )
+        assert result == ["<p><strong>UPDATE</strong></p>"]


### PR DESCRIPTION
## Summary

Fixes broken/unprofessional **Comments** boxes in issue-update emails (literal `None`, raw TipTap nodes).

Closes #9523  
Related: #9218 (same `|safe` path; this PR is rendering correctness, not XSS sanitizer)

### Problem

Deleted comments leave `new_value`/`old_value` as SQL `NULL`.  
`notification_task` did `str(None)` → `"None"`, and `create_payload` treated that string as real comment body. Batched create+delete then rendered e.g. **UPDATE** + **None** as two white boxes under Comments.

Regular comments were also never run through HTML post-processing (only mentions were), so `mention-component` / `image-component` stayed raw in the email.

### Fix

1. **`notification_task`**: `activity_value_as_str()` returns `""` for `None` instead of `"None"`
2. **`create_payload`**: skip `verb=deleted` comment/mention activities; drop empty/`"None"` values
3. **`send_email_notification`**: process **comment** HTML like mentions; convert TipTap nodes (`@name`, `[Image]`, embeds); skip send when body would be empty
4. **Tests**: regression for the exact EQA-6 payload shape observed in production

### Test plan

- [x] Unit tests: `test_email_notification_payload.py` (EQA-6 regression, deleted-only batch, image placeholder)
- [ ] Manual: create short comment → delete it → confirm email either shows only real remaining comments or is skipped
- [ ] Manual: comment with `@mention` + image → email shows `@display_name` and `[Image]`, not custom tags
- [ ] Manual: normal assignee/state updates still render in Updates section

### Notes

Does **not** fully address #9218 (XSS via `|safe`). That still needs a real HTML allowlist/sanitizer on the email path; this PR stops the garbage `"None"` content and makes comments email-readable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed empty, null, or misleading values from email and notification activity details.
  * Deleted comments and mentions are no longer included in activity emails.
  * Preserved valid timestamps and meaningful property changes.
  * Improved email formatting for mentions, images, and embedded issues, including clearer handling of unavailable users.
  * Corrected avatar links and fallback handling for missing avatars.
  * Empty updates are now skipped, preventing notifications with no useful content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->