### PR TITLE
chore(ci): build images natively per architecture and merge by digest

### DIFF
--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -50,13 +50,14 @@ env:
 jobs:
   branch_build_setup:
     name: Build Setup
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       gh_branch_name: ${{ steps.set_env_variables.outputs.TARGET_BRANCH }}
-      gh_buildx_driver: ${{ steps.set_env_variables.outputs.BUILDX_DRIVER }}
-      gh_buildx_version: ${{ steps.set_env_variables.outputs.BUILDX_VERSION }}
-      gh_buildx_platforms: ${{ steps.set_env_variables.outputs.BUILDX_PLATFORMS }}
-      gh_buildx_endpoint: ${{ steps.set_env_variables.outputs.BUILDX_ENDPOINT }}
+      # Per-architecture native build matrix. Every image builds one platform per
+      # job on a runner native to it, so there is no single buildx driver/platform
+      # pair for the run and no Docker Build Cloud endpoint.
+      gh_build_matrix: ${{ steps.set_env_variables.outputs.BUILD_MATRIX }}
+      gh_expected_platforms: ${{ steps.set_env_variables.outputs.EXPECTED_PLATFORMS }}
 
       dh_img_web: ${{ steps.set_env_variables.outputs.DH_IMG_WEB }}
       dh_img_space: ${{ steps.set_env_variables.outputs.DH_IMG_SPACE }}
@@ -76,17 +77,21 @@ jobs:
       - id: set_env_variables
         name: Set Environment Variables
         run: |
+          # One runner per architecture. arm64 is built natively rather than under
+          # emulation, so there is no cloud builder and no QEMU leg. Both labels are
+          # GitHub-hosted 4 vCPU / 16 GB instances, so a single matrix covers the
+          # JS monorepo images as well as the light ones.
+          AMD64='{"arch":"amd64","platform":"linux/amd64","runner":"ubuntu-24.04"}'
+          ARM64='{"arch":"arm64","platform":"linux/arm64","runner":"ubuntu-24.04-arm"}'
+
           if [ "${{ env.ARM64_BUILD }}" == "true" ] || ([ "${{ env.BUILD_TYPE }}" == "Release" ] && [ "${{ env.IS_PRERELEASE }}" != "true" ]); then
-            echo "BUILDX_DRIVER=cloud" >> $GITHUB_OUTPUT
-            echo "BUILDX_VERSION=lab:latest" >> $GITHUB_OUTPUT
-            echo "BUILDX_PLATFORMS=linux/amd64,linux/arm64" >> $GITHUB_OUTPUT
-            echo "BUILDX_ENDPOINT=makeplane/plane-dev" >> $GITHUB_OUTPUT
+            echo "BUILD_MATRIX=[${AMD64},${ARM64}]" >> $GITHUB_OUTPUT
+            echo "EXPECTED_PLATFORMS=linux/amd64,linux/arm64" >> $GITHUB_OUTPUT
           else
-            echo "BUILDX_DRIVER=docker-container" >> $GITHUB_OUTPUT
-            echo "BUILDX_VERSION=latest" >> $GITHUB_OUTPUT
-            echo "BUILDX_PLATFORMS=linux/amd64" >> $GITHUB_OUTPUT
-            echo "BUILDX_ENDPOINT=" >> $GITHUB_OUTPUT
+            echo "BUILD_MATRIX=[${AMD64}]" >> $GITHUB_OUTPUT
+            echo "EXPECTED_PLATFORMS=linux/amd64" >> $GITHUB_OUTPUT
           fi
+
           BR_NAME=$( echo "${{ env.TARGET_BRANCH }}" |sed 's/[^a-zA-Z0-9.-]//g')
           echo "TARGET_BRANCH=$BR_NAME" >> $GITHUB_OUTPUT
 
@@ -136,13 +141,31 @@ jobs:
         name: Checkout Files
         uses: actions/checkout@v6
 
+  # Native per-architecture image builds.
+  #
+  # Each branch_build_push_<image> job below builds ONE platform on a runner
+  # native to it and pushes an untagged manifest addressed only by its digest.
+  # The paired branch_merge_<image> job stitches those digests into the
+  # multi-arch manifest and applies the tags -- so any job consuming an image BY
+  # TAG must depend on the merge job, never the build job. GitHub does not warn
+  # when a needs: entry is missing; the dependent job simply runs early.
+  #
+  # buildx-driver is pinned to the local docker-container driver: each leg builds
+  # its own architecture natively, so a remote builder buys nothing. The Docker
+  # Build Cloud path (makeplane/plane-dev) is gone from this workflow rather than
+  # left as a no-op switch.
   branch_build_push_admin:
