### PR TITLE
[SECUR-247] fix(security): scope ProjectMemberPermission POST to the URL project

### DIFF
--- a/apps/api/plane/app/permissions/project.py
+++ b/apps/api/plane/app/permissions/project.py
@@ -66,12 +66,16 @@ class ProjectMemberPermission(BasePermission):
                 project_id=view.project_id,
                 is_active=True,
             ).exists()
-        ## Only workspace owners or admins can create the projects
+        # Scope POST to the URL project, as the other two branches already do.
+        # A workspace-only check let any member create sub-resources in a project
+        # they do not belong to — including a deploy board, which returns the
+        # public anchor and exposes a Secret project to anonymous callers.
         if request.method == "POST":
-            return WorkspaceMember.objects.filter(
+            return ProjectMember.objects.filter(
                 workspace__slug=view.workspace_slug,
                 member=request.user,
                 role__in=[ROLE.ADMIN.value, ROLE.MEMBER.value],
+                project_id=view.project_id,
                 is_active=True,
             ).exists()
 

--- a/apps/api/plane/app/views/project/base.py
+++ b/apps/api/plane/app/views/project/base.py
@@ -561,6 +561,12 @@ class DeployBoardViewSet(BaseViewSet):
             },
         )
 
+        # project_id comes from the URL and was never checked against slug, so a
+        # caller could aim their own workspace at another tenant's project id.
+        # Defence in depth: the permission class now binds both.
+        if not Project.objects.filter(pk=project_id, workspace__slug=slug).exists():
+            return Response({"error": "Project not found"}, status=status.HTTP_404_NOT_FOUND)
+
         project_deploy_board, _ = DeployBoard.objects.get_or_create(
             entity_name="project", entity_identifier=project_id, project_id=project_id
         )

--- a/apps/api/plane/app/views/project/base.py
+++ b/apps/api/plane/app/views/project/base.py
@@ -565,7 +565,7 @@ class DeployBoardViewSet(BaseViewSet):
         # caller could aim their own workspace at another tenant's project id.
         # Defence in depth: the permission class now binds both.
         if not Project.objects.filter(pk=project_id, workspace__slug=slug).exists():
