### PR TITLE
Fix regex check for tag_name to get latest release

### DIFF
--- a/deployments/cli/community/install.sh
+++ b/deployments/cli/community/install.sh
@@ -57,7 +57,7 @@ function spinner() {
 
 function checkLatestRelease(){
     echo "Checking for the latest release..." >&2
-    local latest_release=$(curl -sSL https://api.github.com/repos/$GH_REPO/releases/latest |  grep -o '"tag_name": "[^"]*"' | sed 's/"tag_name": "//;s/"//g')
+    local latest_release=$(curl -sSL https://api.github.com/repos/$GH_REPO/releases/latest |  grep -o '"tag_name":\s*"[^"]*"' | sed 's/"tag_name":\*"//;s/"//g')
     if [ -z "$latest_release" ]; then
         echo "Failed to check for the latest release. Exiting..." >&2
         exit 1

--- a/deployments/swarm/community/swarm.sh
+++ b/deployments/swarm/community/swarm.sh
@@ -38,7 +38,7 @@ EOF
 
 function checkLatestRelease(){
     echo "Checking for the latest release..." >&2
-    local latest_release=$(curl -s https://api.github.com/repos/$GH_REPO/releases/latest |  grep -o '"tag_name": "[^"]*"' | sed 's/"tag_name": "//;s/"//g')
+    local latest_release=$(curl -s https://api.github.com/repos/$GH_REPO/releases/latest |  grep -o '"tag_name":\s*"[^"]*"' | sed 's/"tag_name":\s*"//;s/"//g')
     if [ -z "$latest_release" ]; then
         echo "Failed to check for the latest release. Exiting..." >&2
         exit 1


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
When attempting to install the community edition, a check is performed to get the latest release. Due to inconsistent responses from GitHub, the previous regex supplied might not match the return (it always expects a space, sometimes one is not supplied) and then the check fails.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

### Test Scenarios 
```sh
$ date && curl -sSL https://api.github.com/repos/makeplane/plane/releases/latest |  grep -o '"tag_name": "[^"]*"' | sed 's/"tag_name": "//;s/"//g'
Tue Aug  4 10:38:41 CDT 2026
$ date && curl -sSL https://api.github.com/repos/makeplane/plane/releases/latest |  grep -o '"tag_name":\s*"[^"]*"' | sed 's/"tag_name":\s*"//;s/"//g'
Tue Aug  4 10:38:45 CDT 2026
v1.4.0
```

### References
<!-- Link related issues if there are any -->
#8911 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved latest-release detection during CLI and Swarm deployments.
  * Release tags are now recognized correctly when GitHub’s response includes varying whitespace formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->