### PR TITLE
fix(membership): block self-rejoin after admin removes a member

### DIFF
--- a/apps/api/plane/api/views/member.py
+++ b/apps/api/plane/api/views/member.py
@@ -226,6 +226,7 @@ class ProjectMemberDetailAPIEndpoint(ProjectMemberListCreateAPIEndpoint):
     def delete(self, request, slug, project_id, pk):
         project_member = ProjectMember.objects.get(project_id=project_id, workspace__slug=slug, pk=pk)
         project_member.is_active = False
+        project_member.access_revoked = True
         project_member.save()
         return Response(status=status.HTTP_204_NO_CONTENT)
 

--- a/apps/api/plane/app/views/project/invite.py
+++ b/apps/api/plane/app/views/project/invite.py
@@ -154,9 +154,31 @@ class UserProjectInvitationsViewset(BaseViewSet):
         # network check above (GHSA-45hc-q4mw-jhxm).
         validated_project_ids = [str(p.id) for p in projects]
 
-        # If the user was already part of workspace
+        # Admin-removed members cannot self-join until an admin re-adds or invites them
+        revoked_project_ids = list(
+            ProjectMember.objects.filter(
+                workspace__slug=slug,
+                project_id__in=validated_project_ids,
+                member=request.user,
+                is_active=False,
+                access_revoked=True,
+            ).values_list("project_id", flat=True)
+        )
+        if revoked_project_ids:
+            return Response(
+                {
+                    "error": "Your access to this project was revoked. Ask a project admin to add you again."
+                },
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
+        # Reactivate only voluntary leavers (not admin-revoked)
         _ = ProjectMember.objects.filter(
-            workspace__slug=slug, project_id__in=validated_project_ids, member=request.user
+            workspace__slug=slug,
+            project_id__in=validated_project_ids,
+            member=request.user,
+            is_active=False,
+            access_revoked=False,
         ).update(is_active=True)
 
         ProjectMember.objects.bulk_create(
@@ -167,6 +189,7 @@ class UserProjectInvitationsViewset(BaseViewSet):
                     role=workspace_role,
                     workspace=workspace,
                     created_by=request.user,
+                    access_revoked=False,
                 )
                 for project_id in validated_project_ids
             ],
@@ -251,7 +274,7 @@ class ProjectJoinEndpoint(BaseAPIView):
 
                 # Check if the user was already a member of project then activate the user
                 project_member = ProjectMember.objects.filter(
-                    workspace_id=project_invite.workspace_id, member=user
+                    workspace_id=project_invite.workspace_id, project_id=project_id, member=user
                 ).first()
                 if project_member is None:
                     # Create a Project Member
@@ -259,10 +282,12 @@ class ProjectJoinEndpoint(BaseAPIView):
                         project_id=project_id,
                         member=user,
                         role=project_invite.role,
+                        access_revoked=False,
                     )
                 else:
                     project_member.is_active = True
-                    project_member.role = project_member.role
+                    project_member.role = project_invite.role
+                    project_member.access_revoked = False
                     project_member.save()
 
                 return Response(

--- a/apps/api/plane/app/views/project/member.py
+++ b/apps/api/plane/app/views/project/member.py
@@ -89,10 +89,13 @@ class ProjectMemberViewSet(BaseViewSet):
         ):
             project_member.role = member_roles[str(project_member.member_id)]
             project_member.is_active = True
+            project_member.access_revoked = False
             bulk_project_members.append(project_member)
 
         # Update the roles of the existing members
-        ProjectMember.objects.bulk_update(bulk_project_members, ["is_active", "role"], batch_size=100)
+        ProjectMember.objects.bulk_update(
+            bulk_project_members, ["is_active", "role", "access_revoked"], batch_size=100
+        )
 
         # Get the minimum sort_order for each member in the workspace
         member_sort_orders = (
@@ -280,10 +283,17 @@ class ProjectMemberViewSet(BaseViewSet):
                     status=status.HTTP_403_FORBIDDEN,
                 )
 
+        was_active = project_member.is_active
         serializer = ProjectMemberSerializer(project_member, data=request.data, partial=True)
 
         if serializer.is_valid():
             serializer.save()
