### PR TITLE
fix(web): link active cycle progress empty state to cycle work items

### DIFF
--- a/apps/web/core/components/cycles/active-cycle/progress.tsx
+++ b/apps/web/core/components/cycles/active-cycle/progress.tsx
@@ -6,6 +6,7 @@
 
 import { observer } from "mobx-react";
 import { useTheme } from "next-themes";
+import Link from "next/link";
 // plane imports
 import { PROGRESS_STATE_GROUPS_DETAILS } from "@plane/constants";
 import { useTranslation } from "@plane/i18n";
@@ -26,7 +27,7 @@ export type ActiveCycleProgressProps = {
 };
 
 export const ActiveCycleProgress = observer(function ActiveCycleProgress(props: ActiveCycleProgressProps) {
-  const { handleFiltersUpdate, cycle } = props;
+  const { handleFiltersUpdate, cycle, workspaceSlug, projectId } = props;
   // theme hook
   const { resolvedTheme } = useTheme();
   // plane hooks
@@ -52,7 +53,9 @@ export const ActiveCycleProgress = observer(function ActiveCycleProgress(props: 
     <div className="flex min-h-[17rem] flex-col gap-5 rounded-lg border border-subtle bg-surface-1 px-3.5 py-4">
       <div className="flex flex-col gap-3">
         <div className="flex items-center justify-between gap-4">
-          <h3 className="text-14 font-semibold text-tertiary">{t("project_cycles.active_cycle.progress")}</h3>
+          <Link href={`/${workspaceSlug}/projects/${projectId}/cycles/${cycle?.id}`}>
+            <h3 className="text-14 font-semibold text-tertiary">{t("project_cycles.active_cycle.progress")}</h3>
+          </Link>
           {cycle.total_issues > 0 && (
             <span className="flex gap-1 rounded-xs px-3 py-1 text-13 font-medium whitespace-nowrap text-placeholder">
               {`${cycle.completed_issues + cycle.cancelled_issues}/${cycle.total_issues - cycle.cancelled_issues} ${
@@ -104,9 +107,11 @@ export const ActiveCycleProgress = observer(function ActiveCycleProgress(props: 
           )}
         </div>
       ) : (
-        <div className="flex h-full w-full items-center justify-center">
-          <SimpleEmptyState title={t("active_cycle.empty_state.progress.title")} assetPath={resolvedPath} />
-        </div>
+        <Link href={`/${workspaceSlug}/projects/${projectId}/cycles/${cycle?.id}`}>
+          <div className="flex h-full w-full items-center justify-center">
+            <SimpleEmptyState title={t("active_cycle.empty_state.progress.title")} assetPath={resolvedPath} />
+          </div>
+        </Link>
       )}
     </div>
   ) : (


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
Updated `apps/web/core/components/cycles/active-cycle/progress.tsx` to make the cycle progress chart empty state link to the work items of that cycle. 
Wrapped h3 tag containing "Progress" chart title and div tag containing "SimpleEmptyState" with Link tag to cycle page.
Matches the current behavior of work item burndown chart in `apps/web/core/components/cycles/active-cycle/productivity.tsx` 

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Files Changed
`apps/web/core/components/cycles/active-cycle/progress.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added navigation from the active cycle progress card to the associated project.
  * Progress headings and empty states now link directly to the relevant cycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->