### PR TITLE
fix: expand=state returns bare UUID or crashes for issues with null or soft-deleted state

### DIFF
--- a/apps/api/plane/api/serializers/base.py
+++ b/apps/api/plane/api/serializers/base.py
@@ -106,11 +106,18 @@ class BaseSerializer(serializers.ModelSerializer):
                     }
                     # Check if field in expansion  then expand the field
                     if expand in expansion:
-                        if isinstance(response.get(expand), list):
-                            exp_serializer = expansion[expand](getattr(instance, expand), many=True)
+                        is_many = isinstance(response.get(expand), list)
+                        related_obj = getattr(instance, expand, None)
+                        if related_obj is not None:
+                            if is_many:
+                                exp_serializer = expansion[expand](related_obj, many=True)
+                            else:
+                                exp_serializer = expansion[expand](related_obj)
+                            response[expand] = exp_serializer.data
                         else:
-                            exp_serializer = expansion[expand](getattr(instance, expand))
-                        response[expand] = exp_serializer.data
+                            # Related object is null or could not be resolved
+                            # (e.g. soft-deleted) - fall back to the raw id
+                            response[expand] = getattr(instance, f"{expand}_id", None)
                     else:
                         # You might need to handle this case differently
                         response[expand] = getattr(instance, f"{expand}_id", None)

--- a/apps/api/plane/api/serializers/base.py
+++ b/apps/api/plane/api/serializers/base.py
@@ -2,6 +2,9 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # See the LICENSE file for details.
 
+# Django imports
+from django.core.exceptions import ObjectDoesNotExist
+
 # Third party imports
 from rest_framework import serializers
 
@@ -107,7 +110,17 @@ class BaseSerializer(serializers.ModelSerializer):
                     # Check if field in expansion  then expand the field
                     if expand in expansion:
                         is_many = isinstance(response.get(expand), list)
-                        related_obj = getattr(instance, expand, None)
+                        try:
+                            related_obj = getattr(instance, expand, None)
+                        except ObjectDoesNotExist:
+                            # Forward FK descriptor raises RelatedObjectDoesNotExist
+                            # (a subclass of both the model's DoesNotExist and
+                            # AttributeError) when select_related isn't present
+                            # and the target row can't be resolved through the
+                            # filtered manager (e.g. soft-deleted). Catch it
+                            # explicitly rather than relying on getattr's default
+                            # only covering AttributeError incidentally.
+                            related_obj = None
                         if related_obj is not None:
                             if is_many:
                                 exp_serializer = expansion[expand](related_obj, many=True)

--- a/apps/api/plane/api/views/issue.py
+++ b/apps/api/plane/api/views/issue.py
@@ -237,15 +237,19 @@ class WorkspaceIssueAPIEndpoint(BaseAPIView):
         This endpoint provides workspace-level access to work items.
         """
         if issue_identifier and project_identifier:
-            issue = Issue.issue_objects.annotate(
-                sub_issues_count=Issue.issue_objects.filter(parent=OuterRef("id"))
-                .order_by()
-                .annotate(count=Func(F("id"), function="Count"))
-                .values("count")
-            ).get(
-                workspace__slug=slug,
-                project__identifier=project_identifier,
-                sequence_id=issue_identifier,
+            issue = (
+                Issue.issue_objects.annotate(
+                    sub_issues_count=Issue.issue_objects.filter(parent=OuterRef("id"))
+                    .order_by()
+                    .annotate(count=Func(F("id"), function="Count"))
+                    .values("count")
+                )
+                .select_related("state")
+                .get(
+                    workspace__slug=slug,
+                    project__identifier=project_identifier,
+                    sequence_id=issue_identifier,
+                )
             )
             return Response(
                 IssueSerializer(issue, fields=self.fields, expand=self.expand).data,
@@ -579,12 +583,16 @@ class IssueDetailAPIEndpoint(BaseAPIView):
         Supports filtering, ordering, and field selection through query parameters.
         """
 
-        issue = Issue.issue_objects.annotate(
-            sub_issues_count=Issue.issue_objects.filter(parent=OuterRef("id"))
-            .order_by()
-            .annotate(count=Func(F("id"), function="Count"))
-            .values("count")
-        ).get(workspace__slug=slug, project_id=project_id, pk=pk)
+        issue = (
+            Issue.issue_objects.annotate(
+                sub_issues_count=Issue.issue_objects.filter(parent=OuterRef("id"))
+                .order_by()
+                .annotate(count=Func(F("id"), function="Count"))
+                .values("count")
+            )
+            .select_related("state")
+            .get(workspace__slug=slug, project_id=project_id, pk=pk)
+        )
         return Response(
             IssueSerializer(issue, fields=self.fields, expand=self.expand).data,
             status=status.HTTP_200_OK,

--- a/apps/api/plane/tests/contract/api/test_work_item_state_expand.py
+++ b/apps/api/plane/tests/contract/api/test_work_item_state_expand.py
@@ -110,3 +110,64 @@ class TestWorkItemDetailStateExpand:
         )
         assert str(response.data["state"]["id"]) == str(state.id)
         assert response.data["state"]["name"] == state.name
