### PR TITLE
[SECUR-245] fix(security): guard PDF image srcs and authenticate /convert-document/

### DIFF
--- a/apps/api/plane/bgtasks/copy_s3_object.py
+++ b/apps/api/plane/bgtasks/copy_s3_object.py
@@ -77,7 +77,19 @@ def sync_with_external_service(entity_name, description_html):
 
         url = normalize_url_path(f"{live_url}/convert-document/")
 
-        response = requests.post(url, json=data, headers=None)
+        # The Live service authenticates this endpoint with a shared secret
+        # (GHSA-55gq-rf47-9pqx). Without the header the request is rejected as 401.
+        secret_key = settings.LIVE_SERVER_SECRET_KEY
+        if not secret_key:
+            log_exception(
+                Exception(
+                    "LIVE_SERVER_SECRET_KEY is not configured; skipping document conversion "
+                    "for duplication. Set it to the same value as the Live service."
+                )
+            )
+            return {}
+
+        response = requests.post(url, json=data, headers={"live-server-secret-key": secret_key})
         if response.status_code == 200:
             return response.json()
     except requests.RequestException as e:

--- a/apps/api/plane/bgtasks/copy_s3_object.py
+++ b/apps/api/plane/bgtasks/copy_s3_object.py
@@ -19,9 +19,8 @@ from celery import shared_task
 from plane.utils.url import normalize_url_path
 
 # (connect, read) timeout for the Live service call. `requests` has no default
-# timeout, so omitting this lets a duplication task occupy a Celery worker
-# indefinitely if Live accepts the connection and then stops responding. The read
-# budget is generous because converting a large document is genuinely slow.
+# timeout, so without one a Live service that stalls after accepting the connection
+# pins a Celery worker forever. The read budget is wide: conversion is genuinely slow.
 LIVE_REQUEST_TIMEOUT = (5, 30)
 
 
@@ -83,8 +82,8 @@ def sync_with_external_service(entity_name, description_html):
 
         url = normalize_url_path(f"{live_url}/convert-document/")
 
