### PR TITLE
fix(utils): keep 0 alpha in oklchToCSS output

### DIFF
--- a/packages/utils/src/theme/color-conversion.ts
+++ b/packages/utils/src/theme/color-conversion.ts
@@ -58,7 +58,7 @@ export function hexToOKLCH(hex: string): OKLCH {
  */
 export function oklchToCSS(oklch: OKLCH, alpha?: number): string {
   const { l, c, h } = oklch;
-  return `oklch(${l.toFixed(4)} ${c.toFixed(4)} ${h.toFixed(2)}${alpha ? ` / ${alpha.toFixed(2)}%` : ""})`;
+  return `oklch(${l.toFixed(4)} ${c.toFixed(4)} ${h.toFixed(2)}${alpha != null ? ` / ${alpha.toFixed(2)}%` : ""})`;
 }
 
 /**


### PR DESCRIPTION
### Bug

`oklchToCSS` (`packages/utils/src/theme/color-conversion.ts`) appends the alpha channel only when `alpha` is truthy:

```ts
`...${alpha ? ` / ${alpha.toFixed(2)}%` : ""})`
```

Because `0` is falsy, an alpha of `0` (fully transparent) is dropped and the colour renders **opaque** instead of transparent:

```ts
oklchToCSS({ l: 0.5, c: 0.1, h: 250 }, 0)
// before: "oklch(0.5000 0.1000 250.00)"        // opaque
// after:  "oklch(0.5000 0.1000 250.00 / 0.00%)" // transparent
```

This is reachable via `theme-application.ts`, which builds the `--alpha-white-*` / `--alpha-black-*` tokens with `oklchToCSS(neutralOKLCH, value * 100)` — a `0` alpha token would come out opaque.

### Fix

Guard with `alpha != null` so `0` is emitted while an omitted `alpha` still produces no alpha channel. Verified against `alpha = 0`, a positive alpha, and an omitted alpha. (`packages/utils` has no unit-test runner configured, so no test file is included.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected color formatting so fully transparent colors retain their alpha value in CSS output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->