### PR TITLE
fix(api): notify subscribers on comment, link and work item delete via REST API

### DIFF
--- a/apps/api/plane/api/views/issue.py
+++ b/apps/api/plane/api/views/issue.py
@@ -871,6 +871,8 @@ class IssueDetailAPIEndpoint(BaseAPIView):
             project_id=str(project_id),
             current_instance=current_instance,
             epoch=int(timezone.now().timestamp()),
+            notification=True,
+            origin=base_host(request=request, is_app=True),
         )
         return Response(status=status.HTTP_204_NO_CONTENT)
 
@@ -1208,6 +1210,8 @@ class IssueLinkListCreateAPIEndpoint(BaseAPIView):
                 actor_id=str(link.created_by_id),
                 current_instance=None,
                 epoch=int(timezone.now().timestamp()),
+                notification=True,
+                origin=base_host(request=request, is_app=True),
             )
             serializer = IssueLinkSerializer(link)
             return Response(serializer.data, status=status.HTTP_201_CREATED)
@@ -1319,6 +1323,8 @@ class IssueLinkDetailAPIEndpoint(BaseAPIView):
                 project_id=str(project_id),
                 current_instance=current_instance,
                 epoch=int(timezone.now().timestamp()),
+                notification=True,
+                origin=base_host(request=request, is_app=True),
             )
             serializer = IssueLinkSerializer(issue_link)
             return Response(serializer.data, status=status.HTTP_200_OK)
@@ -1352,6 +1358,8 @@ class IssueLinkDetailAPIEndpoint(BaseAPIView):
             project_id=str(project_id),
             current_instance=current_instance,
             epoch=int(timezone.now().timestamp()),
+            notification=True,
+            origin=base_host(request=request, is_app=True),
         )
         issue_link.delete()
         return Response(status=status.HTTP_204_NO_CONTENT)
@@ -1495,6 +1503,8 @@ class IssueCommentListCreateAPIEndpoint(BaseAPIView):
                 project_id=str(self.kwargs.get("project_id")),
                 current_instance=None,
                 epoch=int(timezone.now().timestamp()),
+                notification=True,
+                origin=base_host(request=request, is_app=True),
             )
 
             # Send the model activity
@@ -1635,6 +1645,8 @@ class IssueCommentDetailAPIEndpoint(BaseAPIView):
                 project_id=str(project_id),
                 current_instance=current_instance,
                 epoch=int(timezone.now().timestamp()),
+                notification=True,
+                origin=base_host(request=request, is_app=True),
             )
             # Send the model activity
             model_activity.delay(
@@ -1681,6 +1693,8 @@ class IssueCommentDetailAPIEndpoint(BaseAPIView):
             project_id=str(project_id),
             current_instance=current_instance,
             epoch=int(timezone.now().timestamp()),
+            notification=True,
+            origin=base_host(request=request, is_app=True),
         )
         return Response(status=status.HTTP_204_NO_CONTENT)
 

