### PR TITLE
fix(aio): exec supervisord so the container handles stop signals

### DIFF
--- a/deployments/aio/community/start.sh
+++ b/deployments/aio/community/start.sh
@@ -189,7 +189,7 @@ main(){
     # load plane.env as exported variables
     export $(grep -v '^#' plane.env | xargs)
 
-    /usr/local/bin/supervisord -c /etc/supervisor/conf.d/supervisor.conf
+    exec /usr/local/bin/supervisord -c /etc/supervisor/conf.d/supervisor.conf
 }
 
 main "$@"


### PR DESCRIPTION
## Description

`main()` in the AIO entrypoint ends by launching supervisord as a child process:

```sh
    /usr/local/bin/supervisord -c /etc/supervisor/conf.d/supervisor.conf
```

Because it is not `exec`'d, PID 1 stays `bash` running `start.sh`. A non-interactive bash ignores `SIGINT`
and does not forward signals to children, so a stop signal sent to the container reaches nothing that acts
on it: supervisord never begins its shutdown, and the runtime waits out its full stop timeout before
killing the container. On Docker (`SIGTERM`, 10 s default) this shows up as every `docker stop` taking the
full grace period; on platforms that send `SIGINT` — Fly.io, for example — the container sits until the
hard kill.

Adding `exec` makes supervisord PID 1, so it receives signals directly and shuts its programs down. In our
deployment container stop went from the full timeout to about two seconds.

The call is the last statement of `main()`, followed only by `main "$@"`, so `exec` replaces the shell
without skipping any code.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Diff

```diff
--- a/deployments/aio/community/start.sh
+++ b/deployments/aio/community/start.sh
@@ main(){
     # load plane.env as exported variables
     export $(grep -v '^#' plane.env | xargs)
 
-    /usr/local/bin/supervisord -c /etc/supervisor/conf.d/supervisor.conf
+    exec /usr/local/bin/supervisord -c /etc/supervisor/conf.d/supervisor.conf
 }
```

## Test scenarios

| Check | Before | After |
|---|---|---|
| `ps` inside a running container | PID 1 is `bash /app/start.sh` | PID 1 is `supervisord` |
| `docker stop` (SIGTERM) | waits the full grace period, then SIGKILL | exits in ~2 s, programs shut down |
| stop signal `SIGINT` (Fly.io) | ignored; container waits for hard kill | supervisord shuts down |
| normal startup, all services | unchanged | unchanged |

## References

Observed on `makeplane/plane-aio-community:v1.4.1` running on Fly.io, where the stop signal is `SIGINT`.
We currently carry this as a local patch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved application process handling during startup by running Supervisor directly as the main process.
  * Existing Supervisor configuration and startup behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->