### PR TITLE
[GIT-229] fix: bucket cycle/module analytics chart by Issue.created_at

### DIFF
--- a/apps/api/plane/app/views/analytic/project_analytics.py
+++ b/apps/api/plane/app/views/analytic/project_analytics.py
@@ -199,7 +199,7 @@ class ProjectAdvanceAnalyticsChartEndpoint(ProjectAdvanceAnalyticsBaseView):
                 end_date = cycle.end_date.date()
             else:
                 return {"data": [], "schema": {}}
-            queryset = Issue.issue_objects.filter(id__in=cycle_issues)
+            queryset = queryset.filter(id__in=cycle_issues)
 
         elif module_id is not None:
             module_issues = ModuleIssue.objects.filter(**self.filters["base_filters"], module_id=module_id).values_list(
@@ -211,7 +211,7 @@ class ProjectAdvanceAnalyticsChartEndpoint(ProjectAdvanceAnalyticsBaseView):
                 end_date = module.target_date
             else:
                 return {"data": [], "schema": {}}
-            queryset = Issue.issue_objects.filter(id__in=module_issues)
+            queryset = queryset.filter(id__in=module_issues)
 
         else:
             project = Project.objects.filter(id=project_id).first()

--- a/apps/api/plane/app/views/analytic/project_analytics.py
+++ b/apps/api/plane/app/views/analytic/project_analytics.py
@@ -199,7 +199,7 @@ class ProjectAdvanceAnalyticsChartEndpoint(ProjectAdvanceAnalyticsBaseView):
                 end_date = cycle.end_date.date()
             else:
                 return {"data": [], "schema": {}}
-            queryset = cycle_issues
+            queryset = Issue.issue_objects.filter(id__in=cycle_issues)
 
         elif module_id is not None:
             module_issues = ModuleIssue.objects.filter(**self.filters["base_filters"], module_id=module_id).values_list(
@@ -211,7 +211,7 @@ class ProjectAdvanceAnalyticsChartEndpoint(ProjectAdvanceAnalyticsBaseView):
                 end_date = module.target_date
             else:
                 return {"data": [], "schema": {}}
-            queryset = module_issues
+            queryset = Issue.issue_objects.filter(id__in=module_issues)
 
         else:
             project = Project.objects.filter(id=project_id).first()
@@ -226,7 +226,7 @@ class ProjectAdvanceAnalyticsChartEndpoint(ProjectAdvanceAnalyticsBaseView):
                 queryset.values("created_at__date")
                 .annotate(
                     created_count=Count("id"),
-                    completed_count=Count("id", filter=Q(issue__state__group="completed")),
+                    completed_count=Count("id", filter=Q(state__group="completed")),
                 )
                 .order_by("created_at__date")
             )

--- a/apps/api/plane/tests/unit/views/test_project_analytics_chart.py
+++ b/apps/api/plane/tests/unit/views/test_project_analytics_chart.py
@@ -1,0 +1,84 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""
+Regression test for the cycle/module work-item completion chart.
+
+``ProjectAdvanceAnalyticsChartEndpoint.work_item_completion_chart`` reassigns
+its queryset to a bare ``CycleIssue``/``ModuleIssue`` id list
+(``values_list("issue_id", flat=True)``) when a ``cycle_id``/``module_id`` is
+given, then buckets the chart with ``queryset.values("created_at__date")``.
+Because the queryset is still shaped like ``CycleIssue``, not ``Issue``, that
+groups by *when the issue was added to the cycle* instead of *when the issue
+was created* -- so the "work items created" line on a cycle/module chart is
+keyed to the wrong date entirely.
+
+See: https://github.com/makeplane/plane/issues/9177
+"""
+
+from datetime import timedelta
+
+import pytest
+from django.utils import timezone
+
+from plane.app.views.analytic.project_analytics import ProjectAdvanceAnalyticsChartEndpoint
+from plane.db.models import Cycle, CycleIssue, Issue, Project, ProjectMember, State
+from plane.utils.date_utils import get_analytics_filters
+
+
+@pytest.mark.unit
+@pytest.mark.django_db
+class TestCycleWorkItemCompletionChartDateBucketing:
+    def _build_view(self, workspace, user):
+        view = ProjectAdvanceAnalyticsChartEndpoint()
+        view.filters = get_analytics_filters(slug=workspace.slug, user=user, type="chart")
+        return view
+
+    def test_cycle_chart_buckets_by_issue_created_at_not_cycle_issue_created_at(self, workspace, create_user):
+        project = Project.objects.create(name="Project 1", workspace=workspace)
+        ProjectMember.objects.create(project=project, member=create_user, is_active=True)
+        state = State.objects.create(project=project, name="Done", color="#000000", group="completed")
+
+        today = timezone.now().date()
+        issue_created_on = today - timedelta(days=10)
+        added_to_cycle_on = today - timedelta(days=2)
+
+        cycle = Cycle.objects.create(
+            project=project,
+            name="Cycle 1",
+            owned_by=create_user,
+            start_date=timezone.now() - timedelta(days=15),
+            end_date=timezone.now(),
+        )
+        issue = Issue.objects.create(project=project, name="Issue 1", state=state)
+        # created_at is auto_now_add — bypass save() to pin it to a controlled date.
+        Issue.objects.filter(pk=issue.pk).update(
+            created_at=timezone.make_aware(timezone.datetime.combine(issue_created_on, timezone.datetime.min.time()))
+        )
+
+        cycle_issue = CycleIssue.objects.create(project=project, cycle=cycle, issue=issue)
+        CycleIssue.objects.filter(pk=cycle_issue.pk).update(
+            created_at=timezone.make_aware(
+                timezone.datetime.combine(added_to_cycle_on, timezone.datetime.min.time())
+            )
+        )
+
+        view = self._build_view(workspace, create_user)
+        result = view.work_item_completion_chart(project_id=project.id, cycle_id=cycle.id)
+
+        by_key = {entry["key"]: entry for entry in result["data"]}
+        issue_created_key = issue_created_on.strftime("%Y-%m-%d")
+        added_to_cycle_key = added_to_cycle_on.strftime("%Y-%m-%d")
+
+        assert by_key[issue_created_key]["created_issues"] == 1, (
+            "expected the cycle chart to bucket the work item under the date it was "
+            f"actually created ({issue_created_key}), but got "
+            f"{by_key[issue_created_key]['created_issues']} -- it is bucketing by "
+            "CycleIssue.created_at (when the issue was added to the cycle) instead "
+            "of Issue.created_at"
+        )
+        assert by_key[added_to_cycle_key]["created_issues"] == 0, (
+            f"the work item leaked into the {added_to_cycle_key} bucket (the date it "
+            "was added to the cycle) instead of staying under its own creation date"
+        )


### PR DESCRIPTION
### Description
`work_item_completion_chart()` (`apps/api/plane/app/views/analytic/project_analytics.py`) reassigned its queryset to a bare `CycleIssue`/`ModuleIssue` id projection when scoped to a cycle or module, instead of an `Issue` queryset. The subsequent `.values("created_at__date")` grouping then resolved against the **join table's** `created_at` (when the issue was added to the cycle/module) rather than the issue's own creation date — so the "work items created" line on every cycle/module analytics chart was bucketed under the wrong date.

The `completed_count` annotation's `issue__state__group` traversal was itself a symptom — it only made sense because the queryset was still `CycleIssue`-shaped.

Fix: keep the queryset as `Issue.issue_objects.filter(id__in=cycle_issues/module_issues)`, matching the pattern already used a few lines above in `get_work_items_stats()` in the same file, and correct the `completed_count` filter from `issue__state__group` to `state__group` to match.

Reproduced and verified against the real Postgres-backed test stack (`docker-compose-test.yml`) — full details and before/after test output posted on the linked issue.

Closes #9177 (GIT-229)

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots here -->
This is a backend data-bucketing bug (dates on a chart resolve against the wrong column) rather than a visual glitch, so a screenshot wouldn't show the discrepancy — see the automated reproduction in the Test Scenarios section and on the linked issue instead.

### Test Scenarios
Added `apps/api/plane/tests/unit/views/test_project_analytics_chart.py`:
- Builds a real `Workspace -> Project -> Cycle -> Issue -> CycleIssue` graph with an issue created 10 days ago but added to its cycle 2 days ago.
- Calls `work_item_completion_chart()` directly and asserts the "created" count lands under the issue's actual creation date, not the date it was added to the cycle.
- Before the fix: fails with `assert 0 == 1` (work item missing from its true creation-date bucket).
- After the fix: passes.
- Full unit suite (`pytest -m unit`) re-run after the fix: 343 passed, 0 failed — no regressions.

### References
- Closes #9177
- Plane work item: GIT-229


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed completion charts filtered by cycles or modules to accurately aggregate issue states and completion counts.
  * Corrected chart date bucketing so items are grouped by when the issue was created, rather than when it was added to a cycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->