### PR TITLE
fix: restore public asset storage initialization

### DIFF
--- a/apps/api/plane/api/views/asset.py
+++ b/apps/api/plane/api/views/asset.py
@@ -335,7 +335,7 @@ class UserServerAssetEndpoint(BaseAPIView):
         )
 
         # Get the presigned URL
-        storage = S3Storage(request=request, is_server=True)
+        storage = S3Storage(request=request)
         # Generate a presigned URL to share an S3 object
         presigned_url = storage.generate_presigned_post(object_name=asset_key, file_type=type, file_size=size_limit)
         # Return the presigned URL
@@ -448,7 +448,7 @@ class GenericAssetEndpoint(BaseAPIView):
             # Force attachment disposition for script-capable MIME types (e.g. SVG)
             # to prevent same-origin XSS when the asset URL shares the app's origin
             # (default MinIO self-hosted setup).
-            storage = S3Storage(request=request, is_server=True)
+            storage = S3Storage(request=request)
             asset_mime_type = (asset.attributes.get("type") or "").split(";")[0].strip().lower()
             disposition = (
                 "attachment" if asset_mime_type in settings.SCRIPT_CAPABLE_MIME_TYPES else "inline"
@@ -578,7 +578,7 @@ class GenericAssetEndpoint(BaseAPIView):
         )
 
         # Get the presigned URL
-        storage = S3Storage(request=request, is_server=True)
+        storage = S3Storage(request=request)
         presigned_url = storage.generate_presigned_post(object_name=asset_key, file_type=type, file_size=size_limit)
 
         return Response(

--- a/apps/api/plane/tests/contract/api/test_asset_storage.py
+++ b/apps/api/plane/tests/contract/api/test_asset_storage.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Contract tests for storage initialization in public asset endpoints."""
+
+from unittest import mock
+
+import pytest
+from rest_framework import status
+
+from plane.db.models import FileAsset
+
+
+@pytest.mark.contract
+class TestPublicAssetStorageInitialization:
+    """Public asset endpoints must construct ``S3Storage`` with its supported API."""
+
+    @pytest.mark.django_db
+    def test_member_can_generate_generic_asset_download(self, api_key_client, workspace, create_user):
+        """The generic download route returns a URL using the supported storage API."""
+        asset = FileAsset.objects.create(
+            attributes={"name": "screenshot.png", "type": "image/png", "size": 1024},
+            asset=f"{workspace.id}/screenshot.png",
+            size=1024,
+            workspace=workspace,
+            created_by=create_user,
+            entity_type=FileAsset.EntityTypeContext.ISSUE_ATTACHMENT,
+            is_uploaded=True,
+            storage_metadata={"size": 1024},
+        )
+        url = f"/api/v1/workspaces/{workspace.slug}/assets/{asset.id}/"
+
+        with mock.patch("plane.api.views.asset.S3Storage", autospec=True) as mock_storage:
+            mock_storage.return_value.generate_presigned_url.return_value = "https://signed.example/download"
+            response = api_key_client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK, f"Got {response.status_code}: {response.data!r}"
+        assert response.data["asset_url"] == "https://signed.example/download"
+        mock_storage.assert_called_once_with(request=mock.ANY)
+
+    @pytest.mark.django_db
+    def test_member_can_generate_generic_asset_upload(self, api_key_client, workspace):
+        """The generic upload route creates its asset using the supported storage API."""
+        url = f"/api/v1/workspaces/{workspace.slug}/assets/"
+        payload = {"name": "screenshot.png", "type": "image/png", "size": 1024}
+
+        with mock.patch("plane.api.views.asset.S3Storage", autospec=True) as mock_storage:
+            mock_storage.return_value.generate_presigned_post.return_value = {
+                "url": "https://signed.example/upload",
+                "fields": {},
+            }
+            response = api_key_client.post(url, payload, format="json")
+
+        assert response.status_code == status.HTTP_200_OK, f"Got {response.status_code}: {response.data!r}"
+        assert FileAsset.objects.filter(id=response.data["asset_id"], workspace=workspace).exists()
+        mock_storage.assert_called_once_with(request=mock.ANY)
+
+    @pytest.mark.django_db
+    def test_user_can_generate_server_asset_upload(self, api_key_client, create_user):
+        """The server upload route creates a user asset using the supported storage API."""
+        url = "/api/v1/assets/user-assets/server/"
+        payload = {
+            "name": "avatar.png",
+            "type": "image/png",
+            "size": 1024,
+            "entity_type": FileAsset.EntityTypeContext.USER_AVATAR,
+        }
+
+        with mock.patch("plane.api.views.asset.S3Storage", autospec=True) as mock_storage:
+            mock_storage.return_value.generate_presigned_post.return_value = {
+                "url": "https://signed.example/upload",
+                "fields": {},
+            }
+            response = api_key_client.post(url, payload, format="json")
+
+        assert response.status_code == status.HTTP_200_OK, f"Got {response.status_code}: {response.data!r}"
+        assert FileAsset.objects.filter(id=response.data["asset_id"], user=create_user).exists()
+        mock_storage.assert_called_once_with(request=mock.ANY)


### PR DESCRIPTION
### Description

The public API asset routes currently instantiate `S3Storage` with an unsupported `is_server` keyword. `S3Storage.__init__` has always accepted only `request`, so authenticated generic uploads, downloads, and server-backed user uploads fail with HTTP 500 before a presigned URL is generated.

This removes the invalid keyword from all three call sites and uses the same request-aware constructor as the adjacent working asset routes. The regression tests autospec the real `S3Storage` signature, so future constructor/caller drift fails at the API contract boundary instead of being hidden by a permissive mock.

This is intentionally narrower than #9114: it fixes the callers without adding a second storage mode or changing MinIO endpoint selection. Presigned URLs are returned to clients, so preserving the existing request-derived public endpoint behavior is the safer compatibility choice.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)

Not applicable; this fixes public REST API responses.

### Test Scenarios

- Reproduced the regression with autospecced storage: generic GET and POST returned HTTP 500 with `TypeError: got an unexpected keyword argument 'is_server'` before the fix.
- `pytest plane/tests/contract/api/test_asset_storage.py plane/tests/contract/api/test_generic_asset.py -vv` — 7 passed.
- `ruff check plane/api/views/asset.py plane/tests/contract/api/test_asset_storage.py plane/tests/contract/api/test_generic_asset.py` — passed.
- `ruff format --check plane/tests/contract/api/test_asset_storage.py plane/tests/contract/api/test_generic_asset.py` — passed.
- Full public API contract directory: 59 passed; 2 existing rate-limit-state failures. Both unrelated failures pass in isolation after resetting the documented ephemeral test stack.

### References

Fixes #8680
Fixes #9563
Related alternative: #9114


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved asset upload and download handling for more reliable storage operations.
  * Presigned asset URLs and asset ownership associations continue to be generated correctly.

* **Tests**
  * Added coverage for public asset upload and download workflows, including storage initialization and asset associations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->