### PR TITLE
fix(web): default new work item to the first project in sidebar order

### DIFF
--- a/apps/web/core/components/issues/issue-modal/provider.tsx
+++ b/apps/web/core/components/issues/issue-modal/provider.tsx
@@ -11,6 +11,7 @@ import type { ISearchIssueResponse, TIssue } from "@plane/types";
 // components
 import { IssueModalContext } from "@/components/issues/issue-modal/context";
 // hooks
+import { useProject } from "@/hooks/store/use-project";
 import { useUser } from "@/hooks/store/user/user-user";
 
 export type TIssueModalProviderProps = {
@@ -26,8 +27,15 @@ export const IssueModalProvider = observer(function IssueModalProvider(props: TI
   const [selectedParentIssue, setSelectedParentIssue] = useState<ISearchIssueResponse | null>(null);
   // store hooks
   const { projectsWithCreatePermissions } = useUser();
+  const { joinedProjectIds } = useProject();
   // derived values
-  const projectIdsWithCreatePermissions = Object.keys(projectsWithCreatePermissions ?? {});
+  // `projectsWithCreatePermissions` is keyed by project id in whatever order the
+  // permission map came back in, so deriving the list from `joinedProjectIds` keeps it in
+  // the order projects are listed in the sidebar and the project dropdown, and leaves out
+  // archived projects.
+  const projectIdsWithCreatePermissions = joinedProjectIds.filter(
+    (projectId) => !!projectsWithCreatePermissions?.[projectId]
+  );
 
   return (
     <IssueModalContext.Provider


### PR DESCRIPTION
### Description

The **New work item** modal preselects `allowedProjectIds[0]`, and the issue modal provider builds that list with `Object.keys(projectsWithCreatePermissions)`. That map is the response of `GET /api/users/me/workspaces/<slug>/project-roles/`, whose key order is the `ProjectMember` default ordering `("-created_at",)` — the order the user joined the projects, newest first.

Everything the user sees is ordered by `sort_order` instead: the sidebar and the modal's own `ProjectDropdown` both read `joinedProjectIds` from the project store. The two orders match on a fresh workspace and drift apart as soon as projects are dragged into a different order, since dragging writes `ProjectUserProperty.sort_order` and leaves `ProjectMember.created_at` untouched. The preselected project then has no relation to the list the user is looking at.

The permission map is also not filtered by `archived_at`, so an archived project can end up as `allowedProjectIds[0]`. It is absent from the dropdown (that list excludes archived projects), so the modal preselects a project the user cannot see or pick, and saving fails with a 500 from the work item create endpoint.

This derives the fallback list from `joinedProjectIds` and keeps only the projects the user can create in. The list stays in the order the user sees, archived projects drop out, and everything else about the modal is unchanged — a project id from the route still wins over the fallback, and an explicit `allowedProjectIds` prop is still passed straight through.

Fixes #9592

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)

Six projects, with the sidebar dragged into the order `Alpha, Bravo, Echo, Delta, Charlie, Foxtrot`.

**Before** — the modal preselects `Foxtrot`, the *last* project in the sidebar:

<img width="1440" height="900" alt="Create new work item modal preselecting Foxtrot while the sidebar starts with Alpha" src="https://github.com/user-attachments/assets/f610c87f-8bc9-4f96-b916-6c80b8a87454" />

**After** — the modal preselects `Alpha`, the first project in the sidebar:

<img width="1440" height="900" alt="Create new work item modal preselecting Alpha, matching the top of the sidebar" src="https://github.com/user-attachments/assets/1162a9ba-6340-4a4d-a0a4-c699069d7270" />

**Archived-project variant, before the change** — `Foxtrot` is archived, so it is gone from the sidebar and from the modal's project dropdown, yet the modal still preselects it and `Save` returns a 500:

<img width="1440" height="900" alt="Create new work item modal preselecting the archived Foxtrot project, which is absent from the sidebar" src="https://github.com/user-attachments/assets/4c11e756-548c-4a6c-85bd-53a259702b48" />

### Test Scenarios

Verified against a self-hosted v1.4.1 stack (`makeplane/plane-backend:v1.4.1` and friends) with the web app running from source, in a workspace with six projects that were dragged out of their default order:

- Home → **New work item** preselects `Alpha`, the first project in the sidebar, instead of `Foxtrot`. The dropdown order and contents are unchanged.
- With `Foxtrot` archived: before the change the modal preselected it and `Save` returned `500`; after the change the modal preselects `Alpha` and the work item is created.
- Unarchiving `Foxtrot` puts it back at the bottom of the sidebar, and the default stays `Alpha`.
- Opening the modal from inside a project (`/<workspace>/projects/<id>/issues/`) still preselects that project — the route still takes precedence over the fallback.
- `pnpm --filter web check:types`, `oxlint` and `oxfmt --check` pass on the changed file.

No unit tests are included: `apps/web` has no test runner configured, so there is nowhere to hang a spec for this yet.

### References

Fixes #9592


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Project selection now respects sidebar order.
  * Archived projects are excluded from project creation options.
  * Only projects where you have create permissions are shown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