+            if was_active and serializer.instance.is_active is False:
+                serializer.instance.access_revoked = True
+                serializer.instance.save(update_fields=["access_revoked", "updated_at"])
+            elif (not was_active) and serializer.instance.is_active is True:
+                serializer.instance.access_revoked = False
+                serializer.instance.save(update_fields=["access_revoked", "updated_at"])
             return Response(serializer.data, status=status.HTTP_200_OK)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
@@ -317,6 +327,7 @@ class ProjectMemberViewSet(BaseViewSet):
             )
 
         project_member.is_active = False
+        project_member.access_revoked = True
         project_member.save()
         return Response(status=status.HTTP_204_NO_CONTENT)
 
@@ -343,8 +354,9 @@ class ProjectMemberViewSet(BaseViewSet):
                 },
                 status=status.HTTP_400_BAD_REQUEST,
             )
-        # Deactivate the user
+        # Deactivate the user (voluntary leave — public self-join still allowed)
         project_member.is_active = False
+        project_member.access_revoked = False
         project_member.save()
         return Response(status=status.HTTP_204_NO_CONTENT)
 

--- a/apps/api/plane/app/views/workspace/invite.py
+++ b/apps/api/plane/app/views/workspace/invite.py
@@ -206,6 +206,7 @@ class WorkspaceJoinEndpoint(BaseAPIView):
                     ).first()
                     if workspace_member is not None:
                         workspace_member.is_active = True
+                        workspace_member.access_revoked = False
                         workspace_member.role = workspace_invite.role
                         workspace_member.save()
                     else:
@@ -214,6 +215,7 @@ class WorkspaceJoinEndpoint(BaseAPIView):
                             workspace=workspace_invite.workspace,
                             member=user,
                             role=workspace_invite.role,
+                            access_revoked=False,
                         )
 
                     # Set the user last_workspace_id to the accepted workspace
@@ -287,7 +289,7 @@ class UserWorkspaceInvitationsViewSet(BaseViewSet):
             )
             # Update the WorkspaceMember for this specific invitation
             WorkspaceMember.objects.filter(workspace_id=invitation.workspace_id, member=request.user).update(
-                is_active=True, role=invitation.role
+                is_active=True, role=invitation.role, access_revoked=False
             )
 
             # Track event

--- a/apps/api/plane/app/views/workspace/member.py
+++ b/apps/api/plane/app/views/workspace/member.py
@@ -143,9 +143,10 @@ class WorkSpaceMemberViewSet(BaseViewSet):
         # Deactivate the users from the projects where the user is part of
         _ = ProjectMember.objects.filter(
             workspace__slug=slug, member_id=workspace_member.member_id, is_active=True
-        ).update(is_active=False, updated_at=timezone.now())
+        ).update(is_active=False, access_revoked=True, updated_at=timezone.now())
 
         workspace_member.is_active = False
+        workspace_member.access_revoked = True
         workspace_member.save()
         return Response(status=status.HTTP_204_NO_CONTENT)
 
@@ -199,8 +200,9 @@ class WorkSpaceMemberViewSet(BaseViewSet):
             workspace__slug=slug, member_id=workspace_member.member_id, is_active=True
         ).update(is_active=False, updated_at=timezone.now())
 
-        # # Deactivate the user
+        # # Deactivate the user (voluntary leave)
         workspace_member.is_active = False
+        workspace_member.access_revoked = False
         workspace_member.save()
         return Response(status=status.HTTP_204_NO_CONTENT)
 

