### PR TITLE
feat: allow private project views for the owning user

### DIFF
--- a/apps/api/plane/app/serializers/view.py
+++ b/apps/api/plane/app/serializers/view.py
@@ -64,7 +64,6 @@ class IssueViewSerializer(DynamicBaseSerializer):
             "project",
             "query",
             "owned_by",
-            "access",
             "is_locked",
         ]
 

--- a/apps/api/plane/app/views/view/base.py
+++ b/apps/api/plane/app/views/view/base.py
@@ -314,6 +314,9 @@ class IssueViewViewSet(BaseViewSet):
     @allow_permission(allowed_roles=[ROLE.ADMIN, ROLE.MEMBER, ROLE.GUEST])
     def retrieve(self, request, slug, project_id, pk):
         issue_view = self.get_queryset().filter(pk=pk, project_id=project_id).first()
+        if issue_view is None:
+            return Response({"error": "View not found"}, status=status.HTTP_404_NOT_FOUND)
+
         project = Project.objects.get(id=project_id)
         """
         if the role is guest and guest_view_all_features is false and owned by is not 

--- a/apps/web/core/components/views/form.tsx
+++ b/apps/web/core/components/views/form.tsx
@@ -24,8 +24,11 @@ import { EViewAccess, EIssuesStoreType } from "@plane/types";
 import { Input, TextArea } from "@plane/ui";
 import { getComputedDisplayFilters, getComputedDisplayProperties, getTabIndex } from "@plane/utils";
 // components
+import { AccessField } from "@/components/common/access-field";
 import { DisplayFiltersSelection, FiltersDropdown } from "@/components/issues/issue-layouts/filters";
 import { WorkItemFiltersRow } from "@/components/work-item-filters/filters-row";
+// helpers
+import { VIEW_ACCESS_SPECIFIERS } from "@/helpers/views.helper";
 // hooks
 import { useProject } from "@/hooks/store/use-project";
 import { usePlatformOS } from "@/hooks/use-platform-os";
@@ -79,6 +82,8 @@ export const ProjectViewForm = observer(function ProjectViewForm(props: Props) {
   // derived values
   const projectDetails = getProjectById(projectId);
   const logoValue = watch("logo_props");
+  const accessValue = watch("access");
+  const i18nAccessLabel = VIEW_ACCESS_SPECIFIERS.find((access) => access.key === accessValue)?.i18n_label;
   const workItemFilters: IIssueFilters = {
     richFilters: getValues("rich_filters"),
     displayFilters: getValues("display_filters"),
@@ -278,19 +283,36 @@ export const ProjectViewForm = observer(function ProjectViewForm(props: Props) {
           </div>
         </div>
       </div>
-      <div className="flex items-center justify-end gap-2 border-t-[0.5px] border-subtle px-5 py-4">
-        <Button variant="secondary" size="lg" onClick={handleClose} tabIndex={getIndex("cancel")}>
-          {t("common.cancel")}
-        </Button>
-        <Button variant="primary" size="lg" type="submit" tabIndex={getIndex("submit")} loading={isSubmitting}>
-          {data
-            ? isSubmitting
-              ? t("common.updating")
-              : t("view.update.label")
-            : isSubmitting
-              ? t("common.creating")
-              : t("view.create.label")}
-        </Button>
+      <div className="flex items-center justify-between gap-2 border-t-[0.5px] border-subtle px-5 py-4">
+        <div className="flex items-center gap-2">
+          <Controller
+            control={control}
+            name="access"
+            render={({ field: { value, onChange } }) => (
+              <AccessField
+                onChange={onChange}
+                value={value ?? EViewAccess.PUBLIC}
+                accessSpecifiers={VIEW_ACCESS_SPECIFIERS}
+                isMobile={isMobile}
+              />
+            )}
+          />
+          <h6 className="text-11 font-medium">{t(i18nAccessLabel || "")}</h6>
+        </div>
+        <div className="flex items-center justify-end gap-2">
+          <Button variant="secondary" size="lg" onClick={handleClose} tabIndex={getIndex("cancel")}>
+            {t("common.cancel")}
+          </Button>
+          <Button variant="primary" size="lg" type="submit" tabIndex={getIndex("submit")} loading={isSubmitting}>
+            {data
+              ? isSubmitting
+                ? t("common.updating")
+                : t("view.update.label")
+              : isSubmitting
+                ? t("common.creating")
+                : t("view.create.label")}
+          </Button>
+        </div>
       </div>
     </form>
   );


### PR DESCRIPTION
### Description
Project views already had a private/public `access` field and list filtering by owner, but `access` was read-only on the API and the create/edit form had no access control. Users could not actually create personal private views.

This PR enables private project views end-to-end:
- Make `access` writable on `IssueViewSerializer` so clients can create/update Private (`0`) or Public (`1`) views
- Add a Public/Private access selector to the project view form (same pattern as Pages)
- Return `404` when retrieving a view that is not visible to the requesting user (e.g. another member’s private view)

Private views remain visible only to the owner; public views stay shared with project members.

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots of the Public/Private selector on create/edit project view -->

### Test Scenarios
- Create a project view with **Private** access → it appears in the creator’s Views list with the lock icon
- As another project member, open the same project’s Views list → the private view is not listed
- Open the private view URL directly as another member → receives `404`
- Create a **Public** view → both members can see and open it
- Owner edits a private view and switches access to **Public** → other members can see it afterward
- Owner can still update/delete their own private view

### References
<!-- Link related GitHub issue / Plane work item if any -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added access controls to view forms, including localized access labels.
  * View access settings can now be updated when editing a view.

* **Bug Fixes**
  * Requests for unavailable views now return a clear “Not Found” response instead of continuing with missing data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->