### PR TITLE
docs: add Zenith Hosting deploy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Getting started with Plane is simple. Choose the setup that works best for you:
 | -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Docker               | [![Docker](https://img.shields.io/badge/docker-%230db7ed.svg?style=for-the-badge&logo=docker&logoColor=white)](https://developers.plane.so/self-hosting/methods/docker-compose)         |
 | Kubernetes           | [![Kubernetes](https://img.shields.io/badge/kubernetes-%23326ce5.svg?style=for-the-badge&logo=kubernetes&logoColor=white)](https://developers.plane.so/self-hosting/methods/kubernetes) |
+| Managed hosting      | [<img alt="Deploy with Zenith" src="https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg" height="40">](https://zenith.hosting/host/plane) |
 
 `Instance admins` can configure instance settings with [God mode](https://developers.plane.so/self-hosting/govern/instance-admin).
 


### PR DESCRIPTION
### Description

hey, i work on Zenith Hosting, a startup doing one-click hosting for open source apps. we added Plane to our marketplace, so this PR adds a small "Deploy with Zenith" badge as a row in the installation methods table under Installation (links to https://zenith.hosting/host/plane).

we share a cut of revenue with the projects we host. happy to explain if you're curious: hello@zenith.hosting

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [x] Documentation update

### Screenshots and Media (if applicable)

N/A. the badge renders inline in the existing installation methods table, matching the Docker and Kubernetes rows.

### Test Scenarios

N/A, README-only change. checked that the badge image and the link both resolve, and that the table still renders correctly in GitHub markdown preview.

### References

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a managed hosting installation option with a link to Zenith hosting and a deployment button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->