+
+
+@pytest.mark.contract
+class TestWorkspaceIssueByIdentifierStateExpand:
+    """Same #9534 regression as ``TestWorkItemDetailStateExpand``, but
+    against ``WorkspaceIssueAPIEndpoint`` -- the workspace-scoped
+    retrieve-by-identifier route (``.../work-items/{project_identifier}-
+    {sequence_id}/``) rather than the UUID-based ``work-items/{id}/`` route.
+    Both endpoints build their own ad hoc queryset in ``get()`` instead of
+    reusing ``get_queryset()``, so the fix (``.select_related("state")``)
+    had to be applied to each independently.
+    """
+
+    def get_url(self, workspace_slug, project_identifier, sequence_id):
+        return f"/api/v1/workspaces/{workspace_slug}/work-items/{project_identifier}-{sequence_id}/"
+
+    @pytest.mark.django_db
+    def test_null_state_expands_to_null_without_crashing(self, api_key_client, workspace, project):
+        """A work item with no state assigned returns `"state": null` when
+        expand=state is requested, instead of crashing or leaking a stale
+        default."""
+        issue = Issue.objects.create(
+            name="Issue with null state",
+            workspace=workspace,
+            project=project,
+        )
+        # Issue.save() auto-assigns a default state whenever state is None
+        # at save time; force it back to NULL to simulate a genuine orphan.
+        Issue.objects.filter(pk=issue.pk).update(state=None)
+        issue.refresh_from_db()
+
+        url = self.get_url(workspace.slug, project.identifier, issue.sequence_id)
+        response = api_key_client.get(url, {"expand": "state"})
+
+        assert response.status_code == status.HTTP_200_OK, f"Got {response.status_code}: {response.data!r}"
+        assert response.data["state"] is None
+
+    @pytest.mark.django_db
+    def test_soft_deleted_state_still_expands(self, api_key_client, workspace, project, state):
+        """A work item whose state was soft-deleted after assignment still
+        returns the fully expanded state object (not a bare UUID, and not
+        a 404/500 from `State.DoesNotExist`)."""
+        issue = Issue.objects.create(
+            name="Issue with soft-deleted state",
+            workspace=workspace,
+            project=project,
+            state=state,
+        )
+
+        state.delete()  # soft delete: sets deleted_at, row still exists
+        assert state.deleted_at is not None
+
+        url = self.get_url(workspace.slug, project.identifier, issue.sequence_id)
+        response = api_key_client.get(url, {"expand": "state"})
+
+        assert response.status_code == status.HTTP_200_OK, f"Got {response.status_code}: {response.data!r}"
+        assert isinstance(response.data["state"], dict), (
+            f"Expected expanded state object, got bare value: {response.data['state']!r}"
+        )
+        assert str(response.data["state"]["id"]) == str(state.id)
+        assert response.data["state"]["name"] == state.name