-            return Response({"error": "Project not found"}, status=status.HTTP_404_NOT_FOUND)
+            return Response({"error": "Project does not exist"}, status=status.HTTP_404_NOT_FOUND)
 
         project_deploy_board, _ = DeployBoard.objects.get_or_create(
             entity_name="project", entity_identifier=project_id, project_id=project_id

--- a/apps/api/plane/tests/contract/app/test_deploy_board_project_scope_app.py
+++ b/apps/api/plane/tests/contract/app/test_deploy_board_project_scope_app.py
@@ -20,7 +20,7 @@ import pytest
 from rest_framework import status
 from rest_framework.test import APIClient
 
-from plane.db.models import Project, ProjectMember, User, WorkspaceMember
+from plane.db.models import DeployBoard, Project, ProjectMember, User, Workspace, WorkspaceMember
 
 
 def deploy_board_url(slug, project_id):
@@ -89,3 +89,105 @@ class TestDeployBoardProjectScope:
         assert response.status_code == status.HTTP_200_OK, (
             f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
         )
+
+
+@pytest.fixture
+def secret_project(db, workspace, create_user):
+    """A Secret (network=0) project that ``create_user`` administers."""
+    project = Project.objects.create(
+        name="Secret Project",
+        identifier="SEC",
+        workspace=workspace,
+        network=0,
+        created_by=create_user,
+    )
+    ProjectMember.objects.create(
+        project=project, member=create_user, workspace=workspace, role=20
+    )
+    return project
+
+
+@pytest.fixture
+def foreign_project(db, create_user):
+    """A project in a DIFFERENT workspace that nobody here belongs to."""
+    unique_id = uuid4().hex[:8]
+    owner = User.objects.create(
+        email=f"victim-{unique_id}@plane.so", username=f"victim_{unique_id}"
+    )
+    other_ws = Workspace.objects.create(
+        name="Victim Workspace", slug=f"victim-{unique_id}", owner=owner
+    )
+    WorkspaceMember.objects.create(workspace=other_ws, member=owner, role=20)
+    return Project.objects.create(
+        name="Victim Project",
+        identifier="VIC",
+        workspace=other_ws,
+        network=0,
+        created_by=owner,
+    )
+
+
+@pytest.mark.contract
+class TestDeployBoardCreateProjectScope:
+    """POST is the publish action: it returns the public anchor.
+
+    ``ProjectMemberPermission``'s POST branch previously checked workspace
+    membership only, so a workspace member who was not in the project could
+    publish it and receive the anchor — which Space serves to anonymous callers.
+    """
+
+    @pytest.mark.django_db
+    def test_non_project_member_cannot_publish(self, outsider_client, workspace, secret_project):
+        response = outsider_client.post(
+            deploy_board_url(workspace.slug, secret_project.id), {}, format="json"
+        )
+        assert response.status_code == status.HTTP_403_FORBIDDEN, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+
+    @pytest.mark.django_db
+    def test_denied_publish_leaks_no_anchor_and_creates_no_board(
+        self, outsider_client, workspace, secret_project
+    ):
+        """The response must not carry an anchor, and no board may be created.
+
+        A 403 that still created the DeployBoard would leave the project
+        published even though the API refused the caller.
+        """
+        response = outsider_client.post(
+            deploy_board_url(workspace.slug, secret_project.id), {}, format="json"
+        )
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert "anchor" not in str(getattr(response, "data", "")).lower()
+        assert not DeployBoard.objects.filter(
+            entity_name="project", entity_identifier=secret_project.id
+        ).exists(), "a denied publish must not create a DeployBoard"
+
+    @pytest.mark.django_db
+    def test_project_member_can_publish(self, session_client, workspace, secret_project):
+        """Positive control: scoping POST must not break the legitimate publish."""
+        response = session_client.post(
+            deploy_board_url(workspace.slug, secret_project.id), {}, format="json"
+        )
+        assert response.status_code == status.HTTP_200_OK, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+        assert DeployBoard.objects.filter(
+            entity_name="project", entity_identifier=secret_project.id
+        ).exists()
+
+    @pytest.mark.django_db
+    def test_cannot_publish_another_workspaces_project(
+        self, session_client, workspace, foreign_project
+    ):
+        """Own slug + a foreign project id must not publish the victim's project."""
+        response = session_client.post(
+            deploy_board_url(workspace.slug, foreign_project.id), {}, format="json"
+        )
+        assert response.status_code in (
+            status.HTTP_403_FORBIDDEN,
+            status.HTTP_404_NOT_FOUND,
+        ), f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        assert not DeployBoard.objects.filter(
+            entity_name="project", entity_identifier=foreign_project.id
+        ).exists(), "a cross-workspace publish must not create a DeployBoard"

--- a/apps/api/plane/utils/permissions/project.py
+++ b/apps/api/plane/utils/permissions/project.py
@@ -66,12 +66,16 @@ class ProjectMemberPermission(BasePermission):
                 project_id=view.project_id,
                 is_active=True,
             ).exists()
-        ## Only workspace owners or admins can create the projects
+        # Scope POST to the URL project, as the other two branches already do.
+        # A workspace-only check would let any member create sub-resources in a
+        # project they do not belong to. Kept identical to the copy in
+        # app/permissions/project.py — the two must not drift.
         if request.method == "POST":
