### PR TITLE
fix(cycles): make transfer_cycle_issues atomic

### DIFF
--- a/apps/api/plane/tests/unit/utils/test_cycle_transfer_issues.py
+++ b/apps/api/plane/tests/unit/utils/test_cycle_transfer_issues.py
@@ -1,0 +1,162 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Regression tests for the transfer_cycle_issues atomicity bug (#9599).
+
+transfer_cycle_issues used to persist the source cycle's progress_snapshot
+and then, in a second, unrelated DB write, move the CycleIssue rows to the
+destination cycle. If the process crashed or the DB errored between the two
+writes, the source cycle was left marked with a snapshot while its issues
+were never actually transferred - a data-integrity bug with no recovery
+path. Both writes must happen inside a single atomic transaction so a
+failure during the issue move rolls back the snapshot write as well.
+"""
+
+from unittest import mock
+
+import pytest
+from django.http import HttpRequest
+
+from plane.db.models import Cycle, CycleIssue, Issue, Project, ProjectMember, State
+from plane.utils.cycle_transfer_issues import transfer_cycle_issues
+
+
+@pytest.fixture
+def project(db, workspace, create_user):
+    project = Project.objects.create(
+        name="Test Project",
+        identifier="TCT",
+        workspace=workspace,
+        created_by=create_user,
+        cycle_view=True,
+    )
+    ProjectMember.objects.create(project=project, member=create_user, role=20, is_active=True)
+    return project
+
+
+@pytest.fixture
+def backlog_state(db, project, create_user):
+    return State.objects.create(
+        name="Backlog",
+        project=project,
+        workspace=project.workspace,
+        group="backlog",
+        default=True,
+    )
+
+
+@pytest.fixture
+def source_cycle(db, project, create_user):
+    return Cycle.objects.create(
+        name="Source Cycle",
+        project=project,
+        workspace=project.workspace,
+        owned_by=create_user,
+    )
+
+
+@pytest.fixture
+def destination_cycle(db, project, create_user):
+    return Cycle.objects.create(
+        name="Destination Cycle",
+        project=project,
+        workspace=project.workspace,
+        owned_by=create_user,
+    )
+
+
+@pytest.fixture
+def incomplete_cycle_issue(db, project, create_user, backlog_state, source_cycle):
+    """A single incomplete issue assigned to the source cycle."""
+    issue = Issue.objects.create(
+        name="Incomplete Issue",
+        workspace=project.workspace,
+        project=project,
+        state=backlog_state,
+        created_by=create_user,
+    )
+    return CycleIssue.objects.create(
+        issue=issue,
+        cycle=source_cycle,
+        project=project,
+        workspace=project.workspace,
+        created_by=create_user,
+    )
+
+
+@pytest.fixture
+def dummy_request():
+    request = HttpRequest()
+    request.META["HTTP_HOST"] = "app.plane.so"
+    return request
+
+
+@pytest.mark.unit
+@pytest.mark.django_db
+class TestTransferCycleIssuesAtomicity:
+    def test_bulk_update_failure_rolls_back_snapshot(
+        self,
+        project,
+        source_cycle,
+        destination_cycle,
+        incomplete_cycle_issue,
+        create_user,
+        dummy_request,
+    ):
+        """If the CycleIssue move fails, the earlier progress_snapshot write
+        must also be rolled back - the two must be all-or-nothing."""
+        assert source_cycle.progress_snapshot == {}
+
+        with mock.patch(
+            "plane.utils.cycle_transfer_issues.CycleIssue.objects.bulk_update",
+            side_effect=RuntimeError("simulated crash mid-transfer"),
+        ):
+            with pytest.raises(RuntimeError):
+                transfer_cycle_issues(
+                    slug=project.workspace.slug,
+                    project_id=str(project.id),
+                    cycle_id=str(source_cycle.id),
+                    new_cycle_id=str(destination_cycle.id),
+                    request=dummy_request,
+                    user_id=str(create_user.id),
+                )
+
+        source_cycle.refresh_from_db()
+        incomplete_cycle_issue.refresh_from_db()
+
+        # The snapshot write must have been rolled back alongside the failed
+        # issue move - not left committed on its own.
+        assert source_cycle.progress_snapshot == {}
+        # The issue must still belong to the source cycle.
+        assert incomplete_cycle_issue.cycle_id == source_cycle.id
+
+    def test_successful_transfer_moves_issues_and_saves_snapshot(
+        self,
+        project,
+        source_cycle,
+        destination_cycle,
+        incomplete_cycle_issue,
+        create_user,
+        dummy_request,
+        settings,
+    ):
+        settings.WEB_URL = "http://app.plane.so"
+
+        with mock.patch("plane.utils.cycle_transfer_issues.issue_activity.delay"):
+            result = transfer_cycle_issues(
+                slug=project.workspace.slug,
+                project_id=str(project.id),
+                cycle_id=str(source_cycle.id),
+                new_cycle_id=str(destination_cycle.id),
+                request=dummy_request,
+                user_id=str(create_user.id),
+            )
+
+        assert result == {"success": True}
+
+        source_cycle.refresh_from_db()
+        incomplete_cycle_issue.refresh_from_db()
+
+        assert source_cycle.progress_snapshot != {}
+        assert incomplete_cycle_issue.cycle_id == destination_cycle.id

--- a/apps/api/plane/utils/cycle_transfer_issues.py
+++ b/apps/api/plane/utils/cycle_transfer_issues.py
@@ -16,7 +16,7 @@ from django.db.models import (
     Value,
     When,
 )
-from django.db import models
+from django.db import models, transaction
 from django.db.models.functions import Cast, Concat
 from django.utils import timezone
 
@@ -404,58 +404,65 @@ def transfer_cycle_issues(
         cycle_id=cycle_id,
     )
 
-    # Get the current cycle and save progress snapshot
-    current_cycle = Cycle.objects.filter(workspace__slug=slug, project_id=project_id, pk=cycle_id).first()
-
-    current_cycle.progress_snapshot = {
-        "total_issues": old_cycle.total_issues,
-        "completed_issues": old_cycle.completed_issues,
-        "cancelled_issues": old_cycle.cancelled_issues,
-        "started_issues": old_cycle.started_issues,
-        "unstarted_issues": old_cycle.unstarted_issues,
-        "backlog_issues": old_cycle.backlog_issues,
-        "distribution": {
-            "labels": label_distribution_data,
-            "assignees": assignee_distribution_data,
-            "completion_chart": completion_chart,
-        },
-        "estimate_distribution": (
-            {}
-            if not estimate_type
-            else {
-                "labels": label_estimate_distribution,
-                "assignees": assignee_estimate_distribution,
-                "completion_chart": estimate_completion_chart,
-            }
-        ),
-    }
-    current_cycle.save(update_fields=["progress_snapshot"])
-
-    # Get issues to transfer (only incomplete issues)
-    cycle_issues = CycleIssue.objects.filter(
-        cycle_id=cycle_id,
-        project_id=project_id,
-        workspace__slug=slug,
-        issue__archived_at__isnull=True,
-        issue__is_draft=False,
-        issue__state__group__in=["backlog", "unstarted", "started"],
-    )
-
-    updated_cycles = []
+    # Persist the progress snapshot and move the incomplete issues to the new
+    # cycle in a single atomic transaction. Without this, a process crash or
+    # DB error between the two writes leaves the source cycle marked with a
+    # snapshot while its issues were never actually transferred.
     update_cycle_issue_activity = []
-    for cycle_issue in cycle_issues:
-        cycle_issue.cycle_id = new_cycle_id
-        updated_cycles.append(cycle_issue)
-        update_cycle_issue_activity.append(
-            {
-                "old_cycle_id": str(cycle_id),
-                "new_cycle_id": str(new_cycle_id),
-                "issue_id": str(cycle_issue.issue_id),
-            }
+    with transaction.atomic():
+        # Get the current cycle and save progress snapshot
+        current_cycle = (
+            Cycle.objects.select_for_update().filter(workspace__slug=slug, project_id=project_id, pk=cycle_id).first()
         )
 
-    # Bulk update cycle issues
-    cycle_issues = CycleIssue.objects.bulk_update(updated_cycles, ["cycle_id"], batch_size=100)
+        current_cycle.progress_snapshot = {
+            "total_issues": old_cycle.total_issues,
+            "completed_issues": old_cycle.completed_issues,
+            "cancelled_issues": old_cycle.cancelled_issues,
+            "started_issues": old_cycle.started_issues,
+            "unstarted_issues": old_cycle.unstarted_issues,
+            "backlog_issues": old_cycle.backlog_issues,
+            "distribution": {
+                "labels": label_distribution_data,
+                "assignees": assignee_distribution_data,
+                "completion_chart": completion_chart,
+            },
+            "estimate_distribution": (
+                {}
+                if not estimate_type
+                else {
+                    "labels": label_estimate_distribution,
+                    "assignees": assignee_estimate_distribution,
+                    "completion_chart": estimate_completion_chart,
+                }
+            ),
+        }
+        current_cycle.save(update_fields=["progress_snapshot"])
+
+        # Get issues to transfer (only incomplete issues)
+        cycle_issues = CycleIssue.objects.filter(
+            cycle_id=cycle_id,
+            project_id=project_id,
+            workspace__slug=slug,
+            issue__archived_at__isnull=True,
+            issue__is_draft=False,
+            issue__state__group__in=["backlog", "unstarted", "started"],
+        )
+
+        updated_cycles = []
+        for cycle_issue in cycle_issues:
+            cycle_issue.cycle_id = new_cycle_id
+            updated_cycles.append(cycle_issue)
+            update_cycle_issue_activity.append(
+                {
+                    "old_cycle_id": str(cycle_id),
+                    "new_cycle_id": str(new_cycle_id),
+                    "issue_id": str(cycle_issue.issue_id),
+                }
+            )
+
+        # Bulk update cycle issues
+        CycleIssue.objects.bulk_update(updated_cycles, ["cycle_id"], batch_size=100)
 
     # Capture Issue Activity
     issue_activity.delay(


### PR DESCRIPTION
### Description
`transfer_cycle_issues` (in `apps/api/plane/utils/cycle_transfer_issues.py`) persists the source cycle's `progress_snapshot` and then moves its `CycleIssue` rows to the destination cycle in two separate, sequential DB writes:

```python
current_cycle.save(update_fields=["progress_snapshot"])   # committed first
...
CycleIssue.objects.bulk_update(updated_cycles, ["cycle_id"], batch_size=100)   # may never run
```

If the worker process is killed (OOM, deploy restart, DB connection timeout) or a DB error occurs after the first write but before the second, the source cycle ends up marked with a progress snapshot (appearing "completed" in the UI) while its issues were never actually moved to the destination cycle. There is no recovery path through the UI once this happens.

This PR wraps both writes in a single `transaction.atomic()` block (matching the existing idiom used elsewhere in the codebase, e.g. `plane/app/views/view/base.py`), with `select_for_update()` on the cycle row so the snapshot save and the issue move either both commit or both roll back together.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

### Test Scenarios
Added `apps/api/plane/tests/unit/utils/test_cycle_transfer_issues.py`:
- `test_bulk_update_failure_rolls_back_snapshot`: simulates a crash during `CycleIssue.objects.bulk_update` (via a raised exception) and asserts the source cycle's `progress_snapshot` is rolled back to `{}` and the issue is still assigned to the source cycle. This test fails against the pre-fix code (verified locally) and passes with the fix.
- `test_successful_transfer_moves_issues_and_saves_snapshot`: confirms the happy path still works - snapshot is saved and the issue is moved to the destination cycle.

Ran locally against a local Postgres/Redis:
```
python -m pytest plane/tests/unit/utils/test_cycle_transfer_issues.py -v
# 2 passed
```
Also ran `ruff check` and `ruff format --check` on the touched files (clean).

### References
Fixes #9599

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cycle issue transfers to complete atomically.
  * Prevented partial updates when a transfer fails, keeping issue assignments and progress data consistent.

* **Tests**
  * Added regression coverage for successful transfers and rollback behavior when an error occurs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->