### PR TITLE
fix(api): add the documented work item relation removal endpoint

### DIFF
--- a/apps/api/plane/api/serializers/__init__.py
+++ b/apps/api/plane/api/serializers/__init__.py
@@ -26,6 +26,7 @@ from .issue import (
     IssueLinkCreateSerializer,
     IssueLinkUpdateSerializer,
     IssueRelationCreateSerializer,
+    IssueRelationRemoveSerializer,
     IssueRelationResponseSerializer,
     IssueRelationSerializer,
     RelatedIssueSerializer,

--- a/apps/api/plane/api/urls/work_item.py
+++ b/apps/api/plane/api/urls/work_item.py
@@ -18,6 +18,7 @@ from plane.api.views import (
     WorkspaceIssueAPIEndpoint,
     IssueSearchEndpoint,
     IssueRelationListCreateAPIEndpoint,
+    IssueRelationRemoveAPIEndpoint,
 )
 
 # Deprecated url patterns
@@ -150,6 +151,11 @@ new_url_patterns = [
         "workspaces/<str:slug>/projects/<uuid:project_id>/work-items/<uuid:issue_id>/relations/",
         IssueRelationListCreateAPIEndpoint.as_view(http_method_names=["get", "post"]),
         name="work-item-relation-list",
+    ),
+    path(
+        "workspaces/<str:slug>/projects/<uuid:project_id>/work-items/<uuid:issue_id>/relations/remove/",
+        IssueRelationRemoveAPIEndpoint.as_view(http_method_names=["post"]),
+        name="work-item-relation-remove",
     ),
 ]
 

