### PR TITLE
fix(i18n): localize toast accessibility labels

### DIFF
--- a/packages/i18n/scripts/__tests__/toast-accessibility-localization.test.ts
+++ b/packages/i18n/scripts/__tests__/toast-accessibility-localization.test.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2023-present Plane Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+const REPOSITORY_ROOT = path.resolve(import.meta.dirname, "../../../..");
+
+function read(relativePath: string): string {
+  return fs.readFileSync(path.join(REPOSITORY_ROOT, relativePath), "utf8");
+}
+
+test("toast controls use existing translations for accessibility labels", () => {
+  const source = read("packages/propel/src/toast/toast.tsx");
+  const manifest = JSON.parse(read("packages/propel/package.json"));
+
+  assert.match(source, /import\s+\{\s*useTranslation\s*\}\s+from\s+"@plane\/i18n"/);
+  assert.match(source, /<BaseToast\.Viewport[^>]*aria-label=\{t\("notifications"\)\}/s);
+  assert.match(source, /<BaseToast\.Close[^>]*aria-label=\{t\("close"\)\}/s);
+  assert.equal(manifest.dependencies["@plane/i18n"], "workspace:*");
+});

--- a/packages/propel/package.json
+++ b/packages/propel/package.json
@@ -65,6 +65,7 @@
     "@base-ui-components/react": "catalog:",
     "@plane/constants": "workspace:*",
     "@plane/hooks": "workspace:*",
+    "@plane/i18n": "workspace:*",
     "@plane/types": "workspace:*",
     "@plane/utils": "workspace:*",
     "@tanstack/react-table": "catalog:",

--- a/packages/propel/src/toast/toast.tsx
+++ b/packages/propel/src/toast/toast.tsx
@@ -7,6 +7,7 @@
 import * as React from "react";
 import { Toast as BaseToast } from "@base-ui-components/react/toast";
 import { AlertTriangle, CheckIcon, InfoIcon, XIcon } from "lucide-react";
+import { useTranslation } from "@plane/i18n";
 import { CloseIcon } from "../icons/actions/close-icon";
 // spinner
 import { CircularBarSpinner } from "../spinners/circular-bar-spinner";
@@ -56,10 +57,12 @@ export type ToastProps = {
 const toastManager = BaseToast.createToastManager();
 
 export function Toast(props: ToastProps) {
+  const { t } = useTranslation();
+
   return (
     <BaseToast.Provider toastManager={toastManager}>
       <BaseToast.Portal>
-        <BaseToast.Viewport data-theme={props.theme}>
+        <BaseToast.Viewport data-theme={props.theme} aria-label={t("notifications")}>
           <ToastList />
         </BaseToast.Viewport>
       </BaseToast.Portal>
@@ -112,6 +115,7 @@ function ToastList() {
 }
 
 function ToastRender({ id, toast }: { id: React.Key; toast: BaseToast.Root.ToastObject }) {
+  const { t } = useTranslation();
   const toastData = toast.data as SetToastProps;
   const type = toastData.type as TOAST_TYPE;
   const data = TOAST_DATA[type];
@@ -163,7 +167,10 @@ function ToastRender({ id, toast }: { id: React.Key; toast: BaseToast.Root.Toast
         e.preventDefault();
       }}
     >
-      <BaseToast.Close className="absolute top-3 right-3 cursor-pointer text-icon-secondary hover:text-icon-tertiary">
+      <BaseToast.Close
+        aria-label={t("close")}
+        className="absolute top-3 right-3 cursor-pointer text-icon-secondary hover:text-icon-tertiary"
+      >
         <CloseIcon strokeWidth={1.5} width={16} height={16} />
       </BaseToast.Close>
       <div className="flex w-full items-start gap-2 p-4">

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1564,6 +1564,9 @@ importers:
       '@plane/hooks':
         specifier: workspace:*
         version: link:../hooks
+      '@plane/i18n':
+        specifier: workspace:*
+        version: link:../i18n
       '@plane/types':
         specifier: workspace:*
         version: link:../types


### PR DESCRIPTION
### Description

The shared Propel toast component does not provide locale-aware accessible names for its notification viewport or close control. As a result, assistive technology can receive no explicit label or an English library default even when the active Plane language is not English.

This PR localizes those hidden accessibility labels by:

- adding `@plane/i18n` as an explicit Propel dependency;
- setting the toast viewport label with the existing `notifications` translation key;
- setting each close control label with the existing `close` translation key; and
- adding a focused regression test that protects the translated labels and package dependency.

No new translation keys are introduced. The existing keys are already translated across all supported locales, including `通知` / `关闭` for Simplified Chinese and `通知` / `關閉` for Traditional Chinese.

This PR intentionally covers only toast accessibility text. Other visible localization surfaces are being kept in separate reviewable changes.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)

There is no visual change. The resulting accessible markup uses the active locale:

```tsx
<BaseToast.Viewport aria-label={t("notifications")} />
<BaseToast.Close aria-label={t("close")} />
```

### Test Scenarios

- Regression test: `node --test --experimental-strip-types packages/i18n/scripts/__tests__/toast-accessibility-localization.test.ts`
- `pnpm turbo run build --filter=@plane/propel...`
  - 6/6 build tasks completed successfully.
- `tsc --noEmit -p packages/propel/tsconfig.json`
- Changed-file OxLint with `--deny-warnings`
- Changed-file oxfmt check
- `pnpm --filter @plane/i18n check:sync`
  - all 19 locales contain the same 3,837 keys.
- `git diff --check`

### References

- Part of #9089.
- Extracted as a small, independently reviewable localization fix from the broader hard-coded UI audit.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Added localized accessibility labels for toast notifications and their close buttons.
  * Toast labels now use the app’s existing translations for a more consistent experience across supported languages.

* **Tests**
  * Added coverage to verify translated toast labels and localization support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->