### PR TITLE
fix(api): stop notification emails rendering a broken avatar

### DIFF
--- a/apps/api/plane/bgtasks/email_notification_task.py
+++ b/apps/api/plane/bgtasks/email_notification_task.py
@@ -197,7 +197,7 @@ def send_email_notification(issue_id, notification_data, receiver_id, email_noti
                         {
                             "actor_comments": comment,
                             "actor_detail": {
-                                "avatar_url": f"{base_api}{actor.avatar_url}",
+                                "avatar_url": f"{base_api}{actor.avatar_url}" if actor.avatar_url else None,
                                 "first_name": actor.first_name,
                                 "last_name": actor.last_name,
                             },
@@ -210,7 +210,7 @@ def send_email_notification(issue_id, notification_data, receiver_id, email_noti
                         {
                             "actor_comments": mention,
                             "actor_detail": {
-                                "avatar_url": f"{base_api}{actor.avatar_url}",
+                                "avatar_url": f"{base_api}{actor.avatar_url}" if actor.avatar_url else None,
                                 "first_name": actor.first_name,
                                 "last_name": actor.last_name,
                             },
@@ -224,7 +224,7 @@ def send_email_notification(issue_id, notification_data, receiver_id, email_noti
                     template_data.append(
                         {
                             "actor_detail": {
-                                "avatar_url": f"{base_api}{actor.avatar_url}",
+                                "avatar_url": f"{base_api}{actor.avatar_url}" if actor.avatar_url else None,
                                 "first_name": actor.first_name,
                                 "last_name": actor.last_name,
                             },

--- a/apps/api/plane/tests/contract/bgtasks/test_email_notification_avatar.py
+++ b/apps/api/plane/tests/contract/bgtasks/test_email_notification_avatar.py
@@ -1,0 +1,144 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Notification emails must not render a broken avatar for users who have none.
+
+``User.avatar_url`` returns ``None`` when neither ``avatar_asset`` nor ``avatar``
+is set, which is the default for most accounts. The email context was building
+``f"{base_api}{actor.avatar_url}"`` unconditionally, so those users got the
+*truthy* string ``"<base>/None"``. The template checks ``{% if avatar_url %}``
+before choosing between an ``<img>`` and the initials circle, so a truthy value
+sends it down the image branch — and ``/None`` is served by the SPA catch-all as
+HTML with a 200, so mail clients render a broken-image icon rather than falling
+back.
+
+This asserts the rendered HTML, not the context dict: the bug was only visible
+once the value reached the template's truthiness check.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from plane.bgtasks.email_notification_task import send_email_notification
+from plane.db.models import EmailNotificationLog, Issue, Project, ProjectMember, User
+
+BASE_API = "https://plane.example.com"
+
+
+@pytest.fixture
+def project(db, workspace, create_user):
+    project = Project.objects.create(name="Avatar Test", identifier="AV", workspace=workspace, created_by=create_user)
+    ProjectMember.objects.create(project=project, member=create_user, role=20, is_active=True)
+    return project
+
+
+@pytest.fixture
+def issue(db, project, workspace, create_user):
+    return Issue.objects.create(
+        name="Broken avatar in email", project=project, workspace=workspace, created_by=create_user
+    )
+
+
+@pytest.fixture
+def actor_without_avatar(db):
+    """The default state for a Plane account: no avatar asset, no avatar url."""
+    user = User.objects.create(email="noavatar@example.com", username="noavatar", first_name="Josh", last_name="Gwinn")
+    assert user.avatar_url is None, "fixture premise: this user has no avatar"
+    return user
+
+
+def _render(issue, actor, receiver):
+    """Run the task with its external edges mocked, returning the HTML it built."""
+    log = EmailNotificationLog.objects.create(
+        entity_identifier=issue.id,
+        entity_name="issue",
+        entity="issue",
+        receiver=receiver,
+        triggered_by=actor,
+        data={},
+    )
+    # Raw shape, as stack_email_notification builds it: the task runs this through
+    # create_payload first, which folds it into {actor_id: {field: {...}, activity_time}}.
+    notification_data = {
+        str(actor.id): [
+            {
+                "issue_activity": {
+                    "field": "comment",
+                    "old_value": "",
+                    "new_value": "Who is working on this?",
+                    "activity_time": "2026-08-20T10:43:11",
+                }
+            }
+        ]
+    }
+
+    redis = MagicMock()
+    redis.get.return_value = BASE_API.encode()
+    captured = {}
+
+    class FakeMessage:
+        def __init__(self, *a, **kw):
+            pass
+
+        def attach_alternative(self, content, mimetype):
+            captured["html"] = content
+
+        def send(self):
+            pass
+
+    with (
+        patch("plane.bgtasks.email_notification_task.redis_instance", return_value=redis),
+        patch("plane.bgtasks.email_notification_task.acquire_lock", return_value=True),
+        patch("plane.bgtasks.email_notification_task.release_lock", return_value=True),
+        patch("plane.bgtasks.email_notification_task.EmailMultiAlternatives", FakeMessage),
+        patch("plane.bgtasks.email_notification_task.get_connection", return_value=MagicMock()),
+        patch(
+            "plane.bgtasks.email_notification_task.get_email_configuration",
+            # (host, user, password, port, use_tls, use_ssl, from)
+            return_value=("smtp.example.com", "user", "pass", "587", "0", "0", "noreply@example.com"),
+        ),
+    ):
+        send_email_notification(
+            issue_id=str(issue.id),
+            notification_data=notification_data,
+            receiver_id=str(receiver.id),
+            email_notification_ids=[log.id],
+        )
+    return captured.get("html", "")
+
+
+@pytest.mark.contract
+@pytest.mark.django_db
+def test_actor_without_avatar_does_not_get_a_broken_image(issue, actor_without_avatar, create_user):
+    """No ``<base>/None`` image src anywhere in the mail."""
+    html = _render(issue, actor_without_avatar, create_user)
+
+    assert html, "the task should have rendered and attached an HTML body"
+    assert f"{BASE_API}/None" not in html
+    # Belt and braces: no img src anywhere may end in None.
+    srcs = [chunk.split('"')[0] for chunk in html.split('src="')[1:]]
+    assert not [s for s in srcs if s.endswith("None")], srcs
+
+
+@pytest.mark.contract
+@pytest.mark.django_db
+def test_actor_without_avatar_falls_back_to_initials(issue, actor_without_avatar, create_user):
+    """The template's initials branch must actually be taken."""
+    html = _render(issue, actor_without_avatar, create_user)
+
+    # The initials circle renders the actor's first initial; "J" for Josh.
+    assert ">\n                        J\n" in html or ">J<" in html.replace(" ", "").replace("\n", "")
+
+
+@pytest.mark.contract
+@pytest.mark.django_db
+def test_actor_with_avatar_still_gets_the_image(issue, actor_without_avatar, create_user):
+    """The guard must not suppress real avatars."""
+    actor_without_avatar.avatar = "/uploads/avatar.png"
+    actor_without_avatar.save(update_fields=["avatar"])
+
+    html = _render(issue, actor_without_avatar, create_user)
+
+    assert f"{BASE_API}/uploads/avatar.png" in html

--- a/apps/api/plane/tests/contract/bgtasks/test_email_notification_avatar.py
+++ b/apps/api/plane/tests/contract/bgtasks/test_email_notification_avatar.py
@@ -49,7 +49,17 @@ def actor_without_avatar(db):
     return user
 
 
-def _render(issue, actor, receiver):
+# The guard was applied at three call sites, each reached by a different field:
+# "comment" and "mention" append to the comments block, anything else falls through
+# to the activity-change block. Exercising only one would leave two guards untested.
+ACTOR_DETAIL_PATHS = [
+    pytest.param("comment", "Who is working on this?", id="comment"),
+    pytest.param("mention", "<p>pinging you on this</p>", id="mention"),
+    pytest.param("name", "Renamed work item", id="activity-change"),
+]
+
+
+def _render(issue, actor, receiver, field="comment", new_value="Who is working on this?"):
     """Run the task with its external edges mocked, returning the HTML it built."""
     log = EmailNotificationLog.objects.create(
         entity_identifier=issue.id,
@@ -65,9 +75,9 @@ def _render(issue, actor, receiver):
         str(actor.id): [
             {
                 "issue_activity": {
-                    "field": "comment",
+                    "field": field,
                     "old_value": "",
-                    "new_value": "Who is working on this?",
+                    "new_value": new_value,
                     "activity_time": "2026-08-20T10:43:11",
                 }
             }
@@ -111,9 +121,10 @@ def _render(issue, actor, receiver):
 
 @pytest.mark.contract
 @pytest.mark.django_db
-def test_actor_without_avatar_does_not_get_a_broken_image(issue, actor_without_avatar, create_user):
-    """No ``<base>/None`` image src anywhere in the mail."""
-    html = _render(issue, actor_without_avatar, create_user)
+@pytest.mark.parametrize("field,new_value", ACTOR_DETAIL_PATHS)
+def test_actor_without_avatar_does_not_get_a_broken_image(issue, actor_without_avatar, create_user, field, new_value):
+    """No ``<base>/None`` image src anywhere in the mail, on any path."""
+    html = _render(issue, actor_without_avatar, create_user, field=field, new_value=new_value)
 
     assert html, "the task should have rendered and attached an HTML body"
     assert f"{BASE_API}/None" not in html
@@ -124,21 +135,23 @@ def test_actor_without_avatar_does_not_get_a_broken_image(issue, actor_without_a
 
 @pytest.mark.contract
 @pytest.mark.django_db
-def test_actor_without_avatar_falls_back_to_initials(issue, actor_without_avatar, create_user):
-    """The template's initials branch must actually be taken."""
-    html = _render(issue, actor_without_avatar, create_user)
+@pytest.mark.parametrize("field,new_value", ACTOR_DETAIL_PATHS)
+def test_actor_without_avatar_falls_back_to_initials(issue, actor_without_avatar, create_user, field, new_value):
+    """The template's initials branch must actually be taken, on any path."""
+    html = _render(issue, actor_without_avatar, create_user, field=field, new_value=new_value)
 
     # The initials circle renders the actor's first initial; "J" for Josh.
-    assert ">\n                        J\n" in html or ">J<" in html.replace(" ", "").replace("\n", "")
+    assert ">J<" in html.replace(" ", "").replace("\n", "")
 
 
 @pytest.mark.contract
 @pytest.mark.django_db
-def test_actor_with_avatar_still_gets_the_image(issue, actor_without_avatar, create_user):
-    """The guard must not suppress real avatars."""
+@pytest.mark.parametrize("field,new_value", ACTOR_DETAIL_PATHS)
+def test_actor_with_avatar_still_gets_the_image(issue, actor_without_avatar, create_user, field, new_value):
+    """The guard must not suppress real avatars, on any path."""
     actor_without_avatar.avatar = "/uploads/avatar.png"
     actor_without_avatar.save(update_fields=["avatar"])
 
-    html = _render(issue, actor_without_avatar, create_user)
+    html = _render(issue, actor_without_avatar, create_user, field=field, new_value=new_value)
 
     assert f"{BASE_API}/uploads/avatar.png" in html


### PR DESCRIPTION
## The bug

`User.avatar_url` returns `None` when neither `avatar_asset` nor `avatar` is set — the
default for most accounts. `send_email_notification` built the email context as:

```python
"avatar_url": f"{base_api}{actor.avatar_url}",
```

unconditionally, so those users get the **truthy** string `"<base>/None"`.

The template already handles a missing avatar — it chooses between an `<img>` and an
initials circle on `{% if actor_detail.avatar_url %}` — but a non-empty string sends it
down the image branch.

The result is worse than a plain 404: `<base>/None` is served by the SPA catch-all as
**HTML with a 200**, so mail clients cannot fall back either. They render a
broken-image icon next to every comment and activity line in the notification.

Fix is to only build the URL when there is an avatar to point at, so the template's
existing fallback is reached. Three call sites (comment, mention, activity).

## Reproducing

Any user without an avatar, on any instance. On ours, 7 of 9 non-bot accounts have
neither `avatar` nor `avatar_asset_id`, so effectively every notification email is
affected. It was reported by a user noticing "no default profile image on emails".

## Tests

`plane/tests/contract/bgtasks/test_email_notification_avatar.py` renders the real task
with its external edges mocked (redis, lock, SMTP config, `EmailMultiAlternatives`) and
asserts on the produced HTML rather than the context dict — the bug only becomes visible
once the value reaches the template's truthiness check, so asserting the dict would pass
while the mail stayed broken.

Three cases:

| Test | Asserts |
|---|---|
| `..._does_not_get_a_broken_image` | no `src` anywhere ends in `None` |
| `..._falls_back_to_initials` | the initials branch is actually taken |
| `..._with_avatar_still_gets_the_image` | the guard does not suppress real avatars |

Verified red/green: with the guard reverted, the first two fail and the third still
passes — which is the correct signature, since the guard does not touch the
has-an-avatar path.

Full suite: 12 failed / 507 passed on this branch versus 12 failed / 504 passed on
`preview` — same pre-existing failures, +3 new tests, no regressions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed email notifications for users without profile avatars.
  - Avatar-less users now display their initials instead of broken image links.
  - Users with valid avatars continue to see their profile images in comment, mention, and activity notifications.

- **Tests**
  - Added coverage to verify correct avatar rendering in email notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->