-    name: Build-Push Admin Docker Image
-    runs-on: ubuntu-22.04
+    name: Build-Push Admin Docker Image (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 90
     needs: [branch_build_setup]
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.branch_build_setup.outputs.gh_build_matrix) }}
     steps:
       - name: Admin Build and Push
-        uses: makeplane/actions/build-push@v1.4.0
+        uses: makeplane/actions/build-push@v1.6.0
         with:
           build-release: ${{ needs.branch_build_setup.outputs.build_release }}
           build-prerelease: ${{ needs.branch_build_setup.outputs.build_prerelease }}
@@ -153,18 +176,47 @@ jobs:
           docker-image-name: ${{ needs.branch_build_setup.outputs.dh_img_admin }}
           build-context: .
           dockerfile-path: ./apps/admin/Dockerfile.admin
-          buildx-driver: ${{ needs.branch_build_setup.outputs.gh_buildx_driver }}
-          buildx-version: ${{ needs.branch_build_setup.outputs.gh_buildx_version }}
-          buildx-platforms: ${{ needs.branch_build_setup.outputs.gh_buildx_platforms }}
-          buildx-endpoint: ${{ needs.branch_build_setup.outputs.gh_buildx_endpoint }}
+          buildx-driver: docker-container
+          buildx-version: latest
+          buildx-platforms: ${{ matrix.platform }}
+          buildx-endpoint: ""
+          push-by-digest: "true"
+          # Without a per-arch cache ref the two legs overwrite each other's
+          # buildcache tag, since it is not platform-indexed.
+          cache-scope-suffix: -${{ matrix.arch }}
+          digest-artifact-name: digest-admin-${{ matrix.arch }}
+
+  branch_merge_admin:
+    name: Merge Admin Manifest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    needs: [branch_build_setup, branch_build_push_admin]
+    steps:
+      - name: Merge Admin Manifest
+        uses: makeplane/actions/merge-manifest@v1.6.0
+        with:
+          build-release: ${{ needs.branch_build_setup.outputs.build_release }}
+          build-prerelease: ${{ needs.branch_build_setup.outputs.build_prerelease }}
+          release-version: ${{ needs.branch_build_setup.outputs.release_version }}
+          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
+          docker-image-owner: makeplane
+          docker-image-name: ${{ needs.branch_build_setup.outputs.dh_img_admin }}
+          digest-artifact-pattern: digest-admin-*
+          expected-platforms: ${{ needs.branch_build_setup.outputs.gh_expected_platforms }}
 
   branch_build_push_web:
-    name: Build-Push Web Docker Image
-    runs-on: ubuntu-22.04
+    name: Build-Push Web Docker Image (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 90
     needs: [branch_build_setup]
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.branch_build_setup.outputs.gh_build_matrix) }}
     steps:
       - name: Web Build and Push
-        uses: makeplane/actions/build-push@v1.4.0
+        uses: makeplane/actions/build-push@v1.6.0
         with:
           build-release: ${{ needs.branch_build_setup.outputs.build_release }}
           build-prerelease: ${{ needs.branch_build_setup.outputs.build_prerelease }}
@@ -175,18 +227,47 @@ jobs:
           docker-image-name: ${{ needs.branch_build_setup.outputs.dh_img_web }}
           build-context: .
           dockerfile-path: ./apps/web/Dockerfile.web
