### PR TITLE
fix(ci): check out the PR head SHA so the version check works for fork PRs

### DIFF
--- a/.github/workflows/check-version.yml
+++ b/.github/workflows/check-version.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Setup Node.js


### PR DESCRIPTION
### Description

`check-version.yml` checks out `ref: ${{ github.head_ref }}`, which is the bare branch name. That only resolves when the branch lives in this repository, so the version check fails for every pull request coming from a fork, before the comparison even runs. From run 30335374576 (PR #9485, head repo `okxint/plane`):

```
##[error]A branch or tag with the name 'fix/webhook-url-validation-error-message' could not be found
```

The same failure shows up in run 26230557089 (`fix/pages-nav-guest-access`). Same-repo PRs are unaffected, which is why the check mostly looks healthy: the other recent failures of this workflow are the intended version-equality gate doing its job.

The fix is to check out `${{ github.event.pull_request.head.sha }}` instead. GitHub makes the PR head commit fetchable from the base repository even for forks, and it pins the exact commit the PR proposes rather than whatever the branch has moved to since.

One thing I deliberately did not do: switch the trigger to `pull_request_target`. The job runs `node -p` against the PR's `package.json`, so it should keep the read-only token that `pull_request` provides.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)

Not applicable, CI-only change. The error line above is from the linked run logs.

### Test Scenarios

I cannot trigger this workflow from a fork PR against `preview` since it only runs on PRs targeting `master`, so verification was against the run history: fork-PR runs fail on the checkout step with the error above, same-repo runs proceed to the version comparison. After this change the checkout resolves for both cases; the rest of the job (`git fetch origin master:master`, checkout of `master`, version comparison) is unaffected because it operates on the base repository's refs.

### References

Failing runs 30335374576 and 26230557089 on this workflow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved pull request validation reliability by ensuring checks run against the exact submitted commit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->