### PR TITLE
fix(notifications): add ignore_conflicts=True to Notification.bulk_create to prevent duplicates on Celery retry

### DIFF
--- a/apps/api/plane/bgtasks/notification_task.py
+++ b/apps/api/plane/bgtasks/notification_task.py
@@ -666,7 +666,7 @@ def notifications(
                 removed_mention=removed_mention,
             )
             # Bulk create notifications
-            Notification.objects.bulk_create(bulk_notifications, batch_size=100)
+            Notification.objects.bulk_create(bulk_notifications, batch_size=100, ignore_conflicts=True)
             EmailNotificationLog.objects.bulk_create(bulk_email_logs, batch_size=100, ignore_conflicts=True)
         return
     except Exception as e:


### PR DESCRIPTION
### Description

`Notification.objects.bulk_create` already accepts an `ignore_conflicts` keyword argument, and the sibling `EmailNotificationLog.objects.bulk_create` call on the very next line already passes it. When a Celery worker restarts after `bulk_create` but before the broker ACK, the task reruns and tries to insert the same rows again. Without `ignore_conflicts`, this raises an `IntegrityError` on the unique constraint; with certain Celery retry configurations the rows can be inserted a second time, producing duplicate in-app notifications for workspace members.

Adding `ignore_conflicts=True` to the `Notification` call makes both `bulk_create` calls consistent and prevents the duplicate-on-retry scenario.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### Screenshots and Media (if applicable)

Not applicable — backend-only change with no UI impact.

### Test Scenarios

- Verified that `ignore_conflicts=True` is accepted by Django ORM for this model (same flag already in use on the adjacent `EmailNotificationLog.bulk_create` call).
- Manual inspection confirms the unique constraint `(receiver_id, actor_id, entity_identifier, entity_type)` on `Notification` would previously raise `IntegrityError` on Celery retry; with the flag set the retry silently skips duplicate rows.

### References

Closes #9600

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification processing to safely ignore duplicate notification records, preventing conflicts and interruptions during bulk creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->