### PR TITLE
fix(auth): default HTTP_USER_AGENT to empty string in save_user_data

### DIFF
--- a/apps/api/plane/authentication/adapter/base.py
+++ b/apps/api/plane/authentication/adapter/base.py
@@ -237,7 +237,7 @@ class Adapter:
         user.last_active = timezone.now()
         user.last_login_time = timezone.now()
         user.last_login_ip = get_client_ip(request=self.request)
-        user.last_login_uagent = self.request.META.get("HTTP_USER_AGENT")
+        user.last_login_uagent = self.request.META.get("HTTP_USER_AGENT", "")
         user.token_updated_at = timezone.now()
         # Activate provisioned accounts that have never been deactivated.
         # Explicitly-deactivated accounts are rejected earlier in

--- a/apps/api/plane/tests/contract/app/test_authentication.py
+++ b/apps/api/plane/tests/contract/app/test_authentication.py
@@ -217,6 +217,31 @@ class TestSignInEndpoint:
         assert "_auth_user_id" in django_client.session
 
     @pytest.mark.django_db
+    def test_user_login_without_user_agent_header(self, setup_user, setup_instance):
+        """Sign-in must succeed even when the request has no User-Agent header.
+
+        Regression test for #9672: some programmatic clients (e.g. Rust's
+        reqwest) send no User-Agent by default. `save_user_data()` used to
+        read `HTTP_USER_AGENT` with no default, so a missing header stored
+        `None` into the non-nullable `last_login_uagent` column and the
+        resulting `IntegrityError` bubbled up as an unhandled 500 instead of
+        completing the sign-in.
+        """
+        # Unlike the `django_client` fixture, a plain `Client()` sends no
+        # User-Agent header at all, matching the reported reproduction.
+        client = Client()
+        url = reverse("sign-in")
+
+        response = client.post(url, {"email": "user@plane.so", "password": "user@123"}, follow=False)
+
+        # Must redirect (successful sign-in), not 500.
+        assert response.status_code == 302
+        assert "error_code" not in response.url
+
+        setup_user.refresh_from_db()
+        assert setup_user.last_login_uagent == ""
+
+    @pytest.mark.django_db
     def test_next_path_redirection(self, django_client, setup_user, setup_instance):
         """Test sign-in with next_path parameter"""
         url = reverse("sign-in")


### PR DESCRIPTION
## Description

Fixes #9672. `POST /auth/sign-in/` (email/password) returns an unhandled
HTTP 500 when the request has no `User-Agent` header, *after* credentials
are verified successfully. Any programmatic client that omits the header
(for example Rust's `reqwest`, which sends no `User-Agent` by default)
cannot sign in even with correct credentials.

**Root cause**: `Adapter.save_user_data()` in
`apps/api/plane/authentication/adapter/base.py` reads the header with no
default:

```python
user.last_login_uagent = self.request.META.get("HTTP_USER_AGENT")
```

When the header is absent this returns `None`. `last_login_uagent` is
`models.TextField(blank=True)` - `blank=True` but not `null=True`, so the
column is `NOT NULL`. Saving `None` raises an `IntegrityError`, which is
not an `AuthenticationException`, so it isn't caught by the sign-in view's
error handling and Django returns a generic 500 instead of completing the
sign-in.

The sibling login code path already handles this correctly, which is the
inconsistency this PR resolves:

```python
# apps/api/plane/authentication/utils/login.py
"user_agent": request.META.get("HTTP_USER_AGENT", ""),
```

## Fix

One-line change, defaulting the header to `""` in `save_user_data()` to
match the existing pattern in `login.py`:

```python
user.last_login_uagent = self.request.META.get("HTTP_USER_AGENT", "")
```

## Tests

Added `test_user_login_without_user_agent_header` to `TestSignInEndpoint`
in `apps/api/plane/tests/contract/app/test_authentication.py`. It signs in
with a plain `Client()` (no `User-Agent` header, unlike the module's
`django_client` fixture which always sets one), and asserts a 302 redirect
(successful sign-in) instead of a 500, plus that `last_login_uagent` is
saved as `""`.

Verified the test fails against the pre-fix code: reverted the one-line
fix locally and reran the new test, which failed with exactly the
reported error -
`django.db.utils.IntegrityError: null value in column "last_login_uagent"
of relation "users" violates not-null constraint` - reproducing the bug
end-to-end. Re-applied the fix and the test passes.

Ran the full `TestSignInEndpoint` class (7 tests) and the full
`test_authentication.py` file locally against Postgres + Redis:

- All 7 `TestSignInEndpoint` tests pass, including the new regression test.
- 12 pre-existing failures in `TestMagicLinkGenerate` /
  `TestMagicSignIn` / `TestMagicSignUp` / verify-attempt classes, all with
  `SMTP_NOT_CONFIGURED` (error code 5025) - this local environment has no
  SMTP configured. Confirmed these are unrelated to this change and
  pre-existing on `preview` before this diff (same failures reproduce with
  the fix fully reverted).
- `ruff check` clean on both changed files.
- `ruff format --check` on both files flags only pre-existing, unrelated
  formatting drift elsewhere in each file (confirmed identical against
  `preview` before this change) - none of it touches the lines this PR
  changes.

## AI assistance disclosure

This fix was implemented with Claude Code assistance (code, tests, and PR
description), reviewed and verified locally before submission, per this
repo's own convention of `Co-authored-by: Claude <noreply@anthropic.com>`
trailers on AI-assisted commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sign-in now succeeds when the browser does not provide a User-Agent header.
  * Prevented server errors during login caused by missing User-Agent information.
  * Missing User-Agent data is safely recorded as an empty value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->