### PR TITLE
chore: set issue type on GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/--bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/--bug-report.yaml
@@ -1,6 +1,7 @@
 name: Bug report
 description: Create a bug report to help us improve Plane
 title: "[bug]: "
+type: Bug
 labels: [🐛bug, plane]
 assignees: [vihar, pushya22]
 body:
@@ -55,19 +56,21 @@ body:
       - Safari
       - Other
 - type: dropdown
-  id: variant
+  id: edition
   attributes:
-    label: Variant
+    label: Edition
+    description: Which edition of Plane are you using?
     options:
+      - Community
+      - Commercial
       - Cloud
-      - Self-hosted
-      - Local
   validations:
     required: true
 - type: input
   id: version
   attributes:
     label: Version
+    description: Which version of Plane are you using? If Cloud, mention it as latest
     placeholder: v0.17.0-dev
   validations:
     required: true

--- a/.github/ISSUE_TEMPLATE/--feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/--feature-request.yaml
@@ -1,6 +1,7 @@
 name: Feature request
 description: Suggest a feature to improve Plane
 title: "[feature]: "
+type: Feature
 labels: [✨feature, plane]
 assignees: [vihar, pushya22]
 body:


### PR DESCRIPTION
### Description

Wires the GitHub issue forms up to the org-level **Issue Types** and aligns them with the newly created **Issue Fields**.

- Added `type: Bug` to the bug report form and `type: Feature` to the feature request form. Issues opened from these templates are now automatically tagged with the corresponding org issue type, so they land correctly in type-based filters and views without manual triage.
- Renamed the bug form's `Variant` dropdown to `Edition` and changed its options from `Cloud / Self-hosted / Local` to `Community / Commercial / Cloud`, matching the `Edition` issue field exactly.
- Added descriptions to `Edition` and `Version` mirroring their issue-field descriptions.

**Note on Issue Fields:** GitHub issue form YAML has no key or input type for setting issue field values — fields are org-level config, pinned to an issue type, and rendered in the issue sidebar outside the form. The template can't populate them. The form inputs are kept so reporters still supply Edition/Version as part of the submission; a maintainer with triage access copies the values into the sidebar fields. (GitHub doesn't document whether non-collaborators can set sidebar field values at creation, so dropping the inputs risked losing that data on community-filed bugs.)

The `type:` values are matched by exact string against the enabled org issue types (`Task`, `Bug`, `Feature`, `Documentation`) — renaming a type in org settings will silently stop the template from applying it.

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [x] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots here -->

### Test Scenarios

- Open **New issue → Bug report** on this branch and submit; confirm the created issue shows type **Bug** in the sidebar and still carries the `🐛bug` / `plane` labels.
- Open **New issue → Feature request** and submit; confirm the created issue shows type **Feature**.
- On the bug form, confirm the **Edition** dropdown offers `Community / Commercial / Cloud` and is required, and that **Version** shows its new description.
- Confirm the `Edition` and `Version` issue fields render in the sidebar of a Bug-typed issue (requires them to be pinned to the `Bug` type in org settings).
- Both YAML files parse cleanly and only use documented top-level keys.

### References

Follow-ups not included here: the `Documentation` issue type has no matching template yet, and the `🐛bug` / `✨feature` labels are now redundant with issue types.

https://claude.ai/code/session_017DPVwh1J21mZYRHjpTL7zg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved the bug report form with clearer product edition options and updated version-reporting guidance.
  * Explicitly categorized bug reports and feature requests in issue forms for more consistent submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->