--- a/apps/api/plane/db/migrations/0123_projectmember_access_revoked.py
+++ b/apps/api/plane/db/migrations/0123_projectmember_access_revoked.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("db", "0122_alter_draftissue_assignees_alter_issue_assignees_and_more"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="projectmember",
+            name="access_revoked",
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/apps/api/plane/db/migrations/0124_workspacemember_access_revoked.py
+++ b/apps/api/plane/db/migrations/0124_workspacemember_access_revoked.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("db", "0123_projectmember_access_revoked"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="workspacemember",
+            name="access_revoked",
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/apps/api/plane/db/migrations/0125_mark_inactive_members_access_revoked.py
+++ b/apps/api/plane/db/migrations/0125_mark_inactive_members_access_revoked.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+from django.db import migrations
+
+
+def mark_inactive_members_revoked(apps, schema_editor):
+    WorkspaceMember = apps.get_model("db", "WorkspaceMember")
+    ProjectMember = apps.get_model("db", "ProjectMember")
+    WorkspaceMember.objects.filter(is_active=False).update(access_revoked=True)
+    ProjectMember.objects.filter(is_active=False).update(access_revoked=True)
+
+
+def noop_reverse(apps, schema_editor):
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("db", "0124_workspacemember_access_revoked"),
+    ]
+
+    operations = [
+        migrations.RunPython(mark_inactive_members_revoked, noop_reverse),
+    ]

--- a/apps/api/plane/db/models/project.py
+++ b/apps/api/plane/db/models/project.py
@@ -222,6 +222,8 @@ class ProjectMember(ProjectBaseModel):
     preferences = models.JSONField(default=get_default_preferences)
     sort_order = models.FloatField(default=65535)
     is_active = models.BooleanField(default=True)
+    # Set when an admin removes the member; blocks self-join until admin re-adds/invites
+    access_revoked = models.BooleanField(default=False)
 
     def save(self, *args, **kwargs):
         if self._state.adding and self.member:

--- a/apps/api/plane/db/models/workspace.py
+++ b/apps/api/plane/db/models/workspace.py
@@ -208,6 +208,8 @@ class WorkspaceMember(BaseModel):
     default_props = models.JSONField(default=get_default_props)
     issue_props = models.JSONField(default=get_issue_props)
     is_active = models.BooleanField(default=True)
+    # Set when an admin removes the member; blocks rejoin until invited again
+    access_revoked = models.BooleanField(default=False)
     getting_started_checklist = models.JSONField(default=dict)
     tips = models.JSONField(default=dict)
     explored_features = models.JSONField(default=dict)

--- a/apps/api/plane/tests/unit/utils/test_project_access_revoked.py
+++ b/apps/api/plane/tests/unit/utils/test_project_access_revoked.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+import pytest
+
+from plane.db.models import ProjectMember
+
+
+@pytest.mark.unit
+def test_project_member_has_access_revoked_field():
+    field = ProjectMember._meta.get_field("access_revoked")
+    assert field.default is False

--- a/apps/web/core/components/project/confirm-project-member-remove.tsx
+++ b/apps/web/core/components/project/confirm-project-member-remove.tsx
@@ -73,7 +73,8 @@ export const ConfirmProjectMemberRemove = observer(function ConfirmProjectMember
                 ) : (
                   <>
                     Are you sure you want to remove member- <span className="font-bold">{data?.display_name}</span>?
-                    They will no longer have access to this project. This action cannot be undone.
+                    They will no longer have access to this project and cannot rejoin until you add or invite them
+                    again.
                   </>
                 )}
               </p>
@@ -85,7 +86,7 @@ export const ConfirmProjectMemberRemove = observer(function ConfirmProjectMember
         <Button variant="secondary" size="lg" onClick={handleClose}>
           Cancel
         </Button>
-        <Button variant="error-fill" size="lg" tabIndex={1} onClick={handleDeletion} loading={isDeleteLoading}>
+        <Button variant="error-fill" size="lg" onClick={handleDeletion} loading={isDeleteLoading}>
           {isCurrentUser ? (isDeleteLoading ? "Leaving..." : "Leave") : isDeleteLoading ? "Removing..." : "Remove"}
         </Button>
       </div>

--- a/apps/web/core/components/project/join-project-modal.tsx
+++ b/apps/web/core/components/project/join-project-modal.tsx
@@ -7,6 +7,7 @@
 import { useState } from "react";
 // types
 import { Button } from "@plane/propel/button";
+import { TOAST_TYPE, setToast } from "@plane/propel/toast";
 import type { IProject } from "@plane/types";
 // ui
 import { EModalPosition, EModalWidth, ModalCore } from "@plane/ui";
@@ -40,8 +41,16 @@ export function JoinProjectModal(props: TJoinProjectModalProps) {
         handleClose();
         return;
       })