-          buildx-driver: ${{ needs.branch_build_setup.outputs.gh_buildx_driver }}
-          buildx-version: ${{ needs.branch_build_setup.outputs.gh_buildx_version }}
-          buildx-platforms: ${{ needs.branch_build_setup.outputs.gh_buildx_platforms }}
-          buildx-endpoint: ${{ needs.branch_build_setup.outputs.gh_buildx_endpoint }}
+          buildx-driver: docker-container
+          buildx-version: latest
+          buildx-platforms: ${{ matrix.platform }}
+          buildx-endpoint: ""
+          push-by-digest: "true"
+          # Without a per-arch cache ref the two legs overwrite each other's
+          # buildcache tag, since it is not platform-indexed.
+          cache-scope-suffix: -${{ matrix.arch }}
+          digest-artifact-name: digest-web-${{ matrix.arch }}
+
+  branch_merge_web:
+    name: Merge Web Manifest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    needs: [branch_build_setup, branch_build_push_web]
+    steps:
+      - name: Merge Web Manifest
+        uses: makeplane/actions/merge-manifest@v1.6.0
+        with:
+          build-release: ${{ needs.branch_build_setup.outputs.build_release }}
+          build-prerelease: ${{ needs.branch_build_setup.outputs.build_prerelease }}
+          release-version: ${{ needs.branch_build_setup.outputs.release_version }}
+          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
+          docker-image-owner: makeplane
+          docker-image-name: ${{ needs.branch_build_setup.outputs.dh_img_web }}
+          digest-artifact-pattern: digest-web-*
+          expected-platforms: ${{ needs.branch_build_setup.outputs.gh_expected_platforms }}
 
   branch_build_push_space:
-    name: Build-Push Space Docker Image
-    runs-on: ubuntu-22.04
+    name: Build-Push Space Docker Image (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 90
     needs: [branch_build_setup]
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.branch_build_setup.outputs.gh_build_matrix) }}
     steps:
       - name: Space Build and Push
-        uses: makeplane/actions/build-push@v1.4.0
+        uses: makeplane/actions/build-push@v1.6.0
         with:
           build-release: ${{ needs.branch_build_setup.outputs.build_release }}
           build-prerelease: ${{ needs.branch_build_setup.outputs.build_prerelease }}
@@ -197,18 +278,47 @@ jobs:
           docker-image-name: ${{ needs.branch_build_setup.outputs.dh_img_space }}
           build-context: .
           dockerfile-path: ./apps/space/Dockerfile.space
-          buildx-driver: ${{ needs.branch_build_setup.outputs.gh_buildx_driver }}
-          buildx-version: ${{ needs.branch_build_setup.outputs.gh_buildx_version }}
-          buildx-platforms: ${{ needs.branch_build_setup.outputs.gh_buildx_platforms }}
-          buildx-endpoint: ${{ needs.branch_build_setup.outputs.gh_buildx_endpoint }}
+          buildx-driver: docker-container
+          buildx-version: latest
+          buildx-platforms: ${{ matrix.platform }}
+          buildx-endpoint: ""
+          push-by-digest: "true"
+          # Without a per-arch cache ref the two legs overwrite each other's
+          # buildcache tag, since it is not platform-indexed.
+          cache-scope-suffix: -${{ matrix.arch }}
+          digest-artifact-name: digest-space-${{ matrix.arch }}
+
+  branch_merge_space:
+    name: Merge Space Manifest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    needs: [branch_build_setup, branch_build_push_space]
+    steps:
+      - name: Merge Space Manifest
+        uses: makeplane/actions/merge-manifest@v1.6.0
+        with:
+          build-release: ${{ needs.branch_build_setup.outputs.build_release }}
+          build-prerelease: ${{ needs.branch_build_setup.outputs.build_prerelease }}
+          release-version: ${{ needs.branch_build_setup.outputs.release_version }}
+          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
+          docker-image-owner: makeplane
+          docker-image-name: ${{ needs.branch_build_setup.outputs.dh_img_space }}
+          digest-artifact-pattern: digest-space-*
+          expected-platforms: ${{ needs.branch_build_setup.outputs.gh_expected_platforms }}
 
   branch_build_push_live:
-    name: Build-Push Live Collaboration Docker Image
-    runs-on: ubuntu-22.04
+    name: Build-Push Live Collaboration Docker Image (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 90
     needs: [branch_build_setup]
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.branch_build_setup.outputs.gh_build_matrix) }}
     steps:
       - name: Live Build and Push
-        uses: makeplane/actions/build-push@v1.4.0
+        uses: makeplane/actions/build-push@v1.6.0
         with:
           build-release: ${{ needs.branch_build_setup.outputs.build_release }}
           build-prerelease: ${{ needs.branch_build_setup.outputs.build_prerelease }}
@@ -219,18 +329,47 @@ jobs:
           docker-image-name: ${{ needs.branch_build_setup.outputs.dh_img_live }}
           build-context: .
           dockerfile-path: ./apps/live/Dockerfile.live
