### PR TITLE
fix(i18n): include locale assets in package builds

### DIFF
--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -18,6 +18,7 @@
     "generate:types": "tsx scripts/generate-types.ts",
     "sync:check": "tsx scripts/sync-check.ts",
     "check:sync": "tsx scripts/sync-check.ts --ci",
+    "test": "pnpm run build && tsx --test scripts/__tests__/*.test.ts",
     "check:lint": "oxlint --max-warnings=9 .",
     "check:types": "pnpm run generate:types && tsc --noEmit",
     "check:format": "oxfmt --check .",

--- a/packages/i18n/scripts/__tests__/locale-assets.test.ts
+++ b/packages/i18n/scripts/__tests__/locale-assets.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2023-present Plane Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+const PACKAGE_ROOT = path.resolve(import.meta.dirname, "../..");
+
+const listJsonAssets = (root: string): string[] =>
+  fs
+    .readdirSync(root, { recursive: true, withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".json"))
+    .map((entry) => path.relative(root, path.join(entry.parentPath, entry.name)).replaceAll("\\", "/"))
+    .toSorted();
+
+test("the built package includes every locale asset", () => {
+  const sourceLocaleRoot = path.join(PACKAGE_ROOT, "src/locales");
+  const builtLocaleRoot = path.join(PACKAGE_ROOT, "dist/locales");
+
+  assert.equal(fs.existsSync(builtLocaleRoot), true, "expected dist/locales to be created by the package build");
+  assert.deepEqual(listJsonAssets(builtLocaleRoot), listJsonAssets(sourceLocaleRoot));
+});
+
+test("the built entry resolves dynamic locale imports inside dist", () => {
+  const builtEntry = fs.readFileSync(path.join(PACKAGE_ROOT, "dist/index.js"), "utf8");
+
+  assert.match(builtEntry, /import\(`\.\/locales\/\$\{[^}]+\}\/\$\{[^}]+\}\.json`\)/);
+});

--- a/packages/i18n/scripts/tsconfig.json
+++ b/packages/i18n/scripts/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2022",
+    "lib": ["ES2023"],
     "module": "Node16",
     "moduleResolution": "Node16",
     "esModuleInterop": true,

--- a/packages/i18n/src/core/instance.ts
+++ b/packages/i18n/src/core/instance.ts
@@ -4,7 +4,7 @@
  * See the LICENSE file for details.
  */
 
-import i18n from "i18next";
+import { createInstance } from "i18next";
 import { initReactI18next } from "react-i18next";
 import ICU from "i18next-icu";
 import resourcesToBackend from "i18next-resources-to-backend";
@@ -13,12 +13,13 @@ import { NAMESPACES, DEFAULT_NAMESPACE } from "../constants/namespaces";
 
 import type { i18n as I18nInstance } from "i18next";
 
-export const i18nInstance: I18nInstance = i18n.createInstance();
+export const i18nInstance: I18nInstance = createInstance();
 
 i18nInstance
   .use(ICU)
   .use(initReactI18next)
-  .use(resourcesToBackend((language: string, namespace: string) => import(`../locales/${language}/${namespace}.json`)));
+  // Locale assets are copied beside the bundled dist entry by tsdown.
+  .use(resourcesToBackend((language: string, namespace: string) => import(`./locales/${language}/${namespace}.json`)));
 
 const initialLng =
   typeof window !== "undefined" ? localStorage.getItem(LANGUAGE_STORAGE_KEY) || FALLBACK_LANGUAGE : FALLBACK_LANGUAGE;

--- a/packages/i18n/tsdown.config.ts
+++ b/packages/i18n/tsdown.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   entry: ["src/index.ts"],
   format: ["esm"],
   dts: true,
+  copy: ["src/locales"],
   platform: "neutral",
   exports: true,
 });


### PR DESCRIPTION
### Description

The built `@plane/i18n` package currently emits its JavaScript and declaration files without the JSON locale resources consumed by the runtime loader. In addition, the emitted loader resolves `../locales/...`, which points outside the package's `dist` directory. Consumers that run against the packaged build can therefore fail to load non-English resources even though the source locale files exist.

This PR fixes the packaging boundary for every supported locale by:

- copying `src/locales` to `dist/locales` as part of the `tsdown` build;
- resolving dynamic resource imports from `./locales/...` in the emitted entry;
- adding build-level regression tests that compare every source and built JSON asset and verify the emitted import path; and
- using the named `createInstance` import while touching the loader, which keeps the changed file lint-clean without changing behavior.

This is deliberately limited to the i18n package runtime and build output. It does not change translations, application UI copy, database content, or deployment configuration.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)

Not applicable. This fixes package build output rather than a visual component.

### Test Scenarios

- `pnpm --filter @plane/i18n test`
  - builds the package;
  - verifies all 532 locale JSON assets are present in `dist/locales`; and
  - verifies the emitted loader imports `./locales/${language}/${namespace}.json`.
- `pnpm --filter @plane/i18n check:types`
- `pnpm --filter @plane/i18n check:sync`
  - all 19 locales contain the same 3,837 keys.
- Changed-file OxLint with `--deny-warnings`
- Changed-file oxfmt check
- `pnpm turbo run build --filter=web --output-logs=errors-only`
  - 11/11 tasks completed successfully.
- `git diff --check`

### References

- Follow-up to the i18n architecture introduced in #8898.
- Related to the localization tracking work in #9089.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed locale loading in built packages so translated content is available at runtime.
  * Ensured locale assets are included and resolved correctly in production builds.

* **Tests**
  * Added automated checks confirming built locale files match source assets and dynamic loading works as expected.
  * Added a test command for building the package and running TypeScript tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->