-      .catch(() => {
-        console.error("Error joining project");
+      .catch((err: unknown) => {
+        const message =
+          err && typeof err === "object" && "error" in err && typeof (err as { error?: unknown }).error === "string"
+            ? (err as { error: string }).error
+            : "Could not join this project. Ask an admin to add you.";
+        setToast({
+          type: TOAST_TYPE.ERROR,
+          title: "Access denied",
+          message,
+        });
       })
       .finally(() => {
         setIsJoiningLoading(false);
@@ -62,7 +71,7 @@ export function JoinProjectModal(props: TJoinProjectModalProps) {
         <Button variant="secondary" size="lg" onClick={handleClose}>
           Cancel
         </Button>
-        <Button variant="primary" size="lg" tabIndex={1} type="submit" onClick={handleJoin} loading={isJoiningLoading}>
+        <Button variant="primary" size="lg" type="submit" onClick={handleJoin} loading={isJoiningLoading}>
           {isJoiningLoading ? "Joining..." : "Join Project"}
         </Button>
       </div>

--- a/apps/web/core/layouts/auth-layout/project-wrapper.tsx
+++ b/apps/web/core/layouts/auth-layout/project-wrapper.tsx
@@ -10,6 +10,7 @@ import { observer } from "mobx-react";
 import useSWR from "swr";
 // plane imports
 import { EUserPermissions, EUserPermissionsLevel } from "@plane/constants";
+import { TOAST_TYPE, setToast } from "@plane/propel/toast";
 import { GANTT_TIMELINE_TYPE } from "@plane/types";
 // components
 import { ProjectAccessRestriction } from "@/components/auth-screens/project/project-access-restriction";
@@ -139,7 +140,19 @@ export const ProjectAuthWrapper = observer(function ProjectAuthWrapper(props: IP
   // handle join project
   const handleJoinProject = () => {
     setIsJoiningProject(true);
-    joinProject(workspaceSlug, projectId).finally(() => setIsJoiningProject(false));
+    joinProject(workspaceSlug, projectId)
+      .catch((err: unknown) => {
+        const message =
+          err && typeof err === "object" && "error" in err && typeof (err as { error?: unknown }).error === "string"
+            ? (err as { error: string }).error
+            : "Could not join this project. Ask an admin to add you.";
+        setToast({
+          type: TOAST_TYPE.ERROR,
+          title: "Access denied",
+          message,
+        });
+      })
+      .finally(() => setIsJoiningProject(false));
   };
 
   const isProjectLoading = (isParentLoading || isProjectDetailsLoading) && !projectDetailsError;


### PR DESCRIPTION
### Description
After an admin removes someone from a project or workspace, that user should not regain access by clicking Join on a public project. This adds an `access_revoked` flag on `ProjectMember` and `WorkspaceMember`:

- Admin remove / deactivate sets `access_revoked=True` (along with `is_active=False`)
- Voluntary leave keeps `access_revoked=False` so public rejoin still works
- Self-join (`POST .../projects/invitations/`) returns 403 when access was revoked
- Admin add / invite acceptance clears `access_revoked` and restores access
- Existing inactive memberships are backfilled as revoked for safety
- Join UI shows the API error via toast; remove-member copy clarifies they cannot self-rejoin

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
N/A

### Test Scenarios
- [ ] As admin, remove a member from a **public** project
- [ ] As that user, click Join → expect 403 / access-denied toast; membership stays inactive
- [ ] As admin, add or invite that user again → they regain access
- [ ] As a member, voluntarily leave a public project, then Join again → succeeds
- [ ] Workspace admin remove similarly blocks rejoin until invite/add
- [ ] Run migrations `0123`–`0125` and confirm inactive rows get `access_revoked=True`

### References
Fixes https://github.com/makeplane/plane/issues/9662


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added access revocation tracking for workspace and project memberships.
  * Removed members can no longer rejoin until they are invited again.
  * Invitation acceptance restores access and allows reactivation.
  * Voluntarily leaving remains distinct from administrator removal.

* **Bug Fixes**
  * Prevented explicitly removed members from bypassing access restrictions when joining.

* **UI Improvements**
  * Project removal messaging now explains rejoining requirements.
  * Project join failures display clear error notifications, including server-provided details when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->