### PR TITLE
fix(api): prevent crash from null member_ids on workspace modules endpoint (was mislabeled as feat)

### DIFF
--- a/apps/api/plane/app/views/workspace/module.py
+++ b/apps/api/plane/app/views/workspace/module.py
@@ -3,7 +3,10 @@
 # See the LICENSE file for details.
 
 # Django imports
-from django.db.models import Prefetch, Q, Count
+from django.contrib.postgres.aggregates import ArrayAgg
+from django.contrib.postgres.fields import ArrayField
+from django.db.models import Prefetch, Q, Count, UUIDField, Value
+from django.db.models.functions import Coalesce
 
 # Third party modules
 from rest_framework import status
@@ -107,6 +110,19 @@ class WorkspaceModulesEndpoint(BaseAPIView):
                         issue_module__deleted_at__isnull=True,
                     ),
                     distinct=True,
+                )
+            )
+            .annotate(
+                member_ids=Coalesce(
+                    ArrayAgg(
+                        "members__id",
+                        distinct=True,
+                        filter=Q(
+                            members__id__isnull=False,
+                            modulemember__deleted_at__isnull=True,
+                        ),
+                    ),
+                    Value([], output_field=ArrayField(UUIDField())),
                 )
             )
             .order_by(self.kwargs.get("order_by", "-created_at"))

--- a/packages/utils/src/module.ts
+++ b/packages/utils/src/module.ts
@@ -30,8 +30,8 @@ export const orderModules = (modules: IModule[], orderByKey: TModuleOrderByOptio
   let orderedModules: IModule[] = [];
   if (modules.length === 0 || !orderByKey) return [];
 
-  if (orderByKey === "name") orderedModules = [...modules].sort((a, b) => naturalSort(a.name, b.name));
-  if (orderByKey === "-name") orderedModules = [...modules].sort((a, b) => naturalSort(b.name, a.name));
+  if (orderByKey === "name") orderedModules = [...modules].toSorted((a, b) => naturalSort(a.name, b.name));
+  if (orderByKey === "-name") orderedModules = [...modules].toSorted((a, b) => naturalSort(b.name, a.name));
   if (["progress", "-progress"].includes(orderByKey))
     orderedModules = sortBy(modules, [
       (m) => {
@@ -71,7 +71,7 @@ export const shouldFilterModule = (
     if (filterKey === "lead" && filters.lead && filters.lead.length > 0)
       fallsInFilters = fallsInFilters && filters.lead.includes(`${module.lead_id}`);
     if (filterKey === "members" && filters.members && filters.members.length > 0) {
-      const memberIds = module.member_ids;
+      const memberIds = module.member_ids ?? [];
       fallsInFilters = fallsInFilters && filters.members.some((memberId) => memberIds.includes(memberId));
     }
     if (filterKey === "start_date" && filters.start_date && filters.start_date.length > 0) {


### PR DESCRIPTION
### Description
`WorkspaceModulesEndpoint` (`GET /api/workspaces/{slug}/modules/`) never annotated `member_ids` on its queryset, unlike the project-scoped modules endpoint which does. Since the serializer field allows null, every module returned by this endpoint serialized `member_ids` as `null` instead of `[]`.

That `null` got written into the shared frontend module cache (via `fetchWorkspaceModules`/`fetchModulesSlim`, triggered on workspace-wide pages like "Your Work"). Once poisoned, opening a project's Modules view with an active "Members" filter (which persists in `localStorage`, so it recurs on every visit) crashed the whole page with:

```
TypeError: Cannot read properties of null (reading 'includes')
```

Fix:
- `apps/api/plane/app/views/workspace/module.py`: annotate `member_ids` with `Coalesce(ArrayAgg(...), Value([]))`, matching the project-scoped endpoint, so it always returns `[]` instead of `null`.
- `packages/utils/src/module.ts`: defensive null-guard in `shouldFilterModule` (`module.member_ids ?? []`) so a null value can no longer crash the filter regardless of where it originates.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
Before:

https://github.com/user-attachments/assets/40f421d6-d1da-4c8e-81cf-00f50dafc469

After:

https://github.com/user-attachments/assets/5d2d73d1-3d68-400e-8064-ece41c7736ec



### Test Scenarios
Reproduced live end-to-end in a local dev instance:
1. Applied a "Members" filter on a project's Modules view (persists in `localStorage`).
2. Visited a workspace-wide page ("Your Work → Assigned") to trigger `fetchWorkspaceModules`, poisoning the shared module cache with `member_ids: null`.
3. Navigated back to the Modules tab via client-side nav — reproduced the exact crash and stack trace reported by users.
4. Applied the fix, restarted the API, and replayed the same steps — confirmed the API now returns `member_ids: []` and the page no longer crashes.

### References
Reported by multiple users in Slack (CE support thread) — no linked work item.
