### PR TITLE
fix(web): stop the command palette re-filtering server search results

### DIFF
--- a/apps/web/core/components/navigation/top-nav-power-k.tsx
+++ b/apps/web/core/components/navigation/top-nav-power-k.tsx
@@ -14,6 +14,7 @@ import { cn } from "@plane/utils";
 // power-k
 import type { TPowerKCommandConfig, TPowerKContext } from "@/components/power-k/core/types";
 import { ProjectsAppPowerKCommandsList } from "@/components/power-k/ui/modal/commands-list";
+import { powerKCommandFilter } from "@/components/power-k/ui/modal/filter";
 import { PowerKModalFooter } from "@/components/power-k/ui/modal/footer";
 import { useIssueDetail } from "@/hooks/store/use-issue-detail";
 import { usePowerK } from "@/hooks/store/use-power-k";
@@ -256,11 +257,7 @@ export const TopNavPowerK = observer(() => {
       >
         {isOpen && (
           <Command
-            filter={(i18nValue: string, search: string) => {
-              if (i18nValue === "no-results") return 1;
-              if (i18nValue.toLowerCase().includes(search.toLowerCase())) return 1;
-              return 0;
-            }}
+            filter={powerKCommandFilter}
             shouldFilter={searchTerm.length > 0}
             className="flex h-full w-full flex-col"
           >

--- a/apps/web/core/components/power-k/ui/modal/filter.ts
+++ b/apps/web/core/components/power-k/ui/modal/filter.ts
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2023-present Plane Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+/**
+ * Prefix marking a `Command.Item` whose match was decided by the search API
+ * rather than by the text cmdk can see.
+ */
+export const POWER_K_SERVER_RESULT_PREFIX = "server-result:";
+
+/**
+ * Filter for the Power-K palette.
+ *
+ * Static commands still match on their visible label. Server-driven search
+ * results are passed through untouched: the API matched them against fields
+ * the palette never renders — a work item's description, for one — so
+ * re-filtering here on the visible title would silently discard exactly the
+ * results the search was meant to surface. It would also drop multi-word
+ * matches whose words are not adjacent in the title, since this is a
+ * contiguous substring test.
+ */
+export const powerKCommandFilter = (value: string, search: string): number => {
+  if (value === "no-results") return 1;
+  if (value.startsWith(POWER_K_SERVER_RESULT_PREFIX)) return 1;
+  return value.toLowerCase().includes(search.toLowerCase()) ? 1 : 0;
+};

--- a/apps/web/core/components/power-k/ui/modal/search-results.tsx
+++ b/apps/web/core/components/power-k/ui/modal/search-results.tsx
@@ -13,6 +13,7 @@ import type { IWorkspaceSearchResults } from "@plane/types";
 import { useAppRouter } from "@/hooks/use-app-router";
 // helpers
 import { PowerKModalCommandItem } from "./command-item";
+import { POWER_K_SERVER_RESULT_PREFIX } from "./filter";
 import { POWER_K_SEARCH_RESULTS_GROUPS_MAP } from "./search-results-map";
 
 type Props = {
@@ -40,7 +41,7 @@ export const PowerKModalSearchResults = observer(function PowerKModalSearchResul
         return (
           <Command.Group key={key} heading={currentSection.title}>
             {section.map((item) => {
-              let value = `${key}-${item?.id}-${item.name}`;
+              let value = `${POWER_K_SERVER_RESULT_PREFIX}${key}-${item?.id}-${item.name}`;
 
               if ("project__identifier" in item) {
                 value = `${value}-${item.project__identifier}`;

--- a/apps/web/core/components/power-k/ui/modal/wrapper.tsx
+++ b/apps/web/core/components/power-k/ui/modal/wrapper.tsx
@@ -13,6 +13,7 @@ import { usePowerK } from "@/hooks/store/use-power-k";
 // local imports
 import type { TPowerKCommandConfig, TPowerKContext } from "../../core/types";
 import type { TPowerKCommandsListProps } from "./commands-list";
+import { powerKCommandFilter } from "./filter";
 import { PowerKModalFooter } from "./footer";
 import { PowerKModalHeader } from "./header";
 
@@ -145,11 +146,7 @@ export const ProjectsAppPowerKModalWrapper = observer(function ProjectsAppPowerK
             >
               <Dialog.Panel className="divide-opacity-10 relative flex w-full max-w-2xl transform flex-col items-center justify-center divide-y divide-subtle-1 rounded-lg bg-surface-1 shadow-raised-200 transition-all">
                 <Command
-                  filter={(i18nValue: string, search: string) => {
-                    if (i18nValue === "no-results") return 1;
-                    if (i18nValue.toLowerCase().includes(search.toLowerCase())) return 1;
-                    return 0;
-                  }}
+                  filter={powerKCommandFilter}
                   shouldFilter={searchTerm.length > 0}
                   onKeyDown={handleKeyDown}
                   className="w-full"


### PR DESCRIPTION
### Description

The command palette asks the search API for results and then discards the ones whose match it cannot see.

Both `power-k/ui/modal/wrapper.tsx` and `navigation/top-nav-power-k.tsx` pass `cmdk` this filter:

```ts
filter={(i18nValue: string, search: string) => {
  if (i18nValue === "no-results") return 1;
  if (i18nValue.toLowerCase().includes(search.toLowerCase())) return 1;
  return 0;
}}
```

An item's value is built in `search-results.tsx` from its title, project identifier and sequence id. But `GlobalSearchEndpoint` does not match on those fields alone — it also matches a work item by `sequence_id` against any number in the query, and such a work item's title need not contain the query at all. The `includes()` test then fails and the item is removed from the DOM entirely.

**Reproduction on a stock instance.** Search `<any word> <an issue number>` — for example `level 3 rate`, in a workspace where some work item is numbered 3:

```
GET /api/workspaces/<slug>/search/?search=level%203%20rate&workspace_search=true&entities=issue
  -> results.issue = ["DUROPC-3", "MEASU-3"]

document.querySelectorAll('[cmdk-item]')
  -> []
```

The network tab shows results arriving while the palette says there are none.

The general defect is broader than the `sequence_id` case: the server has already decided the match, against columns the client cannot inspect, so re-deciding it on the visible title can only ever discard correct results. Any future widening of what the endpoint searches would be silently invisible in the UI.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [x] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

The refactoring box is ticked because the filter was duplicated verbatim between the two palettes; it is extracted to a single `powerKCommandFilter` rather than fixed twice.

### Approach

Static commands genuinely need client-side filtering — they are rendered up front and narrowed as you type — so that behaviour is unchanged.

Server-driven results are passed through untouched, marked by a `server-result:` prefix on the item value. This follows the escape hatch the existing `no-results` sentinel already established in the same function, rather than introducing a new mechanism.

Net change is −11/+6 across three files, plus one new 28-line module.

### Test Scenarios

- **Before/after on the reproduction above**: the two work items matched by `sequence_id` now render; previously `[cmdk-item]` was empty while the API returned both.
- **Static commands unaffected**: typing `theme`, `settings`, `invite` still narrows the Create/Navigate/Account/Preferences groups exactly as before.
- **Title matches unaffected**: a query that is a contiguous substring of a title behaves identically.
- **Both palettes**: verified in the ⌘K modal and the top-nav palette, which had separate copies of the filter.
- `pnpm exec oxfmt --check` clean on the four touched files; `oxlint --max-warnings=11957` passes.
- `docker build -f ./apps/web/Dockerfile.web` succeeds against this branch, and the built bundle contains the new filter.

Verified against a self-hosted instance seeded with real data, on `preview` (`1c8a60f8`).

### References

Related, though this fixes the client half only and neither depends on it: #3370, #7108.

---

Developed with AI assistance; every claim above was reproduced and verified by hand against a running instance before submitting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Power-K command search consistency across navigation and modal interfaces.
  - Server-provided search results now remain visible alongside locally matched commands.
  - Preserved the no-results state while applying case-insensitive matching to static commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->