### PR TITLE
fix(analytics): scope Cycle and Module lookups by workspace slug to prevent cross-workspace data leak

### DIFF
--- a/apps/api/plane/app/views/analytic/project_analytics.py
+++ b/apps/api/plane/app/views/analytic/project_analytics.py
@@ -193,7 +193,7 @@ class ProjectAdvanceAnalyticsChartEndpoint(ProjectAdvanceAnalyticsBaseView):
             cycle_issues = CycleIssue.objects.filter(**self.filters["base_filters"], cycle_id=cycle_id).values_list(
                 "issue_id", flat=True
             )
-            cycle = Cycle.objects.filter(id=cycle_id).first()
+            cycle = Cycle.objects.filter(id=cycle_id, workspace__slug=self._workspace_slug).first()
             if cycle and cycle.start_date:
                 start_date = cycle.start_date.date()
                 end_date = cycle.end_date.date()
@@ -205,7 +205,7 @@ class ProjectAdvanceAnalyticsChartEndpoint(ProjectAdvanceAnalyticsBaseView):
             module_issues = ModuleIssue.objects.filter(**self.filters["base_filters"], module_id=module_id).values_list(
                 "issue_id", flat=True
             )
-            module = Module.objects.filter(id=module_id).first()
+            module = Module.objects.filter(id=module_id, workspace__slug=self._workspace_slug).first()
             if module and module.start_date:
                 start_date = module.start_date
                 end_date = module.target_date


### PR DESCRIPTION
## What

Add workspace__slug=self._workspace_slug to the Cycle and Module filter calls in the analytics charts endpoint.

## Why

ProjectAdvanceAnalyticsStatsEndpoint and ProjectAdvanceAnalyticsChartEndpoint accept cycle_id and module_id as query params and look them up with only the primary key:

  cycle = Cycle.objects.filter(id=cycle_id).first()    # no workspace scope
  module = Module.objects.filter(id=module_id).first()  # no workspace scope

An authenticated member of Workspace A can supply a cycle or module UUID from Workspace B. Permission validation confirms the caller is a Workspace A member but does not validate that the supplied IDs belong to Workspace A. The response leaks Workspace B start_date and end_date.

## How

before: cycle = Cycle.objects.filter(id=cycle_id).first()
after:  cycle = Cycle.objects.filter(id=cycle_id, workspace__slug=self._workspace_slug).first()

before: module = Module.objects.filter(id=module_id).first()
after:  module = Module.objects.filter(id=module_id, workspace__slug=self._workspace_slug).first()

The existing if cycle and cycle.start_date guards already return an empty response when the lookup returns None.

Closes #9601

harsh4vardhan

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project analytics charts to ensure cycle and module data comes only from the selected workspace.
  * Preserved existing chart behavior while preventing unrelated workspace data from appearing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->