-            return WorkspaceMember.objects.filter(
+            return ProjectMember.objects.filter(
                 workspace__slug=view.workspace_slug,
                 member=request.user,
                 role__in=[ROLE.ADMIN.value, ROLE.MEMBER.value],
+                project_id=view.project_id,
                 is_active=True,
             ).exists()
 


### PR DESCRIPTION
## Summary

`ProjectMemberPermission.has_permission` scopes its SAFE_METHODS branch and its trailing (write) branch to `project_id=view.project_id`. **The POST branch checked workspace membership only.** Any workspace MEMBER could therefore create sub-resources in a project they do not belong to.

Verified against `preview` @ `1c8a60f858`. Closes 2 HIGH advisories (SECUR-247 carries the mapping).

## Impact

The reported vector is deploy-board creation — the publish action:

1. Attacker is a role-15 workspace MEMBER with **no `ProjectMember` row** for a `network=0` (Secret) project
2. `POST .../project-deploy-boards/` returns `200` and the **public anchor**
3. Space's `AllowAny` endpoints serve that anchor to **unauthenticated** callers — work-item list and detail, including `description_html`

A second report notes `project_id` from the URL was never checked against `slug`, so a user who owns any workspace on the instance could aim their own slug at another tenant's project id.

## The change

```python
# before — workspace only
if request.method == "POST":
    return WorkspaceMember.objects.filter(
        workspace__slug=view.workspace_slug, member=request.user,
        role__in=[ROLE.ADMIN.value, ROLE.MEMBER.value], is_active=True).exists()

# after — matches the branches either side
    return ProjectMember.objects.filter(
        workspace__slug=view.workspace_slug, member=request.user,
        role__in=[ROLE.ADMIN.value, ROLE.MEMBER.value],
        project_id=view.project_id, is_active=True).exists()
```

Plus `DeployBoardViewSet.create` now validates `project_id` against `slug` before `get_or_create`.

## Blast radius — please read

`ProjectMemberPermission` is shared. I audited every consumer:

| Consumer | POST via this class? | Effect |
| :--- | :--- | :--- |
| `DeployBoardViewSet` | yes | **fixed** — the reported vector |
| `LabelListCreateAPIEndpoint.post` | yes | **also fixed** — a workspace member could create labels in a project they weren't in |
| `LabelDetailAPIEndpoint` | inherits | same |
| `ProjectMemberListCreateAPIEndpoint` | **no** — overrides `get_permissions()` to `ProjectAdminPermission` for non-GET | unaffected |
| `ProjectMemberLiteAPIEndpoint` | GET only | unaffected |

So the diff closes label creation too. That is the same root cause, not scope creep — but it is more than the two advisories name, and worth knowing when reviewing.

**`ProjectBasePermission` is deliberately untouched.** It has a near-identical POST branch at `project.py:25`, but there the workspace-only check is *correct* — it genuinely guards project creation. Its misuse by the archive endpoint is tracked separately (SECUR-249). `ProjectMemberPermission` is not used for project creation anywhere; the stale comment claiming otherwise is likely how this survived review, and is now replaced.

## Update after review

Two Copilot findings, both valid and both fixed in `f494bfd76d`:

**A duplicate permission class.** `plane/utils/permissions/project.py` holds a second `ProjectMemberPermission` which — comments aside — was byte-identical, including the unscoped POST branch. It *is* imported (`api/views/member.py:23`), but its POST branch is currently unreachable: `ProjectMemberListCreateAPIEndpoint.get_permissions()` routes non-GET to `ProjectAdminPermission`, and the other consumer is GET-only. So it was a latent hazard rather than a second live vector. Scoped anyway — two same-named classes that have already drifted make reintroduction easy, and this repo has previously had to patch the same duplication in the page permission classes. Both copies now note they must not drift.

Worth flagging that my original blast-radius audit grepped for the class *name* and never checked import sources, which is how I missed it.

**404 wording.** The new guard said `"Project not found"`; the module already uses `"Project does not exist"` (`base.py:230`). Aligned.

Consolidating the two permission modules is the real fix but is wider than a security patch should carry — worth its own ticket.

I did **not** add `workspace_id` to `get_or_create`'s lookup keys — that changes matching semantics and risks creating duplicate boards against existing rows where `workspace` is null. The validation is a separate guard.

## Tests

Extended `test_deploy_board_project_scope_app.py`, which already covered the SAFE_METHODS sibling of this same class. Four new tests:

- non-project-member publish → 403
- denied publish leaks **no anchor** and creates **no `DeployBoard` row** (a 403 that still created the board would leave the project published)
- **positive control** — project member can still publish
- own slug + foreign project id → rejected, no board created

**Fail-before verified:** 3 failed / 3 passed unpatched → 6 passed patched. The positive control and both pre-existing tests pass in *both* runs, confirming they are independent of the change.

```
6 passed in 4.59s
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted publishing permissions to members of the selected project.
  * Prevented publishing content from projects in another workspace.
  * Invalid or unauthorized publishing requests now return an error without creating a deploy board.
  * Prevented unauthorized users from accessing project publishing data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
