### PR TITLE
fix(web): delete reaction map entries by id

### DIFF
--- a/apps/web/core/store/issue/issue-details/comment_reaction.store.ts
+++ b/apps/web/core/store/issue/issue-details/comment_reaction.store.ts
@@ -182,7 +182,7 @@ export class IssueCommentReactionStore implements IIssueCommentReactionStore {
       if (currentReaction && currentReaction.id) {
         runInAction(() => {
           pull(this.commentReactions[commentId][reaction], currentReaction.id);
-          delete this.commentReactionMap[reaction];
+          delete this.commentReactionMap[currentReaction.id];
         });
       }
 

--- a/apps/web/core/store/issue/issue-details/reaction.store.ts
+++ b/apps/web/core/store/issue/issue-details/reaction.store.ts
@@ -149,7 +149,7 @@ export class IssueReactionStore implements IIssueReactionStore {
     if (currentReaction && currentReaction.id) {
       runInAction(() => {
         pull(this.reactions[issueId][reaction], currentReaction.id);
-        delete this.reactionMap[reaction];
+        delete this.reactionMap[currentReaction.id];
       });
     }
 


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->

When removing a work item or comment reaction, the store deleted from the reaction map using the emoji string instead of the reaction id. Entries are stored by id on create, so the old entry was left behind.

This PR deletes by `currentReaction.id` in both issue and comment reaction stores.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->
NA

### References
<!-- Link related issues if there are any -->
NA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed removal of comment reactions so the correct reaction is deleted.
  - Fixed removal of issue reactions to keep reaction displays accurate after deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->