-          buildx-driver: ${{ needs.branch_build_setup.outputs.gh_buildx_driver }}
-          buildx-version: ${{ needs.branch_build_setup.outputs.gh_buildx_version }}
-          buildx-platforms: ${{ needs.branch_build_setup.outputs.gh_buildx_platforms }}
-          buildx-endpoint: ${{ needs.branch_build_setup.outputs.gh_buildx_endpoint }}
+          buildx-driver: docker-container
+          buildx-version: latest
+          buildx-platforms: ${{ matrix.platform }}
+          buildx-endpoint: ""
+          push-by-digest: "true"
+          # Without a per-arch cache ref the two legs overwrite each other's
+          # buildcache tag, since it is not platform-indexed.
+          cache-scope-suffix: -${{ matrix.arch }}
+          digest-artifact-name: digest-live-${{ matrix.arch }}
+
+  branch_merge_live:
+    name: Merge Live Collaboration Manifest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    needs: [branch_build_setup, branch_build_push_live]
+    steps:
+      - name: Merge Live Collaboration Manifest
+        uses: makeplane/actions/merge-manifest@v1.6.0
+        with:
+          build-release: ${{ needs.branch_build_setup.outputs.build_release }}
+          build-prerelease: ${{ needs.branch_build_setup.outputs.build_prerelease }}
+          release-version: ${{ needs.branch_build_setup.outputs.release_version }}
+          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
+          docker-image-owner: makeplane
+          docker-image-name: ${{ needs.branch_build_setup.outputs.dh_img_live }}
+          digest-artifact-pattern: digest-live-*
+          expected-platforms: ${{ needs.branch_build_setup.outputs.gh_expected_platforms }}
 
   branch_build_push_api:
-    name: Build-Push API Server Docker Image
-    runs-on: ubuntu-22.04
+    name: Build-Push API Server Docker Image (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 60
     needs: [branch_build_setup]
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.branch_build_setup.outputs.gh_build_matrix) }}
     steps:
       - name: Backend Build and Push
-        uses: makeplane/actions/build-push@v1.4.0
+        uses: makeplane/actions/build-push@v1.6.0
         with:
           build-release: ${{ needs.branch_build_setup.outputs.build_release }}
           build-prerelease: ${{ needs.branch_build_setup.outputs.build_prerelease }}
@@ -241,18 +380,47 @@ jobs:
           docker-image-name: ${{ needs.branch_build_setup.outputs.dh_img_backend }}
           build-context: ./apps/api
           dockerfile-path: ./apps/api/Dockerfile.api
-          buildx-driver: ${{ needs.branch_build_setup.outputs.gh_buildx_driver }}
-          buildx-version: ${{ needs.branch_build_setup.outputs.gh_buildx_version }}
-          buildx-platforms: ${{ needs.branch_build_setup.outputs.gh_buildx_platforms }}
-          buildx-endpoint: ${{ needs.branch_build_setup.outputs.gh_buildx_endpoint }}
+          buildx-driver: docker-container
+          buildx-version: latest
+          buildx-platforms: ${{ matrix.platform }}
+          buildx-endpoint: ""
+          push-by-digest: "true"
+          # Without a per-arch cache ref the two legs overwrite each other's
+          # buildcache tag, since it is not platform-indexed.
+          cache-scope-suffix: -${{ matrix.arch }}
+          digest-artifact-name: digest-api-${{ matrix.arch }}
+
+  branch_merge_api:
+    name: Merge API Server Manifest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    needs: [branch_build_setup, branch_build_push_api]
+    steps:
+      - name: Merge API Server Manifest
+        uses: makeplane/actions/merge-manifest@v1.6.0
+        with:
+          build-release: ${{ needs.branch_build_setup.outputs.build_release }}
+          build-prerelease: ${{ needs.branch_build_setup.outputs.build_prerelease }}
+          release-version: ${{ needs.branch_build_setup.outputs.release_version }}
+          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
+          docker-image-owner: makeplane
+          docker-image-name: ${{ needs.branch_build_setup.outputs.dh_img_backend }}
+          digest-artifact-pattern: digest-api-*
+          expected-platforms: ${{ needs.branch_build_setup.outputs.gh_expected_platforms }}
 
   branch_build_push_proxy:
-    name: Build-Push Proxy Docker Image
-    runs-on: ubuntu-22.04
+    name: Build-Push Proxy Docker Image (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 60
     needs: [branch_build_setup]
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.branch_build_setup.outputs.gh_build_matrix) }}
     steps:
       - name: Proxy Build and Push
