### PR TITLE
fix: resolve text attachment MIME types

### DIFF
--- a/apps/api/plane/settings/common.py
+++ b/apps/api/plane/settings/common.py
@@ -533,6 +533,7 @@ ATTACHMENT_MIME_TYPES = [
     "text/css",
     "text/javascript",
     "application/json",
+    "application/yaml",
     "text/xml",
     "text/csv",
     "application/xml",

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "build": "tsdown",
     "dev": "tsdown --watch --no-clean",
+    "test": "vitest run",
     "check:lint": "oxlint --max-warnings=6 .",
     "check:types": "tsc --noEmit",
     "check:format": "oxfmt --check .",
@@ -30,6 +31,7 @@
   "devDependencies": {
     "@plane/typescript-config": "workspace:*",
     "tsdown": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   }
 }

--- a/packages/services/src/file/helper.test.ts
+++ b/packages/services/src/file/helper.test.ts
@@ -14,6 +14,9 @@ const metadata = (name: string, type = "", contents: BlobPart[] = ["key: value"]
 describe("getFileMetaDataForUpload", () => {
   it.each([
     ["program.txt", "text/plain"],
+    ["program.md", "text/markdown"],
+    ["program.markdown", "text/markdown"],
+    ["program.csv", "text/csv"],
     ["program.yaml", "application/yaml"],
     ["program.yml", "application/yaml"],
   ])("detects %s without browser MIME", async (name, expected) => {

--- a/packages/services/src/file/helper.test.ts
+++ b/packages/services/src/file/helper.test.ts
@@ -34,8 +34,12 @@ describe("getFileMetaDataForUpload", () => {
   });
 
   it("does not apply fallback to an unsafe filename", async () => {
-    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
 
-    expect((await metadata("payload.exe.yaml")).type).toBe("");
+    try {
+      expect((await metadata("payload.exe.yaml")).type).toBe("");
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 });

--- a/packages/services/src/file/helper.test.ts
+++ b/packages/services/src/file/helper.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2023-present Plane Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+import { getFileMetaDataForUpload } from "./helper";
+
+const metadata = (name: string, type = "", contents: BlobPart[] = ["key: value"]) =>
+  getFileMetaDataForUpload(new File(contents, name, { type }));
+
+describe("getFileMetaDataForUpload", () => {
+  it.each([
+    ["program.txt", "text/plain"],
+    ["program.yaml", "application/yaml"],
+    ["program.yml", "application/yaml"],
+  ])("detects %s without browser MIME", async (name, expected) => {
+    expect((await metadata(name)).type).toBe(expected);
+  });
+
+  it("falls back to browser MIME", async () => {
+    expect((await metadata("program.log", "text/plain")).type).toBe("text/plain");
+  });
+
+  it("prefers signature detection", async () => {
+    const pngHeader = new Uint8Array([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00,
+      0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4, 0x89,
+    ]);
+
+    expect((await metadata("image.yaml", "application/yaml", [pngHeader])).type).toBe("image/png");
+  });
+
+  it("does not apply fallback to an unsafe filename", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    expect((await metadata("payload.exe.yaml")).type).toBe("");
+  });
+});

--- a/packages/services/src/file/helper.ts
+++ b/packages/services/src/file/helper.ts
@@ -10,6 +10,15 @@ import { fileTypeFromBuffer } from "file-type";
 import type { TFileMetaDataLite, TFileSignedURLResponse } from "@plane/types";
 import { DANGEROUS_EXTENSIONS } from "@plane/constants";
 
+const TEXT_MIME_TYPES_BY_EXTENSION: Record<string, string> = {
+  txt: "text/plain",
+  md: "text/markdown",
+  markdown: "text/markdown",
+  csv: "text/csv",
+  yaml: "application/yaml",
+  yml: "application/yaml",
+};
+
 /**
  * @description Filename validation - checks for double extensions and dangerous patterns
  * @param {string} filename
@@ -92,6 +101,7 @@ const validateAndDetectFileType = async (file: File): Promise<string> => {
   const filenameError = validateFilename(file.name);
   if (filenameError) {
     console.warn(`File validation warning: ${filenameError}`);
+    return "";
   }
 
   try {
@@ -103,8 +113,8 @@ const validateAndDetectFileType = async (file: File): Promise<string> => {
     console.warn("Error detecting file type from signature:", _error);
   }
 
-  // fallback for unknown files
-  return "";
+  const extension = file.name.split(".").pop()?.toLowerCase() ?? "";
+  return TEXT_MIME_TYPES_BY_EXTENSION[extension] || file.type || "";
 };
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1665,6 +1665,9 @@ importers:
       typescript:
         specifier: 5.8.3
         version: 5.8.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.12.0)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@22.12.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))
 
   packages/shared-state:
     dependencies:


### PR DESCRIPTION
Fall back to known text extensions and browser-provided MIME types when signature detection returns no result. Add YAML to the attachment allowlist and cover upload metadata behavior with unit tests.

### Description

Plain-text attachments do not have binary signatures, so `file-type` returns no MIME type for formats such as TXT, Markdown, CSV, and YAML. The client consequently sent an empty `type`, which the API rejected with `Invalid file type`.

This change:

- resolves known text extensions after signature detection;
- falls back to the browser-provided MIME type for other files;
- keeps signature detection authoritative when content and extension disagree;
- rejects unsafe filenames before applying MIME fallbacks;
- adds `application/yaml` to the backend attachment allowlist;
- adds unit coverage for extension detection, browser fallback, signature precedence, and unsafe filenames.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)

Not applicable. This change does not modify the UI.

### Test Scenarios

- `pnpm --filter=@plane/services test` — 6 tests passed.
- `pnpm --filter=@plane/services check:types` — passed.
- `pnpm --filter=@plane/services check:lint` — passed with 0 errors.
- Formatting check for the changed service files — passed.
- `git diff --check` — passed.

Unit tests verify:

- TXT, YAML, and YML detection without a browser MIME type;
- fallback to a browser-provided MIME type;
- signature detection taking precedence over the filename;
- unsafe filenames not receiving an extension fallback.

### References

- Fixes #9026
- Related to #8847

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for uploading YAML files.
  * Improved file type detection for Markdown, CSV, and other common text files using filename extensions and browser-provided metadata.
  * File signatures take priority, with safer handling of invalid filenames and more reliable fallback detection.

* **Tests**
  * Added coverage for extension-based detection, browser fallbacks, signature precedence, and unsafe filenames.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->