### PR TITLE
fix: [bug]: `network` (project visibility) is silently ignored on create/upda...

### DIFF
--- a/apps/api/plane/api/serializers/project.py
+++ b/apps/api/plane/api/serializers/project.py
@@ -76,6 +76,7 @@ class ProjectCreateSerializer(BaseSerializer):
             "project_lead",
             "default_assignee",
             "identifier",
+            "network",
             "icon_prop",
             "emoji",
             "cover_image",


### PR DESCRIPTION
Fixes #9576

## Root cause

`network` missing from public API project serializer field list

## Changes

- Added `network` to `ProjectCreateSerializer.Meta.fields` (inherited by `ProjectUpdateSerializer`), so POST/PATCH on /api/v1/workspaces/{slug}/projects/ now accept and persist the field; DRF's generated ChoiceField validates against Project.NETWORK_CHOICES (0/2) and rejects invalid values with a 400.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Project creation now supports specifying network details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->