### PR TITLE
fix(i18n): localize project insight labels

### DIFF
--- a/apps/web/core/components/analytics/overview/project-insights.tsx
+++ b/apps/web/core/components/analytics/overview/project-insights.tsx
@@ -11,7 +11,6 @@ import useSWR from "swr";
 // plane package imports
 import { useTranslation } from "@plane/i18n";
 import { EmptyStateCompact } from "@plane/propel/empty-state";
-import type { TChartData } from "@plane/types";
 // hooks
 import { useAnalytics } from "@/hooks/store/use-analytics";
 // services
@@ -28,6 +27,22 @@ const RadarChart = lazy(function RadarChart() {
 
 const analyticsService = new AnalyticsService();
 
+type TProjectInsightDatum = {
+  key: string;
+  name: string;
+  count: number;
+};
+
+const PROJECT_INSIGHT_LABEL_KEYS: Record<string, string> = {
+  work_items: "common.work_items",
+  cycles: "common.cycles",
+  modules: "common.modules",
+  intake: "intake",
+  members: "common.members",
+  pages: "common.pages",
+  views: "common.views",
+};
+
 const ProjectInsights = observer(function ProjectInsights() {
   const params = useParams();
   const { t } = useTranslation();
@@ -38,7 +53,7 @@ const ProjectInsights = observer(function ProjectInsights() {
   const { data: projectInsightsData, isLoading: isLoadingProjectInsight } = useSWR(
     `radar-chart-project-insights-${workspaceSlug}-${selectedDuration}-${selectedProjects}-${selectedCycle}-${selectedModule}-${isPeekView}`,
     () =>
-      analyticsService.getAdvanceAnalyticsCharts<TChartData<string, string>[]>(
+      analyticsService.getAdvanceAnalyticsCharts<TProjectInsightDatum[]>(
         workspaceSlug,
         "projects",
         {
@@ -50,6 +65,14 @@ const ProjectInsights = observer(function ProjectInsights() {
         isPeekView
       )
   );
+  const localizedProjectInsightsData = projectInsightsData?.map((item) => {
+    const translationKey = PROJECT_INSIGHT_LABEL_KEYS[String(item.key)];
+
+    return {
+      ...item,
+      name: translationKey ? t(translationKey) : item.name,
+    };
+  });
 
   return (
     <AnalyticsSectionWrapper
@@ -68,11 +91,11 @@ const ProjectInsights = observer(function ProjectInsights() {
         />
       ) : (
         <div className="gap-8 lg:flex">
-          {projectInsightsData && (
+          {localizedProjectInsightsData && (
             <Suspense fallback={<ProjectInsightsLoader />}>
               <RadarChart
                 className="h-[350px] w-full text-accent-primary lg:w-3/5"
-                data={projectInsightsData}
+                data={localizedProjectInsightsData}
                 dataKey="key"
                 radars={[
                   {
@@ -103,7 +126,7 @@ const ProjectInsights = observer(function ProjectInsights() {
                 <div>{t("workspace_analytics.trend_on_charts")}</div>
                 <div>{t("common.work_items")}</div>
               </div>
-              {projectInsightsData?.map((item) => (
+              {localizedProjectInsightsData?.map((item) => (
                 <div key={item.key} className="flex items-center justify-between text-13 text-primary">
                   <div>{item.name}</div>
                   <div className="flex items-center gap-1">

--- a/packages/i18n/scripts/__tests__/project-insights-localization.test.ts
+++ b/packages/i18n/scripts/__tests__/project-insights-localization.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2023-present Plane Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+const REPOSITORY_ROOT = path.resolve(import.meta.dirname, "../../../..");
+
+function read(relativePath: string): string {
+  return fs.readFileSync(path.join(REPOSITORY_ROOT, relativePath), "utf8");
+}
+
+test("project insight labels use stable API keys instead of backend English names", () => {
+  const component = read("apps/web/core/components/analytics/overview/project-insights.tsx");
+  const api = read("apps/api/plane/app/views/analytic/advance.py");
+  const commonLocale = JSON.parse(read("packages/i18n/src/locales/en/common.json"));
+  const apiDataBlock = api.match(/data\s*=\s*\{([\s\S]*?)\n\s*\}/)?.[1];
+
+  assert.ok(apiDataBlock, "expected the project chart API data mapping");
+
+  const apiKeys = [...apiDataBlock.matchAll(/^\s*"([a-z_]+)":/gm)].map((match) => match[1]);
+  const labelMapBlock = component.match(/PROJECT_INSIGHT_LABEL_KEYS[^=]*=\s*\{([\s\S]*?)\n\};/)?.[1];
+
+  assert.ok(labelMapBlock, "expected a frontend translation-key map for project insight dimensions");
+  for (const key of apiKeys) {
+    const translationKey = labelMapBlock.match(new RegExp(`${key}:\\s*"([^"]+)"`))?.[1];
+    assert.ok(translationKey, `expected a translation key for ${key}`);
+
+    const value = translationKey.split(".").reduce<unknown>((node, segment) => {
+      if (!node || typeof node !== "object") return undefined;
+      return (node as Record<string, unknown>)[segment];
+    }, commonLocale);
+    assert.equal(typeof value, "string", `expected ${translationKey} to resolve to a leaf string`);
+  }
+
+  assert.match(component, /data=\{localizedProjectInsightsData\}/);
+  assert.doesNotMatch(component, /data=\{projectInsightsData\}/);
+  assert.doesNotMatch(component, /\{projectInsightsData\?\.map/);
+});

--- a/packages/i18n/scripts/__tests__/project-insights-localization.test.ts
+++ b/packages/i18n/scripts/__tests__/project-insights-localization.test.ts
@@ -40,5 +40,6 @@ test("project insight labels use stable API keys instead of backend English name
 
   assert.match(component, /data=\{localizedProjectInsightsData\}/);
   assert.doesNotMatch(component, /data=\{projectInsightsData\}/);
-  assert.doesNotMatch(component, /\{projectInsightsData\?\.map/);
+  assert.match(component, /\{localizedProjectInsightsData\?\.map\(\(item\) => \(/);
+  assert.doesNotMatch(component, /\{projectInsightsData(?:\?\.|\.)map\(\(item\) => \(/);
 });


### PR DESCRIPTION
### Description

The advanced analytics API returns both a stable machine key and an English display name for each project-insight dimension. The Web client currently passes that English `name` directly to the radar chart and summary list, so labels such as **Work Items**, **Cycles**, **Modules**, **Intake**, **Members**, **Pages**, and **Views** remain English after a user selects another language.

This PR keeps the API contract unchanged and localizes the presentation layer by:

- defining a small map from the seven stable API keys to existing Plane translation keys;
- replacing only the system-provided display names before data reaches the radar chart;
- using the same localized data in the adjacent summary list; and
- retaining the backend name as a forward-compatible fallback for any future unknown dimension.

The mapping intentionally does not translate user-created project, state, label, member, cycle, or module names. No new locale keys or placeholder translations are added.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)

Before: project-insight radar axes and the summary list always render the English names returned by the API.

After: those seven system dimensions follow the active Plane locale, while unknown and user-defined names remain unchanged.

### Test Scenarios

- Regression test verifies that every project dimension returned by the API has a frontend translation mapping, that each mapping resolves to an existing leaf string, and that both chart and summary use the localized data.
- `node --test --experimental-strip-types packages/i18n/scripts/__tests__/project-insights-localization.test.ts`
- `pnpm --filter web check:types`
- `pnpm turbo run build --filter=web --output-logs=errors-only`
  - 11/11 tasks completed successfully.
- Changed-file OxLint with `--deny-warnings`
- Changed-file oxfmt check
- `pnpm --filter @plane/i18n check:sync`
  - all 19 locales contain the same 3,837 keys.
- `git diff --check`

### References

- Part of #9089.
- Extracted as an independently reviewable dynamic-label fix from the broader localization audit.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Project insights in analytics charts and summary lists now display localized names.
  * Known insight labels are translated using the selected language.

* **Tests**
  * Added coverage to verify insight dimensions resolve to the correct English translations and appear localized in charts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->