--- a/apps/api/plane/tests/contract/api/test_work_item_state_expand.py
+++ b/apps/api/plane/tests/contract/api/test_work_item_state_expand.py
@@ -1,0 +1,112 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+import pytest
+from rest_framework import status
+
+from plane.db.models import Issue, Project, ProjectMember, State
+
+
+@pytest.fixture
+def project(db, workspace, create_user):
+    """Create a test project with the requesting user as an active member."""
+    project = Project.objects.create(
+        name="Test Project",
+        identifier="TP",
+        workspace=workspace,
+        created_by=create_user,
+    )
+    ProjectMember.objects.create(
+        project=project,
+        member=create_user,
+        role=20,  # Admin
+        is_active=True,
+    )
+    return project
+
+
+@pytest.fixture
+def state(db, workspace, project):
+    return State.objects.create(
+        name="Todo",
+        project=project,
+        workspace=workspace,
+        group="backlog",
+        default=True,
+    )
+
+
+@pytest.mark.contract
+class TestWorkItemDetailStateExpand:
+    """Regression tests for #9534: GET .../work-items/{id}/?expand=state
+    returning a bare UUID (or crashing) instead of the expanded state object
+    for work items whose ``state`` cannot be resolved through the normal
+    manager-filtered path.
+
+    ``BaseSerializer.to_representation`` expands relations via
+    ``getattr(instance, expand)``, which for ``state`` traverses Django's
+    forward FK descriptor. That descriptor queries through the target
+    model's ``_base_manager`` (here, ``StateManager``, a soft-deletion
+    manager) unless the relation is already cached via ``select_related``.
+    Two data conditions defeat that expansion:
+
+    1. ``state_id`` is NULL -- the FK is genuinely unset.
+    2. ``state_id`` points at a ``State`` row that has since been
+       soft-deleted (``deleted_at`` is not NULL) while the issue itself
+       is untouched.
+
+    The fix adds ``.select_related("state")`` to the work-item detail
+    endpoint's queryset (so soft-deleted states are still resolved via the
+    JOIN, bypassing the manager filter) and makes the expansion in
+    ``BaseSerializer.to_representation`` fall back to the raw id instead of
+    raising when the related object still can't be resolved.
+    """
+
+    def get_url(self, workspace_slug, project_id, issue_id):
+        return f"/api/v1/workspaces/{workspace_slug}/projects/{project_id}/work-items/{issue_id}/"
+
+    @pytest.mark.django_db
+    def test_null_state_expands_to_null_without_crashing(self, api_key_client, workspace, project):
+        """A work item with no state assigned returns `"state": null` when
+        expand=state is requested, instead of crashing or leaking a stale
+        default."""
+        issue = Issue.objects.create(
+            name="Issue with null state",
+            workspace=workspace,
+            project=project,
+        )
+        # Issue.save() auto-assigns a default state whenever state is None
+        # at save time; force it back to NULL to simulate a genuine orphan.
+        Issue.objects.filter(pk=issue.pk).update(state=None)
+
+        url = self.get_url(workspace.slug, project.id, issue.id)
+        response = api_key_client.get(url, {"expand": "state"})
+
+        assert response.status_code == status.HTTP_200_OK, f"Got {response.status_code}: {response.data!r}"
+        assert response.data["state"] is None
+
+    @pytest.mark.django_db
+    def test_soft_deleted_state_still_expands(self, api_key_client, workspace, project, state):
+        """A work item whose state was soft-deleted after assignment still
+        returns the fully expanded state object (not a bare UUID, and not
+        a 404/500 from `State.DoesNotExist`)."""
+        issue = Issue.objects.create(
+            name="Issue with soft-deleted state",
+            workspace=workspace,
+            project=project,
+            state=state,
+        )
+
+        state.delete()  # soft delete: sets deleted_at, row still exists
+        assert state.deleted_at is not None
+
+        url = self.get_url(workspace.slug, project.id, issue.id)
+        response = api_key_client.get(url, {"expand": "state"})
+
+        assert response.status_code == status.HTTP_200_OK, f"Got {response.status_code}: {response.data!r}"
+        assert isinstance(response.data["state"], dict), (
+            f"Expected expanded state object, got bare value: {response.data['state']!r}"
+        )
+        assert str(response.data["state"]["id"]) == str(state.id)
+        assert response.data["state"]["name"] == state.name


### PR DESCRIPTION
Closes #9534

## Root cause
`IssueDetailAPIEndpoint.get()` and `WorkspaceIssueAPIEndpoint.get()` build one-off querysets that skip `.select_related("state")` (unlike their sibling `get_queryset()` methods). When `expand=state` is requested, `BaseSerializer.to_representation()` resolves the related object via `getattr(instance, "state")`, which goes through Django's forward-FK descriptor and `StateManager` — a `SoftDeletionManager` subclass filtering `deleted_at__isnull=True`.

This means:
- For issues whose state has been soft-deleted, this lookup raises `State.DoesNotExist`, surfaced as a 404/500-style error response instead of a usable payload.
- More generally, any endpoint route that skips `select_related` for an expand-eligible relation is exposed to the same class of bug.

## Fix
1. Added `.select_related("state")` to the inline querysets in `IssueDetailAPIEndpoint.get()` and `WorkspaceIssueAPIEndpoint.get()`, matching the pattern already used in their `get_queryset()` methods. This performs a plain SQL `LEFT JOIN` that bypasses the soft-delete-filtering manager, resolving the state correctly even when it's been soft-deleted.
2. Added a defensive fallback in `BaseSerializer.to_representation()`: if the related object can't be resolved (e.g. `None`), it now falls back to the raw `{expand}_id` value instead of raising an unhandled exception. This guards against the same issue in any other expand path that might miss `select_related`.

## Testing
Added two regression tests in `plane/tests/contract/api/test_work_item_state_expand.py`:
- Issue with `state=None` → `expand=state` returns `200` with `"state": null`.
- Issue whose state is soft-deleted → `expand=state` returns `200` with the fully expanded state object (not a bare UUID, not a crash).

Verified manually against a local seeded DB and via the full contract test suite (`docker compose -f docker-compose-test.yml run --rm --build api-tests pytest`) — both new tests pass; no regressions introduced.

## Scope note
A related issue exists in `IssueListCreateAPIEndpoint`'s `external_id`/`external_source` lookup branch (uses `Issue.objects` instead of `Issue.issue_objects`, missing `select_related`), but it's a distinct bug (different manager, different filtering semantics) — filing separately rather than bundling here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved issue detail responses when expanding state information.
  * Correctly returns `null` for issues without a state.
  * Preserves expanded state details when an assigned state has been soft-deleted.
  * Improved reliability and performance when loading issue state data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->