### PR TITLE
fix(editor): prevent duplicate tab when clicking links in read-only view

### DIFF
--- a/packages/editor/src/core/extensions/custom-link/helpers/clickHandler.ts
+++ b/packages/editor/src/core/extensions/custom-link/helpers/clickHandler.ts
@@ -50,6 +50,11 @@ export function clickHandler(options: ClickHandlerOptions): Plugin {
             return false;
           }
 
+          // Suppress the native anchor navigation: in a non-editable view
+          // ProseMirror doesn't swallow the click, so without this the
+          // browser opens a second tab via the underlying <a target="_blank">
+          // in addition to the one below (#9386).
+          event.preventDefault();
           window.open(href, target);
 
           return true;


### PR DESCRIPTION
## Summary

Left-clicking a link inside a **read-only** rendered comment or work-item
description (e.g. a PR URL) opens it in two identical tabs instead of one.
Editable mode is unaffected.

## Root cause

`clickHandler.ts`'s ProseMirror click handler calls `window.open(href, target)`
but never calls `event.preventDefault()`. In an **editable** view, ProseMirror
suppresses the native anchor click (the editor is `contenteditable`), so only
`window.open()` fires. In a **read-only** view that suppression doesn't
happen, so the native `<a target="_blank">` navigation *also* fires — one tab
from `window.open()`, a second from the browser following the anchor itself.

## Fix

Call `event.preventDefault()` before `window.open()`, so the native anchor
navigation is suppressed in both editable and read-only modes. One line.

## Tests

`packages/editor` currently has no test runner configured (no `test` script,
no vitest/jest dependency — unlike `apps/live`/`packages/codemods`, which do
have vitest set up). Adding a test harness to this package is out of scope
for a one-line fix, so I didn't bootstrap one. I verified by tracing the
exact code path: `event.button !== 0` already short-circuits non-left-clicks
(explaining why middle-click already worked), and the added
`preventDefault()` sits in the only branch that calls `window.open()`, before
the return that lets the click bubble.

- `oxlint` on the changed file — clean.
- `oxfmt --check` on the changed file — clean.
- `pnpm check:types` in `packages/editor` — no new errors introduced (the
  package currently fails to type-check on a clean checkout too, with
  unrelated `@plane/utils`/`@plane/types`/etc. "cannot find module" errors
  from unbuilt workspace packages; confirmed identical with and without this
  change via `git stash`).

## Related issue

Fixes #9386


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate navigation when opening links, including links configured to open in a new tab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->