--- a/apps/api/plane/api/views/__init__.py
+++ b/apps/api/plane/api/views/__init__.py
@@ -31,6 +31,7 @@ from .issue import (
     IssueAttachmentDetailAPIEndpoint,
     IssueSearchEndpoint,
     IssueRelationListCreateAPIEndpoint,
+    IssueRelationRemoveAPIEndpoint,
 )
 
 from .cycle import (

--- a/apps/api/plane/api/views/issue.py
+++ b/apps/api/plane/api/views/issue.py
@@ -47,6 +47,7 @@ from plane.api.serializers import (
     IssueCommentSerializer,
     IssueLinkSerializer,
     IssueRelationCreateSerializer,
+    IssueRelationRemoveSerializer,
     IssueRelationResponseSerializer,
     IssueRelationSerializer,
     IssueSerializer,
@@ -88,7 +89,7 @@ from plane.utils.order_queryset import (
 from plane.bgtasks.storage_metadata_task import get_asset_object_metadata
 from .base import BaseAPIView
 from plane.utils.host import base_host
-from plane.utils.issue_relation_mapper import get_actual_relation
+from plane.utils.issue_relation_mapper import get_actual_relation, get_inverse_relation
 from plane.bgtasks.webhook_task import model_activity
 from plane.app.permissions import ROLE
 from plane.utils.openapi import (
@@ -2587,3 +2588,96 @@ class IssueRelationListCreateAPIEndpoint(BaseAPIView):
             serializer_class(refetched_relations, many=True).data,
             status=status.HTTP_201_CREATED,
         )
+
+
+class IssueRelationRemoveAPIEndpoint(BaseAPIView):
+    """Issue Relation Remove Endpoint"""
+
+    serializer_class = IssueRelationRemoveSerializer
+    model = IssueRelation
+    permission_classes = [ProjectEntityPermission]
+
+    @work_item_relation_docs(
+        operation_id="remove_work_item_relation",
+        summary="Remove work item relation",
+        description="Remove an existing relationship between two work items. The relation is matched in either direction, so the same request works whether it was created from this work item or from the related one.",  # noqa E501
+        parameters=[
+            ISSUE_ID_PARAMETER,
+        ],
+        request=OpenApiRequest(
+            request=IssueRelationRemoveSerializer,
+            examples=[
+                OpenApiExample(
+                    name="Remove relation",
+                    value={"related_issue": "550e8400-e29b-41d4-a716-446655440000"},
+                )
+            ],
+        ),
+        responses={
+            204: OpenApiResponse(description="Work item relation removed successfully"),
+            400: INVALID_REQUEST_RESPONSE,
+            404: ISSUE_NOT_FOUND_RESPONSE,
+        },
+    )
+    def post(self, request, slug, project_id, issue_id):
+        """Remove work item relation
+
+        Remove the relation between a work item and a related work item.
+        Automatically tracks relation removal activity for both work items.
+        """
+        # Validate request data using serializer
+        serializer = IssueRelationRemoveSerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+        related_issue_id = serializer.validated_data["related_issue"]
+
+        # The work item has to live in the project the request is scoped to,
+        # otherwise membership of that project would not authorize the removal.
+        if not Issue.objects.filter(pk=issue_id, project_id=project_id, workspace__slug=slug).exists():
+            return Response({"error": "Work item not found"}, status=status.HTTP_404_NOT_FOUND)
+
+        # Relations can cross projects so only workspace scope is enforced.
+        # The pair is matched in both directions since either work item may be
+        # the source of the stored relation.
+        issue_relation = (
+            IssueRelation.objects.filter(
+                Q(issue_id=issue_id, related_issue_id=related_issue_id)
+                | Q(issue_id=related_issue_id, related_issue_id=issue_id),
+                workspace__slug=slug,
+            )
+            .select_related("related_issue__state")
+            .first()
+        )
+
+        if issue_relation is None:
+            return Response(
+                {"error": "Work item relation not found"},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        # Stored relations are directional. Report the type as seen from the
+        # work item in the path so the activity feed reads the right way round.
+        relation_type = issue_relation.relation_type
+        if str(issue_relation.related_issue_id) == str(issue_id):
+            relation_type = get_inverse_relation(relation_type)
+
+        current_instance = json.dumps(IssueRelationSerializer(issue_relation).data, cls=DjangoJSONEncoder)
+        issue_relation.delete()
+
+        issue_activity.delay(
+            type="issue_relation.activity.deleted",
+            requested_data=json.dumps(
+                {"related_issue": str(related_issue_id), "relation_type": relation_type},
+                cls=DjangoJSONEncoder,
+            ),
+            actor_id=str(request.user.id),
+            issue_id=str(issue_id),
+            project_id=str(project_id),
+            current_instance=current_instance,
+            epoch=int(timezone.now().timestamp()),
+            notification=True,
+            origin=base_host(request=request, is_app=True),
+        )
+
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/apps/api/plane/app/views/issue/relation.py
+++ b/apps/api/plane/app/views/issue/relation.py
@@ -277,6 +277,11 @@ class IssueRelationViewSet(BaseViewSet):
             Q(issue_id=related_issue, related_issue_id=issue_id) | Q(issue_id=issue_id, related_issue_id=related_issue)
         )
         issue_relations = issue_relations.first()
+        if issue_relations is None:
+            return Response(
+                {"error": "Work item relation not found"},
+                status=status.HTTP_404_NOT_FOUND,
+            )
         current_instance = json.dumps(IssueRelationSerializer(issue_relations).data, cls=DjangoJSONEncoder)
         issue_relations.delete()
         issue_activity.delay(

--- a/apps/api/plane/app/views/issue/relation.py
+++ b/apps/api/plane/app/views/issue/relation.py
@@ -277,11 +277,6 @@ class IssueRelationViewSet(BaseViewSet):
             Q(issue_id=related_issue, related_issue_id=issue_id) | Q(issue_id=issue_id, related_issue_id=related_issue)
         )
         issue_relations = issue_relations.first()
-        if issue_relations is None:
-            return Response(
-                {"error": "Work item relation not found"},
-                status=status.HTTP_404_NOT_FOUND,
-            )
         current_instance = json.dumps(IssueRelationSerializer(issue_relations).data, cls=DjangoJSONEncoder)
         issue_relations.delete()
         issue_activity.delay(

--- a/apps/api/plane/tests/conftest.py
+++ b/apps/api/plane/tests/conftest.py
@@ -3,9 +3,11 @@
 # See the LICENSE file for details.
 
 import pytest
+from django.core.cache import cache
 from rest_framework.test import APIClient
 from pytest_django.fixtures import django_db_setup
 
+from plane.api.rate_limit import ApiKeyRateThrottle
 from plane.db.models import User, Workspace, WorkspaceMember
 from plane.db.models.api import APIToken
 
@@ -60,6 +62,11 @@ def api_token(db, create_user):
 @pytest.fixture
 def api_key_client(api_client, api_token):
     """Return an API key authenticated client for external API testing"""
+    # ApiKeyRateThrottle counts requests per token in the shared cache, which
+    # outlives the test that made them. Every test reuses the same token, so
+    # the history accumulates until later tests are rate limited into 429s.
+    # Give each test the full budget.
+    cache.delete(f"{ApiKeyRateThrottle.scope}:{api_token.token}")
     api_client.credentials(HTTP_X_API_KEY=api_token.token)
     return api_client
 

--- a/apps/api/plane/tests/contract/api/test_work_item_relations.py
+++ b/apps/api/plane/tests/contract/api/test_work_item_relations.py
@@ -80,11 +80,9 @@ class TestWorkItemRelationRemoveContract:
     """
 
     def get_remove_url(self, workspace_slug, project_id, issue_id):
-        """Helper to build the relation removal endpoint URL."""
         return f"/api/v1/workspaces/{workspace_slug}/projects/{project_id}/work-items/{issue_id}/relations/remove/"
 
     def get_list_url(self, workspace_slug, project_id, issue_id):
-        """Helper to build the relation list/create endpoint URL."""
         return f"/api/v1/workspaces/{workspace_slug}/projects/{project_id}/work-items/{issue_id}/relations/"
 
     @pytest.mark.django_db

--- a/apps/api/plane/tests/contract/api/test_work_item_relations.py
+++ b/apps/api/plane/tests/contract/api/test_work_item_relations.py
@@ -1,0 +1,266 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+from unittest.mock import patch
+
+import pytest
+from rest_framework import status
+
+from plane.db.models import Issue, IssueRelation, Project, ProjectMember, State
+
+
+def _make_project(workspace, create_user, name, identifier):
+    """Create a project with the requesting user as an active admin member."""
+    project = Project.objects.create(
+        name=name,
+        identifier=identifier,
+        workspace=workspace,
+        created_by=create_user,
+    )
+    ProjectMember.objects.create(
+        project=project,
+        member=create_user,
+        role=20,  # Admin role
+        is_active=True,
+    )
+    # A default state is required for work items created in the project
+    State.objects.create(
+        name="Backlog",
+        color="#000000",
+        group="backlog",
+        default=True,
+        project=project,
+        workspace=workspace,
+        created_by=create_user,
+    )
+    return project
+
+
+@pytest.fixture
+def project(db, workspace, create_user):
+    return _make_project(workspace, create_user, "Test Project", "TP")
+
+
+@pytest.fixture
+def other_project(db, workspace, create_user):
+    """A second project in the same workspace, so relations can cross projects."""
+    return _make_project(workspace, create_user, "Other Project", "OP")
+
+
+@pytest.fixture
+def issue(db, workspace, project, create_user):
+    return Issue.objects.create(
+        name="Blocked Issue",
+        project=project,
+        workspace=workspace,
+        created_by=create_user,
+    )
+
+
+@pytest.fixture
+def related_issue(db, workspace, project, create_user):
+    return Issue.objects.create(
+        name="Blocking Issue",
+        project=project,
+        workspace=workspace,
+        created_by=create_user,
+    )
+
+
+@pytest.mark.contract
+class TestWorkItemRelationRemoveContract:
+    """
+    Contract: the documented relation removal endpoint
+
+    ``POST /api/v1/workspaces/{slug}/projects/{project_id}/work-items/{issue_id}/relations/remove/``
+
+    exists on the external REST API, so relations created through the API can
+    also be removed through it. See makeplane/plane#9584.
+    """
+
+    def get_remove_url(self, workspace_slug, project_id, issue_id):
+        """Helper to build the relation removal endpoint URL."""
+        return f"/api/v1/workspaces/{workspace_slug}/projects/{project_id}/work-items/{issue_id}/relations/remove/"
+
+    def get_list_url(self, workspace_slug, project_id, issue_id):
+        """Helper to build the relation list/create endpoint URL."""
+        return f"/api/v1/workspaces/{workspace_slug}/projects/{project_id}/work-items/{issue_id}/relations/"
+
+    @pytest.mark.django_db
+    def test_remove_relation_returns_204_and_deletes_the_relation(
+        self, api_key_client, workspace, project, issue, related_issue
+    ):
+        """The relation stored from the work item in the path is removed."""
+        IssueRelation.objects.create(
+            issue=issue,
+            related_issue=related_issue,
+            relation_type="blocked_by",
+            project=project,
+            workspace=workspace,
+        )
+        url = self.get_remove_url(workspace.slug, project.id, issue.id)
+
+        response = api_key_client.post(url, {"related_issue": str(related_issue.id)}, format="json")
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT, f"Got {response.status_code}: {response.data!r}"
+        assert not IssueRelation.objects.filter(issue=issue, related_issue=related_issue).exists()
+
+    @pytest.mark.django_db
+    def test_remove_relation_matches_the_reverse_direction(
+        self, api_key_client, workspace, project, issue, related_issue
+    ):
+        """A relation stored the other way round is removable from either side.
+
+        ``blocked_by`` is stored once, so the work item on the ``blocking`` side
+        has to match on ``related_issue_id`` instead of ``issue_id``.
+        """
+        IssueRelation.objects.create(
+            issue=related_issue,
+            related_issue=issue,
+            relation_type="blocked_by",
+            project=project,
+            workspace=workspace,
+        )
+        url = self.get_remove_url(workspace.slug, project.id, issue.id)
+
+        response = api_key_client.post(url, {"related_issue": str(related_issue.id)}, format="json")
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT, f"Got {response.status_code}: {response.data!r}"
+        assert not IssueRelation.objects.filter(issue=related_issue, related_issue=issue).exists()
+
+    @pytest.mark.django_db
+    def test_remove_relation_across_projects(
+        self, api_key_client, workspace, project, other_project, issue, create_user
+    ):
+        """Relations may cross projects, so removal is scoped to the workspace."""
+        cross_project_issue = Issue.objects.create(
+            name="Cross Project Issue",
+            project=other_project,
+            workspace=workspace,
+            created_by=create_user,
+        )
+        IssueRelation.objects.create(
+            issue=issue,
+            related_issue=cross_project_issue,
+            relation_type="relates_to",
+            project=project,
+            workspace=workspace,
+        )
+        url = self.get_remove_url(workspace.slug, project.id, issue.id)
+
+        response = api_key_client.post(url, {"related_issue": str(cross_project_issue.id)}, format="json")
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT, f"Got {response.status_code}: {response.data!r}"
+        assert not IssueRelation.objects.filter(issue=issue, related_issue=cross_project_issue).exists()
+
+    @pytest.mark.django_db
+    def test_remove_missing_relation_returns_404(self, api_key_client, workspace, project, issue, related_issue):
+        """No matching relation is a 404, not an unhandled AttributeError → 500."""
+        url = self.get_remove_url(workspace.slug, project.id, issue.id)
+
+        response = api_key_client.post(url, {"related_issue": str(related_issue.id)}, format="json")
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND, f"Got {response.status_code}: {response.data!r}"
+
+    @pytest.mark.django_db
+    def test_remove_relation_for_work_item_outside_the_project_returns_404(
+        self, api_key_client, workspace, project, other_project, related_issue, create_user
+    ):
+        """The work item in the path has to belong to the project in the path.
+
+        Otherwise membership of the path project would authorize removing
+        relations of work items in projects the caller cannot see.
+        """
+        foreign_issue = Issue.objects.create(
+            name="Foreign Issue",
+            project=other_project,
+            workspace=workspace,
+            created_by=create_user,
+        )
+        IssueRelation.objects.create(
+            issue=foreign_issue,
+            related_issue=related_issue,
+            relation_type="blocked_by",
+            project=other_project,
+            workspace=workspace,
+        )
+        url = self.get_remove_url(workspace.slug, project.id, foreign_issue.id)
+
+        response = api_key_client.post(url, {"related_issue": str(related_issue.id)}, format="json")
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND, f"Got {response.status_code}: {response.data!r}"
+        assert IssueRelation.objects.filter(issue=foreign_issue, related_issue=related_issue).exists()
+
+    @pytest.mark.django_db
+    def test_remove_relation_without_related_issue_returns_400(self, api_key_client, workspace, project, issue):
+        """``related_issue`` is required."""
+        url = self.get_remove_url(workspace.slug, project.id, issue.id)
+
+        response = api_key_client.post(url, {}, format="json")
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, f"Got {response.status_code}: {response.data!r}"
+        assert "related_issue" in response.data
+
+    @pytest.mark.django_db
+    def test_remove_relation_with_malformed_related_issue_returns_400(self, api_key_client, workspace, project, issue):
+        """A non-UUID ``related_issue`` is rejected before the database is touched."""
+        url = self.get_remove_url(workspace.slug, project.id, issue.id)
+
+        response = api_key_client.post(url, {"related_issue": "not-a-uuid"}, format="json")
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, f"Got {response.status_code}: {response.data!r}"
+
+    @pytest.mark.django_db
+    def test_remove_relation_dispatches_deletion_activity(
+        self, api_key_client, workspace, project, issue, related_issue
+    ):
+        """Removal records activity for both work items, like the web app does."""
+        IssueRelation.objects.create(
+            issue=related_issue,
+            related_issue=issue,
+            relation_type="blocked_by",
+            project=project,
+            workspace=workspace,
+        )
+        url = self.get_remove_url(workspace.slug, project.id, issue.id)
+
+        with patch("plane.api.views.issue.issue_activity") as mock_issue_activity:
+            response = api_key_client.post(url, {"related_issue": str(related_issue.id)}, format="json")
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT, f"Got {response.status_code}: {response.data!r}"
+
+        mock_issue_activity.delay.assert_called_once()
+        kwargs = mock_issue_activity.delay.call_args.kwargs
+        assert kwargs["type"] == "issue_relation.activity.deleted"
+        assert kwargs["notification"] is True
+        # The activity feed needs the relation type as seen from the work item
+        # in the path, which is the inverse of how this one is stored.
+        assert '"relation_type": "blocking"' in kwargs["requested_data"]
+
+    @pytest.mark.django_db
+    def test_relation_round_trip_through_the_public_api(self, api_key_client, workspace, project, issue, related_issue):
+        """Create, read and remove a relation using only documented endpoints."""
+        list_url = self.get_list_url(workspace.slug, project.id, issue.id)
+
+        create_response = api_key_client.post(
+            list_url,
+            {"relation_type": "blocked_by", "issues": [str(related_issue.id)]},
+            format="json",
+        )
+        assert create_response.status_code == status.HTTP_201_CREATED
+
+        read_response = api_key_client.get(list_url)
+        assert read_response.status_code == status.HTTP_200_OK
+        assert [ref["issue_id"] for ref in read_response.data["blocked_by"]] == [str(related_issue.id)]
+
+        remove_response = api_key_client.post(
+            self.get_remove_url(workspace.slug, project.id, issue.id),
+            {"related_issue": str(related_issue.id)},
+            format="json",
+        )
+        assert remove_response.status_code == status.HTTP_204_NO_CONTENT
+
+        read_response = api_key_client.get(list_url)
+        assert read_response.status_code == status.HTTP_200_OK
+        assert read_response.data["blocked_by"] == []


### PR DESCRIPTION
### Description

The API reference documents a work-item relation removal endpoint:

```
POST /api/v1/workspaces/{workspace_slug}/projects/{project_id}/work-items/{work_item_id}/relations/remove/
{"related_issue": "<uuid>"}
```

but that route was never registered, so it returns 404 on every instance. Relations can be created and listed through the public API and never removed, which leaves an integration able to build a dependency graph but unable to correct it. The only working path is the internal app API (`POST /api/workspaces/.../issues/{id}/remove-relation/`), which uses `BaseSessionAuthentication` and so rejects an `X-API-Key` — unusable server-to-server.

This registers the documented route so the docs page and the code agree.

**What changed**

- **`apps/api/plane/api/views/issue.py`** — new `IssueRelationRemoveAPIEndpoint`. It consumes `IssueRelationRemoveSerializer`, which was already written with the exact request shape from the docs page but was never imported or referenced by anything.
- **`apps/api/plane/api/urls/work_item.py`** — registers `.../work-items/<issue_id>/relations/remove/` under the `work-items` prefix the docs advertise, next to the existing `relations/` list/create route.
- **`apps/api/plane/api/serializers/__init__.py`**, **`apps/api/plane/api/views/__init__.py`** — export the serializer and the endpoint.
- **`apps/api/plane/tests/conftest.py`** (second commit) — `ApiKeyRateThrottle` counts requests per API key in the shared cache, and every contract test authenticates with the same token, so the history accumulated across the whole session. Once the suite crossed 60 requests inside a minute, whichever tests ran next were rate limited into 429s regardless of what they asserted — adding tests anywhere could break tests elsewhere, which is exactly what happened when the tests below were added. The `api_key_client` fixture now clears the token's throttle history so each test starts with the full budget.

**Behaviour of the new endpoint**

- The relation is matched **in either direction**. `blocked_by` is stored once, so a work item on the `blocking` side has to match on `related_issue_id` rather than `issue_id`; the same request body works from either end.
- Matching is scoped to the **workspace**, not the project, because relations may cross projects — the same scope the list/create endpoint uses.
- The work item in the path must belong to the **project in the path**, otherwise membership of that project would not actually authorize removing relations of work items in projects the caller cannot see. A mismatch is a 404.
- A relation that does not exist is a **404**, not a 500.
- A pair with relations stored in **both directions** — e.g. `A blocked_by B` and `B relates_to A` are two distinct rows, both permitted by the unique constraint on the directed pair — removes the most recently created one. The documented request body carries no `relation_type` to disambiguate with, so this matches what the app API already does.
- Removal dispatches `issue_relation.activity.deleted` with `notification=True`, matching what the web app does. The stored relation is directional, so the relation type is reported as seen from the work item in the path (a stored `blocked_by` whose `related_issue` is the path item is reported as `blocking`) — otherwise the activity entries on the two work items read the wrong way round.
- Returns `204 No Content` with an empty body, as documented.

The OpenAPI schema is generated from the views, so the endpoint now appears in the generated reference under **Work Item Relations** with operation id `remove_work_item_relation`.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### Test Scenarios

New contract tests in `apps/api/plane/tests/contract/api/test_work_item_relations.py` (9 tests, all passing):

- removing a relation returns 204 and deletes it
- a relation stored in the reverse direction is removable from either side
- a relation that crosses projects is removable
- a relation that does not exist returns 404
- a work item that does not belong to the project in the path returns 404 and leaves the relation intact
- a missing `related_issue` returns 400
- a malformed (non-UUID) `related_issue` returns 400
- removal dispatches `issue_relation.activity.deleted` with `notification=True` and the relation type as seen from the path work item
- a full round trip — create, list, remove, list — using only the documented public endpoints

Run with:

```bash
docker compose -f docker-compose-test.yml run --rm api-tests pytest plane/tests/contract/api/test_work_item_relations.py
```

The full suite passes — 525 tests, run twice back to back to confirm the throttle history no longer leaks between tests:

```bash
docker compose -f docker-compose-test.yml run --rm api-tests pytest plane/tests
```

The generated OpenAPI schema was checked too (`ENABLE_DRF_SPECTACULAR=1 python manage.py spectacular`): the endpoint appears at the documented path under the **Work Item Relations** tag with `operationId: remove_work_item_relation`, an `IssueRelationRemoveRequest` body and 204/400/401/403/404 responses, and adds no new schema warnings.

`ruff check` and `ruff format` are clean on every file touched.

### Out of scope

`IssueRelationViewSet.remove_relation` on the **app** API has the same `.first()` → `.delete()` crash (`AttributeError` → HTTP 500 when the relation does not exist). That is already fixed in #9531 (SECUR-243), which touches the same handler to bind the URL work item to the URL project, so it is deliberately left out here rather than carried in both branches. Nothing in this PR depends on it — the new public endpoint has its own 404 and does not share that code path.

### References

Closes #9584


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to remove relationships between work items through the API.
  * Supports removing relationships regardless of their direction, with project and workspace validation.
  * Records activity when a relationship is removed.
* **Bug Fixes**
  * Improved test isolation by clearing API key rate-limit state between tests.
* **Tests**
  * Added coverage for valid removals, missing or invalid requests, cross-project relationships, and complete relationship workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
