### PR TITLE
fix: runtime crash in dropdowns from headlessui v2 Fragment check (React 19 upgrade regression)

### DIFF
--- a/apps/web/core/components/dropdowns/cycle/index.tsx
+++ b/apps/web/core/components/dropdowns/cycle/index.tsx
@@ -83,9 +83,7 @@ export const CycleDropdown = observer(function CycleDropdown(props: Props) {
     handleClose();
   };
 
-  const comboButton = (
-    <>
-      {button ? (
+  const comboButton = button ? (
         <button
           ref={setReferenceElement}
           type="button"
@@ -130,9 +128,7 @@ export const CycleDropdown = observer(function CycleDropdown(props: Props) {
             )}
           </DropdownButton>
         </button>
-      )}
-    </>
-  );
+      );
 
   return (
     <ComboDropDown

--- a/apps/web/core/components/dropdowns/estimate.tsx
+++ b/apps/web/core/components/dropdowns/estimate.tsx
@@ -159,9 +159,7 @@ export const EstimateDropdown = observer(function EstimateDropdown(props: Props)
     handleClose();
   };
 
-  const comboButton = (
-    <>
-      {button ? (
+  const comboButton = button ? (
         <button
           ref={setReferenceElement}
           type="button"
@@ -214,9 +212,7 @@ export const EstimateDropdown = observer(function EstimateDropdown(props: Props)
             )}
           </DropdownButton>
         </button>
-      )}
-    </>
-  );
+      );
 
   return (
     <ComboDropDown

--- a/apps/web/core/components/dropdowns/intake-state/base.tsx
+++ b/apps/web/core/components/dropdowns/intake-state/base.tsx
@@ -135,9 +135,7 @@ export const WorkItemStateDropdownBase = observer(function WorkItemStateDropdown
     handleClose();
   };
 
-  const comboButton = (
-    <>
-      {button ? (
+  const comboButton = button ? (
         <button
           ref={setReferenceElement}
           type="button"
@@ -197,9 +195,7 @@ export const WorkItemStateDropdownBase = observer(function WorkItemStateDropdown
             )}
           </DropdownButton>
         </button>
-      )}
-    </>
-  );
+      );
 
   return (
     // oxlint-disable-next-line jsx_a11y/no-static-element-interactions

--- a/apps/web/core/components/dropdowns/member/base.tsx
+++ b/apps/web/core/components/dropdowns/member/base.tsx
@@ -108,9 +108,7 @@ export const MemberDropdownBase = observer(function MemberDropdownBase(props: TM
     }
   };
 
-  const comboButton = (
-    <>
-      {button ? (
+  const comboButton = button ? (
         <button
           ref={setReferenceElement}
           type="button"
@@ -159,9 +157,7 @@ export const MemberDropdownBase = observer(function MemberDropdownBase(props: TM
             )}
           </DropdownButton>
         </button>
-      )}
-    </>
-  );
+      );
 
   return (
     <ComboDropDown

--- a/apps/web/core/components/dropdowns/module/base.tsx
+++ b/apps/web/core/components/dropdowns/module/base.tsx
@@ -111,9 +111,7 @@ export const ModuleDropdownBase = observer(function ModuleDropdownBase(props: TM
     }
   }, [isOpen, isMobile]);
 
-  const comboButton = (
-    <>
-      {button ? (
+  const comboButton = button ? (
         <button
           ref={setReferenceElement}
           type="button"
@@ -171,9 +169,7 @@ export const ModuleDropdownBase = observer(function ModuleDropdownBase(props: TM
             />
           </DropdownButton>
         </button>
-      )}
-    </>
-  );
+      );
 
   return (
     <ComboDropDown

--- a/apps/web/core/components/dropdowns/priority.tsx
+++ b/apps/web/core/components/dropdowns/priority.tsx
@@ -398,9 +398,7 @@ export function PriorityDropdown(props: Props) {
       ? BackgroundButton
       : TransparentButton;
 
-  const comboButton = (
-    <>
-      {button ? (
+  const comboButton = button ? (
         <button
           ref={setReferenceElement}
           type="button"
@@ -440,9 +438,7 @@ export function PriorityDropdown(props: Props) {
             renderToolTipByDefault={renderByDefault}
           />
         </button>
-      )}
-    </>
-  );
+      );
 
   return (
     <ComboDropDown

--- a/apps/web/core/components/dropdowns/project/base.tsx
+++ b/apps/web/core/components/dropdowns/project/base.tsx
@@ -174,9 +174,7 @@ export const ProjectDropdownBase = observer(function ProjectDropdownBase(props: 
     }
   };
 
-  const comboButton = (
-    <>
-      {button ? (
+  const comboButton = button ? (
         <button
           ref={setReferenceElement}
           type="button"
@@ -219,9 +217,7 @@ export const ProjectDropdownBase = observer(function ProjectDropdownBase(props: 
             )}
           </DropdownButton>
         </button>
-      )}
-    </>
-  );
+      );
 
   return (
     <ComboDropDown

--- a/apps/web/core/components/dropdowns/state/base.tsx
+++ b/apps/web/core/components/dropdowns/state/base.tsx
@@ -136,9 +136,7 @@ export const WorkItemStateDropdownBase = observer(function WorkItemStateDropdown
     handleClose();
   };
 
-  const comboButton = (
-    <>
-      {button ? (
+  const comboButton = button ? (
         <button
           ref={setReferenceElement}
           type="button"
@@ -199,9 +197,7 @@ export const WorkItemStateDropdownBase = observer(function WorkItemStateDropdown
             )}
           </DropdownButton>
         </button>
-      )}
-    </>
-  );
+      );
 
   return (
     // oxlint-disable-next-line jsx_a11y/no-static-element-interactions


### PR DESCRIPTION
### Description
The React 19 upgrade (#9530) bumped `@headlessui/react` v1.7.19 → v2.2.10 (required — v1 reads APIs removed in React 19). Headless UI v2 added a stricter check on `Combobox.Button as={Fragment}` sites: the child must resolve to a single real element, not a Fragment.

Eight dropdown components (`priority`, `estimate`, `intake-state`, `member`, `module`, `cycle`, `state`, `project`) had a pre-existing, previously-harmless pattern of wrapping their button ternary in `<>{cond ? <button/> : <button/>}</>` before passing it to `Combobox.Button`. Under v1 this was silently tolerated; under v2 the child's `type === Fragment` now throws `"Passing props on Fragment!"` at runtime — crashing these dropdowns on `preview` post-#9530.

Fix: drop the redundant outer `<>...</>` in each of the 8 files — the ternary already evaluates to a single element, so the Fragment wrapper was never needed.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

| Error Msg | 
| --- | 
| <img width="1076" height="887" alt="Screenshot 2026-08-27 at 2 40 30 PM" src="https://github.com/user-attachments/assets/20d55d55-ed2b-4b7b-b296-856ba2dc9b1d" /> |


### Test Scenarios
- `pnpm --filter web run check:types` — zero errors
- `pnpm run build` — 16/16 tasks pass
- Manually exercised priority, state, module, member, cycle, project, estimate, and intake-state dropdowns — button renders and opens without the runtime error

### References
Runtime regression introduced by the `@headlessui/react` v1→v2 bump in #9530 (React 19 upgrade), which surfaced this latent Fragment-wrap bug.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified button rendering across dropdown menus.
  * Preserved existing button appearance, behavior, and support for custom buttons.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->