### PR TITLE
fix: tag_name grep fails to match compact JSON from GitHub API

### DIFF
--- a/deployments/cli/community/install.sh
+++ b/deployments/cli/community/install.sh
@@ -57,7 +57,7 @@ function spinner() {
 
 function checkLatestRelease(){
     echo "Checking for the latest release..." >&2
-    local latest_release=$(curl -sSL https://api.github.com/repos/$GH_REPO/releases/latest |  grep -o '"tag_name": "[^"]*"' | sed 's/"tag_name": "//;s/"//g')
+    local latest_release=$(curl -sSL https://api.github.com/repos/$GH_REPO/releases/latest |  grep -o '"tag_name": *"[^"]*"' | sed 's/"tag_name": *"//;s/"//g')
     if [ -z "$latest_release" ]; then
         echo "Failed to check for the latest release. Exiting..." >&2
         exit 1


### PR DESCRIPTION
GitHub's API returns compact JSON with no space after the colon ("tag_name":"v1.4.0"), but the grep pattern requires one ("tag_name": "). This silently empties $latest_release, which then fails architecture image lookups with an invalid reference instead of actually stopping at the intended exit 1.

### Type of Change
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release version detection when formatting includes whitespace after the JSON field separator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->