### PR TITLE
[WEB-8510] fix(web): fix clipped/overlapping LayoutDropDown button in Create View modal

### DIFF
--- a/apps/web/core/components/dropdowns/layout.tsx
+++ b/apps/web/core/components/dropdowns/layout.tsx
@@ -11,11 +11,11 @@ import { ISSUE_LAYOUT_MAP } from "@plane/constants";
 import { useTranslation } from "@plane/i18n";
 import { CheckIcon } from "@plane/propel/icons";
 import { EIssueLayoutTypes } from "@plane/types";
+import { getButtonStyling } from "@plane/propel/button";
 import { Dropdown } from "@plane/ui";
 import { cn } from "@plane/utils";
 // components
 import { IssueLayoutIcon } from "@/components/issues/issue-layouts/layout-icon";
-import { getIconButtonStyling } from "@plane/propel/icon-button";
 
 type TLayoutDropDown = {
   onChange: (value: EIssueLayoutTypes) => void;
@@ -74,7 +74,7 @@ export const LayoutDropDown = observer(function LayoutDropDown(props: TLayoutDro
       value={value?.toString()}
       keyExtractor={keyExtractor}
       options={options}
-      buttonContainerClassName={cn(getIconButtonStyling("secondary", "lg"), "w-auto px-2")}
+      buttonContainerClassName={cn(getButtonStyling("secondary", "lg"))}
       buttonContent={buttonContent}
       renderItem={itemContent}
       disableSearch


### PR DESCRIPTION
### Description
`LayoutDropDown` (used for the layout selector in the "Create/Update View" modal) was styled with `getIconButtonStyling`, which is built for icon-only buttons — it forces a fixed square shape (`aspect-square` + a fixed `size-7`). Since this dropdown's button renders an icon *and* a text label ("List", "Board", etc.), the label got clipped (e.g. "List" rendered as "Lis") and the button visually overlapped the adjacent "Display" button.

Fix: use `getButtonStyling` instead — the same helper already used by comparable text+icon dropdown triggers elsewhere in the codebase (e.g. `ProjectOrderByDropdown`), which gives a fixed height with auto width instead of a forced square.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
Before: "List" label clipped to "Lis", overlapping the "Display" button.
<img width="706" height="456" alt="Screenshot 2026-08-04 at 5 44 01 PM" src="https://github.com/user-attachments/assets/8dba3610-4512-48c3-89ac-56715cc9b874" />


After: button renders at full width with the complete "List" label and proper spacing.
<img width="710" height="464" alt="Screenshot 2026-08-04 at 5 48 56 PM" src="https://github.com/user-attachments/assets/3f5feffe-9b71-4664-a48a-4fe065b9e0aa" />



### Test Scenarios
Reproduced and verified in a local dev instance:
1. Opened Project → Views → "Add view" to bring up the "Create View" modal.
2. Confirmed the layout dropdown button previously clipped its label and overlapped the neighboring "Display" button.
3. Applied the fix and re-opened the modal — button now renders at correct width with the full "List" label, no overlap.

### References
WEB-8510
