### PR TITLE
fix(email): use SELECT FOR UPDATE SKIP LOCKED to prevent duplicate email dispatch on concurrent Celery Beat runs

### DIFF
--- a/apps/api/plane/bgtasks/email_notification_task.py
+++ b/apps/api/plane/bgtasks/email_notification_task.py
@@ -45,15 +45,30 @@ def release_lock(lock_id):
 
 @shared_task
 def stack_email_notification():
-    # get all email notifications
-    email_notifications = EmailNotificationLog.objects.filter(processed_at__isnull=True).order_by("receiver").values()
+    # Claim unprocessed records inside an atomic transaction using SELECT FOR UPDATE SKIP LOCKED.
+    # This prevents concurrent Celery workers (e.g., overlapping Beat runs on multi-pod deployments)
+    # from reading the same rows and dispatching duplicate emails.
+    from django.db import transaction as db_transaction
+    with db_transaction.atomic():
+        email_notifications = list(
+            EmailNotificationLog.objects.filter(processed_at__isnull=True)
+            .select_for_update(skip_locked=True)
+            .order_by("receiver")
+            .values()
+        )
+
+        if not email_notifications:
+            return
+
+        # Mark the claimed rows as processed immediately so other workers skip them.
+        claimed_ids = [n.get("id") for n in email_notifications]
+        EmailNotificationLog.objects.filter(pk__in=claimed_ids).update(processed_at=timezone.now())
 
     # Create the below format for each of the issues
     # {"issue_id" : { "actor_id1": [ { data }, { data } ], "actor_id2": [ { data }, { data } ] }}
 
     # Convert to unique receivers list
     receivers = list(set([str(notification.get("receiver_id")) for notification in email_notifications]))
-    processed_notifications = []
     # Loop through all the issues to create the emails
     for receiver_id in receivers:
         # Notification triggered for the receiver
@@ -67,8 +82,6 @@ def stack_email_notification():
             payload.setdefault(receiver_notification.get("entity_identifier"), {}).setdefault(
                 str(receiver_notification.get("triggered_by_id")), []
             ).append(receiver_notification.get("data"))
-            # append processed notifications
-            processed_notifications.append(receiver_notification.get("id"))
             email_notification_ids.append(receiver_notification.get("id"))
 
         # Create emails for all the issues
@@ -79,9 +92,6 @@ def stack_email_notification():
                 receiver_id=receiver_id,
                 email_notification_ids=email_notification_ids,
             )
-
-    # Update the email notification log
-    EmailNotificationLog.objects.filter(pk__in=processed_notifications).update(processed_at=timezone.now())
 
 
 def create_payload(notification_data):


### PR DESCRIPTION
## What

Rewrite the read-dispatch-update sequence in stack_email_notification to claim rows atomically with select_for_update(skip_locked=True) before dispatching.

## Why

stack_email_notification currently:
1. Reads unprocessed records
2. Dispatches email sub-tasks
3. Marks records as processed (after dispatch)

In multi-pod deployments, or when task execution exceeds the 5-minute Beat schedule, two workers execute the task concurrently. Both read the same unprocessed rows at step 1, dispatch duplicates at step 2, and both mark the same rows at step 3. Every subscriber receives duplicate emails.

## How

Wrap steps 1 and 3 in a single transaction.atomic() block and apply select_for_update(skip_locked=True) to the query. A second concurrent worker skips rows already locked by the first. Rows are marked processed_at inside the transaction (before dispatch) so no row is dispatched twice.

Closes #9602

harsh4vardhan

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved email notification processing when multiple jobs run at the same time.
  * Notifications are now claimed and marked as processed more reliably, reducing duplicate handling.
  * Notification jobs now exit cleanly when no pending notifications are available.
  * Email delivery status updates continue to be tracked after notifications are dispatched.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->