-        uses: makeplane/actions/build-push@v1.4.0
+        uses: makeplane/actions/build-push@v1.6.0
         with:
           build-release: ${{ needs.branch_build_setup.outputs.build_release }}
           build-prerelease: ${{ needs.branch_build_setup.outputs.build_prerelease }}
@@ -263,23 +431,47 @@ jobs:
           docker-image-name: ${{ needs.branch_build_setup.outputs.dh_img_proxy }}
           build-context: ./apps/proxy
           dockerfile-path: ./apps/proxy/Dockerfile.ce
-          buildx-driver: ${{ needs.branch_build_setup.outputs.gh_buildx_driver }}
-          buildx-version: ${{ needs.branch_build_setup.outputs.gh_buildx_version }}
-          buildx-platforms: ${{ needs.branch_build_setup.outputs.gh_buildx_platforms }}
-          buildx-endpoint: ${{ needs.branch_build_setup.outputs.gh_buildx_endpoint }}
+          buildx-driver: docker-container
+          buildx-version: latest
+          buildx-platforms: ${{ matrix.platform }}
+          buildx-endpoint: ""
+          push-by-digest: "true"
+          # Without a per-arch cache ref the two legs overwrite each other's
+          # buildcache tag, since it is not platform-indexed.
+          cache-scope-suffix: -${{ matrix.arch }}
+          digest-artifact-name: digest-proxy-${{ matrix.arch }}
 
-  branch_build_push_aio:
+  branch_merge_proxy:
+    name: Merge Proxy Manifest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    needs: [branch_build_setup, branch_build_push_proxy]
+    steps:
+      - name: Merge Proxy Manifest
+        uses: makeplane/actions/merge-manifest@v1.6.0
+        with:
+          build-release: ${{ needs.branch_build_setup.outputs.build_release }}
+          build-prerelease: ${{ needs.branch_build_setup.outputs.build_prerelease }}
+          release-version: ${{ needs.branch_build_setup.outputs.release_version }}
+          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
+          docker-image-owner: makeplane
+          docker-image-name: ${{ needs.branch_build_setup.outputs.dh_img_proxy }}
+          digest-artifact-pattern: digest-proxy-*
+          expected-platforms: ${{ needs.branch_build_setup.outputs.gh_expected_platforms }}
+
+  # Split out of branch_build_push_aio: build.sh generates the dist/ assets and
+  # uploads them as one artifact. Run inside a matrix, both legs would collide on
+  # that artifact name and could embed different generated content under a single
+  # manifest tag. Generate once, consume twice.
+  prepare_aio_assets:
     if: ${{ needs.branch_build_setup.outputs.aio_build == 'true' }}
-    name: Build-Push AIO Docker Image
-    runs-on: ubuntu-22.04
-    needs:
-      - branch_build_setup
-      - branch_build_push_admin
-      - branch_build_push_web
-      - branch_build_push_space
-      - branch_build_push_live
-      - branch_build_push_api
-      - branch_build_push_proxy
+    name: Prepare AIO Assets
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    needs: [branch_build_setup]
+    outputs:
+      aio_build_version: ${{ steps.prepare_aio_assets.outputs.AIO_BUILD_VERSION }}
     steps:
       - name: Checkout Files
         uses: actions/checkout@v6
@@ -303,8 +495,29 @@ jobs:
           path: ./deployments/aio/community/dist
           name: aio-assets-dist
 
+  # AIO pulls the other images in by tag, so it needs the merge jobs -- the tags
+  # do not exist until the merges run.
+  branch_build_push_aio:
+    if: ${{ needs.branch_build_setup.outputs.aio_build == 'true' }}
+    name: Build-Push AIO Docker Image (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.branch_build_setup.outputs.gh_build_matrix) }}
+    needs:
+      - branch_build_setup
+      - prepare_aio_assets
+      - branch_merge_admin
+      - branch_merge_web
+      - branch_merge_space
+      - branch_merge_live
+      - branch_merge_api
+      - branch_merge_proxy
+    steps:
       - name: AIO Build and Push
-        uses: makeplane/actions/build-push@v1.4.0
+        uses: makeplane/actions/build-push@v1.6.0
         with:
           build-release: ${{ needs.branch_build_setup.outputs.build_release }}
           build-prerelease: ${{ needs.branch_build_setup.outputs.build_prerelease }}
@@ -315,26 +528,48 @@ jobs:
           docker-image-name: ${{ needs.branch_build_setup.outputs.dh_img_aio }}
           build-context: ./deployments/aio/community
           dockerfile-path: ./deployments/aio/community/Dockerfile
