### PR TITLE
fix(web): keep app usable on transient instance fetch failure

### DIFF
--- a/apps/web/core/lib/wrappers/instance-wrapper.tsx
+++ b/apps/web/core/lib/wrappers/instance-wrapper.tsx
@@ -36,7 +36,7 @@ const InstanceWrapper = observer(function InstanceWrapper(props: TInstanceWrappe
       </div>
     );
 
-  if (instanceSWRError) return <MaintenanceView />;
+  if (instanceSWRError && !instance) return <MaintenanceView />;
 
   // something went wrong while in the request
   if (error && error?.status === "error") return <>{children}</>;


### PR DESCRIPTION
﻿### Description
Only show the maintenance empty state when `/api/instances/` fails and instance data was never loaded. Avoid flipping to the startup error screen on brief API restarts or 502s after a successful load.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
N/A

### Test Scenarios
- [ ] Load web app successfully (instance info present)
- [ ] Briefly stop/restart API so `GET /api/instances/` fails
- [ ] Confirm app stays usable instead of full maintenance screen
- [ ] Cold start with API down still shows maintenance when no instance data exists

### References
Fixes https://github.com/makeplane/plane/issues/9658


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved maintenance-mode handling so available instance data remains visible when background data refreshes encounter an error.
  * Maintenance view now appears only when instance information is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->