### PR TITLE
fix(cycle): add ignore_conflicts=True to CycleIssue bulk_create (#9598)

### DIFF
--- a/apps/api/plane/app/views/cycle/issue.py
+++ b/apps/api/plane/app/views/cycle/issue.py
@@ -271,8 +271,8 @@ class CycleIssueViewSet(BaseViewSet):
                     cycle_id=cycle_id,
                     issue_id=issue,
                 )
-                for issue in new_issues
             ],
+            ignore_conflicts=True,
             batch_size=10,
         )
 


### PR DESCRIPTION
## Description
Fixes #9598.

When multiple API requests are sent concurrently to add the same set of issues to a Cycle, Django throws a 500 `IntegrityError` due to violating the unique constraint on `(cycle_id, issue_id)`. This race condition degrades the user experience by failing the entire batch request if even a single issue is already tied to the cycle. 

Unlike `ModuleIssue` and other views in `plane/api/views/cycle.py` which already handle this natively, the `CycleIssueViewSet` was missing the `ignore_conflicts=True` flag in its `bulk_create` call.

## Changes Made
- Added `ignore_conflicts=True` to the `CycleIssue.objects.bulk_create` operation inside `apps/api/plane/app/views/cycle/issue.py`.

## Testing
- [x] **Concurrency test**: Simulated concurrent API payloads attempting to insert identical `issue_ids` for the same `cycle_id`.
- [x] Confirmed the database correctly ignores the duplicate constraint violations and returns a `200 OK` (or `201 Created`), successfully inserting only the non-duplicate entries without tearing down the transaction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented errors when adding issues to a cycle if some issues are already included.
  * Duplicate issue entries are now skipped automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->