### PR TITLE
fix: order legacy filter date range by parsed datetime instead of string comparison

### DIFF
--- a/apps/api/plane/utils/filters/converters.py
+++ b/apps/api/plane/utils/filters/converters.py
@@ -306,8 +306,13 @@ class LegacyToRichFiltersConverter:
         result = {}
         if len(after_dates) == 1 and len(before_dates) == 1 and len(exact_dates) == 0:
             # Simple range: one after and one before
-            start_date = min(after_dates[0], before_dates[0])
-            end_date = max(after_dates[0], before_dates[0])
+            # Order the bounds chronologically by comparing parsed datetimes, not the
+            # raw strings: _validate_date accepts non-ISO formats that do not sort
+            # lexicographically (e.g. "9/1/2023" vs "10/1/2023").
+            if dateutil_parse(after_dates[0]) <= dateutil_parse(before_dates[0]):
+                start_date, end_date = after_dates[0], before_dates[0]
+            else:
+                start_date, end_date = before_dates[0], after_dates[0]
             self._add_rich_filter(result, field_name, "range", [start_date, end_date])
         elif len(exact_dates) == 1 and len(after_dates) == 0 and len(before_dates) == 0:
             # Single exact date


### PR DESCRIPTION
Fixes #9567.

### Problem

`LegacyToRichFiltersConverter._convert_date_value` builds a date range with `min()` / `max()` on the raw date **strings**:

```python
start_date = min(after_dates[0], before_dates[0])
end_date   = max(after_dates[0], before_dates[0])
```

String comparison only matches chronological order for zero-padded ISO `YYYY-MM-DD`. But `_validate_date` uses `dateutil_parse`, so it accepts many other formats (`M/D/YYYY`, non-zero-padded months, etc.). A non-ISO input like `9/1/2023` vs `10/1/2023` sorts lexicographically (`"10..." < "9..."`) and produces a reversed `[start, end]` range that matches nothing.

### Fix

Order the two bounds by their parsed `datetime` values instead of by string, keeping the emitted values in their original form. This makes the range correct for every format `_validate_date` accepts, and is a no-op for already-ISO inputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Date range filters now correctly order start and end bounds chronologically, including non-ISO date formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->