### PR TITLE
[SECUR-248] fix(security): guard ProjectViewSet PUT — routed verb falls through to DRF

### DIFF
--- a/apps/api/plane/app/views/project/base.py
+++ b/apps/api/plane/app/views/project/base.py
@@ -311,6 +311,14 @@ class ProjectViewSet(BaseViewSet):
             return Response(serializer.data, status=status.HTTP_201_CREATED)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
+    def update(self, request, slug, pk=None):
+        # urls/project.py routes PUT here, but this viewset never defined `update`,
+        # so it fell through to DRF's ModelViewSet.update under the default
+        # IsAuthenticated while partial_update on the same URL requires workspace
+        # or project admin. Route PUT through partial_update so both verbs enforce
+        # the same rule; a full PUT-replace is not meaningful for projects.
+        return self.partial_update(request, slug=slug, pk=pk)
+
     def partial_update(self, request, slug, pk=None):
         # try:
         is_workspace_admin = WorkspaceMember.objects.filter(

--- a/apps/api/plane/tests/contract/app/test_project_put_authz.py
+++ b/apps/api/plane/tests/contract/app/test_project_put_authz.py
@@ -1,0 +1,140 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Contract tests for ``ProjectViewSet`` PUT authorization (SECUR-248).
+
+``urls/project.py`` maps ``"put": "update"``, but the viewset never defined
+``update`` — so PUT fell through to DRF's ``ModelViewSet.update``. The class sets
+no ``permission_classes``, so that generic handler ran under the project default
+of ``IsAuthenticated``, while ``partial_update`` on the *identical* URL requires
+workspace admin or project admin.
+
+A workspace member who is not in a Secret project could therefore PUT it to
+``network=2`` (Public) and then use the legitimate public-join API to add
+themselves — full read plus member-level write on a project they were never in.
+"""
+
+from uuid import uuid4
+
+import pytest
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from plane.db.models import Project, ProjectMember, User, WorkspaceMember
+
+pytestmark = [pytest.mark.contract, pytest.mark.django_db]
+
+
+def project_detail_url(slug, project_id):
+    return f"/api/workspaces/{slug}/projects/{project_id}/"
+
+
+def full_put_body(project, workspace, **overrides):
+    """A COMPLETE PUT body.
+
+    DRF's generic update runs the serializer with partial=False, so an incomplete
+    body 400s on validation before authorization differs at all — the test would
+    then pass with or without the fix. A real caller sends every required field.
+    """
+    body = {
+        "name": project.name,
+        "identifier": project.identifier,
+        "workspace": str(workspace.id),
+        "network": project.network,
+    }
+    body.update(overrides)
+    return body
+
+
+@pytest.fixture
+def secret_project(db, workspace, create_user):
+    """A Secret (network=0) project owned by the workspace owner."""
+    project = Project.objects.create(
+        name="Secret Project",
+        identifier=f"S{uuid4().hex[:3].upper()}",
+        workspace=workspace,
+        network=0,
+        created_by=create_user,
+    )
+    ProjectMember.objects.create(project=project, member=create_user, workspace=workspace, role=20, is_active=True)
+    return project
+
+
+@pytest.fixture
+def outsider_client(db, workspace):
+    """A workspace MEMBER with no membership of ``secret_project``.
+
+    Role 15 (member), not admin — partial_update admits workspace admins, so an
+    admin would be authorised on both verbs and could not show the asymmetry.
+    """
+    uid = uuid4().hex[:8]
+    outsider = User.objects.create(email=f"outsider-{uid}@plane.so", username=f"outsider_{uid}")
+    outsider.set_password("pw")
+    outsider.save()
+    WorkspaceMember.objects.create(workspace=workspace, member=outsider, role=15, is_active=True)
+    client = APIClient()
+    client.force_authenticate(user=outsider)
+    return client
+
+
+@pytest.mark.contract
+class TestProjectPutAuthz:
+    def test_non_member_put_is_denied(self, outsider_client, workspace, secret_project):
+        response = outsider_client.put(
+            project_detail_url(workspace.slug, secret_project.id),
+            full_put_body(secret_project, workspace, name="Renamed", network=2),
+            format="json",
+        )
+        assert response.status_code in (
+            status.HTTP_403_FORBIDDEN,
+            status.HTTP_405_METHOD_NOT_ALLOWED,
+        ), f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+
+    def test_denied_put_does_not_change_network(self, outsider_client, workspace, secret_project):
+        """The 403 must also mean nothing was written.
+
+        A denied response that still flipped network=2 would leave the project
+        published — the actual damage, independent of the status code.
+        """
+        outsider_client.put(
+            project_detail_url(workspace.slug, secret_project.id),
+            full_put_body(secret_project, workspace, name="Renamed", network=2),
+            format="json",
+        )
+        secret_project.refresh_from_db()
+        assert secret_project.network == 0, "a denied PUT must not publish the project"
+        assert secret_project.name == "Secret Project", "a denied PUT must not rename the project"
+
+    def test_put_and_patch_agree(self, outsider_client, workspace, secret_project):
+        """PUT and PATCH on the same URL must reach the same verdict.
+
+        The defect was purely that they disagreed: PATCH 403, PUT 200.
+        """
+        put_status = outsider_client.put(
+            project_detail_url(workspace.slug, secret_project.id),
+            full_put_body(secret_project, workspace, name="X", network=2),
+            format="json",
+        ).status_code
+        patch_status = outsider_client.patch(
+            project_detail_url(workspace.slug, secret_project.id),
+            {"network": 2},
+            format="json",
+        ).status_code
+
+        put_allowed = put_status < 400
+        patch_allowed = patch_status < 400
+        assert put_allowed == patch_allowed, (
+            f"PUT and PATCH disagree on the same URL: PUT={put_status}, PATCH={patch_status}"
+        )
+
+    def test_workspace_admin_put_still_works(self, session_client, workspace, secret_project):
+        """Positive control: guarding PUT must not break the legitimate path."""
+        response = session_client.put(
+            project_detail_url(workspace.slug, secret_project.id),
+            full_put_body(secret_project, workspace, name="Renamed By Admin"),
+            format="json",
+        )
+        assert response.status_code < 400, f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        secret_project.refresh_from_db()
+        assert secret_project.name == "Renamed By Admin"

--- a/apps/api/plane/tests/contract/app/test_project_put_authz.py
+++ b/apps/api/plane/tests/contract/app/test_project_put_authz.py
@@ -2,7 +2,10 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # See the LICENSE file for details.
 
-"""Contract tests for ``ProjectViewSet`` PUT authorization (SECUR-248).
+"""Contract tests for ``ProjectViewSet`` PUT authorization.
+
+PUT must enforce the same authorization as PATCH, not fall through to DRF's
+generic handler under the bare default permission class.
 
 ``urls/project.py`` maps ``"put": "update"``, but the viewset never defined
 ``update`` — so PUT fell through to DRF's ``ModelViewSet.update``. The class sets


### PR DESCRIPTION
## Summary

`app/urls/project.py:40` maps `"put": "update"`, but `ProjectViewSet` never defined `update` — so PUT fell through to DRF's `ModelViewSet.update`. The class sets **no `permission_classes`**, so that generic handler ran under the project default of `IsAuthenticated`, while `partial_update` on the *identical* URL does an inline workspace-admin / project-admin check.

PATCH was authorised. PUT was not.

Verified against `preview` @ `1c8a60f858`. Closes 2 HIGH advisories (SECUR-248 carries the mapping).

## Impact — reproduced

A workspace MEMBER with no `ProjectMember` row for a `network=0` (Secret) project:

1. `PUT .../projects/<id>/` with `network: 2` → **`200 OK`**, project becomes Public
2. Join via the legitimate public-project API → `ProjectMember(role=15)`
3. Full read plus member-level write on a project they were never in

Step 1 confirmed in the fail-before run: an unpatched non-member PUT returns `200` and flips `network`.

## The change

```python
def update(self, request, slug, pk=None):
    return self.partial_update(request, slug=slug, pk=pk)
```

Both verbs now enforce the same rule. A full PUT-replace is not a meaningful operation for projects — the client only ever sends PATCH.

This follows the pattern #9461 established for the work-item / module / intake instances of the same defect. It does **not** need that PR's `partial_update.__wrapped__` trick: `ProjectViewSet.partial_update` carries no decorator (it authorises inline), so calling it directly does not double-authorise.

## Tests

Four contract tests:

- non-member PUT is denied
- a denied PUT **writes nothing** — a 403 that still flipped `network` would leave the project published, which is the actual damage
- **PUT and PATCH reach the same verdict** — the defect was precisely that they disagreed
- **positive control** — a workspace admin PUT still succeeds

**Fail-before verified:** 3 failed / 1 passed unpatched → 4 passed patched. The positive control passes in both runs, confirming it is independent of the change.

⚠️ **The payload must be complete.** DRF's generic `update` runs the serializer with `partial=False`, so an incomplete body 400s on validation *before* authorization differs at all — with a partial body the tests passed with and without the fix and proved nothing. `full_put_body()` exists for that reason and the docstring says so.

## Related — a broader finding

The ticket asked for a sweep for other instances. Checking every `as_view({...})` mapping in `app/urls/` against whether the viewset defines that action, then filtering to classes with **no class-level `permission_classes`**:

| | |
| :--- | ---: |
| routed DRF-generic actions the viewset does not define | 68 |
| of those, on classes with no class-level `permission_classes` | 34 |
| already covered by open PR #9461 | 4 |
| `ProjectViewSet` PUT (this PR) | 1 |
| **unaddressed** | **29** |

Examples, all on classes whose *defined* actions carry `@allow_permission`/`@can` while the undefined one gets nothing: `CycleViewSet` PUT, `IssueViewViewSet` POST, `WorkspaceViewViewSet` POST, `NotificationViewSet` DELETE, `StateViewSet` GET, `ModuleIssueViewSet` PUT/PATCH/GET.

I have **not** verified each is exploitable — some may be protected by `get_queryset` scoping, and `create`/`destroy` on a generic mixin may fail for unrelated reasons. That verification is the work. Tracked separately rather than expanding this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved project update authorization for PUT requests.
  - Unauthorized project updates are rejected without changing project details.
  - Workspace administrators can continue updating projects as expected.
  - PUT and PATCH requests now apply consistent authorization rules.

- **Tests**
  - Added coverage for unauthorized member access and protected project updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->