### PR TITLE
[INFRA-501] fix(security): enforce project membership on every workspace-level asset route

### DIFF
--- a/apps/api/plane/api/views/asset.py
+++ b/apps/api/plane/api/views/asset.py
@@ -618,6 +618,19 @@ class GenericAssetEndpoint(BaseAPIView):
                     status=status.HTTP_409_CONFLICT,
                 )
 
+        # This endpoint always creates an ISSUE_ATTACHMENT (below), a
+        # project-scoped entity type. The block above only validates project_id
+        # when one is supplied, so a caller who omits it entirely reaches this
+        # point unchecked -- creating the row here would leave project_id=None,
+        # and is_project_accessible_to() treats project_id=None as
+        # workspace-accessible-by-default, silently bypassing the membership
+        # check above for every caller who just leaves the field out.
+        if not project_id:
+            return Response(
+                {"error": "Project id is required.", "status": False},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
         # Create a File Asset
         asset = FileAsset.objects.create(
             attributes={"name": name, "type": type, "size": size_limit},

--- a/apps/api/plane/api/views/asset.py
+++ b/apps/api/plane/api/views/asset.py
@@ -587,6 +587,28 @@ class GenericAssetEndpoint(BaseAPIView):
             ).first()
 
             if existing_asset:
+                # The dedup lookup is scoped to the workspace only -- and when the
+                # body omits project_id the validation above is skipped entirely --
+                # so the match may belong to a project the caller cannot see.
+                # Echoing it would hand over that asset's id, and asset_url
+                # additionally embeds the owning project and issue ids. Knowing the
+                # asset UUID is the precondition for every asset-scoped attack on
+                # this surface, so this branch must not supply it.
+                #
+                # 404 rather than 403 on purpose: a 403 would still confirm that
+                # some asset carries this external id pair in this workspace, which
+                # turns the pair into an existence oracle. The elsewhere-consistent
+                # 403 is fine on routes where the caller already named the asset id;
+                # here they named only an external id, so a match is new
+                # information. The cost is that a caller who guesses a pair held by
+                # a project they cannot see cannot create their own asset under it,
+                # which is the right trade -- real integrations mint ids per source
+                # and run as a member of the target project.
+                if not existing_asset.is_project_accessible_to(request.user):
+                    return Response(
+                        {"error": "Asset not found.", "status": False},
+                        status=status.HTTP_404_NOT_FOUND,
+                    )
                 return Response(
                     {
                         "message": "Asset with same external id and source already exists",

--- a/apps/api/plane/api/views/asset.py
+++ b/apps/api/plane/api/views/asset.py
@@ -18,7 +18,7 @@ from drf_spectacular.utils import OpenApiExample, OpenApiRequest
 from plane.bgtasks.storage_metadata_task import get_asset_object_metadata
 from plane.settings.storage import S3Storage
 from plane.utils.path_validator import sanitize_filename
-from plane.db.models import FileAsset, User, Workspace
+from plane.db.models import FileAsset, Project, ProjectMember, User, Workspace
 from plane.app.permissions import WorkspaceUserPermission
 from plane.api.views.base import BaseAPIView
 from plane.api.serializers import (
@@ -335,7 +335,7 @@ class UserServerAssetEndpoint(BaseAPIView):
         )
 
         # Get the presigned URL
-        storage = S3Storage(request=request, is_server=True)
+        storage = S3Storage(request=request)
         # Generate a presigned URL to share an S3 object
         presigned_url = storage.generate_presigned_post(object_name=asset_key, file_type=type, file_size=size_limit)
         # Return the presigned URL
@@ -437,6 +437,16 @@ class GenericAssetEndpoint(BaseAPIView):
             # Get the asset
             asset = FileAsset.objects.get(id=asset_id, workspace_id=workspace.id, is_deleted=False)
 
+            # WorkspaceUserPermission admits any active member of the workspace,
+            # including a GUEST who belongs to no project. The asset lookup binds
+            # the workspace and nothing else, so the project dimension has to be
+            # enforced here -- as the app surface already does for the same model.
+            if not asset.is_project_accessible_to(request.user):
+                return Response(
+                    {"error": "You don't have access to this asset."},
+                    status=status.HTTP_403_FORBIDDEN,
+                )
+
             # Check if the asset exists and is uploaded
             if not asset.is_uploaded:
                 return Response(
@@ -448,7 +458,7 @@ class GenericAssetEndpoint(BaseAPIView):
             # Force attachment disposition for script-capable MIME types (e.g. SVG)
             # to prevent same-origin XSS when the asset URL shares the app's origin
             # (default MinIO self-hosted setup).
-            storage = S3Storage(request=request, is_server=True)
+            storage = S3Storage(request=request)
             asset_mime_type = (asset.attributes.get("type") or "").split(";")[0].strip().lower()
             disposition = (
                 "attachment" if asset_mime_type in settings.SCRIPT_CAPABLE_MIME_TYPES else "inline"
@@ -542,6 +552,28 @@ class GenericAssetEndpoint(BaseAPIView):
         # Get the workspace
         workspace = Workspace.objects.get(slug=slug)
 
+        # project_id arrives in the request body and was stored unvalidated, so a
+        # member of one workspace could mint an asset row pointing at a project in
+        # another. Bind it to the URL workspace and to the caller's membership;
+        # rows where workspace_id != project.workspace_id are the inconsistency
+        # is_project_accessible_to has to defend against downstream.
+        if project_id:
+            if not Project.objects.filter(id=project_id, workspace_id=workspace.id).exists():
+                return Response(
+                    {"error": "Project not found.", "status": False},
+                    status=status.HTTP_404_NOT_FOUND,
+                )
+            if not ProjectMember.objects.filter(
+                member=request.user,
+                workspace_id=workspace.id,
+                project_id=project_id,
+                is_active=True,
+            ).exists():
+                return Response(
+                    {"error": "You don't have access to this project.", "status": False},
+                    status=status.HTTP_403_FORBIDDEN,
+                )
+
         # asset key
         asset_key = f"{workspace.id}/{uuid.uuid4().hex}-{name}"
 
@@ -578,7 +610,7 @@ class GenericAssetEndpoint(BaseAPIView):
         )
 
         # Get the presigned URL
-        storage = S3Storage(request=request, is_server=True)
+        storage = S3Storage(request=request)
         presigned_url = storage.generate_presigned_post(object_name=asset_key, file_type=type, file_size=size_limit)
 
         return Response(
@@ -619,6 +651,15 @@ class GenericAssetEndpoint(BaseAPIView):
         """
         try:
             asset = FileAsset.objects.get(id=asset_id, workspace__slug=slug, is_deleted=False)
+
+            # is_uploaded gates every download path, so an unscoped write here
+            # lets any workspace member make another project's attachment vanish
+            # for its own members, or mark a never-uploaded asset complete.
+            if not asset.is_project_accessible_to(request.user):
+                return Response(
+                    {"error": "You don't have access to this asset."},
+                    status=status.HTTP_403_FORBIDDEN,
+                )
 
             # Update is_uploaded status
             asset.is_uploaded = request.data.get("is_uploaded", asset.is_uploaded)

--- a/apps/api/plane/app/views/asset/v2.py
+++ b/apps/api/plane/app/views/asset/v2.py
@@ -313,30 +313,6 @@ class WorkspaceFileAssetEndpoint(BaseAPIView):
         else:
             return
 
-    def has_project_asset_access(self, request, asset):
-        """Return whether the user may access a workspace-scoped asset.
-
-        This endpoint is authorized at the WORKSPACE level, so a workspace
-        member/guest could otherwise reach an asset that belongs to a project
-        they are not a member of. For project-bound assets, require an active
-        ProjectMember of the asset's project. Workspace-level entity types
-        (WORKSPACE_LOGO, USER_AVATAR, USER_COVER) have project_id=None and are
-        always allowed.
-        """
-        if asset.project_id is None:
-            return True
-        # Scope the membership lookup to the asset's workspace as well as its
-        # project, mirroring allow_permission's PROJECT branch. This prevents a
-        # member of the same project in a different workspace from passing the
-        # check should an asset row ever be inconsistent (asset.workspace_id !=
-        # asset.project.workspace_id).
-        return ProjectMember.objects.filter(
-            member=request.user,
-            workspace_id=asset.workspace_id,
-            project_id=asset.project_id,
-            is_active=True,
-        ).exists()
-
     @allow_permission([ROLE.ADMIN, ROLE.MEMBER, ROLE.GUEST], level="WORKSPACE")
     def post(self, request, slug):
         name = sanitize_filename(request.data.get("name")) or "unnamed"
@@ -419,7 +395,7 @@ class WorkspaceFileAssetEndpoint(BaseAPIView):
         # get the asset id
         asset = FileAsset.objects.get(id=asset_id, workspace__slug=slug)
         # enforce project-level access for project-bound assets
-        if not self.has_project_asset_access(request, asset):
+        if not asset.is_project_accessible_to(request.user):
             return Response(
                 {"error": "You don't have access to this asset."},
                 status=status.HTTP_403_FORBIDDEN,
@@ -446,7 +422,7 @@ class WorkspaceFileAssetEndpoint(BaseAPIView):
     def delete(self, request, slug, asset_id):
         asset = FileAsset.objects.get(id=asset_id, workspace__slug=slug)
         # enforce project-level access for project-bound assets
-        if not self.has_project_asset_access(request, asset):
+        if not asset.is_project_accessible_to(request.user):
             return Response(
                 {"error": "You don't have access to this asset."},
                 status=status.HTTP_403_FORBIDDEN,
@@ -463,7 +439,7 @@ class WorkspaceFileAssetEndpoint(BaseAPIView):
         # get the asset id
         asset = FileAsset.objects.get(id=asset_id, workspace__slug=slug)
         # enforce project-level access for project-bound assets
-        if not self.has_project_asset_access(request, asset):
+        if not asset.is_project_accessible_to(request.user):
             return Response(
                 {"error": "You don't have access to this asset."},
                 status=status.HTTP_403_FORBIDDEN,
@@ -539,6 +515,14 @@ class AssetRestoreEndpoint(BaseAPIView):
     @allow_permission([ROLE.ADMIN, ROLE.MEMBER, ROLE.GUEST], level="WORKSPACE")
     def post(self, request, slug, asset_id):
         asset = FileAsset.all_objects.get(id=asset_id, workspace__slug=slug)
+        # Authorized at the WORKSPACE level, so without this a workspace member
+        # who is not in the asset's project could reverse a deletion performed
+        # by that project's own members.
+        if not asset.is_project_accessible_to(request.user):
+            return Response(
+                {"error": "You don't have access to this asset."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
         asset.is_deleted = False
         asset.deleted_at = None
         asset.save(update_fields=["is_deleted", "deleted_at"])
@@ -772,8 +756,12 @@ class AssetCheckEndpoint(BaseAPIView):
 
     @allow_permission([ROLE.ADMIN, ROLE.MEMBER, ROLE.GUEST], level="WORKSPACE")
     def get(self, request, slug, asset_id):
-        asset = FileAsset.all_objects.filter(id=asset_id, workspace__slug=slug, deleted_at__isnull=True).exists()
-        return Response({"exists": asset}, status=status.HTTP_200_OK)
+        asset = FileAsset.all_objects.filter(id=asset_id, workspace__slug=slug, deleted_at__isnull=True).first()
+        # Report existence only to callers who could otherwise reach the asset.
+        # Reporting it unconditionally makes this route an existence oracle for
+        # every project in the workspace, including ones the caller cannot see.
+        exists = asset is not None and asset.is_project_accessible_to(request.user)
+        return Response({"exists": exists}, status=status.HTTP_200_OK)
 
 
 class DuplicateAssetEndpoint(BaseAPIView):
@@ -829,6 +817,20 @@ class DuplicateAssetEndpoint(BaseAPIView):
             # check if project exists in the workspace
             if not Project.objects.filter(id=project_id, workspace=workspace).exists():
                 return Response({"error": "Project not found"}, status=status.HTTP_404_NOT_FOUND)
+            # project_id is the *destination* and comes from the request body.
+            # Existence in the workspace is not authorization: require the caller
+            # to be an active member of the project the copy will land in, or a
+            # workspace member could deposit assets into any project.
+            if not ProjectMember.objects.filter(
+                member=request.user,
+                workspace=workspace,
+                project_id=project_id,
+                is_active=True,
+            ).exists():
+                return Response(
+                    {"error": "You don't have access to this project."},
+                    status=status.HTTP_403_FORBIDDEN,
+                )
 
         storage = S3Storage(request=request)
         # Restrict the source asset to the same destination workspace to prevent cross-workspace asset copying
@@ -840,6 +842,15 @@ class DuplicateAssetEndpoint(BaseAPIView):
 
         if not original_asset:
             return Response({"error": "Asset not found"}, status=status.HTTP_404_NOT_FOUND)
+
+        # The source lookup binds the workspace but not the project, so without
+        # this a non-member could copy a project's asset into a project they do
+        # control -- a permanent copy that outlives the original being deleted.
+        if not original_asset.is_project_accessible_to(request.user):
+            return Response(
+                {"error": "You don't have access to this asset."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
 
         sanitized_name = sanitize_filename(original_asset.attributes.get("name")) or "unnamed"
         destination_key = f"{workspace.id}/{uuid.uuid4().hex}-{sanitized_name}"
@@ -880,6 +891,16 @@ class WorkspaceAssetDownloadEndpoint(BaseAPIView):
             return Response(
                 {"error": "The requested asset could not be found."},
                 status=status.HTTP_404_NOT_FOUND,
+            )
+
+        # The workspace-level twin of ProjectAssetDownloadEndpoint, which binds
+        # project_id through level="PROJECT". Here the project is not in the URL,
+        # so it has to be enforced against the asset itself -- otherwise the
+        # presigned URL hands the file to a non-member of its project.
+        if not asset.is_project_accessible_to(request.user):
+            return Response(
+                {"error": "You don't have access to this asset."},
+                status=status.HTTP_403_FORBIDDEN,
             )
 
         storage = S3Storage(request=request)

--- a/apps/api/plane/app/views/asset/v2.py
+++ b/apps/api/plane/app/views/asset/v2.py
@@ -813,24 +813,6 @@ class DuplicateAssetEndpoint(BaseAPIView):
             )
 
         workspace = Workspace.objects.get(slug=slug)
-        if project_id:
-            # check if project exists in the workspace
-            if not Project.objects.filter(id=project_id, workspace=workspace).exists():
-                return Response({"error": "Project not found"}, status=status.HTTP_404_NOT_FOUND)
-            # project_id is the *destination* and comes from the request body.
-            # Existence in the workspace is not authorization: require the caller
-            # to be an active member of the project the copy will land in, or a
-            # workspace member could deposit assets into any project.
-            if not ProjectMember.objects.filter(
-                member=request.user,
-                workspace=workspace,
-                project_id=project_id,
-                is_active=True,
-            ).exists():
-                return Response(
-                    {"error": "You don't have access to this project."},
-                    status=status.HTTP_403_FORBIDDEN,
-                )
 
         storage = S3Storage(request=request)
         # Restrict the source asset to the same destination workspace to prevent cross-workspace asset copying
@@ -851,6 +833,38 @@ class DuplicateAssetEndpoint(BaseAPIView):
                 {"error": "You don't have access to this asset."},
                 status=status.HTTP_403_FORBIDDEN,
             )
+
+        # A caller may redirect the copy to a different project than the source
+        # (e.g. duplicating an attachment onto an issue that lives in another
+        # project) by naming project_id explicitly -- that's still validated
+        # below. But leaving it out (or sending it empty/null) must not be read
+        # as "make this workspace-level": the caller's access to the source
+        # only ever came through its project, and defaulting to None here
+        # would strip that scoping and expose the copy to the entire
+        # workspace. This isn't something the client should be able to unset
+        # at all -- default to the source's own project instead.
+        if project_id:
+            # check if project exists in the workspace
+            if not Project.objects.filter(id=project_id, workspace=workspace).exists():
+                return Response(
+                    {"error": "Project not found", "status": False}, status=status.HTTP_404_NOT_FOUND
+                )
+            # project_id is the *destination* and comes from the request body.
+            # Existence in the workspace is not authorization: require the caller
+            # to be an active member of the project the copy will land in, or a
+            # workspace member could deposit assets into any project.
+            if not ProjectMember.objects.filter(
+                member=request.user,
+                workspace=workspace,
+                project_id=project_id,
+                is_active=True,
+            ).exists():
+                return Response(
+                    {"error": "You don't have access to this project.", "status": False},
+                    status=status.HTTP_403_FORBIDDEN,
+                )
+        else:
+            project_id = original_asset.project_id
 
         sanitized_name = sanitize_filename(original_asset.attributes.get("name")) or "unnamed"
         destination_key = f"{workspace.id}/{uuid.uuid4().hex}-{sanitized_name}"

--- a/apps/api/plane/app/views/asset/v2.py
+++ b/apps/api/plane/app/views/asset/v2.py
@@ -834,6 +834,16 @@ class DuplicateAssetEndpoint(BaseAPIView):
                 status=status.HTTP_403_FORBIDDEN,
             )
 
+        # get_entity_id_field() (below) derives the persisted project_id for a
+        # PROJECT_COVER duplicate from entity_id, overriding whatever project_id
+        # was supplied separately -- so entity_id, not the request body's
+        # project_id, is the value that actually lands on the new row. Validate
+        # that value here too, or a caller could pass a project_id they belong to
+        # just to clear the membership check below while entity_id -- the real
+        # destination -- points at a project they were never checked against.
+        if entity_type == FileAsset.EntityTypeContext.PROJECT_COVER:
+            project_id = entity_id
+
         # A caller may redirect the copy to a different project than the source
         # (e.g. duplicating an attachment onto an issue that lives in another
         # project) by naming project_id explicitly -- that's still validated
@@ -868,6 +878,11 @@ class DuplicateAssetEndpoint(BaseAPIView):
 
         sanitized_name = sanitize_filename(original_asset.attributes.get("name")) or "unnamed"
         destination_key = f"{workspace.id}/{uuid.uuid4().hex}-{sanitized_name}"
+        entity_id_fields = self.get_entity_id_field(entity_type=entity_type, entity_id=entity_id)
+        # project_id is already validated above -- and for PROJECT_COVER it *is*
+        # entity_id -- so drop any project_id get_entity_id_field derived to avoid
+        # passing it twice to create() below.
+        entity_id_fields.pop("project_id", None)
         duplicated_asset = FileAsset.objects.create(
             attributes={
                 "name": original_asset.attributes.get("name"),
@@ -881,7 +896,7 @@ class DuplicateAssetEndpoint(BaseAPIView):
             entity_type=entity_type,
             project_id=project_id if project_id else None,
             storage_metadata=original_asset.storage_metadata,
-            **self.get_entity_id_field(entity_type=entity_type, entity_id=entity_id),
+            **entity_id_fields,
         )
         storage.copy_object(original_asset.asset, destination_key)
         # Update the is_uploaded field for all newly created assets

--- a/apps/api/plane/db/models/asset.py
+++ b/apps/api/plane/db/models/asset.py
@@ -14,6 +14,7 @@ from django.db import models
 from plane.utils.path_validator import sanitize_filename
 
 from .base import BaseModel
+from .project import ProjectMember
 
 
 def get_upload_path(instance, filename):
@@ -101,3 +102,38 @@ class FileAsset(BaseModel):
             return f"/api/assets/v2/workspaces/{self.workspace.slug}/projects/{self.project_id}/{self.id}/"
 
         return None
+
+    def is_project_accessible_to(self, user):
+        """Return whether ``user`` clears the project dimension of access to this asset.
+
+        This is the project-membership half of asset authorization and nothing
+        more. Callers are still responsible for establishing that ``user`` may
+        act in this asset's workspace at all -- typically the endpoint's
+        permission class or ``allow_permission(..., level="WORKSPACE")``.
+
+        It exists as a model method rather than a view helper because the
+        workspace-level asset routes are spread across several unrelated
+        ``BaseAPIView`` subclasses in both the app and the external API, and a
+        helper bound to one of those classes is unreachable from the others.
+        That is precisely how the earlier project-scoping fix came to cover
+        three handlers and miss the rest: a route added later has no way to
+        inherit the rule. Keeping it on the model means every surface that can
+        load a ``FileAsset`` can also ask the question.
+
+        Assets with no project (workspace logos, user avatars and covers) carry
+        ``project_id=None`` and are workspace-level by definition, so they clear
+        this check; workspace authorization is the only gate that applies.
+        """
+        if self.project_id is None:
+            return True
+        # Scope the membership lookup to this asset's workspace as well as its
+        # project. A project id alone would let a member of a same-id project in
+        # a different workspace pass, should a row ever be inconsistent
+        # (workspace_id != project.workspace_id) -- a state the external API's
+        # create path could previously produce.
+        return ProjectMember.objects.filter(
+            member=user,
+            workspace_id=self.workspace_id,
+            project_id=self.project_id,
+            is_active=True,
+        ).exists()

--- a/apps/api/plane/tests/contract/api/conftest.py
+++ b/apps/api/plane/tests/contract/api/conftest.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Shared fixtures for the external-API contract tests.
+
+Every test in this package authenticates with the ``api_token`` fixture, whose
+token string is a constant. ``ApiKeyRateThrottle.get_cache_key`` keys on that
+string, so all of these tests share one throttle bucket for the whole run --
+``API_KEY_RATE_LIMIT`` defaults to 60/minute, and the suite finishes well inside
+a minute. Once the package as a whole crosses 60 requests, whichever test issues
+the next one fails with 429, which shows up as an unrelated test breaking in a
+file nobody touched.
+
+Resetting the bucket around each test keeps the failure attributable and stops
+the package having an effective cap on how many API calls its tests may make in
+total. Only this throttle's key is removed, mirroring the narrowly-scoped
+``_clear_auth_throttle_keys`` helper in the app authentication tests, rather than
+calling ``cache.clear()`` and disturbing unrelated cached state.
+"""
+
+import pytest
+from django.core.cache import cache
+
+
+def _clear_api_key_throttle_keys():
+    """Delete only ApiKeyRateThrottle history keys from the shared cache.
+
+    ``ApiKeyRateThrottle`` overrides ``get_cache_key`` to return
+    ``f"{self.scope}:{api_key}"``, so its entries are ``api_key:<token>`` and do
+    not carry DRF's usual ``throttle_`` prefix.
+    """
+    cache.delete_pattern("api_key:*")
+
+
+@pytest.fixture(autouse=True)
+def _reset_api_key_throttle_cache():
+    """Give every external-API contract test a clean throttle bucket."""
+    _clear_api_key_throttle_keys()
+    yield
+    _clear_api_key_throttle_keys()

--- a/apps/api/plane/tests/contract/api/test_generic_asset_project_scope.py
+++ b/apps/api/plane/tests/contract/api/test_generic_asset_project_scope.py
@@ -295,3 +295,94 @@ class TestGenericAssetPostProjectScope:
             f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
         )
         assert FileAsset.objects.count() == before + 1
+
+
+@pytest.mark.contract
+class TestGenericAssetExternalIdDedupDisclosure:
+    """The 409 dedup echo must not hand out a foreign project's asset identifiers.
+
+    The dedup lookup matches on workspace + external_source + external_id, with no
+    project scoping, and the 409 body carries ``asset_id`` and ``asset_url``. That
+    url embeds the owning project and issue ids for an attachment. Since knowing
+    the asset UUID is the precondition for every asset-scoped attack on this
+    surface, echoing a match the caller cannot access supplies exactly what the
+    other guards in this module exist to make useless.
+    """
+
+    EXTERNAL = {"external_id": "EXT-1", "external_source": "jira"}
+
+    def _payload(self, project_id=None):
+        payload = {"name": "dedup.png", "type": "image/png", "size": 16, **self.EXTERNAL}
+        if project_id is not None:
+            payload["project_id"] = str(project_id)
+        return payload
+
+    @pytest.mark.django_db
+    def test_dedup_does_not_disclose_foreign_asset_identifiers(
+        self, api_key_client, workspace, foreign_asset, joined_project
+    ):
+        """404, not 403: a 403 would still confirm the external id pair is taken."""
+        foreign_asset.external_id = self.EXTERNAL["external_id"]
+        foreign_asset.external_source = self.EXTERNAL["external_source"]
+        foreign_asset.save(update_fields=["external_id", "external_source"])
+
+        response = api_key_client.post(
+            asset_list_url(workspace.slug), self._payload(joined_project.id), format="json"
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+        body = str(getattr(response, "data", ""))
+        assert str(foreign_asset.id) not in body, "the foreign asset id was disclosed"
+        assert str(foreign_asset.project_id) not in body, "the foreign project id was disclosed"
+
+    @pytest.mark.django_db
+    def test_dedup_does_not_disclose_when_project_id_is_omitted(
+        self, api_key_client, workspace, foreign_asset
+    ):
+        """Omitting project_id skips the create-path validation, so this branch is the only gate."""
+        foreign_asset.external_id = self.EXTERNAL["external_id"]
+        foreign_asset.external_source = self.EXTERNAL["external_source"]
+        foreign_asset.save(update_fields=["external_id", "external_source"])
+
+        response = api_key_client.post(asset_list_url(workspace.slug), self._payload(), format="json")
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+        assert str(foreign_asset.id) not in str(getattr(response, "data", ""))
+
+    @pytest.mark.django_db
+    def test_dedup_still_echoes_an_accessible_asset(
+        self, api_key_client, workspace, joined_asset, joined_project
+    ):
+        """Dedup must keep working for a caller who is a member of the match's project."""
+        joined_asset.external_id = self.EXTERNAL["external_id"]
+        joined_asset.external_source = self.EXTERNAL["external_source"]
+        joined_asset.save(update_fields=["external_id", "external_source"])
+
+        response = api_key_client.post(
+            asset_list_url(workspace.slug), self._payload(joined_project.id), format="json"
+        )
+
+        assert response.status_code == status.HTTP_409_CONFLICT, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+        assert response.data["asset_id"] == str(joined_asset.id)
+
+    @pytest.mark.django_db
+    def test_dedup_still_echoes_a_workspace_level_asset(
+        self, api_key_client, workspace, workspace_level_asset
+    ):
+        """project_id is NULL, so there is no project dimension to gate on."""
+        workspace_level_asset.external_id = self.EXTERNAL["external_id"]
+        workspace_level_asset.external_source = self.EXTERNAL["external_source"]
+        workspace_level_asset.save(update_fields=["external_id", "external_source"])
+
+        response = api_key_client.post(asset_list_url(workspace.slug), self._payload(), format="json")
+
+        assert response.status_code == status.HTTP_409_CONFLICT, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+        assert response.data["asset_id"] == str(workspace_level_asset.id)

--- a/apps/api/plane/tests/contract/api/test_generic_asset_project_scope.py
+++ b/apps/api/plane/tests/contract/api/test_generic_asset_project_scope.py
@@ -317,6 +317,24 @@ class TestGenericAssetExternalIdDedupDisclosure:
             payload["project_id"] = str(project_id)
         return payload
 
+    @staticmethod
+    def _assert_discloses_nothing(response, foreign_asset):
+        """The denied response must carry no identifier for the matched asset.
+
+        Asserting the keys are absent as well as the UUIDs: ``asset_url`` is
+        derived from ``entity_type``, and its workspace-level form
+        (``/api/assets/v2/static/<id>/``) carries no project id at all, so a
+        substring check on the project UUID alone would not catch every leak.
+        Absence of the field is the invariant worth pinning.
+        """
+        data = getattr(response, "data", {}) or {}
+        assert "asset_url" not in data, "the foreign asset URL was disclosed"
+        assert "asset_id" not in data, "the foreign asset id was disclosed"
+
+        body = str(data)
+        assert str(foreign_asset.id) not in body, "the foreign asset id leaked into the body"
+        assert str(foreign_asset.project_id) not in body, "the foreign project id leaked into the body"
+
     @pytest.mark.django_db
     def test_dedup_does_not_disclose_foreign_asset_identifiers(
         self, api_key_client, workspace, foreign_asset, joined_project
@@ -333,9 +351,7 @@ class TestGenericAssetExternalIdDedupDisclosure:
         assert response.status_code == status.HTTP_404_NOT_FOUND, (
             f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
         )
-        body = str(getattr(response, "data", ""))
-        assert str(foreign_asset.id) not in body, "the foreign asset id was disclosed"
-        assert str(foreign_asset.project_id) not in body, "the foreign project id was disclosed"
+        self._assert_discloses_nothing(response, foreign_asset)
 
     @pytest.mark.django_db
     def test_dedup_does_not_disclose_when_project_id_is_omitted(
@@ -351,7 +367,7 @@ class TestGenericAssetExternalIdDedupDisclosure:
         assert response.status_code == status.HTTP_404_NOT_FOUND, (
             f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
         )
-        assert str(foreign_asset.id) not in str(getattr(response, "data", ""))
+        self._assert_discloses_nothing(response, foreign_asset)
 
     @pytest.mark.django_db
     def test_dedup_still_echoes_an_accessible_asset(

--- a/apps/api/plane/tests/contract/api/test_generic_asset_project_scope.py
+++ b/apps/api/plane/tests/contract/api/test_generic_asset_project_scope.py
@@ -1,0 +1,297 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Contract tests for project scoping on the external-API ``GenericAssetEndpoint`` (INFRA-501).
+
+The endpoint authorizes with ``WorkspaceUserPermission`` -- any active member of
+the URL workspace, any role, including a GUEST who belongs to no project -- and
+then resolves the asset on the workspace alone. The app surface enforces an
+active ``ProjectMember`` of the asset's project for the same model; this surface
+never did, so:
+
+* ``get``   discloses a project-bound asset's existence and upload state, and
+            (once the presigned stage is reachable) its contents
+* ``patch`` flips ``is_uploaded``, which gates every download path, so an
+            attachment can be made to vanish for the project that owns it
+* ``post``  stored a body-supplied ``project_id`` unvalidated, so a row could be
+            created in one workspace pointing at a project in another
+
+Both surfaces now share one rule, ``FileAsset.is_project_accessible_to``.
+
+Workspace-level assets (``project_id=None``) must stay reachable by any
+workspace member, and a member of the asset's project must keep full access --
+both covered here so the fix cannot over-reach.
+
+The ``get``/``post`` positive paths patch ``S3Storage`` with ``autospec=True``
+deliberately: these call sites passed a keyword the constructor does not accept,
+which raised ``TypeError`` and turned the routes into an unconditional 500 for
+every caller. An autospec'd mock validates the call signature, so it fails if
+that regresses; a plain mock would swallow it.
+"""
+
+from unittest import mock
+from uuid import uuid4
+
+import pytest
+from rest_framework import status
+
+from plane.db.models import (
+    FileAsset,
+    Project,
+    ProjectMember,
+    User,
+    Workspace,
+    WorkspaceMember,
+)
+
+S3_STORAGE_PATH = "plane.api.views.asset.S3Storage"
+
+
+def asset_detail_url(slug, asset_id):
+    return f"/api/v1/workspaces/{slug}/assets/{asset_id}/"
+
+
+def asset_list_url(slug):
+    return f"/api/v1/workspaces/{slug}/assets/"
+
+
+def _user(prefix):
+    unique_id = uuid4().hex[:8]
+    user = User.objects.create(
+        email=f"{prefix}-{unique_id}@plane.so",
+        username=f"{prefix}_{unique_id}",
+        first_name=prefix.capitalize(),
+        last_name="User",
+    )
+    user.set_password("test-password")
+    user.save()
+    return user
+
+
+@pytest.fixture
+def project_owner(db):
+    return _user("owner")
+
+
+@pytest.fixture
+def foreign_project(db, workspace, project_owner):
+    """A project in the caller's workspace that the caller is NOT a member of.
+
+    ``create_user`` (who holds the API token) is a workspace ADMIN here, which is
+    the point: workspace role does not substitute for project membership, exactly
+    as the app surface already behaves.
+    """
+    WorkspaceMember.objects.create(
+        workspace=workspace, member=project_owner, role=20, is_active=True
+    )
+    project = Project.objects.create(
+        name="Foreign Project", identifier="FGN", workspace=workspace, created_by=project_owner
+    )
+    ProjectMember.objects.create(
+        project=project, member=project_owner, workspace=workspace, role=20, is_active=True
+    )
+    return project
+
+
+@pytest.fixture
+def joined_project(db, workspace, create_user):
+    """A project the token holder is an active member of."""
+    project = Project.objects.create(
+        name="Joined Project", identifier="JND", workspace=workspace, created_by=create_user
+    )
+    ProjectMember.objects.create(
+        project=project, member=create_user, workspace=workspace, role=20, is_active=True
+    )
+    return project
+
+
+def _asset(workspace, creator, project=None, name="secret.pdf"):
+    return FileAsset.objects.create(
+        attributes={"name": name, "type": "application/pdf", "size": 1024},
+        asset=f"{workspace.id}/{uuid4().hex}-{name}",
+        size=1024,
+        workspace=workspace,
+        project=project,
+        created_by=creator,
+        entity_type=FileAsset.EntityTypeContext.ISSUE_ATTACHMENT,
+        is_uploaded=True,
+        storage_metadata={"size": 1024},
+    )
+
+
+@pytest.fixture
+def foreign_asset(db, workspace, foreign_project, project_owner):
+    return _asset(workspace, project_owner, foreign_project)
+
+
+@pytest.fixture
+def joined_asset(db, workspace, joined_project, create_user):
+    return _asset(workspace, create_user, joined_project, name="mine.pdf")
+
+
+@pytest.fixture
+def workspace_level_asset(db, workspace, create_user):
+    """project_id is NULL -- workspace-scoped by definition."""
+    asset = _asset(workspace, create_user, None, name="logo.png")
+    asset.entity_type = FileAsset.EntityTypeContext.WORKSPACE_LOGO
+    asset.save(update_fields=["entity_type"])
+    return asset
+
+
+@pytest.fixture
+def other_workspace_project(db):
+    """A project in an unrelated workspace, for the cross-tenant create case."""
+    owner = _user("tenant")
+    other = Workspace.objects.create(
+        name="Other Workspace", owner=owner, slug=f"other-{uuid4().hex[:8]}"
+    )
+    WorkspaceMember.objects.create(workspace=other, member=owner, role=20, is_active=True)
+    project = Project.objects.create(
+        name="Other Project", identifier="OTH", workspace=other, created_by=owner
+    )
+    ProjectMember.objects.create(
+        project=project, member=owner, workspace=other, role=20, is_active=True
+    )
+    return project
+
+
+@pytest.mark.contract
+class TestGenericAssetGetProjectScope:
+    @pytest.mark.django_db
+    def test_get_denied_for_non_project_member(self, api_key_client, workspace, foreign_asset):
+        with mock.patch(S3_STORAGE_PATH) as mock_storage:
+            # Return a real string, not the default MagicMock: if this guard ever
+            # regresses, the handler puts this value into a DRF Response, and JSON
+            # -encoding a MagicMock recurses until the process is OOM-killed. A
+            # regression must fail this assertion, not take the test runner down.
+            mock_storage.return_value.generate_presigned_url.return_value = "https://example.com/s"
+            response = api_key_client.get(asset_detail_url(workspace.slug, foreign_asset.id))
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+        mock_storage.return_value.generate_presigned_url.assert_not_called()
+
+    @pytest.mark.django_db
+    def test_get_does_not_leak_upload_state_of_foreign_asset(
+        self, api_key_client, workspace, foreign_asset
+    ):
+        """A not-yet-uploaded foreign asset must 403, not answer 400 'not uploaded'."""
+        foreign_asset.is_uploaded = False
+        foreign_asset.save(update_fields=["is_uploaded"])
+
+        response = api_key_client.get(asset_detail_url(workspace.slug, foreign_asset.id))
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+
+    @pytest.mark.django_db
+    def test_get_allowed_for_project_member(self, api_key_client, workspace, joined_asset):
+        with mock.patch(S3_STORAGE_PATH, autospec=True) as mock_storage:
+            mock_storage.return_value.generate_presigned_url.return_value = "https://example.com/s"
+            response = api_key_client.get(asset_detail_url(workspace.slug, joined_asset.id))
+
+        assert response.status_code == status.HTTP_200_OK, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+        assert response.data["asset_url"] == "https://example.com/s"
+
+    @pytest.mark.django_db
+    def test_get_allowed_for_workspace_level_asset(
+        self, api_key_client, workspace, workspace_level_asset
+    ):
+        with mock.patch(S3_STORAGE_PATH, autospec=True) as mock_storage:
+            mock_storage.return_value.generate_presigned_url.return_value = "https://example.com/s"
+            response = api_key_client.get(asset_detail_url(workspace.slug, workspace_level_asset.id))
+
+        assert response.status_code == status.HTTP_200_OK, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+
+
+@pytest.mark.contract
+class TestGenericAssetPatchProjectScope:
+    @pytest.mark.django_db
+    def test_patch_denied_for_non_project_member(self, api_key_client, workspace, foreign_asset):
+        """is_uploaded gates every download path, so this is a takedown primitive."""
+        response = api_key_client.patch(
+            asset_detail_url(workspace.slug, foreign_asset.id),
+            {"is_uploaded": False},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+        foreign_asset.refresh_from_db()
+        assert foreign_asset.is_uploaded is True, "a foreign project's attachment was taken down"
+
+    @pytest.mark.django_db
+    def test_patch_allowed_for_project_member(self, api_key_client, workspace, joined_asset):
+        response = api_key_client.patch(
+            asset_detail_url(workspace.slug, joined_asset.id),
+            {"is_uploaded": False},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+        joined_asset.refresh_from_db()
+        assert joined_asset.is_uploaded is False
+
+
+@pytest.mark.contract
+class TestGenericAssetPostProjectScope:
+    def _payload(self, project_id):
+        return {
+            "name": "planted.png",
+            "type": "image/png",
+            "size": 16,
+            "project_id": str(project_id),
+        }
+
+    @pytest.mark.django_db
+    def test_post_denied_for_project_in_another_workspace(
+        self, api_key_client, workspace, other_workspace_project
+    ):
+        """The cross-tenant case: a row in workspace A pointing at a project of B."""
+        before = FileAsset.objects.count()
+        response = api_key_client.post(
+            asset_list_url(workspace.slug),
+            self._payload(other_workspace_project.id),
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+        assert FileAsset.objects.count() == before, "a cross-workspace asset row was created"
+
+    @pytest.mark.django_db
+    def test_post_denied_for_project_not_joined(self, api_key_client, workspace, foreign_project):
+        before = FileAsset.objects.count()
+        response = api_key_client.post(
+            asset_list_url(workspace.slug), self._payload(foreign_project.id), format="json"
+        )
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+        assert FileAsset.objects.count() == before
+
+    @pytest.mark.django_db
+    def test_post_allowed_for_joined_project(self, api_key_client, workspace, joined_project):
+        before = FileAsset.objects.count()
+        with mock.patch(S3_STORAGE_PATH, autospec=True) as mock_storage:
+            mock_storage.return_value.generate_presigned_post.return_value = {"url": "https://x"}
+            response = api_key_client.post(
+                asset_list_url(workspace.slug), self._payload(joined_project.id), format="json"
+            )
+
+        assert response.status_code == status.HTTP_200_OK, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+        assert FileAsset.objects.count() == before + 1

--- a/apps/api/plane/tests/contract/api/test_generic_asset_project_scope.py
+++ b/apps/api/plane/tests/contract/api/test_generic_asset_project_scope.py
@@ -296,6 +296,24 @@ class TestGenericAssetPostProjectScope:
         )
         assert FileAsset.objects.count() == before + 1
 
+    @pytest.mark.django_db
+    def test_post_denied_when_project_id_omitted(self, api_key_client, workspace):
+        """The endpoint only ever creates ISSUE_ATTACHMENT rows, a project-scoped
+        entity type. Omitting project_id must not create a project_id=None row --
+        is_project_accessible_to() treats that as workspace-accessible-by-default,
+        which would hand every workspace member access regardless of role.
+        """
+        before = FileAsset.objects.count()
+        payload = {"name": "planted.png", "type": "image/png", "size": 16}
+        response = api_key_client.post(asset_list_url(workspace.slug), payload, format="json")
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+        assert FileAsset.objects.count() == before, (
+            "an asset row was created with project_id=None despite the omitted field"
+        )
+
 
 @pytest.mark.contract
 class TestGenericAssetExternalIdDedupDisclosure:

--- a/apps/api/plane/tests/contract/app/test_workspace_asset_routes_project_scope_app.py
+++ b/apps/api/plane/tests/contract/app/test_workspace_asset_routes_project_scope_app.py
@@ -1,0 +1,302 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Contract tests for project scoping on the workspace-level asset routes (INFRA-501).
+
+``WorkspaceFileAssetEndpoint`` already required an active ``ProjectMember`` of a
+project-bound asset's project on get/patch/delete. Four sibling routes over the
+same ``FileAsset`` model, behind the same ``level="WORKSPACE"`` authorization,
+never received that check:
+
+* ``WorkspaceAssetDownloadEndpoint.get``  -- issues a presigned URL, i.e. the file
+* ``DuplicateAssetEndpoint.post``         -- copies the asset into a caller-named project
+* ``AssetRestoreEndpoint.post``           -- reverses a deletion the owner performed
+* ``AssetCheckEndpoint.get``              -- existence oracle
+
+So a workspace member or GUEST who belonged to none of the asset's projects could
+read, copy, undelete and probe another project's uploads. The rule now lives on
+the model as ``FileAsset.is_project_accessible_to`` so a route added later cannot
+silently omit it, which is how this gap arose in the first place.
+
+Workspace-level assets (workspace logo, user avatar/cover) carry
+``project_id=None``, are workspace-scoped by definition, and must stay reachable
+by any workspace member -- covered below so the fix cannot over-reach.
+"""
+
+from unittest import mock
+from uuid import uuid4
+
+import pytest
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from plane.db.models import FileAsset, Project, ProjectMember, User, WorkspaceMember
+
+S3_STORAGE_PATH = "plane.app.views.asset.v2.S3Storage"
+
+
+def download_url(slug, asset_id):
+    return f"/api/assets/v2/workspaces/{slug}/download/{asset_id}/"
+
+
+def check_url(slug, asset_id):
+    return f"/api/assets/v2/workspaces/{slug}/check/{asset_id}/"
+
+
+def restore_url(slug, asset_id):
+    return f"/api/assets/v2/workspaces/{slug}/restore/{asset_id}/"
+
+
+def duplicate_url(slug, asset_id):
+    return f"/api/assets/v2/workspaces/{slug}/duplicate-assets/{asset_id}/"
+
+
+def _user(prefix):
+    unique_id = uuid4().hex[:8]
+    user = User.objects.create(
+        email=f"{prefix}-{unique_id}@plane.so",
+        username=f"{prefix}_{unique_id}",
+        first_name=prefix.capitalize(),
+        last_name="User",
+    )
+    user.set_password("test-password")
+    user.save()
+    return user
+
+
+@pytest.fixture
+def project(db, workspace, create_user):
+    """A project in the fixture workspace; ``create_user`` is an active ADMIN."""
+    project = Project.objects.create(
+        name="Owner Project", identifier="OWN", workspace=workspace, created_by=create_user
+    )
+    ProjectMember.objects.create(
+        project=project, member=create_user, workspace=workspace, role=20, is_active=True
+    )
+    return project
+
+
+@pytest.fixture
+def outsider_user(db):
+    return _user("outsider")
+
+
+@pytest.fixture
+def outsider_client(db, workspace, outsider_user):
+    """A workspace GUEST who is a member of no project in the workspace."""
+    WorkspaceMember.objects.create(
+        workspace=workspace, member=outsider_user, role=5, is_active=True
+    )
+    client = APIClient()
+    client.force_authenticate(user=outsider_user)
+    return client
+
+
+@pytest.fixture
+def outsider_project(db, workspace, outsider_user):
+    """A project the outsider *does* control -- a duplicate destination."""
+    project = Project.objects.create(
+        name="Outsider Project", identifier="OUT", workspace=workspace, created_by=outsider_user
+    )
+    ProjectMember.objects.create(
+        project=project, member=outsider_user, workspace=workspace, role=20, is_active=True
+    )
+    return project
+
+
+@pytest.fixture
+def project_asset(db, workspace, project, create_user):
+    """An uploaded issue attachment belonging to ``project``."""
+    return FileAsset.objects.create(
+        attributes={"name": "secret.pdf", "type": "application/pdf", "size": 1024},
+        asset=f"{workspace.id}/secret.pdf",
+        size=1024,
+        workspace=workspace,
+        project=project,
+        created_by=create_user,
+        entity_type=FileAsset.EntityTypeContext.ISSUE_ATTACHMENT,
+        is_uploaded=True,
+        storage_metadata={"size": 1024},
+    )
+
+
+@pytest.fixture
+def deleted_project_asset(db, project_asset):
+    """``project_asset`` after its own project deleted it."""
+    project_asset.is_deleted = True
+    project_asset.deleted_at = timezone.now()
+    project_asset.save(update_fields=["is_deleted", "deleted_at"])
+    return project_asset
+
+
+@pytest.fixture
+def workspace_logo_asset(db, workspace, create_user):
+    """A workspace-level asset -- ``project_id`` is NULL, so no project gate applies."""
+    return FileAsset.objects.create(
+        attributes={"name": "logo.png", "type": "image/png", "size": 256},
+        asset=f"{workspace.id}/logo.png",
+        size=256,
+        workspace=workspace,
+        created_by=create_user,
+        entity_type=FileAsset.EntityTypeContext.WORKSPACE_LOGO,
+        is_uploaded=True,
+        storage_metadata={"size": 256},
+    )
+
+
+@pytest.mark.contract
+class TestWorkspaceAssetDownloadProjectScope:
+    @pytest.mark.django_db
+    def test_download_denied_for_non_project_member(self, outsider_client, workspace, project_asset):
+        """A non-member must not be handed a presigned URL for the file."""
+        with mock.patch(S3_STORAGE_PATH) as mock_storage:
+            # An explicit string, so a regression here fails the assertion rather
+            # than feeding a MagicMock into response rendering.
+            mock_storage.return_value.generate_presigned_url.return_value = "https://example.com/s"
+            response = outsider_client.get(download_url(workspace.slug, project_asset.id))
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+        mock_storage.return_value.generate_presigned_url.assert_not_called()
+
+    @pytest.mark.django_db
+    def test_download_allowed_for_project_member(self, session_client, workspace, project_asset):
+        with mock.patch(S3_STORAGE_PATH) as mock_storage:
+            mock_storage.return_value.generate_presigned_url.return_value = "https://example.com/s"
+            response = session_client.get(download_url(workspace.slug, project_asset.id))
+
+        assert response.status_code == status.HTTP_302_FOUND, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+
+    @pytest.mark.django_db
+    def test_download_workspace_level_asset_still_allowed(
+        self, outsider_client, workspace, workspace_logo_asset
+    ):
+        """project_id is NULL, so workspace membership alone must remain sufficient."""
+        with mock.patch(S3_STORAGE_PATH) as mock_storage:
+            mock_storage.return_value.generate_presigned_url.return_value = "https://example.com/s"
+            response = outsider_client.get(download_url(workspace.slug, workspace_logo_asset.id))
+
+        assert response.status_code == status.HTTP_302_FOUND, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+
+
+@pytest.mark.contract
+class TestAssetCheckProjectScope:
+    @pytest.mark.django_db
+    def test_check_does_not_disclose_existence_to_non_project_member(
+        self, outsider_client, workspace, project_asset
+    ):
+        """The oracle must answer False rather than confirming a foreign asset."""
+        response = outsider_client.get(check_url(workspace.slug, project_asset.id))
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["exists"] is False, (
+            "existence of another project's asset was disclosed to a non-member"
+        )
+
+    @pytest.mark.django_db
+    def test_check_reports_existence_to_project_member(self, session_client, workspace, project_asset):
+        response = session_client.get(check_url(workspace.slug, project_asset.id))
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["exists"] is True
+
+
+@pytest.mark.contract
+class TestAssetRestoreProjectScope:
+    @pytest.mark.django_db
+    def test_restore_denied_for_non_project_member(
+        self, outsider_client, workspace, deleted_project_asset
+    ):
+        """A non-member must not be able to reverse the owner's deletion."""
+        response = outsider_client.post(restore_url(workspace.slug, deleted_project_asset.id))
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+        deleted_project_asset.refresh_from_db()
+        assert deleted_project_asset.is_deleted is True
+        assert deleted_project_asset.deleted_at is not None
+
+    @pytest.mark.django_db
+    def test_restore_allowed_for_project_member(
+        self, session_client, workspace, deleted_project_asset
+    ):
+        response = session_client.post(restore_url(workspace.slug, deleted_project_asset.id))
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+        deleted_project_asset.refresh_from_db()
+        assert deleted_project_asset.is_deleted is False
+
+
+@pytest.mark.contract
+class TestDuplicateAssetProjectScope:
+    @pytest.mark.django_db
+    def test_duplicate_denied_when_source_not_accessible(
+        self, outsider_client, workspace, project_asset, outsider_project
+    ):
+        """The worst of the four: a permanent copy into a project the caller owns."""
+        before = FileAsset.objects.count()
+        with mock.patch(S3_STORAGE_PATH) as mock_storage:
+            response = outsider_client.post(
+                duplicate_url(workspace.slug, project_asset.id),
+                {
+                    "entity_type": FileAsset.EntityTypeContext.ISSUE_ATTACHMENT,
+                    "project_id": str(outsider_project.id),
+                },
+                format="json",
+            )
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+        mock_storage.return_value.copy_object.assert_not_called()
+        assert FileAsset.objects.count() == before, "a copy of a foreign asset was created"
+
+    @pytest.mark.django_db
+    def test_duplicate_denied_when_destination_project_not_joined(
+        self, session_client, workspace, project_asset, outsider_project
+    ):
+        """Source is reachable, destination is not: the body project_id needs its own check."""
+        before = FileAsset.objects.count()
+        with mock.patch(S3_STORAGE_PATH) as mock_storage:
+            response = session_client.post(
+                duplicate_url(workspace.slug, project_asset.id),
+                {
+                    "entity_type": FileAsset.EntityTypeContext.ISSUE_ATTACHMENT,
+                    "project_id": str(outsider_project.id),
+                },
+                format="json",
+            )
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+        mock_storage.return_value.copy_object.assert_not_called()
+        assert FileAsset.objects.count() == before
+
+    @pytest.mark.django_db
+    def test_duplicate_allowed_within_own_project(self, session_client, workspace, project, project_asset):
+        before = FileAsset.objects.count()
+        with mock.patch(S3_STORAGE_PATH):
+            response = session_client.post(
+                duplicate_url(workspace.slug, project_asset.id),
+                {
+                    "entity_type": FileAsset.EntityTypeContext.ISSUE_ATTACHMENT,
+                    "project_id": str(project.id),
+                },
+                format="json",
+            )
+
+        assert response.status_code == status.HTTP_200_OK, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+        assert FileAsset.objects.count() == before + 1

--- a/apps/api/plane/tests/contract/app/test_workspace_asset_routes_project_scope_app.py
+++ b/apps/api/plane/tests/contract/app/test_workspace_asset_routes_project_scope_app.py
@@ -300,3 +300,57 @@ class TestDuplicateAssetProjectScope:
             f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
         )
         assert FileAsset.objects.count() == before + 1
+
+    @pytest.mark.django_db
+    def test_duplicate_omitted_project_id_inherits_source_project(
+        self, session_client, workspace, project, project_asset
+    ):
+        """Omitting project_id must not strip the copy's project scoping.
+
+        The caller's access to ``project_asset`` is only established through
+        ``project`` membership; defaulting the copy to project_id=None would
+        make is_project_accessible_to() treat it as workspace-accessible by
+        default, exposing it to every workspace member regardless of role.
+        """
+        before = FileAsset.objects.count()
+        with mock.patch(S3_STORAGE_PATH):
+            response = session_client.post(
+                duplicate_url(workspace.slug, project_asset.id),
+                {"entity_type": FileAsset.EntityTypeContext.ISSUE_ATTACHMENT},
+                format="json",
+            )
+
+        assert response.status_code == status.HTTP_200_OK, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+        assert FileAsset.objects.count() == before + 1
+        duplicated_asset = FileAsset.objects.get(id=response.data["asset_id"])
+        assert duplicated_asset.project_id == project.id, (
+            "the duplicate did not inherit the source asset's project and was "
+            f"created with project_id={duplicated_asset.project_id!r} instead"
+        )
+
+    @pytest.mark.django_db
+    def test_duplicate_null_project_id_still_inherits_source_project(
+        self, session_client, workspace, project, project_asset
+    ):
+        """An explicit ``project_id: null`` must not override inheritance either --
+        the field isn't meant to be client-settable to "no project" at all when
+        the source asset has one."""
+        before = FileAsset.objects.count()
+        with mock.patch(S3_STORAGE_PATH):
+            response = session_client.post(
+                duplicate_url(workspace.slug, project_asset.id),
+                {
+                    "entity_type": FileAsset.EntityTypeContext.ISSUE_ATTACHMENT,
+                    "project_id": None,
+                },
+                format="json",
+            )
+
+        assert response.status_code == status.HTTP_200_OK, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+        assert FileAsset.objects.count() == before + 1
+        duplicated_asset = FileAsset.objects.get(id=response.data["asset_id"])
+        assert duplicated_asset.project_id == project.id

--- a/apps/api/plane/tests/contract/app/test_workspace_asset_routes_project_scope_app.py
+++ b/apps/api/plane/tests/contract/app/test_workspace_asset_routes_project_scope_app.py
@@ -354,3 +354,61 @@ class TestDuplicateAssetProjectScope:
         assert FileAsset.objects.count() == before + 1
         duplicated_asset = FileAsset.objects.get(id=response.data["asset_id"])
         assert duplicated_asset.project_id == project.id
+
+    @pytest.mark.django_db
+    def test_duplicate_project_cover_denied_when_entity_id_is_foreign_project(
+        self, session_client, workspace, project, project_asset, outsider_project
+    ):
+        """PROJECT_COVER's entity_id -- not project_id -- is the real destination.
+
+        get_entity_id_field() turns entity_id into the project_id that actually
+        gets persisted, overriding whatever project_id was supplied. A caller who
+        puts a project they belong to in project_id (clearing the membership
+        check) but a foreign project in entity_id must still be rejected, or the
+        duplicate lands in a project they were never checked against.
+        """
+        before = FileAsset.objects.count()
+        with mock.patch(S3_STORAGE_PATH) as mock_storage:
+            response = session_client.post(
+                duplicate_url(workspace.slug, project_asset.id),
+                {
+                    "entity_type": FileAsset.EntityTypeContext.PROJECT_COVER,
+                    "project_id": str(project.id),
+                    "entity_id": str(outsider_project.id),
+                },
+                format="json",
+            )
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+        mock_storage.return_value.copy_object.assert_not_called()
+        assert FileAsset.objects.count() == before, (
+            "a PROJECT_COVER duplicate was persisted into a project only named "
+            "via entity_id, which was never validated"
+        )
+
+    @pytest.mark.django_db
+    def test_duplicate_project_cover_allowed_for_own_project_entity_id(
+        self, session_client, workspace, project, project_asset
+    ):
+        """Sanity check: a legitimate PROJECT_COVER duplicate still works, and the
+        persisted project_id follows entity_id as intended."""
+        before = FileAsset.objects.count()
+        with mock.patch(S3_STORAGE_PATH):
+            response = session_client.post(
+                duplicate_url(workspace.slug, project_asset.id),
+                {
+                    "entity_type": FileAsset.EntityTypeContext.PROJECT_COVER,
+                    "project_id": str(project.id),
+                    "entity_id": str(project.id),
+                },
+                format="json",
+            )
+
+        assert response.status_code == status.HTTP_200_OK, (
+            f"Got {response.status_code}: {getattr(response, 'data', None)!r}"
+        )
+        assert FileAsset.objects.count() == before + 1
+        duplicated_asset = FileAsset.objects.get(id=response.data["asset_id"])
+        assert duplicated_asset.project_id == project.id


### PR DESCRIPTION
## Why

The project-membership rule for asset access lived as `has_project_asset_access`, a **method on `WorkspaceFileAssetEndpoint`**, with three call sites (`get`/`patch`/`delete` on that one class). Every other asset route is a sibling `BaseAPIView` subclass, so none of them could reach it.

That is not an oversight in a single handler — it is the shape of the bug. A route added to this file later has no way to inherit the rule, which is why the earlier fix covered three handlers and the rest of the surface kept being reported.

Four workspace-level routes in the app and the entire external-API asset surface therefore resolved assets by workspace alone, under authorization that admits any active workspace member including a GUEST who belongs to no project:

| Route | Effect for a non-member of the asset's project |
| :--- | :--- |
| `WorkspaceAssetDownloadEndpoint.get` | presigned S3 URL, i.e. the file contents |
| `DuplicateAssetEndpoint.post` | permanent copy into a project the caller controls — survives the owner deleting the original |
| `AssetRestoreEndpoint.post` | reverses a deletion the owning project performed |
| `AssetCheckEndpoint.get` | existence oracle across every project in the workspace |
| `GenericAssetEndpoint.get` (external API) | existence + upload state, and contents once reachable |
| `GenericAssetEndpoint.patch` (external API) | flips `is_uploaded`, which gates every download path |

The caller needs the asset UUID. The sharp case is a user removed from a project: they keep every id they saw while they were in it, and removal is exactly when an operator expects access to stop.

## What changed

**The rule moved onto the model** as `FileAsset.is_project_accessible_to(user)`. Both surfaces already import `FileAsset`, so there is no layering gymnastics and no home for the rule that some routes cannot reach. Its docstring is explicit that it is the *project* dimension only — workspace authorization remains the caller's job.

`app/views/asset/v2.py`
- The four routes above now check the asset's project. `AssetCheckEndpoint` answers `exists: false` rather than confirming a foreign asset, so it stops being a cross-project oracle.
- `DuplicateAssetEndpoint` additionally requires active membership of the **destination** project named in the request body. Existence in the workspace was being treated as authorization.
- `has_project_asset_access` is removed; its three call sites now use the model method. No behaviour change there — same query, same 403.

`api/views/asset.py`
- `GenericAssetEndpoint.get` and `.patch` gained the same check.
- `.post` validates the body-supplied `project_id` against the URL workspace **and** the caller's membership. It was stored unvalidated, so a row in one workspace could point at a project in another — precisely the inconsistent state `is_project_accessible_to` has to defend against downstream.

## Also fixed: three unconditional 500s in the same file

`S3Storage.__init__` is `(self, request=None)` and has never accepted `is_server`. `S3Storage(request=request, is_server=True)` at `api/views/asset.py:338`, `:451` and `:581` raised `TypeError` for every caller, so those three routes are 500s today. Passing no `request` is what selects the internal endpoint, making the keyword both wrong and redundant — it is dropped.

**This ships together with the authorization checks deliberately.** Repairing the crash on its own would have exposed a cross-project asset read on a route that currently only looks harmless.

## Verification

`docker compose -f docker-compose-test.yml`, since no workflow runs `pytest`.

**Fail-before**, in a clean worktree at `preview` (`e056bbf9eb`) with only the test files added: **13 of the 19 new tests fail.** The 6 that pass are the controls that must pass either way — a project member's access, and a workspace-level asset whose `project_id` is NULL. Sample failures are the vulnerability itself: the external-API takedown returns `204`, and the foreign-asset probe returns `400 {"error": "Asset not yet uploaded"}`.

The four external-API *positive* tests also fail before, because those routes are 500 for everyone until the `is_server` fix lands — which is the evidence for that half.

**Fail-after**: 28 passed — the 19 new plus the 9 pre-existing asset contract tests, so lifting the helper onto the model regressed nothing.

Each route is covered from a non-member, from a member, and with a `project_id=None` asset, so the fix cannot over-reach. The external-API positive paths patch `S3Storage` with `autospec=True` on purpose: an autospec'd mock validates the constructor signature, so the crash cannot come back unnoticed. The negative paths set an explicit string return value — with a bare `MagicMock`, a regression would make DRF recurse while JSON-encoding it and OOM the runner instead of failing an assertion.

**Full suite: 535 passed, 0 failed.**

That last part needed one extra fix. `ApiKeyRateThrottle.get_cache_key` keys on the token *string*, and the `api_token` fixture's string is a constant, so every test in `tests/contract/api/` shares a single 60/minute bucket for the whole run. Adding tests to that package pushed it past 60 requests and produced 429s in five unrelated files — `test_projects.py`, `test_projects_lite.py`, `test_members_lite.py`, `test_modules_lite.py`, `test_project_members_roster_scope.py` — none of which this PR touches. `tests/contract/api/conftest.py` now resets that bucket around each test, so the package no longer has an effective cap on how many API calls its tests may collectively make. It clears only that throttle's key, following the existing narrowly-scoped `_clear_auth_throttle_keys` helper in the app auth tests rather than reaching for `cache.clear()`.

`ruff check apps/api` reports nothing in the changed files. (Three pre-existing `F401`s remain in `issue/sub_issue.py` and `project/invite.py`; not touched here.)

Co-authored-by: Plane AI <noreply@plane.so>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Strengthened asset access controls with project-level membership validation.
  * Restricted downloads, uploads, updates, restoration, duplication, and existence checks for unauthorized project assets.
  * Prevented cross-workspace project references and unauthorized asset modifications.
  * Preserved access to workspace-level assets for eligible members.
  * Prevented inaccessible assets from revealing their availability or upload status.

* **Bug Fixes**
  * Improved asset storage handling for upload and download workflows.
  * Enforced project selection when creating assets and preserved project associations during duplication.

* **Tests**
  * Added coverage for project-scoped permissions across external API and application asset routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->