-          buildx-driver: ${{ needs.branch_build_setup.outputs.gh_buildx_driver }}
-          buildx-version: ${{ needs.branch_build_setup.outputs.gh_buildx_version }}
-          buildx-platforms: ${{ needs.branch_build_setup.outputs.gh_buildx_platforms }}
-          buildx-endpoint: ${{ needs.branch_build_setup.outputs.gh_buildx_endpoint }}
+          buildx-driver: docker-container
+          buildx-version: latest
+          buildx-platforms: ${{ matrix.platform }}
+          buildx-endpoint: ""
+          push-by-digest: "true"
+          cache-scope-suffix: -${{ matrix.arch }}
+          digest-artifact-name: digest-aio-${{ matrix.arch }}
           additional-assets: aio-assets-dist
           additional-assets-dir: ./deployments/aio/community/dist
           build-args: |
-            PLANE_VERSION=${{ steps.prepare_aio_assets.outputs.AIO_BUILD_VERSION }}
+            PLANE_VERSION=${{ needs.prepare_aio_assets.outputs.aio_build_version }}
+
+  branch_merge_aio:
+    name: Merge AIO Manifest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    needs: [branch_build_setup, branch_build_push_aio]
+    steps:
+      - name: Merge AIO Manifest
+        uses: makeplane/actions/merge-manifest@v1.6.0
+        with:
+          build-release: ${{ needs.branch_build_setup.outputs.build_release }}
+          build-prerelease: ${{ needs.branch_build_setup.outputs.build_prerelease }}
+          release-version: ${{ needs.branch_build_setup.outputs.release_version }}
+          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
+          docker-image-owner: makeplane
+          docker-image-name: ${{ needs.branch_build_setup.outputs.dh_img_aio }}
+          digest-artifact-pattern: digest-aio-*
+          expected-platforms: ${{ needs.branch_build_setup.outputs.gh_expected_platforms }}
 
   upload_build_assets:
     name: Upload Build Assets
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs:
       - branch_build_setup
-      - branch_build_push_admin
-      - branch_build_push_web
-      - branch_build_push_space
-      - branch_build_push_live
-      - branch_build_push_api
-      - branch_build_push_proxy
+      - branch_merge_admin
+      - branch_merge_web
+      - branch_merge_space
+      - branch_merge_live
+      - branch_merge_api
+      - branch_merge_proxy
     steps:
       - name: Checkout Files
         uses: actions/checkout@v6
@@ -364,18 +599,25 @@ jobs:
             ./deployments/swarm/community/swarm.sh
 
   publish_release:
+    # Deliberately NO status function here. The default success() gate is what
+    # stops a release when any image fails: a failed build leg skips its
+    # branch_merge_* job, and success() rejects a skipped need.
+    #
+    # That is also why branch_merge_aio is NOT in needs below. AIO runs last (it
+    # needs every other merge), the GitHub release ships no AIO artifact, and
+    # gating on it would let one flaky AIO leg silently discard a finished release.
     if: ${{ needs.branch_build_setup.outputs.build_type == 'Release' }}
     name: Build Release
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs:
       [
         branch_build_setup,
-        branch_build_push_admin,
-        branch_build_push_web,
-        branch_build_push_space,
-        branch_build_push_live,
-        branch_build_push_api,
-        branch_build_push_proxy,
+        branch_merge_admin,
+        branch_merge_web,
+        branch_merge_space,
+        branch_merge_live,
+        branch_merge_api,
+        branch_merge_proxy,
       ]
     env:
       REL_VERSION: ${{ needs.branch_build_setup.outputs.release_version }}


### PR DESCRIPTION
### Description

Every image in `Branch Build CE` now builds **one platform per job on a runner native to that architecture**, pushes an untagged manifest addressed only by its digest, and is stitched into the tagged multi-arch index by a paired `branch_merge_*` job using `docker buildx imagetools create`.

**Why** — arm64 was previously produced either under QEMU emulation or on the shared `makeplane/plane-dev` Docker Build Cloud builder. Emulated arm64 runs 5–10× slower than native, and the Build Cloud builder is shared across repos, has no owner here, and is load-bearing: arm64 is forced on for non-prerelease Releases, so a broken shared builder blocks releases specifically. Both paths are gone — `buildx-driver` is pinned to the local `docker-container` driver, since a leg building its own architecture natively gains nothing from a remote builder.

