### PR TITLE
fix(cycle): ignore_conflicts on add-issue bulk_create to avoid 500 on concurrent adds

### DIFF
--- a/apps/api/plane/app/views/cycle/issue.py
+++ b/apps/api/plane/app/views/cycle/issue.py
@@ -282,6 +282,12 @@ class CycleIssueViewSet(BaseViewSet):
             ignore_conflicts=True,
         )
 
+        # ON CONFLICT DO NOTHING does not populate PKs on skipped rows, so a
+        # concurrent request that lost the race gets its duplicates back here
+        # with pk=None. Drop them before the activity log below, otherwise it
+        # records a "created" entry for an insert that was silently discarded.
+        created_records = [record for record in created_records if record.pk is not None]
+
         # Updated Issues
         updated_records = []
         update_cycle_issue_activity = []

--- a/apps/api/plane/app/views/cycle/issue.py
+++ b/apps/api/plane/app/views/cycle/issue.py
@@ -274,6 +274,12 @@ class CycleIssueViewSet(BaseViewSet):
                 for issue in new_issues
             ],
             batch_size=10,
+            # Concurrent add-issue requests can both pass the unlocked
+            # existing-issue check above and insert the same (cycle, issue),
+            # violating the cycle_issue_when_deleted_at_null unique constraint.
+            # Skip the duplicates instead of raising, matching the module and
+            # external-API equivalents.
+            ignore_conflicts=True,
         )
 
         # Updated Issues


### PR DESCRIPTION
Fixes #9598.

Adding an issue to a cycle can return a 500 under concurrency. `CycleIssueViewSet.create` filters for issues already in the cycle, subtracts them, and bulk-inserts the rest:

```python
existing_issues = [str(ci.issue_id) for ci in cycle_issues]
new_issues = list(set(issues) - set(existing_issues))
...
created_records = CycleIssue.objects.bulk_create([...], batch_size=10)
```

That existing-issue check is a plain filter with no row lock, so two requests adding the same issue to the same cycle can both compute the same `new_issues` and both reach the insert. `CycleIssue` has a partial unique constraint `cycle_issue_when_deleted_at_null` on `(cycle, issue)` where `deleted_at IS NULL`, so the second insert raises `IntegrityError` and the user gets a 500.

The same operation elsewhere in the codebase already guards against this with `ignore_conflicts=True`:

- `module/issue.py` (`ModuleIssue` add-issue), both bulk_create calls
- `api/views/cycle.py` (the external API's cycle add-issue)

Only this app-API path was missed. This adds `ignore_conflicts=True` to match, so a racing duplicate insert is skipped instead of blowing up the request.

I checked the one place the return value is used: `created_records` is serialized into the cycle activity payload, and the consumer (`create_cycle_issue_activity` in `bgtasks/issue_activities_task.py`) only reads `fields.cycle` and `fields.issue` from it, never the primary key. So the fact that `ignore_conflicts=True` leaves the instance PKs unset does not affect anything downstream. Behavior in the normal (non-racing) case is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when adding issues to cycles concurrently.
  * Duplicate cycle-issue entries are now skipped instead of producing an error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->