### PR TITLE
fix(proxy): restore /spaces and /god-mode trailing-slash redirects in AIO config

### DIFF
--- a/apps/proxy/Caddyfile.aio.ce
+++ b/apps/proxy/Caddyfile.aio.ce
@@ -3,6 +3,7 @@
 		max_size {$FILE_SIZE_LIMIT}
 	}
 
+    redir /spaces /spaces/ permanent
     handle /spaces/* {
         reverse_proxy localhost:3002
     }
@@ -18,6 +19,7 @@
         reverse_proxy localhost:3004
     }
 
+	redir /god-mode /god-mode/ permanent
 	handle_path /god-mode* {
         root * /app/admin
         try_files {path} {path}/ /index.html


### PR DESCRIPTION
## Description

`apps/proxy/Caddyfile.ce` redirects the two single-page apps to their trailing-slash form:

```
redir /spaces /spaces/ permanent
redir /god-mode /god-mode/ permanent
```

`apps/proxy/Caddyfile.aio.ce` — the all-in-one variant of the same config — has neither. As a result, on
an AIO deployment `https://<host>/spaces` and `https://<host>/god-mode` (no trailing slash) fall through
to the catch-all `handle_path /*` block and are served the web app's `index.html`, which renders an empty
page. With the trailing slash both work. Every other path in the config is fine without one, so the
failure looks like a broken instance rather than a missing slash.

This PR adds the two `redir` lines to the AIO config, next to the blocks they belong to, mirroring how
`Caddyfile.ce` places them.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Diff

```diff
--- a/apps/proxy/Caddyfile.aio.ce
+++ b/apps/proxy/Caddyfile.aio.ce
@@
 (plane_proxy) {
 	request_body {
 		max_size {$FILE_SIZE_LIMIT}
 	}
 
+    redir /spaces /spaces/ permanent
     handle /spaces/* {
         reverse_proxy localhost:3002
     }
@@
+    redir /god-mode /god-mode/ permanent
     handle_path /god-mode* {
         root * /app/admin
         try_files {path} {path}/ /index.html
         file_server
     }
```

## Test scenarios

Built the community AIO image and requested both paths through the proxy:

| Request | Before | After |
|---|---|---|
| `GET /spaces` | 200, empty page (web app `index.html`) | 308 → `/spaces/`, app loads |
| `GET /spaces/` | works | works |
| `GET /god-mode` | 200, empty page | 308 → `/god-mode/`, admin loads |
| `GET /god-mode/` | works | works |
| `GET /` and `/api/*` | unchanged | unchanged |

Note on placement: Caddy applies its own directive order, so these lines are effective anywhere inside the
site block; they are placed next to the matching handlers purely for readability, as in `Caddyfile.ce`.

## References

Behaviour observed on `makeplane/plane-aio-community:v1.4.1`; config compared against `apps/proxy/Caddyfile.ce`
at `preview`. We currently carry this as a local patch on a self-managed instance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added permanent redirects so `/spaces` and `/god-mode` consistently resolve to their slash-terminated URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->