### PR TITLE
[WEB-8632] fix(web): auto-reload on stale chunk load failure during navigation

### DIFF
--- a/apps/web/app/entry.client.tsx
+++ b/apps/web/app/entry.client.tsx
@@ -17,8 +17,7 @@ void polyfills;
 // stale optimized deps) and auto-reloading would mask them.
 if (import.meta.env.PROD) {
   window.addEventListener("vite:preloadError", (event) => {
-    event.preventDefault();
-    recoverFromStaleAsset();
+    if (recoverFromStaleAsset()) event.preventDefault();
   });
 
   window.addEventListener("error", (event) => {

--- a/apps/web/app/entry.client.tsx
+++ b/apps/web/app/entry.client.tsx
@@ -9,8 +9,27 @@ import { hydrateRoot } from "react-dom/client";
 import { HydratedRouter } from "react-router/dom";
 
 import polyfills from "@/lib/polyfills";
+import { isStaleAssetErrorMessage, recoverFromStaleAsset } from "@/lib/stale-asset-error";
 
 void polyfills;
+
+// Production-only: in dev these errors come from the dev server itself (restarts,
+// stale optimized deps) and auto-reloading would mask them.
+if (import.meta.env.PROD) {
+  window.addEventListener("vite:preloadError", (event) => {
+    event.preventDefault();
+    recoverFromStaleAsset();
+  });
+
+  window.addEventListener("error", (event) => {
+    if (isStaleAssetErrorMessage(event.message || "")) recoverFromStaleAsset();
+  });
+
+  window.addEventListener("unhandledrejection", (event) => {
+    const reason = event.reason instanceof Error ? event.reason.message : String(event.reason ?? "");
+    if (isStaleAssetErrorMessage(reason)) recoverFromStaleAsset();
+  });
+}
 
 startTransition(() => {
   hydrateRoot(

--- a/apps/web/app/root.tsx
+++ b/apps/web/app/root.tsx
@@ -24,6 +24,8 @@ import globalStyles from "@/styles/globals.css?url";
 import type { Route } from "./+types/root";
 // components
 import { LogoSpinner } from "@/components/common/logo-spinner";
+// lib
+import { isStaleAssetError, recoverFromStaleAsset } from "@/lib/stale-asset-error";
 // local
 import { CustomErrorComponent } from "./error";
 import { AppProvider } from "./provider";
@@ -146,5 +148,10 @@ export function HydrateFallback() {
 }
 
 export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
+  // A stale chunk failure surfaces here as React Router's own wrapper error
+  // (the failed dynamic import itself never reaches a window event) — recover
+  // the same way entry.client.tsx does instead of just showing the error page.
+  if (import.meta.env.PROD && isStaleAssetError(error)) recoverFromStaleAsset();
+
   return <CustomErrorComponent error={error} />;
 }

--- a/apps/web/core/lib/stale-asset-error.ts
+++ b/apps/web/core/lib/stale-asset-error.ts
@@ -43,20 +43,24 @@ const hasRecentStaleAssetReload = (): boolean => {
 
 let isRecoveringFromStaleAsset = false;
 
-export const recoverFromStaleAsset = () => {
-  if (isRecoveringFromStaleAsset) return;
+// Returns whether it actually triggered a reload, so callers that can otherwise
+// fall back to default browser error handling (e.g. Vite's preload-error
+// overlay) only suppress that fallback when a reload is really in flight.
+export const recoverFromStaleAsset = (): boolean => {
+  if (isRecoveringFromStaleAsset) return false;
   isRecoveringFromStaleAsset = true;
 
   if (hasRecentStaleAssetReload()) {
     // Second failure in a row — surface to the route error boundary instead of looping.
     isRecoveringFromStaleAsset = false;
-    return;
+    return false;
   }
   try {
     sessionStorage.setItem(STALE_ASSET_RELOAD_KEY, String(Date.now()));
   } catch {
     isRecoveringFromStaleAsset = false;
-    return;
+    return false;
   }
   window.location.reload();
+  return true;
 };

--- a/apps/web/core/lib/stale-asset-error.ts
+++ b/apps/web/core/lib/stale-asset-error.ts
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2023-present Plane Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+// Error signatures produced when a deploy removes hashed assets that an open tab
+// still references (stale-tab version skew).
+const STALE_ASSET_ERROR_SIGNATURES = [
+  "Failed to fetch dynamically imported module", // Chromium
+  "error loading dynamically imported module", // Firefox
+  "Importing a module script failed", // Safari
+  "Unable to preload CSS", // Vite preload helper
+  // React Router's own wrapper when a route module's lazy import fails during
+  // navigation — the original browser error above never reaches here as a
+  // window event, only this synthesized message.
+  "No result returned from dataStrategy for route",
+];
+
+export const isStaleAssetErrorMessage = (message: string): boolean =>
+  STALE_ASSET_ERROR_SIGNATURES.some((signature) => message.includes(signature));
+
+export const isStaleAssetError = (error: unknown): boolean => {
+  const message = error instanceof Error ? error.message : typeof error === "string" ? error : "";
+  return isStaleAssetErrorMessage(message);
+};
+
+// Reload-once-then-fall-through-to-boundary guard, shared by the window-level
+// listeners (entry.client.tsx) and the route ErrorBoundary (root.tsx) so both
+// paths to the same failure share one reload attempt instead of racing.
+const STALE_ASSET_RELOAD_KEY = "__plane_chunk_reload";
+const STALE_ASSET_RELOAD_WINDOW_MS = 30_000;
+
+const hasRecentStaleAssetReload = (): boolean => {
+  try {
+    const lastReloadAt = Number(sessionStorage.getItem(STALE_ASSET_RELOAD_KEY));
+    return Number.isFinite(lastReloadAt) && Date.now() - lastReloadAt < STALE_ASSET_RELOAD_WINDOW_MS;
+  } catch {
+    // No storage means no loop guard — never auto-reload in that case.
+    return true;
+  }
+};
+
+let isRecoveringFromStaleAsset = false;
+
+export const recoverFromStaleAsset = () => {
+  if (isRecoveringFromStaleAsset) return;
+  isRecoveringFromStaleAsset = true;
+
+  if (hasRecentStaleAssetReload()) {
+    // Second failure in a row — surface to the route error boundary instead of looping.
+    isRecoveringFromStaleAsset = false;
+    return;
+  }
+  try {
+    sessionStorage.setItem(STALE_ASSET_RELOAD_KEY, String(Date.now()));
+  } catch {
+    isRecoveringFromStaleAsset = false;
+    return;
+  }
+  window.location.reload();
+};


### PR DESCRIPTION
### Description
Customers on self-hosted CE (and Cloud) reported full-page crashes when switching between projects or views in the nav bar (e.g. Overview → Work Items), reliably reproducible and only recoverable with a manual reload.

**Root cause**: after a new deploy rotates hashed asset filenames, a browser tab still on the old build fails to lazy-load the next route's JS chunk on client-side navigation. React Router 7 wraps that failure into its own generic error (`No result returned from dataStrategy for route ...`), which never reaches a `window.error`/`unhandledrejection` event — only the app's root `ErrorBoundary`. The app had no stale-chunk recovery at all, so this fell straight through to the dead-end "Looks like something went wrong" page.

**Fix** (ported from the equivalent fix already shipped in `plane-ee` [#8781](https://github.com/makeplane/plane-ee/pull/8781), adapted for CE which has no Sentry/telemetry to report to):
- Added `apps/web/core/lib/stale-asset-error.ts`: recognizes known stale-asset signatures (Chromium/Firefox/Safari dynamic-import failures, Vite CSS preload failures, and RR7's `dataStrategy` wrapper message) and exposes a reload-once-then-fall-back-to-boundary guard.
- `entry.client.tsx`: production-only `vite:preloadError` / `error` / `unhandledrejection` listeners trigger recovery for the raw browser-level failures.
- `root.tsx`: the root `ErrorBoundary` now also recognizes the RR7-synthesized error and recovers the same way, since that's the only place this specific failure surfaces.
- A repeat failure within 30s of the last reload (tracked via `sessionStorage`) falls through to the normal error page instead of reload-looping, so a genuine (non-deploy-related) loader bug still surfaces to the user.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

### Screenshots and Media (if applicable)
N/A — error-recovery/event-plumbing fix, no visual change.

### Test Scenarios
- `pnpm run check:types` (react-router typegen + tsc --noEmit) clean on the full web app.
- `oxlint` clean on all touched files.
- Verified `root.tsx`'s `ErrorBoundary` (which also runs during SSR, unlike `entry.client.tsx`) doesn't crash the server render: `sessionStorage` access is wrapped in try/catch and treats an unavailable storage as "recently reloaded," short-circuiting before `window.location.reload()` is ever called.
- Confirmed no other listener in the app already handles `vite:preloadError` / `error` / `unhandledrejection`, so no double-handling.
- Manually reproduced the crash pattern (nav-switch during a simulated stale-chunk failure) and confirmed the page recovers via reload instead of showing the dead-end error screen.

### References
- Upstream fix: [makeplane/plane-ee#8781](https://github.com/makeplane/plane-ee/pull/8781)
- Work item: WEB-8632


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery from stale or outdated browser assets after deployments.
  * Automatically reloads the page once when stale asset errors are detected.
  * Detects stale asset failures during loading, rendering, and background requests.
  * Prevents repeated reload loops and falls back to the existing error screen when recovery is unavailable.
  * Preserves normal application startup and behavior when no stale asset issue is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->