### PR TITLE
fix: nginx :3000 redirect leak + web HydrateFallback React #418

### DIFF
--- a/apps/admin/nginx/nginx.conf
+++ b/apps/admin/nginx/nginx.conf
@@ -20,6 +20,10 @@ http {
   server {
     listen 3000;
 
+    # Behind reverse proxies, keep redirects relative and never leak :3000.
+    absolute_redirect off;
+    port_in_redirect off;
+
     # Security headers
     add_header X-Frame-Options "DENY" always;
     add_header X-Content-Type-Options "nosniff" always;

--- a/apps/space/nginx/nginx.conf
+++ b/apps/space/nginx/nginx.conf
@@ -20,6 +20,10 @@ http {
   server {
     listen 3000;
 
+    # Behind reverse proxies, keep redirects relative and never leak :3000.
+    absolute_redirect off;
+    port_in_redirect off;
+
     location / {
       root   /usr/share/nginx/html;
       index  index.html index.htm;

--- a/apps/web/app/root.tsx
+++ b/apps/web/app/root.tsx
@@ -5,6 +5,7 @@
  */
 
 import type { ReactNode } from "react";
+import { useEffect, useState } from "react";
 import Script from "next/script";
 import { Links, Meta, Outlet, Scripts } from "react-router";
 import type { LinksFunction } from "react-router";
@@ -135,8 +136,17 @@ export default function Root() {
 export function HydrateFallback() {
   const { resolvedTheme } = useTheme();
 
-  // if we are on the server or the theme is not resolved, return an empty div
-  if (typeof window === "undefined" || resolvedTheme === undefined) return <div />;
+  // SPA build (ssr: false) prerenders this on the server as an empty <div />.
+  // On the first client hydration render, next-themes can already resolve the
+  // theme synchronously from localStorage, so rendering LogoSpinner here
+  // mismatches the prerendered HTML and throws React #418 on every load.
+  // Gate on `mounted` so hydration matches the prerender; show the spinner after mount.
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted || resolvedTheme === undefined) return <div />;
 
   return (
     <div className="relative flex h-screen w-full items-center justify-center bg-canvas">

--- a/apps/web/nginx/nginx.conf
+++ b/apps/web/nginx/nginx.conf
@@ -20,6 +20,10 @@ http {
   server {
     listen 3000;
 
+    # Behind reverse proxies, keep redirects relative and never leak :3000.
+    absolute_redirect off;
+    port_in_redirect off;
+
     # Security headers
     add_header X-Frame-Options "DENY" always;
     add_header X-Content-Type-Options "nosniff" always;


### PR DESCRIPTION
## Summary

Self-hosting Plane CE behind Traefik/Ingress still hits two long-standing frontend issues on current `preview` / v1.4.1 images:

1. **nginx leaks `:3000`** on trailing-slash redirects (`Location: http://host:3000/god-mode/`), which browsers then try to open and time out.
2. **React #418** on every web load: SPA prerender emits an empty `<div />` for `HydrateFallback`, but the first client render often already has a resolved theme and paints `LogoSpinner`.

This refreshes two stale open PRs onto current `preview`:

- nginx: same fix as #8826 (still open, ~211 commits behind)
- hydrate: same approach as #9350 (still open, diverged)

## Changes

- `apps/{web,admin,space}/nginx/nginx.conf`: `absolute_redirect off;` + `port_in_redirect off;`
- `apps/web/app/root.tsx`: gate `HydrateFallback` on a `mounted` flag so hydration matches the prerendered empty div

## Test plan

- [ ] Build/serve `plane-frontend` / `plane-admin` images from this branch
- [ ] `curl -sv http://localhost:3000/god-mode` → `Location: /god-mode/` (relative, no `:3000`)
- [ ] Behind Traefik/Ingress TLS: open `/god-mode` and `/god-mode/` without being sent to `:3000`
- [ ] Web app console: no minified React #418 / #423 on cold load (light + dark / system theme)

## Related

- Fixes #8814 (still applicable; prior PR #8826 unmerged)
- Related #8867 / #9350
- Chart-side companion: makeplane/helm-charts#283 (`WEB_URL` https + Traefik trailing-slash)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed redirects so internal port details are no longer exposed when accessing the application through a reverse proxy.
  * Improved initial page loading to prevent hydration flicker while the client initializes and applies the selected theme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->