### PR TITLE
Fix release tag parsing to tolerate spaces around JSON colon

### DIFF
--- a/deployments/cli/community/install.sh
+++ b/deployments/cli/community/install.sh
@@ -57,7 +57,7 @@ function spinner() {
 
 function checkLatestRelease(){
     echo "Checking for the latest release..." >&2
-    local latest_release=$(curl -sSL https://api.github.com/repos/$GH_REPO/releases/latest |  grep -o '"tag_name": "[^"]*"' | sed 's/"tag_name": "//;s/"//g')
+    local latest_release=$(curl -sSL https://api.github.com/repos/$GH_REPO/releases/latest |  grep -o '"tag_name" *: *"[^"]*"' | sed 's/"tag_name" *: *"//;s/"//g')
     if [ -z "$latest_release" ]; then
         echo "Failed to check for the latest release. Exiting..." >&2
         exit 1

--- a/deployments/swarm/community/swarm.sh
+++ b/deployments/swarm/community/swarm.sh
@@ -38,7 +38,7 @@ EOF
 
 function checkLatestRelease(){
     echo "Checking for the latest release..." >&2
-    local latest_release=$(curl -s https://api.github.com/repos/$GH_REPO/releases/latest |  grep -o '"tag_name": "[^"]*"' | sed 's/"tag_name": "//;s/"//g')
+    local latest_release=$(curl -s https://api.github.com/repos/$GH_REPO/releases/latest |  grep -o '"tag_name" *: *"[^"]*"' | sed 's/"tag_name" *: *"//;s/"//g')
     if [ -z "$latest_release" ]; then
         echo "Failed to check for the latest release. Exiting..." >&2
         exit 1


### PR DESCRIPTION
### Description
Fix release version detection in the Community CLI and Swarm installation scripts.

The GitHub Releases API may return JSON without spaces after `:` (for example, `"tag_name":"v1.4.1"`), while the existing pattern expected `"tag_name": "v1.4.1"` exactly. As a result, the latest release could not be detected and installation failed with an empty image tag.

Updated the patterns in:
- `deployments/cli/community/install.sh`
- `deployments/swarm/community/swarm.sh`

The new patterns allow optional spaces around `:`.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
N/A

### Test Scenarios
Verified release detection with both JSON formatting variants:

```json
"tag_name": "v1.4.1"
````

and:

```json
"tag_name":"v1.4.1"
```

Confirmed that both scripts correctly extract `v1.4.1`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved release detection during installation and deployment.
  - Added support for optional spacing in release metadata, ensuring the latest release is identified reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->