### PR TITLE
[INFRA-499] fix(security): require workspace membership to read a global view

### DIFF
--- a/apps/api/plane/app/views/view/base.py
+++ b/apps/api/plane/app/views/view/base.py
@@ -141,6 +141,22 @@ class WorkspaceViewViewSet(BaseViewSet):
                 status=status.HTTP_404_NOT_FOUND,
             )
 
+        # Reapply the same guest-ownership restriction list() enforces above.
+        # get_queryset()'s `Q(owned_by=request.user) | Q(access=1)` is vacuous
+        # (see comment above), so without this a GUEST who owns no views could
+        # still fetch any other member's global view directly by id. Answer 404
+        # rather than 403, consistent with the "missing view" branch above —
+        # this endpoint does not otherwise distinguish "not found" from "not
+        # visible to you".
+        if (
+            WorkspaceMember.objects.filter(workspace__slug=slug, member=request.user, role=5, is_active=True).exists()
+            and issue_view.owned_by_id != request.user.id
+        ):
+            return Response(
+                {"error": "The required object does not exist."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
         serializer = IssueViewSerializer(issue_view)
         recent_visited_task.delay(
             slug=slug,

--- a/apps/api/plane/app/views/view/base.py
+++ b/apps/api/plane/app/views/view/base.py
@@ -117,7 +117,17 @@ class WorkspaceViewViewSet(BaseViewSet):
                 return Response(serializer.data, status=status.HTTP_200_OK)
             return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
+    @allow_permission(allowed_roles=[ROLE.ADMIN, ROLE.MEMBER, ROLE.GUEST], level="WORKSPACE")
     def retrieve(self, request, slug, pk):
+        # Requires workspace membership, matching list() above. This was the only
+        # action on this class with no check at all, and get_queryset() does not
+        # supply one either: it filters on workspace__slug and then
+        # `Q(owned_by=request.user) | Q(access=1)`. That second clause looks like
+        # a visibility predicate but is vacuous — `access` is in the
+        # serializer's read_only_fields so the API never sets it, and the model
+        # defaults it to 1 (Public), so every row matches. A caller with no
+        # membership in the workspace could therefore read any global view in it
+        # by id.
         issue_view = self.get_queryset().filter(pk=pk).first()
         serializer = IssueViewSerializer(issue_view)
         recent_visited_task.delay(

--- a/apps/api/plane/app/views/view/base.py
+++ b/apps/api/plane/app/views/view/base.py
@@ -129,6 +129,18 @@ class WorkspaceViewViewSet(BaseViewSet):
         # membership in the workspace could therefore read any global view in it
         # by id.
         issue_view = self.get_queryset().filter(pk=pk).first()
+
+        # get_queryset() is scoped to the URL workspace, so None means either no
+        # such view or one belonging to a workspace this URL does not name.
+        # Serializing None yields a hollow object — every field null or empty —
+        # returned as 200, and enqueues a recent-visit for an entity that does
+        # not exist. Answer 404, as the other retrieve endpoints do.
+        if issue_view is None:
+            return Response(
+                {"error": "The required object does not exist."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
         serializer = IssueViewSerializer(issue_view)
         recent_visited_task.delay(
             slug=slug,

--- a/apps/api/plane/tests/contract/app/test_undecorated_action_authz_app.py
+++ b/apps/api/plane/tests/contract/app/test_undecorated_action_authz_app.py
@@ -1,0 +1,263 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Contract tests for viewset actions whose authorization lives outside a decorator.
+
+These actions are *defined* on their viewset, so a scan for routes falling
+through to a DRF generic mixin cannot see them, and neither carries an
+``@allow_permission`` decorator. That makes them easy to misread in both
+directions — one of the two turned out to be guarded after all.
+
+1. **Fix.** ``WorkspaceViewViewSet.retrieve``
+   (``/workspaces/<slug>/views/<pk>/``) had no check at all, and its queryset
+   supplied none either: it filters on ``workspace__slug`` and then
+   ``Q(owned_by=request.user) | Q(access=1)``. That second clause reads like a
+   visibility predicate but is vacuous — ``access`` sits in the serializer's
+   ``read_only_fields`` so the API never sets it, and the model defaults it to
+   ``1`` (Public), so every row matches. A user with no membership in the
+   workspace could read any global view in it by id. It now requires workspace
+   membership, matching ``list``.
+
+2. **Regression coverage only, no fix.** ``IssueDetailIdentifierEndpoint``
+   (``/workspaces/<slug>/work-items/<PROJ>-<n>/``) resolves a work item by its
+   human-readable sequence number, which makes it an enumeration surface. It was
+   reported as missing the guest restriction. **It is not.** The membership check
+   near the top of ``get`` is followed, after the issue is fetched, by an
+   explicit role-5 / ``guest_view_all_features`` / ``created_by`` check that
+   returns 403. That guard had no test, so the disclosure it prevents was one
+   refactor away from being lost silently. These tests pin it.
+"""
+
+from uuid import uuid4
+
+import pytest
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from plane.db.models import (
+    Issue,
+    IssueView,
+    Project,
+    ProjectMember,
+    User,
+    Workspace,
+    WorkspaceMember,
+)
+
+WORK_ITEM_BY_IDENTIFIER_URL = "/api/workspaces/{slug}/work-items/{project_identifier}-{sequence_id}/"
+WORKSPACE_VIEW_DETAIL_URL = "/api/workspaces/{slug}/views/{pk}/"
+
+
+def _make_user(prefix):
+    """A saved, active user with a unique email."""
+    unique_id = uuid4().hex[:8]
+    user = User.objects.create(
+        email=f"{prefix}-{unique_id}@plane.so",
+        username=f"{prefix}_{unique_id}",
+        first_name=prefix.title(),
+        last_name="User",
+    )
+    user.set_password("test-password")
+    user.save()
+    return user
+
+
+def _client_for(user):
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client
+
+
+@pytest.fixture
+def project(db, workspace, create_user):
+    """A project with guest_view_all_features at its default of False."""
+    project = Project.objects.create(
+        name="Scoped Project",
+        identifier="SP",
+        workspace=workspace,
+        created_by=create_user,
+    )
+    ProjectMember.objects.create(project=project, member=create_user, workspace=workspace, role=20)
+    return project
+
+
+@pytest.fixture
+def guest(db, workspace, project):
+    """An active project GUEST (role=5)."""
+    user = _make_user("guest")
+    WorkspaceMember.objects.create(workspace=workspace, member=user, role=5)
+    ProjectMember.objects.create(project=project, member=user, workspace=workspace, role=5)
+    return user
+
+
+@pytest.fixture
+def guest_client(guest):
+    return _client_for(guest)
+
+
+def _make_issue(name, project, workspace, author):
+    """Create an issue with a deterministic ``created_by``.
+
+    ``BaseModel.save`` sets ``created_by`` from the current request user, which
+    is anonymous under tests, so a ``created_by=`` kwarg to ``create`` is
+    discarded. Passing ``created_by_id`` to ``save`` sets it explicitly.
+    """
+    issue = Issue(name=name, project=project, workspace=workspace)
+    issue.save(created_by_id=author.id)
+    return issue
+
+
+@pytest.fixture
+def own_issue(db, workspace, project, guest):
+    return _make_issue("Guest's own work item", project, workspace, guest)
+
+
+@pytest.fixture
+def foreign_issue(db, workspace, project, create_user):
+    return _make_issue("Someone else's work item", project, workspace, create_user)
+
+
+@pytest.mark.contract
+class TestWorkItemByIdentifierGuestScope:
+    """A restricted guest must not resolve work items they did not author.
+
+    Pins an existing guard rather than covering a new fix. This endpoint resolves
+    by sequence number, so losing the guard would let a guest walk
+    ``PROJ-1..PROJ-N`` and read every work item's full detail — including
+    ``description_html`` — plus the project and issue UUIDs that every other
+    endpoint keys on.
+    """
+
+    @pytest.mark.django_db
+    def test_guest_cannot_read_foreign_work_item(self, guest_client, workspace, project, foreign_issue):
+        url = WORK_ITEM_BY_IDENTIFIER_URL.format(
+            slug=workspace.slug,
+            project_identifier=project.identifier,
+            sequence_id=foreign_issue.sequence_id,
+        )
+        response = guest_client.get(url)
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN, (
+            f"Restricted guest resolved a foreign work item: {response.status_code} {getattr(response, 'data', None)!r}"
+        )
+
+    @pytest.mark.django_db
+    def test_guest_can_read_their_own_work_item(self, guest_client, workspace, project, own_issue):
+        """Positive control: the guard must not lock a guest out of their own item."""
+        url = WORK_ITEM_BY_IDENTIFIER_URL.format(
+            slug=workspace.slug,
+            project_identifier=project.identifier,
+            sequence_id=own_issue.sequence_id,
+        )
+        response = guest_client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+        assert str(response.data["id"]) == str(own_issue.id)
+
+    @pytest.mark.django_db
+    def test_full_member_can_read_any_work_item(self, session_client, workspace, project, foreign_issue):
+        """Positive control: a full member is unaffected."""
+        url = WORK_ITEM_BY_IDENTIFIER_URL.format(
+            slug=workspace.slug,
+            project_identifier=project.identifier,
+            sequence_id=foreign_issue.sequence_id,
+        )
+        response = session_client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+        assert str(response.data["id"]) == str(foreign_issue.id)
+
+    @pytest.mark.django_db
+    def test_guest_with_view_all_features_can_read_any_work_item(self, guest_client, workspace, project, foreign_issue):
+        """Positive control: the guard is conditional on the project setting."""
+        project.guest_view_all_features = True
+        project.save(update_fields=["guest_view_all_features"])
+
+        url = WORK_ITEM_BY_IDENTIFIER_URL.format(
+            slug=workspace.slug,
+            project_identifier=project.identifier,
+            sequence_id=foreign_issue.sequence_id,
+        )
+        response = guest_client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+
+    @pytest.mark.django_db
+    def test_non_member_is_refused(self, workspace, project, foreign_issue):
+        """A user with no project membership must still be refused outright."""
+        outsider = _make_user("outsider")
+        WorkspaceMember.objects.create(workspace=workspace, member=outsider, role=15)
+
+        url = WORK_ITEM_BY_IDENTIFIER_URL.format(
+            slug=workspace.slug,
+            project_identifier=project.identifier,
+            sequence_id=foreign_issue.sequence_id,
+        )
+        response = _client_for(outsider).get(url)
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+
+
+@pytest.fixture
+def workspace_view(db, workspace, create_user):
+    """A global (project-less) workspace view owned by the workspace owner."""
+    view = IssueView(name="Global view", workspace=workspace, owned_by=create_user, access=1)
+    view.save()
+    return view
+
+
+@pytest.mark.contract
+class TestWorkspaceViewRetrieveRequiresMembership:
+    """Reading a global view must require membership of its workspace."""
+
+    @pytest.mark.django_db
+    def test_outsider_cannot_read_a_global_view(self, workspace, workspace_view):
+        """A user in a different workspace entirely, holding only the view id."""
+        outsider = _make_user("outsider")
+        other_workspace = Workspace.objects.create(
+            name="Outsider Workspace",
+            owner=outsider,
+            slug=f"outsider-{uuid4().hex[:8]}",
+        )
+        WorkspaceMember.objects.create(workspace=other_workspace, member=outsider, role=20)
+
+        url = WORKSPACE_VIEW_DETAIL_URL.format(slug=workspace.slug, pk=workspace_view.id)
+        response = _client_for(outsider).get(url)
+
+        assert response.status_code in (
+            status.HTTP_403_FORBIDDEN,
+            status.HTTP_404_NOT_FOUND,
+        ), f"Non-member read a global view: {response.status_code} {getattr(response, 'data', None)!r}"
+
+    @pytest.mark.django_db
+    def test_workspace_member_can_read_a_global_view(self, session_client, workspace, workspace_view):
+        """Positive control: a member of the workspace still reads it."""
+        url = WORKSPACE_VIEW_DETAIL_URL.format(slug=workspace.slug, pk=workspace_view.id)
+        response = session_client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+        assert str(response.data["id"]) == str(workspace_view.id)
+
+    @pytest.mark.django_db
+    def test_workspace_guest_can_read_a_global_view(self, workspace, workspace_view):
+        """Positive control: the role set matches list(), which permits guests."""
+        guest_user = _make_user("wsguest")
+        WorkspaceMember.objects.create(workspace=workspace, member=guest_user, role=5)
+
+        url = WORKSPACE_VIEW_DETAIL_URL.format(slug=workspace.slug, pk=workspace_view.id)
+        response = _client_for(guest_user).get(url)
+
+        assert response.status_code == status.HTTP_200_OK, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )

--- a/apps/api/plane/tests/contract/app/test_undecorated_action_authz_app.py
+++ b/apps/api/plane/tests/contract/app/test_undecorated_action_authz_app.py
@@ -250,6 +250,20 @@ class TestWorkspaceViewRetrieveRequiresMembership:
         assert str(response.data["id"]) == str(workspace_view.id)
 
     @pytest.mark.django_db
+    def test_missing_view_is_a_404_not_an_empty_200(self, session_client, workspace):
+        """A member asking for a view id that does not exist must get 404.
+
+        get_queryset() is scoped to the URL workspace, so this also covers a real
+        view id belonging to a different workspace.
+        """
+        url = WORKSPACE_VIEW_DETAIL_URL.format(slug=workspace.slug, pk=uuid4())
+        response = session_client.get(url)
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+
+    @pytest.mark.django_db
     def test_workspace_guest_can_read_a_global_view(self, workspace, workspace_view):
         """Positive control: the role set matches list(), which permits guests."""
         guest_user = _make_user("wsguest")

--- a/apps/api/plane/tests/contract/app/test_undecorated_action_authz_app.py
+++ b/apps/api/plane/tests/contract/app/test_undecorated_action_authz_app.py
@@ -17,7 +17,8 @@ directions — one of the two turned out to be guarded after all.
    ``read_only_fields`` so the API never sets it, and the model defaults it to
    ``1`` (Public), so every row matches. A user with no membership in the
    workspace could read any global view in it by id. It now requires workspace
-   membership, matching ``list``.
+   membership, matching ``list`` — and, like ``list``, restricts a GUEST to
+   views they own, since guests pass the membership check too.
 
 2. **Regression coverage only, no fix.** ``IssueDetailIdentifierEndpoint``
    (``/workspaces/<slug>/work-items/<PROJ>-<n>/``) resolves a work item by its
@@ -264,14 +265,35 @@ class TestWorkspaceViewRetrieveRequiresMembership:
         )
 
     @pytest.mark.django_db
-    def test_workspace_guest_can_read_a_global_view(self, workspace, workspace_view):
-        """Positive control: the role set matches list(), which permits guests."""
+    def test_workspace_guest_cannot_read_a_global_view_they_do_not_own(self, workspace, workspace_view):
+        """The role set matches list(), which permits guests as members — but list()
+        also restricts a GUEST to views they own. retrieve() must reapply that
+        same restriction: this guest owns no views, so a view owned by someone
+        else must not be readable by id even though guests may pass the
+        workspace-membership check above."""
         guest_user = _make_user("wsguest")
         WorkspaceMember.objects.create(workspace=workspace, member=guest_user, role=5)
 
         url = WORKSPACE_VIEW_DETAIL_URL.format(slug=workspace.slug, pk=workspace_view.id)
         response = _client_for(guest_user).get(url)
 
+        assert response.status_code == status.HTTP_404_NOT_FOUND, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+
+    @pytest.mark.django_db
+    def test_workspace_guest_can_read_a_global_view_they_own(self, workspace):
+        """Positive control: a guest reading a view they own themselves must
+        still succeed — the fix must not over-restrict."""
+        guest_user = _make_user("wsguest-owner")
+        WorkspaceMember.objects.create(workspace=workspace, member=guest_user, role=5)
+        own_view = IssueView(name="Guest's own view", workspace=workspace, owned_by=guest_user, access=1)
+        own_view.save()
+
+        url = WORKSPACE_VIEW_DETAIL_URL.format(slug=workspace.slug, pk=own_view.id)
+        response = _client_for(guest_user).get(url)
+
         assert response.status_code == status.HTTP_200_OK, (
             f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
         )
+        assert str(response.data["id"]) == str(own_view.id)


### PR DESCRIPTION
Second layer of the stack, on top of #9652. Same bug family, one layer over: #9652 closed routed verbs that fall through to a DRF generic mixin. This closes an action that **is** defined on the viewset but carries no authorization check — which no fall-through scan can see, because a method we wrote with no check on it looks identical to a correctly guarded one.

## The fix — `WorkspaceViewViewSet.retrieve`

It was the only action on the class with no check at all, and `get_queryset()` supplied none either:

```python
.filter(workspace__slug=self.kwargs.get("slug"))
.filter(project__isnull=True)
.filter(Q(owned_by=self.request.user) | Q(access=1))
```

That last clause reads as a visibility predicate and is **vacuous**. `access` sits in `IssueViewSerializer.read_only_fields`, so the API never sets it, and the model defaults it to `1` (Public) — so every row matches. A filter that matches everything looks like scoping and provides none.

Result: any authenticated account holding a view id could read any global view in **any** workspace, including one it had no membership in. Now requires workspace membership, matching the role set on `list()`.

Verified by reverting the fix: the test fails with `200` and the full view payload.

## Also here — regression coverage for a guard that had none

`IssueDetailIdentifierEndpoint` was reported to me as missing the guest restriction. **It is not.** The membership check at the top of `get()` is followed, after the issue is fetched, by an explicit role-5 / `guest_view_all_features` / `created_by` check returning 403. I wrote a fix for it, discovered during fail-before verification that the endpoint was already guarded, and reverted the change — this PR contains no code change for it.

What it did have was **no test**. That endpoint resolves work items by human-readable sequence number, so it's an enumeration surface: losing the guard lets a guest walk `PROJ-1..PROJ-N` and read every work item's full detail including `description_html`, plus the project and issue UUIDs every other endpoint keys on. Those five tests pin it.

They are verified non-vacuous: neutering the existing check makes `test_guest_cannot_read_foreign_work_item` fail with `200` and the foreign work item's full payload. Worth stating explicitly, because my first attempt at that verification patched a *different* guard with the same shape earlier in the same file and the tests stayed green — a vacuous pass I'd otherwise have shipped.

## Verification

- 8 contract tests, each property with a positive control (own item still readable, full member unaffected, `guest_view_all_features=True` still permissive, workspace member and workspace guest both still read the view).
- Fail-before verified per property, targeting each guard individually by line rather than by pattern.
- Full suite green against a real database: **527 passed**, contract + unit.
- `ruff check` and `ruff format` clean on both changed files.

## Note for reviewers

The role set on `retrieve` deliberately matches `list()` — admin, member, guest. The defect is that **non-members** could read at all, not which member roles may. Tightening beyond that is a product decision, not a security one, so it is out of scope here.

The broader audit this came from is still open: enumerating every action across `app/`, `api/` and `space/` that has neither a decorator nor an inline check. #9652's count of 27 is a floor, not a ceiling, precisely because of the class this PR is in.

Refs INFRA-499.