The arm64 trigger condition is unchanged (`arm64: true`, or a non-prerelease `Release`), and **nothing externally visible changes** — the images carry the same names and the same tags, so every consumer (compose files, the AIO Dockerfile, install scripts) keeps referencing them exactly as before.

#### What changed

- **Setup job.** `BUILDX_DRIVER` / `BUILDX_VERSION` / `BUILDX_PLATFORMS` / `BUILDX_ENDPOINT` are replaced by `gh_build_matrix` (a JSON array of `{arch, platform, runner}`) and `gh_expected_platforms`. The Docker Build Cloud endpoint is removed outright rather than left as a no-op switch.
- **Six build jobs** (admin, web, space, live, api, proxy) become matrix jobs with `push-by-digest`, a per-architecture cache scope, and a per-architecture digest artifact.
- **Six new merge jobs** collect those digests, apply the tags, and verify the resulting index.
- **AIO is split in two.** `prepare_aio_assets` runs `build.sh` once and uploads `aio-assets-dist`; `branch_build_push_aio` is the matrix build; `branch_merge_aio` publishes the index.
- Runners move to GitHub-hosted `ubuntu-24.04` / `ubuntu-24.04-arm` (both 4 vCPU / 16 GB, and free on public repos), the shared build actions are bumped to `v1.6.0`, and every job gets a `timeout-minutes`.

#### Three details that are load-bearing rather than cosmetic

- **`cache-scope-suffix` per architecture.** The registry cache manifest is not platform-indexed, so both legs writing `:buildcache` would overwrite each other and roughly half the legs would go cold every run — which could make the split *slower* than a single job.
- **The merge asserts the platform set.** A merge that produced a single-platform index still exits `0`, so it is checked rather than assumed.
- **Tag consumers depend on merge jobs, not build jobs.** The tag does not exist until the merge runs. AIO pulls the other images in by tag, so it now needs the six merges; `upload_build_assets` and `publish_release` were repointed the same way. GitHub does not warn when a `needs:` entry is missing — the dependent job simply runs early against a stale or absent tag.

`publish_release` deliberately keeps **no** status function: a failed build leg skips its merge job, and the default `success()` gate rejects a skipped need. `branch_merge_aio` is intentionally absent from its `needs` so one flaky AIO leg cannot silently discard a finished release.

### Type of Change

- [x] Improvement (change that would cause existing functionality to not work as expected)
- [x] Performance improvements

### Screenshots and Media (if applicable)

<!-- Add screenshots here -->

### Test Scenarios

`actionlint` passes clean on the workflow. The rest can only be proven by running it:

1. Dispatch `Branch Build CE` on this branch with defaults (`arm64: false`). Each image's matrix should have a single amd64 leg, and each `branch_merge_*` should publish an index containing only `linux/amd64`.
2. Re-dispatch with `arm64: true`. Confirm two legs per image, the arm64 one on `ubuntu-24.04-arm`, then:
   ```
   docker buildx imagetools inspect makeplane/plane-frontend:<branch>
   ```
   Expect exactly `linux/amd64` and `linux/arm64`. Spot-check `plane-backend` and `plane-proxy` too.
3. Confirm the arm64 legs built **natively** — no `qemu-x86_64` or binfmt lines in the log, and wall time in line with the amd64 leg rather than 5–10× it.
4. Confirm the legs wrote separate cache refs (`:buildcache-amd64`, `:buildcache-arm64`) and that a second run imports rather than rebuilding from scratch.
5. Dispatch with `aio_build: true` and confirm `prepare_aio_assets` runs once, both AIO legs consume the same `aio-assets-dist` artifact, and the AIO build starts only after all six merges have published their tags.
6. Deliberately fail one build leg and confirm its merge job is skipped and `publish_release` does not run.
7. Run a `Release` build end-to-end and confirm the release is created with the expected assets.

### References

- Depends on `makeplane/actions@v1.6.0` (`build-push` digest mode + the new `merge-manifest` action).

https://claude.ai/code/session_01U45dsLe5GFmTsfpifuNcGQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build & Release**
  * Improved multi-architecture image builds and manifest publishing.
  * Updated build runners and streamlined architecture-specific caching and artifacts.
  * Ensured AIO builds and asset uploads run after the relevant images are assembled.
  * Improved release gating so releases proceed only after required build steps succeed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->