### PR TITLE
fix: handle desktop OAuth handoff fallback

### DIFF
--- a/apps/web/app/routes/core.ts
+++ b/apps/web/app/routes/core.ts
@@ -367,6 +367,9 @@ export const coreRoutes: RouteConfigEntry[] = [
   // ========================================================================
   // Legacy URL redirects for backward compatibility
 
+  // Desktop deep-link fallback: legacy clients navigate plane://open handoffs to /open
+  route("open", "routes/redirects/core/desktop-handoff.tsx"),
+
   // --------------------------------------------------------------------
   // REDIRECT ROUTES
   // --------------------------------------------------------------------

--- a/apps/web/app/routes/redirects/core/desktop-handoff.tsx
+++ b/apps/web/app/routes/redirects/core/desktop-handoff.tsx
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2023-present Plane Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { redirect } from "react-router";
+// helpers
+import { resolveDesktopHandoffRedirect } from "@/helpers/desktop-handoff.helper";
+// types
+import type { Route } from "./+types/desktop-handoff";
+
+export const clientLoader = ({ request }: Route.ClientLoaderArgs) => {
+  const handoffUrl = new URL(request.url);
+  const destination = resolveDesktopHandoffRedirect(handoffUrl.searchParams, handoffUrl.origin);
+
+  throw redirect(destination ?? "/");
+};
+
+export default function DesktopHandoff() {
+  return null;
+}

--- a/apps/web/helpers/desktop-handoff.helper.spec.mjs
+++ b/apps/web/helpers/desktop-handoff.helper.spec.mjs
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2023-present Plane Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { resolveDesktopHandoffRedirect } from "./desktop-handoff.helper.ts";
+
+describe("resolveDesktopHandoffRedirect", () => {
+  it("decodes a version 1 desktop handoff for the current instance", () => {
+    const searchParams = new URLSearchParams({
+      v: "1",
+      o: "aHR0cHM6Ly9hcHAucGxhbmUuc28",
+      p: "L2QvYXV0aC8_dG9rZW49b25lLXRpbWUtdG9rZW4",
+    });
+
+    assert.equal(resolveDesktopHandoffRedirect(searchParams, "https://app.plane.so"), "/d/auth/?token=one-time-token");
+  });
+
+  it("rejects a handoff created for a different instance", () => {
+    const searchParams = new URLSearchParams({
+      v: "1",
+      o: "aHR0cHM6Ly9ldmlsLmV4YW1wbGU",
+      p: "L2QvYXV0aC8_dG9rZW49b25lLXRpbWUtdG9rZW4",
+    });
+
+    assert.equal(resolveDesktopHandoffRedirect(searchParams, "https://app.plane.so"), null);
+  });
+
+  it("rejects a cross-origin path", () => {
+    const searchParams = new URLSearchParams({
+      v: "1",
+      o: "aHR0cHM6Ly9hcHAucGxhbmUuc28",
+      p: "Ly9ldmlsLmV4YW1wbGUvc3RlYWw",
+    });
+
+    assert.equal(resolveDesktopHandoffRedirect(searchParams, "https://app.plane.so"), null);
+  });
+
+  it("rejects unsupported or malformed handoffs", () => {
+    const unsupportedVersion = new URLSearchParams({
+      v: "2",
+      o: "aHR0cHM6Ly9hcHAucGxhbmUuc28",
+      p: "L2QvYXV0aC8_dG9rZW49b25lLXRpbWUtdG9rZW4",
+    });
+    const malformedPayload = new URLSearchParams({ v: "1", o: "%%%", p: "%%%" });
+
+    assert.equal(resolveDesktopHandoffRedirect(unsupportedVersion, "https://app.plane.so"), null);
+    assert.equal(resolveDesktopHandoffRedirect(malformedPayload, "https://app.plane.so"), null);
+  });
+});

--- a/apps/web/helpers/desktop-handoff.helper.ts
+++ b/apps/web/helpers/desktop-handoff.helper.ts
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2023-present Plane Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+const decodeBase64Url = (value: string): string => {
+  const base64 = value
+    .replace(/-/g, "+")
+    .replace(/_/g, "/")
+    .padEnd(Math.ceil(value.length / 4) * 4, "=");
+  const bytes = Uint8Array.from(atob(base64), (character) => character.charCodeAt(0));
+
+  return new TextDecoder().decode(bytes);
+};
+
+export const resolveDesktopHandoffRedirect = (searchParams: URLSearchParams, currentOrigin: string): string | null => {
+  if (searchParams.get("v") !== "1") return null;
+
+  const encodedOrigin = searchParams.get("o");
+  const encodedPath = searchParams.get("p");
+  if (!encodedOrigin || !encodedPath) return null;
+
+  try {
+    const handoffOrigin = new URL(decodeBase64Url(encodedOrigin)).origin;
+    if (handoffOrigin !== currentOrigin) return null;
+
+    const handoffPath = decodeBase64Url(encodedPath);
+    const destination = new URL(handoffPath, `${currentOrigin}/`);
+    if (!handoffPath.startsWith("/") || destination.origin !== currentOrigin) return null;
+
+    return `${destination.pathname}${destination.search}${destination.hash}`;
+  } catch {
+    return null;
+  }
+};

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "react-router dev --port 3000",
     "build": "react-router build",
+    "test": "node --test helpers/desktop-handoff.helper.spec.mjs",
     "preview": "react-router build && serve -s build/client -l 3000",
     "start": "serve -s build/client -l 3000",
     "clean": "rm -rf .turbo && rm -rf .next && rm -rf .react-router && rm -rf node_modules && rm -rf dist && rm -rf build",


### PR DESCRIPTION
### Description

Fixes #9535.

Plane Cloud returns successful desktop OAuth sessions through a versioned deep link:

`plane://open?v=1&o=<base64url-origin>&p=<base64url-path>`

Plane Desktop v3 currently treats the deep-link host (`open`) as a web path and navigates to `/open?... ` instead of decoding the handoff. Because the web app had no compatibility route for that path, authentication middleware sent the user back to sign-in even though Google OAuth had completed successfully.

This change adds a narrow `/open` fallback that:

- decodes version 1 origin and path parameters;
- accepts the handoff only when its decoded origin matches the current Plane instance;
- accepts only same-origin absolute paths;
- redirects invalid or unsupported payloads to the app root.

The desktop protocol handler can still be corrected independently; this fallback restores login for already-released clients and self-hosted instances without weakening the origin boundary.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

### Test plan

- `./node_modules/.bin/turbo run test --filter=web` — 11/11 tasks; 4/4 handoff cases
- `./node_modules/.bin/turbo run check:types --filter=web` — 11/11 tasks
- `./node_modules/.bin/turbo run build --filter=web` — 11/11 tasks
- Changed files pass `oxfmt --check`
- Changed source and test files pass `oxlint --deny-warnings`
- Browser verification against the production build:
  - valid same-origin handoff reached `/d/auth/?token=one-time-token`;
  - different-instance, cross-origin, and malformed handoffs were rejected to `/`.

### Test scenarios

- Valid v1 handoff for the current instance redirects to the decoded OAuth completion path.
- Handoff for another Plane instance is rejected.
- Cross-origin path payload is rejected.
- Unsupported versions and malformed base64url payloads are rejected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for desktop deep-link handoffs through a dedicated route.
  * Valid handoffs now redirect to the requested in-app destination.
  * Invalid, unsupported, malformed, or cross-origin handoffs safely fall back to the home page.

* **Tests**
  * Added coverage for valid handoffs and rejected redirect scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->