--- a/apps/api/plane/api/views/issue.py
+++ b/apps/api/plane/api/views/issue.py
@@ -1497,7 +1497,13 @@ class IssueCommentListCreateAPIEndpoint(BaseAPIView):
 
             issue_activity.delay(
                 type="comment.activity.created",
-                requested_data=json.dumps(serializer.data, cls=DjangoJSONEncoder),
+                # Serialize the saved comment rather than the write serializer: the
+                # latter carries no ``id``, so ``create_comment_activity`` stores the
+                # activity with ``issue_comment_id=None`` and ``notification_task``
+                # then skips comment-mention extraction entirely, which is gated on
+                # that field. The update path already reads the id out of
+                # ``current_instance``, which is why only creates lose mentions.
+                requested_data=json.dumps(IssueCommentSerializer(issue_comment).data, cls=DjangoJSONEncoder),
                 actor_id=str(issue_comment.created_by_id),
                 issue_id=str(self.kwargs.get("issue_id")),
                 project_id=str(self.kwargs.get("project_id")),

--- a/apps/api/plane/tests/conftest.py
+++ b/apps/api/plane/tests/conftest.py
@@ -9,6 +9,33 @@ from pytest_django.fixtures import django_db_setup
 from plane.db.models import User, Workspace, WorkspaceMember
 from plane.db.models.api import APIToken
 
+# Every external-API test authenticates with this one token, so they all share a
+# single ``ApiKeyRateThrottle`` bucket keyed on it.
+TEST_API_TOKEN = "test-api-token-12345"
+
+
+@pytest.fixture(autouse=True)
+def reset_api_key_throttle():
+    """Give each test the full external-API rate limit.
+
+    ``ApiKeyRateThrottle`` keys its bucket on the API token and stores the
+    request history in the Django cache, which is a real Redis in CI and is not
+    rolled back with the database. Because every test reuses ``TEST_API_TOKEN``,
+    the history accumulates across the session until the suite crosses
+    ``API_KEY_RATE_LIMIT`` (60/minute) and later tests start failing with 429s
+    that have nothing to do with what they assert.
+
+    That makes the suite order- and size-dependent: adding tests anywhere can
+    break unrelated ones further down. Clearing the bucket around each test
+    keeps the limit per-test, which is what these tests assume.
+    """
+    from django.core.cache import cache
+
+    key = f"api_key:{TEST_API_TOKEN}"
+    cache.delete(key)
+    yield
+    cache.delete(key)
+
 
 @pytest.fixture(scope="session")
 def django_db_setup(django_db_setup):  # noqa: F811
@@ -52,7 +79,7 @@ def api_token(db, create_user):
     token = APIToken.objects.create(
         user=create_user,
         label="Test API Token",
-        token="test-api-token-12345",
+        token=TEST_API_TOKEN,
     )
     return token
 

--- a/apps/api/plane/tests/contract/api/test_comment_link_notifications.py
+++ b/apps/api/plane/tests/contract/api/test_comment_link_notifications.py
@@ -1,0 +1,204 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Notification parity for the remaining external REST API write paths.
+
+makeplane/plane#9307 fixed this for work item create/update, but the same
+omission was left on comments, links, and work item deletion: those endpoints
+dispatched ``issue_activity`` without ``notification=True``, so the activity was
+recorded and webhooks fired while subscribers were never notified. The web app
+(``plane.app.views.issue``) passes the flag on every one of these paths, so the
+external API was silently the odd one out.
+
+These assert the dispatch contract rather than the delivered notification.
+``notification=True`` is what gates ``notifications.delay(...)`` in
+``issue_activities_task``; the fan-out itself is already covered downstream, and
+mocking at the dispatch boundary keeps these tests from depending on Celery.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from rest_framework import status
+
+from plane.db.models import Issue, IssueComment, IssueLink, Project, ProjectMember, State
+
+
+@pytest.fixture
+def project(db, workspace, create_user):
+    """A project with the user as admin and a default state."""
+    project = Project.objects.create(
+        name="Test Project",
+        identifier="TP",
+        workspace=workspace,
+        created_by=create_user,
+    )
+    ProjectMember.objects.create(project=project, member=create_user, role=20, is_active=True)
+    State.objects.create(
+        name="Backlog",
+        color="#000000",
+        group="backlog",
+        default=True,
+        project=project,
+        workspace=workspace,
+        created_by=create_user,
+    )
+    return project
+
+
+@pytest.fixture
+def create_issue(db, project, workspace, create_user):
+    return Issue.objects.create(
+        name="Existing Issue",
+        project=project,
+        workspace=workspace,
+        created_by=create_user,
+    )
+
+
+@pytest.fixture
+def create_comment(db, project, workspace, create_issue, create_user):
+    return IssueComment.objects.create(
+        comment_html="<p>Existing comment</p>",
+        issue=create_issue,
+        project=project,
+        workspace=workspace,
+        actor=create_user,
+        created_by=create_user,
+    )
+
+
+@pytest.fixture
+def create_link(db, project, workspace, create_issue, create_user):
+    return IssueLink.objects.create(
+        url="https://example.com/original",
+        issue=create_issue,
+        project=project,
+        workspace=workspace,
+        created_by=create_user,
+    )
+
+
+def _dispatched(mock):
+    """The single ``issue_activity.delay`` kwargs dict for this request."""
+    mock.delay.assert_called_once()
+    return mock.delay.call_args.kwargs
+
+
+@pytest.mark.contract
+class TestCommentNotificationContract:
+    """Comment writes through ``/api/v1/...`` must notify, as the web app does."""
+
+    def url(self, workspace, project, issue, pk=None):
+        base = f"/api/v1/workspaces/{workspace.slug}/projects/{project.id}/issues/{issue.id}/comments/"
+        return f"{base}{pk}/" if pk else base
+
+    @pytest.mark.django_db
+    def test_create_comment_notifies(self, api_key_client, workspace, project, create_issue):
+        with patch("plane.api.views.issue.issue_activity") as activity:
+            response = api_key_client.post(
+                self.url(workspace, project, create_issue),
+                {"comment_html": "<p>New comment</p>"},
+                format="json",
+            )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        kwargs = _dispatched(activity)
+        assert kwargs["type"] == "comment.activity.created"
+        assert kwargs["notification"] is True
+        assert kwargs["origin"]
+
+    @pytest.mark.django_db
+    def test_update_comment_notifies(self, api_key_client, workspace, project, create_issue, create_comment):
+        with patch("plane.api.views.issue.issue_activity") as activity:
+            response = api_key_client.patch(
+                self.url(workspace, project, create_issue, create_comment.id),
+                {"comment_html": "<p>Edited comment</p>"},
+                format="json",
+            )
+
+        assert response.status_code == status.HTTP_200_OK
+        kwargs = _dispatched(activity)
+        assert kwargs["type"] == "comment.activity.updated"
+        assert kwargs["notification"] is True
+        assert kwargs["origin"]
+
+    @pytest.mark.django_db
+    def test_delete_comment_notifies(self, api_key_client, workspace, project, create_issue, create_comment):
+        with patch("plane.api.views.issue.issue_activity") as activity:
+            response = api_key_client.delete(self.url(workspace, project, create_issue, create_comment.id))
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        kwargs = _dispatched(activity)
+        assert kwargs["type"] == "comment.activity.deleted"
+        assert kwargs["notification"] is True
+        assert kwargs["origin"]
+
+
+@pytest.mark.contract
+class TestLinkNotificationContract:
+    """Link writes through ``/api/v1/...`` must notify, as the web app does."""
+
+    def url(self, workspace, project, issue, pk=None):
+        base = f"/api/v1/workspaces/{workspace.slug}/projects/{project.id}/issues/{issue.id}/links/"
+        return f"{base}{pk}/" if pk else base
+
+    @pytest.mark.django_db
+    def test_create_link_notifies(self, api_key_client, workspace, project, create_issue):
+        with patch("plane.api.views.issue.issue_activity") as activity:
+            response = api_key_client.post(
+                self.url(workspace, project, create_issue),
+                {"url": "https://example.com/spec"},
+                format="json",
+            )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        kwargs = _dispatched(activity)
+        assert kwargs["type"] == "link.activity.created"
+        assert kwargs["notification"] is True
+        assert kwargs["origin"]
+
+    @pytest.mark.django_db
+    def test_update_link_notifies(self, api_key_client, workspace, project, create_issue, create_link):
+        with patch("plane.api.views.issue.issue_activity") as activity:
+            response = api_key_client.patch(
+                self.url(workspace, project, create_issue, create_link.id),
+                {"url": "https://example.com/updated"},
+                format="json",
+            )
+
+        assert response.status_code == status.HTTP_200_OK
+        kwargs = _dispatched(activity)
+        assert kwargs["type"] == "link.activity.updated"
+        assert kwargs["notification"] is True
+        assert kwargs["origin"]
+
+    @pytest.mark.django_db
+    def test_delete_link_notifies(self, api_key_client, workspace, project, create_issue, create_link):
+        with patch("plane.api.views.issue.issue_activity") as activity:
+            response = api_key_client.delete(self.url(workspace, project, create_issue, create_link.id))
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        kwargs = _dispatched(activity)
+        assert kwargs["type"] == "link.activity.deleted"
+        assert kwargs["notification"] is True
+        assert kwargs["origin"]
+
+
+@pytest.mark.contract
+class TestIssueDeleteNotificationContract:
+    """#9307 covered create and update; deletion was left behind."""
+
+    @pytest.mark.django_db
+    def test_delete_issue_notifies(self, api_key_client, workspace, project, create_issue):
+        url = f"/api/v1/workspaces/{workspace.slug}/projects/{project.id}/issues/{create_issue.id}/"
+
+        with patch("plane.api.views.issue.issue_activity") as activity:
+            response = api_key_client.delete(url)
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        kwargs = _dispatched(activity)
+        assert kwargs["type"] == "issue.activity.deleted"
+        assert kwargs["notification"] is True
+        assert kwargs["origin"]

--- a/apps/api/plane/tests/contract/api/test_comment_link_notifications.py
+++ b/apps/api/plane/tests/contract/api/test_comment_link_notifications.py
@@ -17,6 +17,7 @@ These assert the dispatch contract rather than the delivered notification.
 mocking at the dispatch boundary keeps these tests from depending on Celery.
 """
 
+import json
 from unittest.mock import patch
 
 import pytest
@@ -108,6 +109,28 @@ class TestCommentNotificationContract:
         assert kwargs["type"] == "comment.activity.created"
         assert kwargs["notification"] is True
         assert kwargs["origin"]
+
+    @pytest.mark.django_db
+    def test_create_comment_activity_carries_the_comment_id(self, api_key_client, workspace, project, create_issue):
+        """Without the id, notifying is not enough — @mentions are still dropped.
+
+        ``create_comment_activity`` sets ``issue_comment_id`` from
+        ``requested_data["id"]``, and ``notification_task`` gates *all*
+        comment-mention extraction on that field being set. Serializing the write
+        serializer leaves it null, so a mention in an API-created comment notifies
+        nobody even once ``notification=True`` is passed. Comment *updates* are
+        unaffected, because they read the id from ``current_instance``.
+        """
+        with patch("plane.api.views.issue.issue_activity") as activity:
+            response = api_key_client.post(
+                self.url(workspace, project, create_issue),
+                {"comment_html": "<p>Mentioning someone</p>"},
+                format="json",
+            )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        requested = json.loads(_dispatched(activity)["requested_data"])
+        assert requested.get("id") == response.json()["id"]
 
     @pytest.mark.django_db
     def test_update_comment_notifies(self, api_key_client, workspace, project, create_issue, create_comment):


### PR DESCRIPTION
## Summary

Follow-on to #9307 / #9306. That fix made work items created or updated through the
external REST API notify subscribers. The same omission was left on **every other write
path** in `plane/api/views/issue.py`.

`issue_activity.delay(...)` was dispatched **without `notification=True`**, and that flag
is what gates `notifications.delay(...)` in `issue_activities_task`. So these paths
recorded activity and fired webhooks while subscribers were never notified and no email
was sent.

| Path | Activity | Web app notifies | External API notified |
|---|---|---|---|
| Comment create | `comment.activity.created` | yes | **no** |
| Comment update | `comment.activity.updated` | yes | **no** |
| Comment delete | `comment.activity.deleted` | yes | **no** |
| Link create | `link.activity.created` | yes | **no** |
| Link update | `link.activity.updated` | yes | **no** |
| Link delete | `link.activity.deleted` | yes | **no** |
| Work item delete | `issue.activity.deleted` | yes | **no** |

The user-visible effect: **commenting through the API is silent**, while the identical
action in the web app notifies normally — `plane/app/views/issue/*` passes
`notification=True` on all of these. After this change all 14 `issue_activity.delay`
sites in the file are consistent.

Also worth noting: `notification_task` auto-subscribes the actor to the work item *inside*
the notification path, so an API comment never subscribes its author either — they then
miss subsequent activity on that item as well.

## Verified on a live instance

Traced before writing the fix, to rule out configuration: SMTP healthy, notification
preferences on, 74 items subscribed, and the mail log showed delivery for *reactions* on
the same work item — but zero notifications for 14 comments posted through the API that
day. The dispatch never asks for a notification, so no configuration produces one.

## Question for maintainers — how should bulk/sync callers opt out?

This is the part I would most like guidance on, and I have deliberately **not** guessed.

These paths now notify unconditionally: `notification=True` is hardcoded at the call site,
matching the web app and #9307. **There is no per-request opt-out and an API client cannot
influence it.**

Ongoing integration traffic seems fine — `notification_task` excludes the actor, so a bot
commenting under its own token never notifies itself, recipients are limited to active
project members and subscribers, and email is already batched by
`stack_email_notification`. The case I am unsure about is a **bulk backfill**: importing
historical comments through the API would notify every subscriber once, with no way to
suppress it. The web app never hits this because it is human-paced.

Upstream already draws this distinction — `IssueBulkUpdateDateEndpoint` in
`app/views/issue/base.py` omits the flag deliberately — but there is no equivalent signal
on the external API. Two candidates that need no new public surface:

1. **`external_source` / `external_id`** — already writable on `IssueCommentSerializer`.
   A comment carrying these is by definition a mirrored record from another system rather
   than a fresh human action, which maps closely onto the import case.
2. **`APIToken.user_type == Bot` / `is_service`** — already first-class on the model.

Neither is obviously right: (2) would also suppress genuine bot activity that subscribers
probably *do* want (a CI bot posting "build failed" on an item you watch). (1) only helps
clients that populate those fields.

Happy to implement whichever you prefer, in this PR or a follow-up — or to leave strict
parity as-is if you consider the backfill case out of scope.

## Tests

`test_comment_link_notifications.py` covers all seven paths, following the shape of the
tests added with #9307. They assert the dispatch contract rather than delivery, since
`notification=True` is the gate and the fan-out is covered downstream — which keeps them
off Celery.

Verified red/green: with the source change reverted all 7 fail with
`KeyError: 'notification'`; with it applied all 7 pass.

Full suite, run twice each against an isolated Redis:

| | failed | passed |
|---|---|---|
| `preview` | 12 | 504 |
| this branch | 12 | **511** |

Same 12 pre-existing failures, +7 new tests, no regressions.

## The second commit is separable

`test: reset the shared api-key throttle bucket between tests` can be dropped if you would
rather solve it differently, but the new tests fail without it.

Every external-API test authenticates with the same hardcoded token, and
`ApiKeyRateThrottle` keys its request history on that token in the Django cache — a real
Redis, not rolled back with the database. The history accumulates across the session until
the suite crosses `API_KEY_RATE_LIMIT` (60/minute), after which later tests fail with 429s
unrelated to what they assert.

That makes the suite order- and size-dependent: **adding tests anywhere can break unrelated
tests further down.** Adding the 7 tests above broke 5 in `test_projects.py` /
`test_projects_lite.py` that pass in isolation. Clearing the bucket around each test makes
the limit per-test, which is what these tests already assume.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Notifications are now consistently triggered when issues, comments, and links are created, updated, or deleted through the API.
  * Activity notifications now include the application origin, improving delivery context for subscribers and integrations.
  * Comment activity now retains the saved comment details, supporting accurate comment-mention notifications.
* **Tests**
  * Added coverage for notification behavior across comment, link, and issue deletion API actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->