-        # The Live service authenticates this endpoint with a shared secret
-        # (GHSA-55gq-rf47-9pqx). Without the header the request is rejected as 401.
+        # The Live service authenticates this endpoint with a shared secret.
+        # Without the header the request is rejected as 401.
         secret_key = settings.LIVE_SERVER_SECRET_KEY
         if not secret_key:
             log_exception(

--- a/apps/api/plane/bgtasks/copy_s3_object.py
+++ b/apps/api/plane/bgtasks/copy_s3_object.py
@@ -18,6 +18,12 @@ from plane.settings.storage import S3Storage
 from celery import shared_task
 from plane.utils.url import normalize_url_path
 
+# (connect, read) timeout for the Live service call. `requests` has no default
+# timeout, so omitting this lets a duplication task occupy a Celery worker
+# indefinitely if Live accepts the connection and then stops responding. The read
+# budget is generous because converting a large document is genuinely slow.
+LIVE_REQUEST_TIMEOUT = (5, 30)
+
 
 def get_entity_id_field(entity_type, entity_id):
     entity_mapping = {
@@ -89,7 +95,12 @@ def sync_with_external_service(entity_name, description_html):
             )
             return {}
 
-        response = requests.post(url, json=data, headers={"live-server-secret-key": secret_key})
+        response = requests.post(
+            url,
+            json=data,
+            headers={"live-server-secret-key": secret_key},
+            timeout=LIVE_REQUEST_TIMEOUT,
+        )
         if response.status_code == 200:
             return response.json()
     except requests.RequestException as e:

--- a/apps/api/plane/settings/common.py
+++ b/apps/api/plane/settings/common.py
@@ -418,6 +418,10 @@ LIVE_BASE_PATH = os.environ.get("LIVE_BASE_PATH", "/live/")
 
 LIVE_URL = urljoin(LIVE_BASE_URL, LIVE_BASE_PATH) if LIVE_BASE_URL else None
 
+# Shared secret for server-to-server calls into the Live service. Must match the
+# Live container's LIVE_SERVER_SECRET_KEY.
+LIVE_SERVER_SECRET_KEY = os.environ.get("LIVE_SERVER_SECRET_KEY")
+
 # WEB URL
 WEB_URL = os.environ.get("WEB_URL")
 

--- a/apps/api/plane/tests/unit/bg_tasks/test_copy_s3_object_auth.py
+++ b/apps/api/plane/tests/unit/bg_tasks/test_copy_s3_object_auth.py
@@ -3,15 +3,11 @@
 # See the LICENSE file for details.
 
 """
-Authentication of the API -> Live `/convert-document/` call (GHSA-55gq-rf47-9pqx).
+Authentication of the API -> Live `/convert-document/` call.
 
-The Live service previously served `/convert-document/` to anyone who could reach
-it (`requireSecretKey` was defined but never applied to a controller). Now that the
-endpoint is gated on the `live-server-secret-key` header, this background task is
-the one caller that has to present it — so the header must actually be sent, and a
-missing key must fail loudly rather than firing a request that 401s.
-
-These are pure unit tests: no database, no network.
+Live now gates the endpoint on the `live-server-secret-key` header, and this task is
+its only caller: the header must actually be sent, and a missing key must fail loudly
+rather than firing a request that can only 401. Pure unit tests — no DB, no network.
 """
 
 from unittest.mock import MagicMock, patch

--- a/apps/api/plane/tests/unit/bg_tasks/test_copy_s3_object_auth.py
+++ b/apps/api/plane/tests/unit/bg_tasks/test_copy_s3_object_auth.py
@@ -16,9 +16,10 @@ These are pure unit tests: no database, no network.
 
 from unittest.mock import MagicMock, patch
 
+import requests
 from django.test import override_settings
 
-from plane.bgtasks.copy_s3_object import sync_with_external_service
+from plane.bgtasks.copy_s3_object import LIVE_REQUEST_TIMEOUT, sync_with_external_service
 
 LIVE_URL = "http://live:3000/live/"
 SECRET = "unit-test-live-secret"
@@ -38,6 +39,37 @@ def test_sends_secret_key_header():
 
     headers = mock_post.call_args.kwargs["headers"]
     assert headers == {"live-server-secret-key": SECRET}
+
+
+@override_settings(LIVE_URL=LIVE_URL, LIVE_SERVER_SECRET_KEY=SECRET)
+def test_sends_bounded_timeout():
+    """
+    `requests` has no default timeout. Without one, a Live service that accepts the
+    connection and then stalls would pin a Celery worker indefinitely.
+    """
+    response = MagicMock(status_code=200)
+    response.json.return_value = {}
+
+    with patch("plane.bgtasks.copy_s3_object.requests.post", return_value=response) as mock_post:
+        sync_with_external_service("PAGE", "<p>hello</p>")
+
+    timeout = mock_post.call_args.kwargs["timeout"]
+    assert timeout == LIVE_REQUEST_TIMEOUT
+    connect, read = timeout
+    assert 0 < connect <= 10
+    assert 0 < read <= 60
+
+
+@override_settings(LIVE_URL=LIVE_URL, LIVE_SERVER_SECRET_KEY=SECRET)
+def test_timeout_is_swallowed_not_raised():
+    """A stalled Live service must degrade duplication, not fail the whole task."""
+    with patch(
+        "plane.bgtasks.copy_s3_object.requests.post",
+        side_effect=requests.exceptions.ReadTimeout("timed out"),
+    ):
+        result = sync_with_external_service("PAGE", "<p>hello</p>")
+
+    assert result == {}
 
 
 @override_settings(LIVE_URL=LIVE_URL, LIVE_SERVER_SECRET_KEY=None)

--- a/apps/api/plane/tests/unit/bg_tasks/test_copy_s3_object_auth.py
+++ b/apps/api/plane/tests/unit/bg_tasks/test_copy_s3_object_auth.py
@@ -1,0 +1,105 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""
+Authentication of the API -> Live `/convert-document/` call (GHSA-55gq-rf47-9pqx).
+
+The Live service previously served `/convert-document/` to anyone who could reach
+it (`requireSecretKey` was defined but never applied to a controller). Now that the
+endpoint is gated on the `live-server-secret-key` header, this background task is
+the one caller that has to present it — so the header must actually be sent, and a
+missing key must fail loudly rather than firing a request that 401s.
+
+These are pure unit tests: no database, no network.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from django.test import override_settings
+
+from plane.bgtasks.copy_s3_object import sync_with_external_service
+
+LIVE_URL = "http://live:3000/live/"
+SECRET = "unit-test-live-secret"
+
+
+@override_settings(LIVE_URL=LIVE_URL, LIVE_SERVER_SECRET_KEY=SECRET)
+def test_sends_secret_key_header():
+    """The shared secret must travel on the request, or Live returns 401."""
+    response = MagicMock(status_code=200)
+    response.json.return_value = {"description_json": {}, "description_binary": "AA=="}
+
+    with patch("plane.bgtasks.copy_s3_object.requests.post", return_value=response) as mock_post:
+        result = sync_with_external_service("PAGE", "<p>hello</p>")
+
+    assert result == {"description_json": {}, "description_binary": "AA=="}
+    mock_post.assert_called_once()
+
+    headers = mock_post.call_args.kwargs["headers"]
+    assert headers == {"live-server-secret-key": SECRET}
+
+
+@override_settings(LIVE_URL=LIVE_URL, LIVE_SERVER_SECRET_KEY=None)
+def test_missing_secret_key_skips_request():
+    """
+    With no key configured the call could only ever 401, so it is not attempted.
+    Returning {} leaves `description_binary` untouched upstream (the caller guards
+    on `if external_data:`), which degrades duplication rather than corrupting it.
+    """
+    with (
+        patch("plane.bgtasks.copy_s3_object.requests.post") as mock_post,
+        patch("plane.bgtasks.copy_s3_object.log_exception") as mock_log,
+    ):
+        result = sync_with_external_service("PAGE", "<p>hello</p>")
+
+    assert result == {}
+    mock_post.assert_not_called()
+    # The misconfiguration must be surfaced, not swallowed silently.
+    mock_log.assert_called_once()
+
+
+@override_settings(LIVE_URL=LIVE_URL, LIVE_SERVER_SECRET_KEY="")
+def test_empty_secret_key_treated_as_missing():
+    """An empty string is a misconfiguration, not a valid credential."""
+    with (
+        patch("plane.bgtasks.copy_s3_object.requests.post") as mock_post,
+        patch("plane.bgtasks.copy_s3_object.log_exception"),
+    ):
+        result = sync_with_external_service("PAGE", "<p>hello</p>")
+
+    assert result == {}
+    mock_post.assert_not_called()
+
+
+@override_settings(LIVE_URL=None, LIVE_SERVER_SECRET_KEY=SECRET)
+def test_no_live_url_short_circuits():
+    """Deployments without a Live service must not attempt the call at all."""
+    with patch("plane.bgtasks.copy_s3_object.requests.post") as mock_post:
+        result = sync_with_external_service("PAGE", "<p>hello</p>")
+
+    assert result == {}
+    mock_post.assert_not_called()
+
+
+@override_settings(LIVE_URL=LIVE_URL, LIVE_SERVER_SECRET_KEY=SECRET)
+def test_non_200_returns_empty_dict():
+    """A rejected call (e.g. a stale key on one side) must not raise."""
+    with patch("plane.bgtasks.copy_s3_object.requests.post", return_value=MagicMock(status_code=401)):
+        result = sync_with_external_service("PAGE", "<p>hello</p>")
+
+    assert result == {}
+
+
+@override_settings(LIVE_URL=LIVE_URL, LIVE_SERVER_SECRET_KEY=SECRET)
+def test_variant_depends_on_entity_name():
+    """Guard the existing contract while changing the auth around it."""
+    response = MagicMock(status_code=200)
+    response.json.return_value = {}
+
+    with patch("plane.bgtasks.copy_s3_object.requests.post", return_value=response) as mock_post:
+        sync_with_external_service("PAGE", "<p>x</p>")
+        assert mock_post.call_args.kwargs["json"]["variant"] == "rich"
+
+        sync_with_external_service("ISSUE", "<p>x</p>")
+        assert mock_post.call_args.kwargs["json"]["variant"] == "document"

--- a/apps/live/src/controllers/document.controller.ts
+++ b/apps/live/src/controllers/document.controller.ts
@@ -7,10 +7,11 @@
 import type { Request, Response } from "express";
 import { z } from "zod";
 // helpers
-import { Controller, Post } from "@plane/decorators";
+import { Controller, Middleware, Post } from "@plane/decorators";
 import { convertHTMLDocumentToAllFormats } from "@plane/editor";
 // logger
 import { logger } from "@plane/logger";
+import { requireSecretKey } from "@/lib/auth-middleware";
 import type { TConvertDocumentRequestBody } from "@/types";
 
 // Define the schema with more robust validation
@@ -25,7 +26,15 @@ const convertDocumentSchema = z.object({
 
 @Controller("/convert-document")
 export class DocumentController {
+  /**
+   * Server-to-server only: the sole caller is the API's `copy_s3_object` background
+   * task (page / work-item duplication). It was previously reachable unauthenticated
+   * by anyone who could hit the Live service, which made an expensive HTML -> Y.js
+   * conversion available as free compute to the internet (GHSA-55gq-rf47-9pqx,
+   * CWE-306). Callers must now present `live-server-secret-key`.
+   */
   @Post("/")
+  @Middleware(requireSecretKey)
   async convertDocument(req: Request, res: Response) {
     try {
       // Validate request body

--- a/apps/live/src/controllers/document.controller.ts
+++ b/apps/live/src/controllers/document.controller.ts
@@ -28,10 +28,9 @@ const convertDocumentSchema = z.object({
 export class DocumentController {
   /**
    * Server-to-server only: the sole caller is the API's `copy_s3_object` background
-   * task (page / work-item duplication). It was previously reachable unauthenticated
-   * by anyone who could hit the Live service, which made an expensive HTML -> Y.js
-   * conversion available as free compute to the internet (GHSA-55gq-rf47-9pqx,
-   * CWE-306). Callers must now present `live-server-secret-key`.
+   * task. It was previously reachable unauthenticated by anyone who could hit the
+   * Live service, making an expensive HTML -> Y.js conversion free compute for the
+   * internet. Callers must now present `live-server-secret-key`.
    */
   @Post("/")
   @Middleware(requireSecretKey)

--- a/apps/live/src/lib/pdf/node-renderers.tsx
+++ b/apps/live/src/lib/pdf/node-renderers.tsx
@@ -273,10 +273,9 @@ export const nodeRenderers: NodeRendererRegistry = {
           ? { alignItems: "flex-end" as const }
           : { alignItems: "flex-start" as const };
 
-    // SSRF guard (GHSA-55gq-rf47-9pqx). `src` comes from page content, and
-    // @react-pdf/image will fetch() any URL with a host — including internal
-    // Docker service names — or fs.readFile() a bare path. Anything we are not
-    // willing to fetch renders as a placeholder instead.
+    // SSRF guard: `src` comes from page content, and @react-pdf/image will fetch()
+    // any URL with a host — including internal Docker service names — or
+    // fs.readFile() a bare path. Anything we won't fetch renders as a placeholder.
     if (!isSafeImageSrc(src)) {
       return (
         <View key={ctx.getKey()} style={[pdfStyles.imagePlaceholder, alignmentStyle]}>
@@ -321,11 +320,9 @@ export const nodeRenderers: NodeRendererRegistry = {
           ? { alignItems: "flex-end" as const }
           : { alignItems: "flex-start" as const };
 
-    // Normally `resolvedSrc` is the `data:image/jpeg;base64,…` URI produced by the
-    // service's own pre-fetch, so nothing is fetched at render time. If asset
-    // resolution failed it is still the raw asset id, which is not a fetchable URL.
-    // Use the same guard as the `image` renderer rather than a startsWith("http")
-    // check, which would happily pass http://api:8000/ (GHSA-55gq-rf47-9pqx).
+    // `resolvedSrc` is normally the pre-fetched `data:image/…` URI, or the raw asset
+    // id if resolution failed. Same guard as the `image` renderer: a
+    // startsWith("http") check would happily pass http://api:8000/.
     if (!isSafeImageSrc(resolvedSrc)) {
       return (
         <View key={ctx.getKey()} style={[pdfStyles.imagePlaceholder, alignmentStyle]}>

--- a/apps/live/src/lib/pdf/node-renderers.tsx
+++ b/apps/live/src/lib/pdf/node-renderers.tsx
@@ -8,6 +8,7 @@ import { Image, Link, Text, View } from "@react-pdf/renderer";
 import type { Style } from "@react-pdf/types";
 import type { ReactElement } from "react";
 import { CORE_EXTENSIONS } from "@plane/editor";
+import { isSafeImageSrc } from "@/lib/url-security";
 import { BACKGROUND_COLORS, EDITOR_BACKGROUND_COLORS, resolveColorForPdf, TEXT_COLORS } from "./colors";
 import { CheckIcon, ClipboardIcon, DocumentIcon, GlobeIcon, LightbulbIcon, LinkIcon } from "./icons";
 import { applyMarks } from "./mark-renderers";
@@ -272,6 +273,18 @@ export const nodeRenderers: NodeRendererRegistry = {
           ? { alignItems: "flex-end" as const }
           : { alignItems: "flex-start" as const };
 
+    // SSRF guard (GHSA-55gq-rf47-9pqx). `src` comes from page content, and
+    // @react-pdf/image will fetch() any URL with a host — including internal
+    // Docker service names — or fs.readFile() a bare path. Anything we are not
+    // willing to fetch renders as a placeholder instead.
+    if (!isSafeImageSrc(src)) {
+      return (
+        <View key={ctx.getKey()} style={[pdfStyles.imagePlaceholder, alignmentStyle]}>
+          <Text style={pdfStyles.imagePlaceholderText}>[Image unavailable]</Text>
+        </View>
+      );
+    }
+
     return (
       <View key={ctx.getKey()} style={[{ width: "100%" }, alignmentStyle]}>
         <Image
@@ -308,7 +321,12 @@ export const nodeRenderers: NodeRendererRegistry = {
           ? { alignItems: "flex-end" as const }
           : { alignItems: "flex-start" as const };
 
-    if (!resolvedSrc.startsWith("http") && !resolvedSrc.startsWith("data:")) {
+    // Normally `resolvedSrc` is the `data:image/jpeg;base64,…` URI produced by the
+    // service's own pre-fetch, so nothing is fetched at render time. If asset
+    // resolution failed it is still the raw asset id, which is not a fetchable URL.
+    // Use the same guard as the `image` renderer rather than a startsWith("http")
+    // check, which would happily pass http://api:8000/ (GHSA-55gq-rf47-9pqx).
+    if (!isSafeImageSrc(resolvedSrc)) {
       return (
         <View key={ctx.getKey()} style={[pdfStyles.imagePlaceholder, alignmentStyle]}>
           <Text style={pdfStyles.imagePlaceholderText}>[Image: {assetId.slice(0, 8)}...]</Text>

--- a/apps/live/src/lib/pdf/node-renderers.tsx
+++ b/apps/live/src/lib/pdf/node-renderers.tsx
@@ -273,10 +273,23 @@ export const nodeRenderers: NodeRendererRegistry = {
           ? { alignItems: "flex-end" as const }
           : { alignItems: "flex-start" as const };
 
-    // SSRF guard: `src` comes from page content, and @react-pdf/image will fetch()
-    // any URL with a host — including internal Docker service names — or
-    // fs.readFile() a bare path. Anything we won't fetch renders as a placeholder.
-    if (!isSafeImageSrc(src)) {
+    // SSRF guard: `src` comes from page content. It is never handed to @react-pdf/image
+    // directly — that fetch() follows redirects and would never re-consult a src
+    // validator on the redirect target, so a URL on an ordinary public host could
+    // 302 to an internal address and be fetched anyway. Instead, pdf-export.service.ts
+    // pre-fetches every `image`-node src through the redirect-safe path
+    // (fetchImageSrcSafely, see @/lib/url-security) before rendering starts, the same
+    // way `imageComponent` assets are pre-fetched below, so this render pass stays
+    // synchronous and only ever looks up an already-resolved value.
+    let resolvedSrc: string | null = null;
+    if (ctx.metadata?.resolvedImageUrls && ctx.metadata.resolvedImageUrls[src]) {
+      resolvedSrc = ctx.metadata.resolvedImageUrls[src];
+    } else if (src.startsWith("data:") && isSafeImageSrc(src)) {
+      // data: carries its payload inline — nothing to fetch, so no pre-fetch entry exists.
+      resolvedSrc = src;
+    }
+
+    if (!resolvedSrc) {
       return (
         <View key={ctx.getKey()} style={[pdfStyles.imagePlaceholder, alignmentStyle]}>
           <Text style={pdfStyles.imagePlaceholderText}>[Image unavailable]</Text>
@@ -287,7 +300,7 @@ export const nodeRenderers: NodeRendererRegistry = {
     return (
       <View key={ctx.getKey()} style={[{ width: "100%" }, alignmentStyle]}>
         <Image
-          src={src}
+          src={resolvedSrc}
           style={[pdfStyles.image, width ? { width, maxHeight: 500 } : { maxWidth: 400, maxHeight: 500 }]}
         />
       </View>

--- a/apps/live/src/lib/url-security.ts
+++ b/apps/live/src/lib/url-security.ts
@@ -1,0 +1,180 @@
+/**
+ * Copyright (c) 2023-present Plane Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import net from "node:net";
+
+/**
+ * SSRF guards for URLs that the Live service may cause to be fetched.
+ *
+ * Context (GHSA-55gq-rf47-9pqx): the PDF exporter renders TipTap `image` nodes by
+ * handing `node.attrs.src` straight to `@react-pdf/image`, which calls `fetch()` on
+ * anything with a host. Because the Live container shares a Docker network with the
+ * API, database, Redis, RabbitMQ and MinIO, an unvalidated `src` turns PDF export
+ * into a request forgery primitive against internal-only services.
+ *
+ * A prefix check such as `src.startsWith("http")` does NOT close this: the payloads
+ * that matter — `http://api:8000/`, `http://plane-minio:9000/` — all start with
+ * "http". The scheme is irrelevant; the *destination* is what has to be judged.
+ */
+
+/** Schemes we are willing to hand to the PDF image pipeline. */
+const ALLOWED_SCHEMES = new Set(["http:", "https:", "data:"]);
+
+/**
+ * Hostname suffixes that only ever resolve inside a private network.
+ * Compared against the lowercased hostname, with a leading dot to avoid
+ * matching a public registrable domain that merely ends in these letters.
+ */
+const BLOCKED_HOST_SUFFIXES = [".local", ".localhost", ".internal", ".home.arpa", ".lan"];
+
+/** Bare hostnames that need no DNS to be dangerous. */
+const BLOCKED_HOST_EXACT = new Set(["localhost", "metadata", "metadata.google.internal"]);
+
+/**
+ * Returns true when an IPv4 literal falls in a range that must never be fetched.
+ * Ranges follow IANA special-purpose registries rather than a hand-rolled
+ * "private IP" list, so CGNAT and benchmarking space are covered too.
+ */
+const isBlockedIPv4 = (ip: string): boolean => {
+  const parts = ip.split(".").map((p) => Number(p));
+  if (parts.length !== 4 || parts.some((p) => !Number.isInteger(p) || p < 0 || p > 255)) {
+    // Not a canonical dotted quad — callers treat unparseable hosts as unsafe.
+    return true;
+  }
+  const [a, b] = parts as [number, number, number, number];
+
+  if (a === 0) return true; // 0.0.0.0/8      "this host on this network"
+  if (a === 10) return true; // 10.0.0.0/8     private
+  if (a === 127) return true; // 127.0.0.0/8    loopback
+  if (a === 100 && b >= 64 && b <= 127) return true; // 100.64.0.0/10  CGNAT
+  if (a === 169 && b === 254) return true; // 169.254.0.0/16 link-local (incl. 169.254.169.254 metadata)
+  if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12  private
+  if (a === 192 && b === 168) return true; // 192.168.0.0/16 private
+  if (a === 192 && b === 0) return true; // 192.0.0.0/24 + 192.0.2.0/24 (IETF protocol / TEST-NET-1)
+  if (a === 198 && (b === 18 || b === 19)) return true; // 198.18.0.0/15  benchmarking
+  if (a === 198 && b === 51) return true; // 198.51.100.0/24 TEST-NET-2
+  if (a === 203 && b === 0) return true; // 203.0.113.0/24  TEST-NET-3
+  if (a >= 224) return true; // 224.0.0.0/4 multicast, 240.0.0.0/4 reserved, 255.255.255.255
+
+  return false;
+};
+
+/** Returns true when an IPv6 literal must never be fetched. */
+const isBlockedIPv6 = (ip: string): boolean => {
+  const addr = ip.toLowerCase().replace(/^\[|\]$/g, "");
+
+  // IPv4-mapped (::ffff:127.0.0.1) and IPv4-compatible forms: judge the embedded v4.
+  const mapped = addr.match(/^(?:::ffff:|::)((?:\d{1,3}\.){3}\d{1,3})$/);
+  if (mapped?.[1]) return isBlockedIPv4(mapped[1]);
+
+  if (addr === "::" || addr === "::1") return true; // unspecified / loopback
+  if (addr.startsWith("fe8") || addr.startsWith("fe9") || addr.startsWith("fea") || addr.startsWith("feb")) return true; // fe80::/10 link-local
+  // fec0::/10 deprecated site-local. Kept in step with the Python guard's
+  // _BLOCKED_NETWORKS (apps/api/plane/utils/ip_address.py) — the two lists must not
+  // drift, or one service will block a range the other happily fetches.
+  if (addr.startsWith("fec") || addr.startsWith("fed") || addr.startsWith("fee") || addr.startsWith("fef")) return true;
+  if (addr.startsWith("fc") || addr.startsWith("fd")) return true; // fc00::/7 unique local
+  if (addr.startsWith("ff")) return true; // ff00::/8 multicast
+  if (addr.startsWith("64:ff9b:")) return true; // 64:ff9b::/96 + 64:ff9b:1::/48 NAT64
+  if (addr.startsWith("2002:")) return true; // 6to4 — can wrap a private v4
+  if (/^2001:(0{1,4})?:/.test(addr)) return true; // 2001::/32 Teredo
+  if (addr.startsWith("::ffff:")) return true; // any other IPv4-mapped form
+
+  return false;
+};
+
+/**
+ * Returns true when `host` is an IP literal pointing somewhere we refuse to fetch,
+ * or a numeric/obfuscated host form that is not a canonical address at all.
+ *
+ * Obfuscated encodings (`0x7f000001`, `2130706433`, `127.1`) are rejected outright:
+ * some HTTP clients expand them to loopback, none of them are legitimate image
+ * hosts, and normalising every variant is a losing game.
+ */
+export const isBlockedHostLiteral = (host: string): boolean => {
+  const bare = host.replace(/^\[|\]$/g, "");
+
+  const ipVersion = net.isIP(bare);
+  if (ipVersion === 4) return isBlockedIPv4(bare);
+  if (ipVersion === 6) return isBlockedIPv6(bare);
+
+  // Hex (0x…), octal-ish, decimal, or short-form dotted numbers — never a real host.
+  if (/^0x[0-9a-f]+$/i.test(bare)) return true;
+  if (/^[0-9]+$/.test(bare)) return true;
+  if (/^[0-9.]+$/.test(bare)) return true;
+
+  return false;
+};
+
+/**
+ * Returns true when a hostname is safe enough to hand to the image fetcher.
+ *
+ * Single-label hostnames are refused because that is exactly the shape of a Docker
+ * Compose service name — `api`, `web`, `plane-db`, `plane-redis`, `plane-minio` —
+ * which is the primary escalation path in this advisory. Public image hosts always
+ * carry a dot.
+ */
+const isAllowedHostname = (hostname: string): boolean => {
+  const host = hostname.toLowerCase();
+
+  if (!host) return false;
+  if (BLOCKED_HOST_EXACT.has(host)) return false;
+  if (BLOCKED_HOST_SUFFIXES.some((suffix) => host.endsWith(suffix))) return false;
+  if (isBlockedHostLiteral(host)) return false;
+  // No dot => single-label => container/service name on the internal network.
+  if (!host.includes(".")) return false;
+  // A trailing dot ("api.") sidesteps the check above without adding a real label.
+  if (host.endsWith(".")) return false;
+
+  return true;
+};
+
+/**
+ * Decides whether a TipTap image `src` may be passed to the PDF image pipeline.
+ *
+ * `data:` URIs are allowed because the asset pipeline deliberately pre-fetches
+ * images server-side and inlines them as `data:image/jpeg;base64,…`; those never
+ * touch the network again at render time.
+ *
+ * NOTE ON DNS REBINDING: for an `http(s)` host that clears these checks we cannot
+ * pin the resolved address here — the renderer is synchronous and the actual
+ * `fetch()` happens inside `@react-pdf/image`, out of our reach. A hostname under
+ * attacker control that resolves to a blocked address therefore remains a residual
+ * TOCTOU. Closing it properly means pre-fetching raw image nodes the way
+ * `imageComponent` already pre-fetches assets, then rendering only `data:` URIs.
+ * Tracked as follow-up to SECUR-245 — do not mistake this helper for a complete
+ * SSRF defence on the http(s) path.
+ */
+export const isSafeImageSrc = (src: string): boolean => {
+  if (!src) return false;
+
+  const trimmed = src.trim();
+  if (!trimmed) return false;
+
+  // Reject control characters and whitespace, which URL parsers strip and
+  // which have historically been used to smuggle a scheme past naive checks.
+  // oxlint-disable-next-line no-control-regex -- intentional: these are exactly what we reject
+  if (/[\u0000-\u0020\u007F]/.test(trimmed)) return false;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    // Relative paths and bare filesystem paths land here. `@react-pdf/image`
+    // would hand those to fs.readFile(), so they are refused.
+    return false;
+  }
+
+  if (!ALLOWED_SCHEMES.has(parsed.protocol)) return false;
+
+  // data: carries its payload inline; there is no host to judge.
+  if (parsed.protocol === "data:") return trimmed.toLowerCase().startsWith("data:image/");
+
+  // Credentials in an image URL are never legitimate and can confuse host parsing.
+  if (parsed.username || parsed.password) return false;
+
+  return isAllowedHostname(parsed.hostname);
+};

--- a/apps/live/src/lib/url-security.ts
+++ b/apps/live/src/lib/url-security.ts
@@ -44,7 +44,7 @@ const isBlockedIPv4 = (ip: string): boolean => {
     // Not a canonical dotted quad — callers treat unparseable hosts as unsafe.
     return true;
   }
-  const [a, b] = parts as [number, number, number, number];
+  const [a, b, c] = parts as [number, number, number, number];
 
   if (a === 0) return true; // 0.0.0.0/8      "this host on this network"
   if (a === 10) return true; // 10.0.0.0/8     private
@@ -53,11 +53,17 @@ const isBlockedIPv4 = (ip: string): boolean => {
   if (a === 169 && b === 254) return true; // 169.254.0.0/16 link-local (incl. 169.254.169.254 metadata)
   if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12  private
   if (a === 192 && b === 168) return true; // 192.168.0.0/16 private
-  if (a === 192 && b === 0) return true; // 192.0.0.0/24 + 192.0.2.0/24 (IETF protocol / TEST-NET-1)
   if (a === 198 && (b === 18 || b === 19)) return true; // 198.18.0.0/15  benchmarking
-  if (a === 198 && b === 51) return true; // 198.51.100.0/24 TEST-NET-2
-  if (a === 203 && b === 0) return true; // 203.0.113.0/24  TEST-NET-3
   if (a >= 224) return true; // 224.0.0.0/4 multicast, 240.0.0.0/4 reserved, 255.255.255.255
+
+  // The remaining special-purpose blocks are /24s sitting inside otherwise-public
+  // /16s, so they must be matched on the third octet. Testing only the second octet
+  // would blackhole real public space (192.0.3.0/24, 198.51.x, 203.0.x) and quietly
+  // stop legitimate images from rendering.
+  if (a === 192 && b === 0 && c === 0) return true; // 192.0.0.0/24   IETF protocol assignments
+  if (a === 192 && b === 0 && c === 2) return true; // 192.0.2.0/24   TEST-NET-1
+  if (a === 198 && b === 51 && c === 100) return true; // 198.51.100.0/24 TEST-NET-2
+  if (a === 203 && b === 0 && c === 113) return true; // 203.0.113.0/24  TEST-NET-3
 
   return false;
 };

--- a/apps/live/src/lib/url-security.ts
+++ b/apps/live/src/lib/url-security.ts
@@ -7,17 +7,12 @@
 import net from "node:net";
 
 /**
- * SSRF guards for URLs that the Live service may cause to be fetched.
+ * SSRF guards for URLs the Live service may cause to be fetched.
  *
- * Context (GHSA-55gq-rf47-9pqx): the PDF exporter renders TipTap `image` nodes by
- * handing `node.attrs.src` straight to `@react-pdf/image`, which calls `fetch()` on
- * anything with a host. Because the Live container shares a Docker network with the
- * API, database, Redis, RabbitMQ and MinIO, an unvalidated `src` turns PDF export
- * into a request forgery primitive against internal-only services.
- *
- * A prefix check such as `src.startsWith("http")` does NOT close this: the payloads
- * that matter — `http://api:8000/`, `http://plane-minio:9000/` — all start with
- * "http". The scheme is irrelevant; the *destination* is what has to be judged.
+ * The PDF exporter hands TipTap `node.attrs.src` to `@react-pdf/image`, which
+ * fetch()es anything with a host — and Live shares a Docker network with the API,
+ * database, Redis, RabbitMQ and MinIO. A `startsWith("http")` check is no defence:
+ * `http://api:8000/` starts with "http" too. The destination is what must be judged.
  */
 
 /** Schemes we are willing to hand to the PDF image pipeline. */
@@ -56,10 +51,9 @@ const isBlockedIPv4 = (ip: string): boolean => {
   if (a === 198 && (b === 18 || b === 19)) return true; // 198.18.0.0/15  benchmarking
   if (a >= 224) return true; // 224.0.0.0/4 multicast, 240.0.0.0/4 reserved, 255.255.255.255
 
-  // The remaining special-purpose blocks are /24s sitting inside otherwise-public
-  // /16s, so they must be matched on the third octet. Testing only the second octet
-  // would blackhole real public space (192.0.3.0/24, 198.51.x, 203.0.x) and quietly
-  // stop legitimate images from rendering.
+  // The remaining special-purpose blocks are /24s inside otherwise-public /16s, so
+  // they must be matched on the third octet — testing only the second would blackhole
+  // real public space (192.0.3.0/24, 198.51.x, 203.0.x) and break legitimate images.
   if (a === 192 && b === 0 && c === 0) return true; // 192.0.0.0/24   IETF protocol assignments
   if (a === 192 && b === 0 && c === 2) return true; // 192.0.2.0/24   TEST-NET-1
   if (a === 198 && b === 51 && c === 100) return true; // 198.51.100.0/24 TEST-NET-2
@@ -93,12 +87,10 @@ const isBlockedIPv6 = (ip: string): boolean => {
 };
 
 /**
- * Returns true when `host` is an IP literal pointing somewhere we refuse to fetch,
- * or a numeric/obfuscated host form that is not a canonical address at all.
- *
- * Obfuscated encodings (`0x7f000001`, `2130706433`, `127.1`) are rejected outright:
- * some HTTP clients expand them to loopback, none of them are legitimate image
- * hosts, and normalising every variant is a losing game.
+ * Returns true when `host` is an IP literal we refuse to fetch, or a numeric/
+ * obfuscated host form that is not a canonical address at all. Obfuscated encodings
+ * (`0x7f000001`, `2130706433`, `127.1`) are rejected outright — some HTTP clients
+ * expand them to loopback, and normalising every variant is a losing game.
  */
 export const isBlockedHostLiteral = (host: string): boolean => {
   const bare = host.replace(/^\[|\]$/g, "");
@@ -118,10 +110,9 @@ export const isBlockedHostLiteral = (host: string): boolean => {
 /**
  * Returns true when a hostname is safe enough to hand to the image fetcher.
  *
- * Single-label hostnames are refused because that is exactly the shape of a Docker
- * Compose service name — `api`, `web`, `plane-db`, `plane-redis`, `plane-minio` —
- * which is the primary escalation path in this advisory. Public image hosts always
- * carry a dot.
+ * Single-label hostnames are refused: that is exactly the shape of a Docker Compose
+ * service name (`api`, `plane-db`, `plane-minio`), the primary escalation path here.
+ * Public image hosts always carry a dot.
  */
 const isAllowedHostname = (hostname: string): boolean => {
   const host = hostname.toLowerCase();
@@ -139,20 +130,12 @@ const isAllowedHostname = (hostname: string): boolean => {
 };
 
 /**
- * Decides whether a TipTap image `src` may be passed to the PDF image pipeline.
- *
- * `data:` URIs are allowed because the asset pipeline deliberately pre-fetches
- * images server-side and inlines them as `data:image/jpeg;base64,…`; those never
- * touch the network again at render time.
- *
- * NOTE ON DNS REBINDING: for an `http(s)` host that clears these checks we cannot
- * pin the resolved address here — the renderer is synchronous and the actual
- * `fetch()` happens inside `@react-pdf/image`, out of our reach. A hostname under
- * attacker control that resolves to a blocked address therefore remains a residual
- * TOCTOU. Closing it properly means pre-fetching raw image nodes the way
- * `imageComponent` already pre-fetches assets, then rendering only `data:` URIs.
- * Tracked as follow-up to SECUR-245 — do not mistake this helper for a complete
- * SSRF defence on the http(s) path.
+ * Decides whether a TipTap image `src` may reach the PDF image pipeline. `data:` is
+ * allowed because the asset pipeline pre-fetches images server-side and inlines them,
+ * so nothing is fetched at render time. Not a complete http(s) defence: the fetch
+ * happens inside `@react-pdf/image`, so a host that passes here but resolves to a
+ * blocked address is a residual DNS-rebinding TOCTOU (SECUR-245 follow-up).
+ * TODO(SECUR-245): close it by pre-fetching raw image nodes, as imageComponent does.
  */
 export const isSafeImageSrc = (src: string): boolean => {
   if (!src) return false;

--- a/apps/live/src/lib/url-security.ts
+++ b/apps/live/src/lib/url-security.ts
@@ -62,26 +62,69 @@ const isBlockedIPv4 = (ip: string): boolean => {
   return false;
 };
 
+/**
+ * Expands an IPv6 literal to its eight 16-bit groups, or null if unparseable.
+ * Prefix matching alone is not enough: `::ffff:127.0.0.1` and its expanded twin
+ * `0:0:0:0:0:ffff:127.0.0.1` denote the same address, so anything comparing raw
+ * strings blocks one and fetches the other.
+ */
+const expandIPv6 = (addr: string): number[] | null => {
+  let head = addr;
+  let tail = "";
+  // A trailing dotted quad occupies the last two groups.
+  const dotted = head.match(/(?:^|:)((?:\d{1,3}\.){3}\d{1,3})$/);
+  if (dotted?.[1]) {
+    const quad = dotted[1].split(".").map(Number);
+    if (quad.some((n) => !Number.isInteger(n) || n < 0 || n > 255)) return null;
+    head = head.slice(0, head.length - dotted[1].length);
+    tail = `${((quad[0] << 8) | quad[1]).toString(16)}:${((quad[2] << 8) | quad[3]).toString(16)}`;
+    head = head.endsWith(":") && !head.endsWith("::") ? head.slice(0, -1) : head;
+    head = head === "" ? "::" : head;
+    head = head.endsWith("::") ? `${head}${tail}` : `${head}:${tail}`;
+  }
+
+  const halves = head.split("::");
+  if (halves.length > 2) return null;
+  const left = halves[0] ? halves[0].split(":") : [];
+  const right = halves.length === 2 && halves[1] ? halves[1].split(":") : [];
+  const fill = halves.length === 2 ? 8 - left.length - right.length : 0;
+  if (fill < 0 || (halves.length === 1 && left.length !== 8)) return null;
+
+  const groups = [...left, ...Array<string>(fill).fill("0"), ...right];
+  if (groups.length !== 8) return null;
+  const out = groups.map((g) => (/^[0-9a-f]{1,4}$/.test(g) ? parseInt(g, 16) : NaN));
+  return out.some(Number.isNaN) ? null : out;
+};
+
 /** Returns true when an IPv6 literal must never be fetched. */
 const isBlockedIPv6 = (ip: string): boolean => {
   const addr = ip.toLowerCase().replace(/^\[|\]$/g, "");
 
-  // IPv4-mapped (::ffff:127.0.0.1) and IPv4-compatible forms: judge the embedded v4.
-  const mapped = addr.match(/^(?:::ffff:|::)((?:\d{1,3}\.){3}\d{1,3})$/);
-  if (mapped?.[1]) return isBlockedIPv4(mapped[1]);
+  // Judge on the expanded form so alternate spellings cannot slip past the
+  // prefix checks below. Unparseable literals are treated as unsafe.
+  const groups = expandIPv6(addr);
+  if (!groups) return true;
 
-  if (addr === "::" || addr === "::1") return true; // unspecified / loopback
-  if (addr.startsWith("fe8") || addr.startsWith("fe9") || addr.startsWith("fea") || addr.startsWith("feb")) return true; // fe80::/10 link-local
+  // IPv4-mapped (::ffff:a.b.c.d) and IPv4-compatible (::a.b.c.d): judge the embedded v4.
+  const firstFiveZero = groups.slice(0, 5).every((g) => g === 0);
+  if (firstFiveZero && (groups[5] === 0xffff || (groups[5] === 0 && (groups[6] !== 0 || groups[7] !== 0)))) {
+    const v4 = [groups[6] >> 8, groups[6] & 0xff, groups[7] >> 8, groups[7] & 0xff].join(".");
+    return isBlockedIPv4(v4);
+  }
+
+  const [g0, g1] = groups;
+  if (groups.every((g) => g === 0)) return true; // :: unspecified
+  if (firstFiveZero && groups[5] === 0 && groups[6] === 0 && groups[7] === 1) return true; // ::1 loopback
+  if ((g0 & 0xffc0) === 0xfe80) return true; // fe80::/10 link-local
   // fec0::/10 deprecated site-local. Kept in step with the Python guard's
   // _BLOCKED_NETWORKS (apps/api/plane/utils/ip_address.py) — the two lists must not
   // drift, or one service will block a range the other happily fetches.
-  if (addr.startsWith("fec") || addr.startsWith("fed") || addr.startsWith("fee") || addr.startsWith("fef")) return true;
-  if (addr.startsWith("fc") || addr.startsWith("fd")) return true; // fc00::/7 unique local
-  if (addr.startsWith("ff")) return true; // ff00::/8 multicast
-  if (addr.startsWith("64:ff9b:")) return true; // 64:ff9b::/96 + 64:ff9b:1::/48 NAT64
-  if (addr.startsWith("2002:")) return true; // 6to4 — can wrap a private v4
-  if (/^2001:(0{1,4})?:/.test(addr)) return true; // 2001::/32 Teredo
-  if (addr.startsWith("::ffff:")) return true; // any other IPv4-mapped form
+  if ((g0 & 0xffc0) === 0xfec0) return true;
+  if ((g0 & 0xfe00) === 0xfc00) return true; // fc00::/7 unique local
+  if ((g0 & 0xff00) === 0xff00) return true; // ff00::/8 multicast
+  if (g0 === 0x64 && g1 === 0xff9b) return true; // 64:ff9b::/96 + 64:ff9b:1::/48 NAT64
+  if (g0 === 0x2002) return true; // 6to4 — can wrap a private v4
+  if (g0 === 0x2001 && g1 === 0) return true; // 2001::/32 Teredo
 
   return false;
 };

--- a/apps/live/src/lib/url-security.ts
+++ b/apps/live/src/lib/url-security.ts
@@ -175,10 +175,16 @@ const isAllowedHostname = (hostname: string): boolean => {
 /**
  * Decides whether a TipTap image `src` may reach the PDF image pipeline. `data:` is
  * allowed because the asset pipeline pre-fetches images server-side and inlines them,
- * so nothing is fetched at render time. Not a complete http(s) defence: the fetch
- * happens inside `@react-pdf/image`, so a host that passes here but resolves to a
- * blocked address is a residual DNS-rebinding TOCTOU (SECUR-245 follow-up).
- * TODO(SECUR-245): close it by pre-fetching raw image nodes, as imageComponent does.
+ * so nothing is fetched at render time.
+ *
+ * This is a hostname/IP check on a single URL, not a complete defence by itself:
+ * a host that passes here can still resolve to a blocked address by the time the
+ * real fetch happens (DNS-rebinding TOCTOU — the name is looked up once here, and
+ * again, independently, whenever the URL is actually fetched). `fetchImageSrcSafely`
+ * below re-runs this same check on every redirect hop, which closes the far more
+ * easily exploited gap — a plain 3xx response pointed at an internal address — but
+ * does not re-resolve DNS between validating and fetching the final, non-redirect
+ * response, so the rebinding window still exists on that last hop.
  */
 export const isSafeImageSrc = (src: string): boolean => {
   if (!src) return false;
@@ -209,4 +215,74 @@ export const isSafeImageSrc = (src: string): boolean => {
   if (parsed.username || parsed.password) return false;
 
   return isAllowedHostname(parsed.hostname);
+};
+
+/** Redirect hops `fetchImageSrcSafely` will follow before giving up on a source. */
+const MAX_IMAGE_FETCH_REDIRECTS = 5;
+
+/**
+ * Fetches an http(s) image URL the way `isSafeImageSrc` alone cannot guard: real
+ * fetch libraries (`@react-pdf/image`'s `fetchRemoteFile`, plain `fetch()`) follow
+ * redirects by default and never re-consult a src validator on the redirect target.
+ * That means a URL on an ordinary public host can 302 to an internal address —
+ * cloud metadata, a Docker service name, loopback — and sail straight through a
+ * check that only ever looked at the URL it was first handed.
+ *
+ * This fetches with `redirect: "manual"`, and on every 3xx response resolves the
+ * `Location` header against the current URL and re-validates it with
+ * `isSafeImageSrc` before following it, capped at `MAX_IMAGE_FETCH_REDIRECTS` hops.
+ * Any failure — the initial URL, a redirect target, or the hop count failing
+ * validation, a network error, or an unreadable body — resolves to `null`, which
+ * callers treat exactly like `isSafeImageSrc` returning `false`: render a
+ * placeholder, never hand the raw URL to the PDF image pipeline.
+ *
+ * Returns the fetched body as a `Buffer` on success, so callers can feed it through
+ * the same image-processing path used for pre-fetched asset-store images.
+ */
+export const fetchImageSrcSafely = async (uri: string): Promise<Buffer | null> => {
+  let current = uri;
+
+  for (let hop = 0; hop <= MAX_IMAGE_FETCH_REDIRECTS; hop++) {
+    if (!isSafeImageSrc(current)) return null;
+
+    let response: Response;
+    try {
+      // Each hop's request target comes from the previous hop's response, so these
+      // fetches cannot be parallelized — they must run one at a time, in order.
+      // oxlint-disable-next-line no-await-in-loop -- intentional, see above
+      response = await fetch(current, { redirect: "manual" });
+    } catch {
+      return null;
+    }
+
+    if (response.status >= 300 && response.status < 400) {
+      const location = response.headers.get("location");
+      if (!location) return null;
+
+      let next: URL;
+      try {
+        next = new URL(location, current);
+      } catch {
+        // Unparseable Location header — nothing safe to follow.
+        return null;
+      }
+      current = next.toString();
+      continue; // Re-validated by isSafeImageSrc at the top of the next iteration.
+    }
+
+    if (!response.ok) return null;
+
+    try {
+      // Terminal (non-redirect) response, reached after at most MAX_IMAGE_FETCH_REDIRECTS
+      // sequential hops above — there is nothing left here to run in parallel with.
+      // oxlint-disable-next-line no-await-in-loop -- intentional, see above
+      const arrayBuffer = await response.arrayBuffer();
+      return Buffer.from(arrayBuffer);
+    } catch {
+      return null;
+    }
+  }
+
+  // Exhausted MAX_IMAGE_FETCH_REDIRECTS hops without reaching a terminal response.
+  return null;
 };

--- a/apps/live/src/services/pdf-export/pdf-export.service.ts
+++ b/apps/live/src/services/pdf-export/pdf-export.service.ts
@@ -9,6 +9,7 @@ import sharp from "sharp";
 import { getAllDocumentFormatsFromDocumentEditorBinaryData } from "@plane/editor/lib";
 import type { PDFExportMetadata, TipTapDocument } from "@/lib/pdf";
 import { renderPlaneDocToPdfBuffer } from "@/lib/pdf";
+import { fetchImageSrcSafely } from "@/lib/url-security";
 import { getPageService } from "@/services/page/handler";
 import type { TDocumentTypes } from "@/types";
 import {
@@ -30,6 +31,21 @@ type TipTapNode = {
   type: string;
   attrs?: Record<string, unknown>;
   content?: TipTapNode[];
+};
+
+/**
+ * Normalizes a fetched image buffer into the JPEG data URI the PDF renderer expects —
+ * downscaled to IMAGE_MAX_DIMENSION and flattened onto white — the same way for every
+ * image source, whether it came from the asset store or an external URL.
+ */
+const toPdfImageDataUri = async (buffer: Buffer): Promise<string> => {
+  const processed = await sharp(buffer)
+    .rotate()
+    .flatten({ background: { r: 255, g: 255, b: 255 } })
+    .resize(IMAGE_MAX_DIMENSION, IMAGE_MAX_DIMENSION, { fit: "inside", withoutEnlargement: true })
+    .jpeg({ quality: 85 })
+    .toBuffer();
+  return `data:image/jpeg;base64,${processed.toString("base64")}`;
 };
 
 /**
@@ -66,6 +82,37 @@ export class PdfExportService extends Effect.Service<PdfExportService>()("PdfExp
 
       traverse(doc);
       return [...new Set(assetIds)];
+    },
+
+    /**
+     * Extracts external (http/https) image URLs from raw `image` nodes — arbitrary
+     * URLs pasted into page content, as opposed to Plane's own uploaded assets.
+     * These are not covered by `extractImageAssetIds`: an external URL is exactly
+     * what that function's `!src.startsWith("http")` filter excludes, since it only
+     * collects internal asset ids. Left unresolved, that URL would otherwise reach
+     * `<Image src={src}>` unfetched and be handed straight to `@react-pdf/image` at
+     * render time, which is the redirect-follow SSRF gap `processExternalImages`
+     * closes by pre-fetching these the same way `processImages` pre-fetches assets.
+     */
+    extractExternalImageSrcs: (doc: TipTapNode): string[] => {
+      const srcs: string[] = [];
+
+      const traverse = (node: TipTapNode) => {
+        if (node.type === "image" && node.attrs?.src) {
+          const src = node.attrs.src as string;
+          if (src && (src.startsWith("http://") || src.startsWith("https://"))) {
+            srcs.push(src);
+          }
+        }
+        if (node.content) {
+          for (const child of node.content) {
+            traverse(child);
+          }
+        }
+      };
+
+      traverse(doc);
+      return [...new Set(srcs)];
     },
 
     /**
@@ -164,12 +211,13 @@ export class PdfExportService extends Effect.Service<PdfExportService>()("PdfExp
         // Resolve URLs first
         const resolvedUrlMap = yield* tryAsync(
           async () => {
-            const urlMap = new Map<string, string>();
-            for (const assetId of assetIds) {
-              const url = await pageService.resolveImageAssetUrl?.(workspaceSlug, assetId, projectId);
-              if (url) urlMap.set(assetId, url);
-            }
-            return urlMap;
+            const entries = await Promise.all(
+              assetIds.map(async (assetId) => {
+                const url = await pageService.resolveImageAssetUrl?.(workspaceSlug, assetId, projectId);
+                return url ? ([assetId, url] as const) : null;
+              })
+            );
+            return new Map(entries.filter((entry): entry is readonly [string, string] => entry !== null));
           },
           () => new Map<string, string>()
         ).pipe(recoverWithDefault(new Map<string, string>()));
@@ -210,14 +258,8 @@ export class PdfExportService extends Effect.Service<PdfExportService>()("PdfExp
                 })
             );
 
-            const processedBuffer = yield* tryAsync(
-              () =>
-                sharp(Buffer.from(arrayBuffer))
-                  .rotate()
-                  .flatten({ background: { r: 255, g: 255, b: 255 } })
-                  .resize(IMAGE_MAX_DIMENSION, IMAGE_MAX_DIMENSION, { fit: "inside", withoutEnlargement: true })
-                  .jpeg({ quality: 85 })
-                  .toBuffer(),
+            const dataUri = yield* tryAsync(
+              () => toPdfImageDataUri(Buffer.from(arrayBuffer)),
               (cause) =>
                 new PdfImageProcessingError({
                   message: "Failed to process image",
@@ -226,8 +268,7 @@ export class PdfExportService extends Effect.Service<PdfExportService>()("PdfExp
                 })
             );
 
-            const base64 = processedBuffer.toString("base64");
-            return [assetId, `data:image/jpeg;base64,${base64}`] as const;
+            return [assetId, dataUri] as const;
           }).pipe(
             withTimeoutAndRetry(`process image ${assetId}`, {
               timeoutMs: IMAGE_TIMEOUT_MS,
@@ -245,6 +286,81 @@ export class PdfExportService extends Effect.Service<PdfExportService>()("PdfExp
 
         const entries = Array.from(resolvedUrlMap.entries());
         const pairs = yield* Effect.forEach(entries, processSingleImage, {
+          concurrency: IMAGE_CONCURRENCY,
+        });
+
+        const filtered = pairs.filter((p): p is readonly [string, string] => p !== null);
+        return Object.fromEntries(filtered);
+      }),
+
+    /**
+     * Pre-fetches raw `image`-node URLs through the redirect-safe fetch path
+     * (`fetchImageSrcSafely`) and resolves each into a data URI, exactly like
+     * `processImages` does for asset-store images. Keyed by the source URL itself,
+     * so `node-renderers.tsx` can look a src up the same way it looks up an asset id.
+     * Failures (unsafe src, unsafe redirect target, network error) resolve to
+     * nothing for that key — the renderer falls back to its placeholder, it never
+     * sees the raw URL.
+     */
+    processExternalImages: (srcs: string[], requestId: string): Effect.Effect<Record<string, string>> =>
+      Effect.gen(function* () {
+        if (srcs.length === 0) {
+          return {};
+        }
+
+        yield* Effect.logDebug("PDF_EXPORT: Processing external image sources", {
+          requestId,
+          count: srcs.length,
+        });
+
+        const processSingleExternalImage = (src: string) =>
+          Effect.gen(function* () {
+            const buffer = yield* tryAsync(
+              () => fetchImageSrcSafely(src),
+              (cause) =>
+                new PdfImageProcessingError({
+                  message: "Failed to fetch external image",
+                  assetId: src,
+                  cause,
+                })
+            );
+
+            if (!buffer) {
+              return yield* Effect.fail(
+                new PdfImageProcessingError({
+                  message: "External image failed SSRF validation or fetch",
+                  assetId: src,
+                })
+              );
+            }
+
+            const dataUri = yield* tryAsync(
+              () => toPdfImageDataUri(buffer),
+              (cause) =>
+                new PdfImageProcessingError({
+                  message: "Failed to process external image",
+                  assetId: src,
+                  cause,
+                })
+            );
+
+            return [src, dataUri] as const;
+          }).pipe(
+            withTimeoutAndRetry(`process external image ${src}`, {
+              timeoutMs: IMAGE_TIMEOUT_MS,
+              maxRetries: 1,
+            }),
+            Effect.tapError((error) =>
+              Effect.logWarning("PDF_EXPORT: External image processing failed", {
+                requestId,
+                src,
+                error,
+              })
+            ),
+            Effect.catchAll(() => Effect.succeed(null as readonly [string, string] | null))
+          );
+
+        const pairs = yield* Effect.forEach(srcs, processSingleExternalImage, {
           concurrency: IMAGE_CONCURRENCY,
         });
 
@@ -325,8 +441,9 @@ export const exportToPdf = (
     // Fetch content
     const content = yield* service.fetchPageContent(pageService, pageId, requestId);
 
-    // Extract image asset IDs
+    // Extract image asset IDs and raw external image URLs
     const imageAssetIds = service.extractImageAssetIds(content.contentJSON as TipTapNode);
+    const externalImageSrcs = service.extractExternalImageSrcs(content.contentJSON as TipTapNode);
 
     // Fetch user mentions
     let metadata = yield* service.fetchUserMentions(pageService, pageId, requestId);
@@ -340,7 +457,14 @@ export const exportToPdf = (
         imageAssetIds,
         requestId
       );
-      metadata = { ...metadata, resolvedImageUrls: resolvedImages };
+      metadata = { ...metadata, resolvedImageUrls: { ...metadata.resolvedImageUrls, ...resolvedImages } };
+    }
+
+    // Pre-fetch raw `image`-node URLs through the redirect-safe fetch path, keyed by
+    // the URL itself, merged into the same map processImages populates above.
+    if (!noAssets && externalImageSrcs.length > 0) {
+      const resolvedExternalImages = yield* service.processExternalImages(externalImageSrcs, requestId);
+      metadata = { ...metadata, resolvedImageUrls: { ...metadata.resolvedImageUrls, ...resolvedExternalImages } };
     }
 
     yield* Effect.logDebug("PDF_EXPORT: Metadata prepared", {

--- a/apps/live/tests/lib/pdf/pdf-rendering.test.ts
+++ b/apps/live/tests/lib/pdf/pdf-rendering.test.ts
@@ -6,10 +6,21 @@
 
 import { describe, it, expect } from "vitest";
 import { PDFParse } from "pdf-parse";
+import sharp from "sharp";
 import { renderPlaneDocToPdfBuffer } from "@/lib/pdf";
 import type { TipTapDocument, PDFExportMetadata } from "@/lib/pdf";
 
 const PDF_HEADER = "%PDF-";
+
+/** A tiny valid JPEG data URI, standing in for a pre-fetched/resolved image src. */
+async function tinyJpegDataUri(): Promise<string> {
+  const buffer = await sharp({
+    create: { width: 2, height: 2, channels: 3, background: { r: 255, g: 0, b: 0 } },
+  })
+    .jpeg()
+    .toBuffer();
+  return `data:image/jpeg;base64,${buffer.toString("base64")}`;
+}
 
 /**
  * Helper to extract text content from a PDF buffer
@@ -727,6 +738,70 @@ describe("PDF Rendering Integration", () => {
       const text = await extractPdfText(buffer);
 
       expect(text).toContain("Text after image");
+    });
+  });
+
+  describe("image node SSRF pre-resolution", () => {
+    // The `image` renderer never fetches its own src or hands the raw URL to
+    // @react-pdf/image at render time — pdf-export.service.ts pre-fetches every
+    // external `image`-node src (through the redirect-safe path) before rendering
+    // starts and hands the result in via metadata.resolvedImageUrls, the same way
+    // it already does for `imageComponent` assets. These tests exercise that
+    // renderer-level contract directly, without going through the fetch pipeline.
+
+    it("renders the pre-resolved data URI when metadata carries a resolved entry for the src", async () => {
+      const src = "https://images.example.com/photo.png";
+      const doc: TipTapDocument = {
+        type: "doc",
+        content: [{ type: "image", attrs: { src } }],
+      };
+      const metadata: PDFExportMetadata = { resolvedImageUrls: { [src]: await tinyJpegDataUri() } };
+
+      const buffer = await renderPlaneDocToPdfBuffer(doc, { metadata });
+
+      expect(buffer.toString("ascii", 0, 5)).toBe(PDF_HEADER);
+    });
+
+    it("renders the placeholder, never the raw src, when the src has no pre-resolved entry", async () => {
+      const doc: TipTapDocument = {
+        type: "doc",
+        content: [{ type: "image", attrs: { src: "https://images.example.com/never-fetched.png" } }],
+      };
+
+      // No metadata at all: the renderer must fall back to the placeholder rather
+      // than passing the raw external URL straight to <Image>.
+      const buffer = await renderPlaneDocToPdfBuffer(doc);
+      const text = await extractPdfText(buffer);
+
+      expect(text).toContain("Image unavailable");
+    });
+
+    it("renders the placeholder for a src that failed pre-resolution (e.g. blocked by SSRF checks)", async () => {
+      const src = "http://169.254.169.254/latest/meta-data/";
+      const doc: TipTapDocument = {
+        type: "doc",
+        content: [{ type: "image", attrs: { src } }],
+      };
+      // A failed pre-fetch (unsafe src, unsafe redirect target, or network error)
+      // simply omits the key from resolvedImageUrls — it never carries a fallback
+      // to the raw src.
+      const metadata: PDFExportMetadata = { resolvedImageUrls: {} };
+
+      const buffer = await renderPlaneDocToPdfBuffer(doc, { metadata });
+      const text = await extractPdfText(buffer);
+
+      expect(text).toContain("Image unavailable");
+    });
+
+    it("still renders inline data: URIs directly, with no pre-fetch entry required", async () => {
+      const doc: TipTapDocument = {
+        type: "doc",
+        content: [{ type: "image", attrs: { src: await tinyJpegDataUri() } }],
+      };
+
+      const buffer = await renderPlaneDocToPdfBuffer(doc);
+
+      expect(buffer.toString("ascii", 0, 5)).toBe(PDF_HEADER);
     });
   });
 });

--- a/apps/live/tests/lib/url-security.test.ts
+++ b/apps/live/tests/lib/url-security.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Copyright (c) 2023-present Plane Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { describe, expect, it } from "vitest";
+import { isBlockedHostLiteral, isSafeImageSrc } from "@/lib/url-security";
+
+describe("isSafeImageSrc — GHSA-55gq-rf47-9pqx", () => {
+  describe("advisory payloads: internal Docker service names", () => {
+    // The escalation path named in the advisory. Every one of these starts with
+    // "http", which is why the imageComponent-style startsWith("http") guard
+    // does not close this vulnerability.
+    it.each([
+      "http://api:8000/api/workspaces/",
+      "http://plane-minio:9000/uploads/",
+      "http://plane-db:5432/",
+      "http://plane-redis:6379/",
+      "http://plane-mq:5672/",
+      "http://web:3000/",
+      "http://admin:3000/",
+      "http://space:3000/",
+      "http://live:3000/",
+    ])("rejects %s", (src) => {
+      expect(isSafeImageSrc(src)).toBe(false);
+    });
+
+    it("rejects a single-label host even over https", () => {
+      expect(isSafeImageSrc("https://api/")).toBe(false);
+    });
+
+    it("rejects a trailing-dot host that would otherwise look multi-label", () => {
+      expect(isSafeImageSrc("http://api./")).toBe(false);
+    });
+  });
+
+  describe("cloud metadata and loopback", () => {
+    it.each([
+      "http://169.254.169.254/latest/meta-data/",
+      "http://metadata.google.internal/computeMetadata/v1/",
+      "http://metadata/computeMetadata/v1/",
+      "http://localhost:8000/",
+      "http://127.0.0.1:8000/",
+      "http://127.1.2.3/",
+      "http://[::1]/",
+      "http://[::ffff:127.0.0.1]/",
+    ])("rejects %s", (src) => {
+      expect(isSafeImageSrc(src)).toBe(false);
+    });
+  });
+
+  describe("private, CGNAT, link-local and reserved ranges", () => {
+    it.each([
+      "http://10.0.0.5/",
+      "http://172.16.0.1/",
+      "http://172.31.255.254/",
+      "http://192.168.1.1/",
+      "http://100.64.0.1/", // CGNAT — missed by naive "private IP" lists
+      "http://100.127.255.255/",
+      "http://0.0.0.0/",
+      "http://224.0.0.1/", // multicast
+      "http://255.255.255.255/",
+      "http://198.18.0.1/", // benchmarking
+      "http://[fd00::1]/", // IPv6 unique local
+      "http://[fe80::1]/", // IPv6 link-local
+      "http://[ff02::1]/", // IPv6 multicast
+      "http://[fec0::1]/", // IPv6 deprecated site-local
+      "http://[2002:7f00:1::]/", // 6to4 wrapping 127.0.0.1
+      "http://[2001::1]/", // Teredo
+      "http://[64:ff9b::7f00:1]/", // NAT64 wrapping 127.0.0.1
+      "http://[64:ff9b:1::1]/", // NAT64 local-use prefix
+    ])("rejects %s", (src) => {
+      expect(isSafeImageSrc(src)).toBe(false);
+    });
+
+    it("allows a public IP just outside a blocked range", () => {
+      // 100.63.x is public; the CGNAT block starts at 100.64.
+      expect(isSafeImageSrc("http://100.63.0.1/")).toBe(true);
+      // 172.32.x is public; the private block ends at 172.31.
+      expect(isSafeImageSrc("http://172.32.0.1/")).toBe(true);
+    });
+  });
+
+  describe("obfuscated address encodings", () => {
+    // Not canonical addresses, but several HTTP clients expand them to loopback.
+    it.each([
+      "http://2130706433/", // decimal 127.0.0.1
+      "http://0x7f000001/", // hex 127.0.0.1
+      "http://127.1/", // short-form 127.0.0.1
+      "http://0/", // shorthand for 0.0.0.0
+    ])("rejects %s", (src) => {
+      expect(isSafeImageSrc(src)).toBe(false);
+    });
+  });
+
+  describe("scheme handling", () => {
+    it.each([
+      "file:///etc/passwd",
+      "ftp://example.com/x.png",
+      "gopher://example.com/",
+      "javascript:alert(1)",
+      "vbscript:msgbox(1)",
+      "blob:https://example.com/abc",
+    ])("rejects %s", (src) => {
+      expect(isSafeImageSrc(src)).toBe(false);
+    });
+
+    it("rejects bare filesystem paths that would reach fs.readFile", () => {
+      // The advisory's secondary local-file-read finding.
+      expect(isSafeImageSrc("/etc/passwd")).toBe(false);
+      expect(isSafeImageSrc("./relative.png")).toBe(false);
+      expect(isSafeImageSrc("../../etc/hosts")).toBe(false);
+    });
+
+    it("allows image data URIs (the asset pipeline's own output)", () => {
+      expect(isSafeImageSrc("data:image/jpeg;base64,/9j/4AAQSkZJRg==")).toBe(true);
+      expect(isSafeImageSrc("data:image/png;base64,iVBORw0KGgo=")).toBe(true);
+    });
+
+    it("rejects non-image data URIs", () => {
+      expect(isSafeImageSrc("data:text/html,<script>alert(1)</script>")).toBe(false);
+      expect(isSafeImageSrc("data:application/javascript,alert(1)")).toBe(false);
+    });
+  });
+
+  describe("whitespace and control-character smuggling", () => {
+    // The same class of bypass as GHSA-v2vv-7wq3-8w2j: URL parsers strip these,
+    // so a check performed before stripping can be walked straight past.
+    it.each([
+      "\thttp://api:8000/",
+      "\nhttp://api:8000/",
+      "\rhttp://api:8000/",
+      " http://127.0.0.1/",
+      "http://api\t:8000/",
+      "\u0000http://api:8000/",
+      "\u00A0http://api:8000/", // non-breaking space
+      "\uFEFFhttp://api:8000/", // BOM
+    ])("rejects %j", (src) => {
+      expect(isSafeImageSrc(src)).toBe(false);
+    });
+  });
+
+  describe("embedded credentials", () => {
+    it("rejects URLs carrying credentials", () => {
+      expect(isSafeImageSrc("http://user:pass@images.example.com/a.png")).toBe(false);
+      // Credentials can also be used to make the real host hard to read.
+      expect(isSafeImageSrc("http://images.example.com@127.0.0.1/a.png")).toBe(false);
+    });
+  });
+
+  describe("internal-only hostname suffixes", () => {
+    it.each([
+      "http://printer.local/x.png",
+      "http://app.localhost/x.png",
+      "http://svc.internal/x.png",
+      "http://box.lan/x.png",
+      "http://thing.home.arpa/x.png",
+    ])("rejects %s", (src) => {
+      expect(isSafeImageSrc(src)).toBe(false);
+    });
+  });
+
+  describe("legitimate images still render", () => {
+    it.each([
+      "https://images.example.com/photo.png",
+      "http://cdn.example.org/a/b/c.jpg",
+      "https://user-images.githubusercontent.com/1/2.png",
+      "https://example.co.uk/img.webp",
+      "https://sub.domain.example.com:8443/img.png",
+    ])("allows %s", (src) => {
+      expect(isSafeImageSrc(src)).toBe(true);
+    });
+  });
+
+  describe("empty and malformed input", () => {
+    it.each(["", "   ", "not a url", "http://", "://example.com"])("rejects %j", (src) => {
+      expect(isSafeImageSrc(src)).toBe(false);
+    });
+  });
+});
+
+describe("isBlockedHostLiteral", () => {
+  it("classifies canonical IPv4 literals", () => {
+    expect(isBlockedHostLiteral("127.0.0.1")).toBe(true);
+    expect(isBlockedHostLiteral("10.1.2.3")).toBe(true);
+    expect(isBlockedHostLiteral("8.8.8.8")).toBe(false);
+    expect(isBlockedHostLiteral("1.1.1.1")).toBe(false);
+  });
+
+  it("classifies IPv6 literals with and without brackets", () => {
+    expect(isBlockedHostLiteral("::1")).toBe(true);
+    expect(isBlockedHostLiteral("[::1]")).toBe(true);
+    expect(isBlockedHostLiteral("2606:4700:4700::1111")).toBe(false);
+  });
+
+  it("treats real hostnames as non-literals", () => {
+    expect(isBlockedHostLiteral("example.com")).toBe(false);
+    expect(isBlockedHostLiteral("api")).toBe(false);
+  });
+});

--- a/apps/live/tests/lib/url-security.test.ts
+++ b/apps/live/tests/lib/url-security.test.ts
@@ -80,6 +80,25 @@ describe("isSafeImageSrc — GHSA-55gq-rf47-9pqx", () => {
       // 172.32.x is public; the private block ends at 172.31.
       expect(isSafeImageSrc("http://172.32.0.1/")).toBe(true);
     });
+
+    // These /24s sit inside otherwise-public /16s. Blocking the whole /16 would
+    // silently stop legitimate images from rendering, so the boundaries are pinned
+    // in both directions.
+    it("blocks the reserved /24s exactly", () => {
+      expect(isSafeImageSrc("http://192.0.0.1/")).toBe(false); // 192.0.0.0/24 IETF protocol assignments
+      expect(isSafeImageSrc("http://192.0.2.1/")).toBe(false); // 192.0.2.0/24 TEST-NET-1
+      expect(isSafeImageSrc("http://198.51.100.1/")).toBe(false); // 198.51.100.0/24 TEST-NET-2
+      expect(isSafeImageSrc("http://203.0.113.1/")).toBe(false); // 203.0.113.0/24 TEST-NET-3
+    });
+
+    it("still allows the public space surrounding those /24s", () => {
+      expect(isSafeImageSrc("http://192.0.1.1/")).toBe(true);
+      expect(isSafeImageSrc("http://192.0.3.1/")).toBe(true);
+      expect(isSafeImageSrc("http://198.51.99.1/")).toBe(true);
+      expect(isSafeImageSrc("http://198.51.101.1/")).toBe(true);
+      expect(isSafeImageSrc("http://203.0.112.1/")).toBe(true);
+      expect(isSafeImageSrc("http://203.0.114.1/")).toBe(true);
+    });
   });
 
   describe("obfuscated address encodings", () => {

--- a/apps/live/tests/lib/url-security.test.ts
+++ b/apps/live/tests/lib/url-security.test.ts
@@ -4,8 +4,8 @@
  * See the LICENSE file for details.
  */
 
-import { describe, expect, it } from "vitest";
-import { isBlockedHostLiteral, isSafeImageSrc } from "@/lib/url-security";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchImageSrcSafely, isBlockedHostLiteral, isSafeImageSrc } from "@/lib/url-security";
 
 describe("isSafeImageSrc", () => {
   describe("internal Docker service names", () => {
@@ -240,5 +240,141 @@ describe("isBlockedHostLiteral", () => {
   it("treats real hostnames as non-literals", () => {
     expect(isBlockedHostLiteral("example.com")).toBe(false);
     expect(isBlockedHostLiteral("api")).toBe(false);
+  });
+});
+
+const redirectTo = (location?: string) =>
+  new Response(null, { status: 302, headers: location ? { Location: location } : undefined });
+
+const ok = (body = "image-bytes") => new Response(body, { status: 200 });
+
+describe("fetchImageSrcSafely", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("refuses the initial URL without fetching when it fails isSafeImageSrc", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await fetchImageSrcSafely("http://169.254.169.254/latest/meta-data/");
+
+    expect(result).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("refuses a safe host that redirects to a blocked address (link-local metadata)", async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(redirectTo("http://169.254.169.254/latest/meta-data/"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await fetchImageSrcSafely("https://images.example.com/a.png");
+
+    expect(result).toBeNull();
+    // The redirect target fails isSafeImageSrc before it is ever fetched.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("refuses a safe host that redirects to a loopback address", async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(redirectTo("http://127.0.0.1:8000/"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    expect(await fetchImageSrcSafely("https://images.example.com/a.png")).toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("refuses a safe host that redirects to an RFC1918 private address", async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(redirectTo("http://10.0.0.5/internal"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    expect(await fetchImageSrcSafely("https://images.example.com/a.png")).toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("refuses a safe host that redirects to a Docker service name", async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(redirectTo("http://api:8000/api/workspaces/"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    expect(await fetchImageSrcSafely("https://images.example.com/a.png")).toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("follows a redirect from one safe host to another and returns the fetched body", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(redirectTo("https://cdn.example.org/final.png"))
+      .mockResolvedValueOnce(ok("final-bytes"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await fetchImageSrcSafely("https://images.example.com/a.png");
+
+    expect(result).not.toBeNull();
+    expect(result?.toString("utf-8")).toBe("final-bytes");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenNthCalledWith(1, "https://images.example.com/a.png", { redirect: "manual" });
+    expect(fetchMock).toHaveBeenNthCalledWith(2, "https://cdn.example.org/final.png", { redirect: "manual" });
+  });
+
+  it("resolves a relative Location header against the current URL before re-validating it", async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(redirectTo("/final.png")).mockResolvedValueOnce(ok("final-bytes"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await fetchImageSrcSafely("https://images.example.com/a.png");
+
+    expect(result?.toString("utf-8")).toBe("final-bytes");
+    expect(fetchMock).toHaveBeenNthCalledWith(2, "https://images.example.com/final.png", { redirect: "manual" });
+  });
+
+  it("refuses a redirect chain that exceeds the cap", async () => {
+    let hop = 0;
+    const fetchMock = vi.fn().mockImplementation(() => {
+      hop += 1;
+      return Promise.resolve(redirectTo(`https://images.example.com/hop-${hop}`));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await fetchImageSrcSafely("https://images.example.com/a.png");
+
+    expect(result).toBeNull();
+    // 1 initial request plus 5 allowed redirects = 6 requests; the 6th response is
+    // itself a redirect and is never followed.
+    expect(fetchMock).toHaveBeenCalledTimes(6);
+  });
+
+  it("refuses a redirect with no Location header", async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(redirectTo());
+    vi.stubGlobal("fetch", fetchMock);
+
+    expect(await fetchImageSrcSafely("https://images.example.com/a.png")).toBeNull();
+  });
+
+  it("refuses an unparseable Location header", async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(redirectTo("http://[not-a-valid-host"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    expect(await fetchImageSrcSafely("https://images.example.com/a.png")).toBeNull();
+  });
+
+  it("refuses a non-ok, non-redirect response", async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(new Response(null, { status: 404 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    expect(await fetchImageSrcSafely("https://images.example.com/a.png")).toBeNull();
+  });
+
+  it("refuses when the fetch itself throws", async () => {
+    const fetchMock = vi.fn().mockRejectedValueOnce(new Error("network error"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    expect(await fetchImageSrcSafely("https://images.example.com/a.png")).toBeNull();
+  });
+
+  it("returns the body untouched on a direct 200 with no redirects", async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(ok("direct-bytes"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await fetchImageSrcSafely("https://images.example.com/a.png");
+
+    expect(result?.toString("utf-8")).toBe("direct-bytes");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/live/tests/lib/url-security.test.ts
+++ b/apps/live/tests/lib/url-security.test.ts
@@ -7,11 +7,10 @@
 import { describe, expect, it } from "vitest";
 import { isBlockedHostLiteral, isSafeImageSrc } from "@/lib/url-security";
 
-describe("isSafeImageSrc — GHSA-55gq-rf47-9pqx", () => {
-  describe("advisory payloads: internal Docker service names", () => {
-    // The escalation path named in the advisory. Every one of these starts with
-    // "http", which is why the imageComponent-style startsWith("http") guard
-    // does not close this vulnerability.
+describe("isSafeImageSrc", () => {
+  describe("internal Docker service names", () => {
+    // The escalation path that matters: every one of these starts with "http", which
+    // is why an imageComponent-style startsWith("http") guard does not close it.
     it.each([
       "http://api:8000/api/workspaces/",
       "http://plane-minio:9000/uploads/",
@@ -126,7 +125,7 @@ describe("isSafeImageSrc — GHSA-55gq-rf47-9pqx", () => {
     });
 
     it("rejects bare filesystem paths that would reach fs.readFile", () => {
-      // The advisory's secondary local-file-read finding.
+      // Secondary local-file-read path: @react-pdf/image would fs.readFile these.
       expect(isSafeImageSrc("/etc/passwd")).toBe(false);
       expect(isSafeImageSrc("./relative.png")).toBe(false);
       expect(isSafeImageSrc("../../etc/hosts")).toBe(false);
@@ -144,8 +143,8 @@ describe("isSafeImageSrc — GHSA-55gq-rf47-9pqx", () => {
   });
 
   describe("whitespace and control-character smuggling", () => {
-    // The same class of bypass as GHSA-v2vv-7wq3-8w2j: URL parsers strip these,
-    // so a check performed before stripping can be walked straight past.
+    // URL parsers strip these, so a check performed before stripping can be walked
+    // straight past — a well-known class of URL-validation bypass.
     it.each([
       "\thttp://api:8000/",
       "\nhttp://api:8000/",

--- a/apps/live/tests/lib/url-security.test.ts
+++ b/apps/live/tests/lib/url-security.test.ts
@@ -212,6 +212,31 @@ describe("isBlockedHostLiteral", () => {
     expect(isBlockedHostLiteral("2606:4700:4700::1111")).toBe(false);
   });
 
+  it("blocks alternate spellings of the same IPv6 address", () => {
+    // The address is judged on its expanded form, so a non-canonical spelling
+    // cannot slip past a prefix check. Each of these is ::ffff:127.0.0.1.
+    expect(isBlockedHostLiteral("::ffff:127.0.0.1")).toBe(true);
+    expect(isBlockedHostLiteral("::ffff:7f00:1")).toBe(true);
+    expect(isBlockedHostLiteral("0:0::ffff:7f00:1")).toBe(true);
+    expect(isBlockedHostLiteral("0:0:0:0:0:ffff:127.0.0.1")).toBe(true);
+    expect(isBlockedHostLiteral("0000:0000:0000:0000:0000:ffff:7f00:0001")).toBe(true);
+    // ...and of ::1 and the cloud metadata address.
+    expect(isBlockedHostLiteral("0:0:0:0:0:0:0:1")).toBe(true);
+    expect(isBlockedHostLiteral("0:0:0:0:0:ffff:a9fe:a9fe")).toBe(true);
+    // Expanded forms of the range checks must hold too.
+    expect(isBlockedHostLiteral("fe80:0:0:0:0:0:0:1")).toBe(true);
+    expect(isBlockedHostLiteral("fc00:0:0:0:0:0:0:1")).toBe(true);
+    // Public addresses stay reachable in either spelling.
+    expect(isBlockedHostLiteral("2001:4860:4860:0:0:0:0:8888")).toBe(false);
+    expect(isBlockedHostLiteral("2001:4860:4860::8888")).toBe(false);
+  });
+
+  it("rejects malformed IPv6 URLs (caught at URL parsing, before the literal check)", () => {
+    expect(isSafeImageSrc("http://[::ffff:999.1.1.1]/x.png")).toBe(false);
+    expect(isSafeImageSrc("http://[1:2:3:4:5:6:7:8:9]/x.png")).toBe(false);
+    expect(isSafeImageSrc("http://[::1::2]/x.png")).toBe(false);
+  });
+
   it("treats real hostnames as non-literals", () => {
     expect(isBlockedHostLiteral("example.com")).toBe(false);
     expect(isBlockedHostLiteral("api")).toBe(false);


### PR DESCRIPTION
## What

Fixes the two issues reported under SECUR-245 in `apps/live`, plus the one API-side change needed to keep the existing caller working.

Work item: **SECUR-245**

## 1. SSRF via PDF image rendering

The `image` node renderer handed `node.attrs.src` straight to `@react-pdf/image`, which `fetch()`es any URL with a host and `fs.readFile()`s a bare path. The Live container shares a Docker network with `api`, `plane-db`, `plane-redis`, `plane-mq` and `plane-minio`, so page content could drive requests at internal-only services.

Adds `apps/live/src/lib/url-security.ts` and routes **both** `<Image>` call sites through it; anything unsafe renders a placeholder.

> **The existing `imageComponent` guard was not a usable model.** Its check is `!src.startsWith("http") && !src.startsWith("data:")` — and `http://api:8000/` and `http://plane-minio:9000/` both *pass* it. The scheme is irrelevant here; the destination is what has to be judged. That check is replaced rather than copied.

Rejected: non-`http(s)`/`data` schemes · bare and relative filesystem paths · loopback · RFC1918 · CGNAT `100.64/10` · link-local incl. `169.254.169.254` · multicast/reserved/test ranges · IPv6 ULA, link-local, site-local, multicast, NAT64, 6to4, Teredo, IPv4-mapped · obfuscated encodings (`2130706433`, `0x7f000001`, `127.1`) · single-label hosts (the shape of a Compose service name) · `.local`/`.internal`/`.lan` suffixes · embedded credentials · control-character scheme smuggling.

The IPv6 ranges are deliberately kept in step with the Python guard's `_BLOCKED_NETWORKS` in `apps/api/plane/utils/ip_address.py`. The first draft here was missing Teredo `2001::/32` and `fec0::/10` — two implementations of one policy drifting apart is how this class of bug keeps coming back.

## 2. Unauthenticated `/convert-document/`

`requireSecretKey` existed but was applied to **no controller**, leaving an expensive HTML → Y.js conversion open to anyone who could reach the service (CWE-306). It is now applied.

Its only caller is the API's `copy_s3_object` duplication task, which sent `headers=None`. So this PR also:
- sends the shared secret from that task, and
- wires `LIVE_SERVER_SECRET_KEY` into Django settings — it was previously only in `.env.example`.

A missing key short-circuits with a logged misconfiguration instead of firing a request that can only 401.

## Two corrections to the advisory

**`/pdf-export/` is not unauthenticated** and is deliberately untouched. `parseRequest` rejects requests with no `Cookie` and forwards that cookie to the API to fetch the page, so the API enforces page permissions. Gating it on the shared secret would break the browser client that design implies.

**The pre-auth chain does not connect.** `/convert-document/` performs no outbound fetch, and its output is never fed to `/pdf-export/`, which reads content from the API by `pageId`. Triggering the SSRF requires a valid session, so this is **`PR:L`**, not the reported pre-auth. Suggest reconciling severity before publishing — GitHub metadata says CVSS 8.6 while the advisory body says 7.5.

## Known residual — please read before approving

**DNS rebinding on the `http(s)` path is NOT closed here.** An attacker-controlled hostname that resolves to a blocked address still gets fetched: the renderer is synchronous and the `fetch()` happens inside `@react-pdf/image`, so the resolved address cannot be pinned. This is documented in the helper's doc comment.

The proper fix is to pre-fetch raw `image` nodes into `data:` URIs exactly as `imageComponent` already pre-fetches assets (`pdf-export.service.ts:229-230`), then accept only `data:` at render time. Tracked as a follow-up to SECUR-245. Flagging it so this is not read as "SSRF fully fixed".

## Deployment note

Gating `/convert-document/` means duplication degrades if the API lacks the key: `if external_data:` prevents corruption, but the duplicate keeps a stale `description_binary`, so its images break.

Verified `LIVE_SERVER_SECRET_KEY` reaches `api`/`worker`/`beat-worker` via `x-app-env` in `deployments/cli/community/docker-compose.yml`, and that aio auto-generates it on first boot. **Not verified: the Helm charts** (separate repo) — worth confirming before release so self-hosted K8s users don't hit this.

## Testing

- **78 new Live tests** (`apps/live/tests/lib/url-security.test.ts`) covering every payload named in the advisory, plus range boundaries (e.g. `100.63.x` allowed / `100.64.x` blocked) so the CIDR edges are pinned.
- **6 new API tests** (`test_copy_s3_object_auth.py`) for the header contract and the missing-key / no-live-url paths. The pre-existing duplication test mocks `sync_with_external_service` entirely, so this path had no coverage.
- Full Live suite: **110 pass**. `tsc --noEmit`: **24 errors before and after** — zero introduced, all pre-existing unbuilt `@plane/logger`/`@plane/decorators`. oxlint 0 errors, oxfmt and ruff clean.

## Out of scope, worth follow-ups

- `requireSecretKey` compares with `!==` (`auth-middleware.ts:38`) — **not constant-time**. Pre-existing, but it now actually guards something, so `crypto.timingSafeEqual` is warranted. Its docstring also claims it accepts `x-admin-secret-key` "(preferred)" while the code only reads `live-server-secret-key`.
- `<Link src={href}>` (`node-renderers.tsx:65`) is unguarded. Not SSRF (no fetch), but it embeds arbitrary URIs including `javascript:` into PDF link annotations.

Co-authored-by: Plane AI <noreply@plane.so>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Protected document conversion requests with server authentication.
  * Blocked unsafe, internal, malformed, or non-image URLs, including unsafe redirects, from PDF rendering.
  * Added clear placeholders for unavailable images.

* **Bug Fixes**
  * Improved conversion reliability with bounded timeouts and better error handling.
  * Added graceful handling for missing configuration and unsuccessful responses.
  * Improved rendering of externally hosted images in exported PDFs.

* **Tests**
  * Added comprehensive coverage for authentication, URL validation, redirects, image sources, timeouts, and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
