### PR TITLE
refactor: migrate web @plane/propel Tooltip to @makeplane/propel

### DIFF
--- a/apps/web/app/(all)/[workspaceSlug]/(projects)/extended-project-sidebar.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/(projects)/extended-project-sidebar.tsx
@@ -117,6 +117,7 @@ export const ExtendedProjectSidebar = observer(function ExtendedProjectSidebar()
               <Tooltip label={t("create_project")}>
                 <button
                   type="button"
+                  aria-label={t("create_project")}
                   className="flex-shrink-0 rounded-sm p-0.5 text-tertiary transition-colors hover:bg-layer-1 hover:text-secondary"
                   onClick={() => {
                     setIsProjectModalOpen(true);

--- a/apps/web/app/(all)/[workspaceSlug]/(projects)/extended-project-sidebar.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/(projects)/extended-project-sidebar.tsx
@@ -13,7 +13,7 @@ import { useTranslation } from "@plane/i18n";
 import { EmptyStateCompact } from "@plane/propel/empty-state";
 import { PlusIcon, SearchIcon } from "@plane/propel/icons";
 import { TOAST_TYPE, setToast } from "@plane/propel/toast";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import { copyUrlToClipboard, orderJoinedProjects } from "@plane/utils";
 // components
 import { CreateProjectModal } from "@/components/project/create-project-modal";
@@ -114,7 +114,7 @@ export const ExtendedProjectSidebar = observer(function ExtendedProjectSidebar()
           <div className="flex items-center justify-between">
             <span className="py-1.5 text-13 font-semibold text-tertiary">Projects</span>
             {isAuthorizedUser && (
-              <Tooltip tooltipHeading={t("create_project")} tooltipContent="">
+              <Tooltip label={t("create_project")}>
                 <button
                   type="button"
                   className="flex-shrink-0 rounded-sm p-0.5 text-tertiary transition-colors hover:bg-layer-1 hover:text-secondary"

--- a/apps/web/app/(all)/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/archives/header.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/archives/header.tsx
@@ -7,7 +7,7 @@
 import { observer } from "mobx-react";
 import { useParams } from "next/navigation";
 import { ArchiveIcon, CycleIcon, ModuleIcon, WorkItemsIcon } from "@plane/propel/icons";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import { EIssuesStoreType } from "@plane/types";
 // ui
 import { Breadcrumbs, Header } from "@plane/ui";
@@ -95,9 +95,10 @@ export const ProjectArchivesHeader = observer(function ProjectArchivesHeader(pro
           </Breadcrumbs>
           {activeTab === "issues" && issueCount && issueCount > 0 ? (
             <Tooltip
-              isMobile={isMobile}
-              tooltipContent={`There are ${issueCount} ${issueCount > 1 ? "work items" : "work item"} in project's archived`}
-              position="bottom"
+              label={`There are ${issueCount} ${issueCount > 1 ? "work items" : "work item"} in project's archived`}
+              layout="stacked"
+              side="bottom"
+              disabled={isMobile}
             >
               <span className="flex flex-shrink-0 cursor-default items-center justify-center rounded-xl bg-accent-primary/20 px-2.5 py-0.5 text-center text-11 font-semibold text-accent-primary">
                 {issueCount}

--- a/apps/web/app/(all)/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/cycles/(detail)/header.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/cycles/(detail)/header.tsx
@@ -21,7 +21,7 @@ import { useTranslation } from "@plane/i18n";
 import { Button } from "@plane/propel/button";
 import { IconButton } from "@plane/propel/icon-button";
 import { CycleIcon } from "@plane/propel/icons";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import type { ICustomSearchSelectOption, IIssueDisplayFilterOptions, IIssueDisplayProperties } from "@plane/types";
 import { EIssuesStoreType, EIssueLayoutTypes } from "@plane/types";
 import { Breadcrumbs, BreadcrumbNavigationSearchDropdown, Header } from "@plane/ui";
@@ -169,11 +169,10 @@ export const CycleIssuesHeader = observer(function CycleIssuesHeader() {
             </Breadcrumbs>
             {workItemsCount && workItemsCount > 0 ? (
               <Tooltip
-                isMobile={isMobile}
-                tooltipContent={`There are ${workItemsCount} ${
-                  workItemsCount > 1 ? "work items" : "work item"
-                } in this cycle`}
-                position="bottom"
+                label={`There are ${workItemsCount} ${workItemsCount > 1 ? "work items" : "work item"} in this cycle`}
+                layout="stacked"
+                side="bottom"
+                disabled={isMobile}
               >
                 <span className="flex flex-shrink-0 cursor-default items-center justify-center rounded-xl bg-accent-primary/20 px-2 text-center text-11 font-semibold text-accent-primary">
                   {workItemsCount}

--- a/apps/web/app/(all)/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/modules/(detail)/header.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/modules/(detail)/header.tsx
@@ -18,7 +18,7 @@ import {
 } from "@plane/constants";
 import { Button } from "@plane/propel/button";
 import { ModuleIcon } from "@plane/propel/icons";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import type { ICustomSearchSelectOption, IIssueDisplayFilterOptions, IIssueDisplayProperties } from "@plane/types";
 import { EIssuesStoreType, EIssueLayoutTypes } from "@plane/types";
 import { Breadcrumbs, Header, BreadcrumbNavigationSearchDropdown } from "@plane/ui";
@@ -163,11 +163,10 @@ export const ModuleIssuesHeader = observer(function ModuleIssuesHeader() {
             </Breadcrumbs>
             {workItemsCount && workItemsCount > 0 ? (
               <Tooltip
-                isMobile={isMobile}
-                tooltipContent={`There are ${workItemsCount} ${
-                  workItemsCount > 1 ? "work items" : "work item"
-                } in this module`}
-                position="bottom"
+                label={`There are ${workItemsCount} ${workItemsCount > 1 ? "work items" : "work item"} in this module`}
+                layout="stacked"
+                side="bottom"
+                disabled={isMobile}
               >
                 <span className="flex flex-shrink-0 cursor-default items-center justify-center rounded-xl bg-accent-primary/20 px-2 text-center text-11 font-semibold text-accent-primary">
                   {workItemsCount}

--- a/apps/web/app/(all)/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/views/(detail)/[viewId]/header.tsx
+++ b/apps/web/app/(all)/[workspaceSlug]/(projects)/projects/(detail)/[projectId]/views/(detail)/[viewId]/header.tsx
@@ -17,7 +17,7 @@ import {
 } from "@plane/constants";
 import { Button } from "@plane/propel/button";
 import { LockIcon, ViewsIcon } from "@plane/propel/icons";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import type { ICustomSearchSelectOption, IIssueDisplayFilterOptions, IIssueDisplayProperties } from "@plane/types";
 import { EIssuesStoreType, EViewAccess, EIssueLayoutTypes } from "@plane/types";
 import { Breadcrumbs, Header, BreadcrumbNavigationSearchDropdown } from "@plane/ui";
@@ -155,7 +155,7 @@ export const ProjectViewIssuesHeader = observer(function ProjectViewIssuesHeader
 
         {viewDetails?.access === EViewAccess.PRIVATE ? (
           <div className="cursor-default text-tertiary">
-            <Tooltip tooltipContent={"Private"}>
+            <Tooltip label={"Private"}>
               <LockIcon className="h-4 w-4" />
             </Tooltip>
           </div>

--- a/apps/web/core/components/analytics/overview/active-project-item.tsx
+++ b/apps/web/core/components/analytics/overview/active-project-item.tsx
@@ -7,7 +7,7 @@
 // plane package imports
 import { Logo } from "@plane/propel/emoji-icon-picker";
 import { ProjectIcon } from "@plane/propel/icons";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import { cn } from "@plane/utils";
 // plane web hooks
 import { useProject } from "@/hooks/store/use-project";
@@ -54,7 +54,7 @@ function ActiveProjectItem(props: Props) {
             )}
           </span>
         </div>
-        <Tooltip tooltipContent={projectDetails?.name} position="top-start">
+        <Tooltip label={projectDetails?.name} layout="stacked" align="start">
           <p className="truncate text-13 font-medium">{projectDetails?.name}</p>
         </Tooltip>
       </div>

--- a/apps/web/core/components/api-token/modal/generated-token-details.tsx
+++ b/apps/web/core/components/api-token/modal/generated-token-details.tsx
@@ -8,7 +8,7 @@ import { useTranslation } from "@plane/i18n";
 import { Button } from "@plane/propel/button";
 import { CopyIcon } from "@plane/propel/icons";
 import { TOAST_TYPE, setToast } from "@plane/propel/toast";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import type { IApiToken } from "@plane/types";
 // ui
 import { renderFormattedDate, renderFormattedTime, copyTextToClipboard } from "@plane/utils";
@@ -48,7 +48,7 @@ export function GeneratedTokenDetails(props: Props) {
         className="mt-4 flex w-full items-center justify-between truncate rounded-md border-[0.5px] border-subtle px-3 py-2 text-13 font-medium outline-none"
       >
         <span className="truncate pr-2">{tokenDetails.token}</span>
-        <Tooltip tooltipContent="Copy secret key" isMobile={isMobile}>
+        <Tooltip label="Copy secret key" disabled={isMobile}>
           <CopyIcon className="h-4 w-4 flex-shrink-0 text-placeholder" />
         </Tooltip>
       </button>

--- a/apps/web/core/components/api-token/token-list-item.tsx
+++ b/apps/web/core/components/api-token/token-list-item.tsx
@@ -7,7 +7,7 @@
 import { useState } from "react";
 import { XCircle } from "lucide-react";
 // plane imports
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import type { IApiToken } from "@plane/types";
 import { renderFormattedDate, calculateTimeAgo, renderFormattedTime } from "@plane/utils";
 // components
@@ -30,7 +30,7 @@ export function ApiTokenListItem(props: Props) {
     <>
       <DeleteApiTokenModal isOpen={deleteModalOpen} onClose={() => setDeleteModalOpen(false)} tokenId={token.id} />
       <div className="group relative flex flex-col justify-center border-b border-subtle py-3">
-        <Tooltip tooltipContent="Delete token" isMobile={isMobile}>
+        <Tooltip label="Delete token" disabled={isMobile}>
           <button
             onClick={() => setDeleteModalOpen(true)}
             className="absolute right-4 hidden place-items-center group-hover:grid"

--- a/apps/web/core/components/base-layouts/layout-switcher.tsx
+++ b/apps/web/core/components/base-layouts/layout-switcher.tsx
@@ -30,12 +30,14 @@ export function LayoutSwitcher(props: Props) {
 
   return (
     <div className="flex items-center gap-1 rounded-md bg-layer-3 p-1">
-      {BASE_LAYOUTS.filter((l) => (layouts ? layouts.includes(l.key) : true)).map((layout) => {
+      {BASE_LAYOUTS.map((layout) => {
+        if (layouts && !layouts.includes(layout.key)) return null;
         const Icon = layout.icon;
         return (
           <Tooltip key={layout.key} label={t(layout.label)} disabled={isMobile}>
             <button
               type="button"
+              aria-label={t(layout.label)}
               className={cn(
                 "group grid h-5.5 w-7 place-items-center overflow-hidden rounded-sm transition-all hover:bg-layer-transparent-hover",
                 {

--- a/apps/web/core/components/base-layouts/layout-switcher.tsx
+++ b/apps/web/core/components/base-layouts/layout-switcher.tsx
@@ -5,7 +5,7 @@
  */
 
 import { useTranslation } from "@plane/i18n";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import type { TBaseLayoutType } from "@plane/types";
 import { cn } from "@plane/utils";
 import { usePlatformOS } from "@/hooks/use-platform-os";
@@ -33,7 +33,7 @@ export function LayoutSwitcher(props: Props) {
       {BASE_LAYOUTS.filter((l) => (layouts ? layouts.includes(l.key) : true)).map((layout) => {
         const Icon = layout.icon;
         return (
-          <Tooltip key={layout.key} tooltipContent={t(layout.label)} isMobile={isMobile}>
+          <Tooltip key={layout.key} label={t(layout.label)} disabled={isMobile}>
             <button
               type="button"
               className={cn(

--- a/apps/web/core/components/common/access-field.tsx
+++ b/apps/web/core/components/common/access-field.tsx
@@ -8,7 +8,7 @@ import type { LucideIcon } from "lucide-react";
 // plane ui
 import { useTranslation } from "@plane/i18n";
 import type { ISvgIcons } from "@plane/propel/icons";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 // plane utils
 import { cn } from "@plane/utils";
 
@@ -34,7 +34,7 @@ export function AccessField(props: Props) {
       {accessSpecifiers.map((access, index) => {
         const label = access.i18n_label ? t(access.i18n_label) : access.label;
         return (
-          <Tooltip key={access.key} tooltipContent={label} isMobile={isMobile}>
+          <Tooltip key={access.key} label={label ?? ""} layout="stacked" disabled={isMobile}>
             <button
               type="button"
               onClick={() => onChange(access.key)}

--- a/apps/web/core/components/common/access-field.tsx
+++ b/apps/web/core/components/common/access-field.tsx
@@ -17,14 +17,12 @@ type Props = {
   value: number;
   accessSpecifiers: {
     key: number;
-    i18n_label?: string;
-    label?: string;
+    i18n_label: string;
     icon: LucideIcon | React.FC<ISvgIcons>;
   }[];
   isMobile?: boolean;
 };
 
-// TODO: Remove label once i18n is done
 export function AccessField(props: Props) {
   const { onChange, value, accessSpecifiers, isMobile = false } = props;
   const { t } = useTranslation();
@@ -32,11 +30,12 @@ export function AccessField(props: Props) {
   return (
     <div className="flex flex-shrink-0 items-stretch gap-0.5 rounded-sm border-[1px] border-subtle p-1">
       {accessSpecifiers.map((access, index) => {
-        const label = access.i18n_label ? t(access.i18n_label) : access.label;
+        const label = t(access.i18n_label);
         return (
-          <Tooltip key={access.key} label={label ?? ""} layout="stacked" disabled={isMobile}>
+          <Tooltip key={access.key} label={label} layout="stacked" disabled={isMobile}>
             <button
               type="button"
+              aria-label={label}
               onClick={() => onChange(access.key)}
               className={cn(
                 "relative flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-xs p-1 transition-all",

--- a/apps/web/core/components/common/activity/activity-block.tsx
+++ b/apps/web/core/components/common/activity/activity-block.tsx
@@ -7,7 +7,7 @@
 import type { FC, ReactNode } from "react";
 import { Network } from "lucide-react";
 // types
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import type { TWorkspaceBaseActivity } from "@plane/types";
 // ui
 // helpers
@@ -46,8 +46,8 @@ export function ActivityBlockComponent(props: TActivityBlockComponent) {
         </div>
         <div className="mt-1">
           <Tooltip
-            isMobile={isMobile}
-            tooltipContent={`${renderFormattedDate(activity.created_at)}, ${renderFormattedTime(activity.created_at)}`}
+            label={`${renderFormattedDate(activity.created_at)}, ${renderFormattedTime(activity.created_at)}`}
+            disabled={isMobile}
           >
             <span className="cursor-help font-medium whitespace-nowrap text-tertiary">
               {calculateTimeAgo(activity.created_at)}

--- a/apps/web/core/components/core/activity.tsx
+++ b/apps/web/core/components/core/activity.tsx
@@ -33,7 +33,7 @@ import {
   RelatedIcon,
   WorkItemsIcon,
 } from "@plane/propel/icons";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import type { IIssueActivity } from "@plane/types";
 import { renderFormattedDate, generateWorkItemLink, capitalizeFirstLetter } from "@plane/utils";
 // helpers
@@ -56,8 +56,9 @@ export function IssueLink({ activity }: { activity: IIssueActivity }) {
 
   return (
     <Tooltip
-      tooltipContent={activity?.issue_detail ? activity.issue_detail.name : "This work item has been deleted"}
-      isMobile={isMobile}
+      label={activity?.issue_detail ? activity.issue_detail.name : "This work item has been deleted"}
+      layout="stacked"
+      disabled={isMobile}
     >
       {activity?.issue_detail ? (
         <a

--- a/apps/web/core/components/core/description-versions/modal.tsx
+++ b/apps/web/core/components/core/description-versions/modal.tsx
@@ -12,7 +12,7 @@ import { useTranslation } from "@plane/i18n";
 import { Button } from "@plane/propel/button";
 import { CopyIcon, ChevronLeftIcon, ChevronRightIcon } from "@plane/propel/icons";
 import { setToast, TOAST_TYPE } from "@plane/propel/toast";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import type { TDescriptionVersion } from "@plane/types";
 import { Avatar, EModalPosition, EModalWidth, Loader, ModalCore } from "@plane/ui";
 import { calculateTimeAgo, cn, getFileURL } from "@plane/utils";
@@ -156,7 +156,7 @@ export const DescriptionVersionsModal = observer(function DescriptionVersionsMod
         {/* End version description */}
         {/* Footer */}
         <div className="flex items-center justify-between gap-2 border-t-[0.5px] border-subtle pt-4">
-          <Tooltip tooltipContent={t("common.actions.copy_markdown")}>
+          <Tooltip label={t("common.actions.copy_markdown")}>
             <IconButton type="button" variant="ghost" size="base" onClick={handleCopyMarkdown} icon={CopyIcon} />
           </Tooltip>
           <div className="flex items-center gap-2">

--- a/apps/web/core/components/core/list/list-item.tsx
+++ b/apps/web/core/components/core/list/list-item.tsx
@@ -6,7 +6,7 @@
 
 import React from "react";
 // ui
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import { ControlLink, Row } from "@plane/ui";
 // helpers
 import { cn } from "@plane/utils";
@@ -86,7 +86,7 @@ export function ListItem(props: IListItemProps) {
           >
             <div className={cn("flex items-center gap-4 truncate", leftElementClassName)}>
               {prependTitleElement && <span className="flex flex-shrink-0 items-center">{prependTitleElement}</span>}
-              <Tooltip tooltipContent={title} position="top" isMobile={isMobile}>
+              <Tooltip label={title} layout="stacked" disabled={isMobile}>
                 <span className="truncate text-13">{title}</span>
               </Tooltip>
             </div>

--- a/apps/web/core/components/core/modals/existing-issues-list-modal.tsx
+++ b/apps/web/core/components/core/modals/existing-issues-list-modal.tsx
@@ -13,7 +13,7 @@ import { useTranslation } from "@plane/i18n";
 import { Button } from "@plane/propel/button";
 import { SearchIcon, CloseIcon } from "@plane/propel/icons";
 import { TOAST_TYPE, setToast } from "@plane/propel/toast";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import type { ISearchIssueResponse, TProjectIssuesSearchParams } from "@plane/types";
 // ui
 import { Switch } from "@makeplane/propel/components/switch";
@@ -193,7 +193,7 @@ export function ExistingIssuesListModal(props: Props) {
             </div>
           )}
           {workspaceLevelToggle && (
-            <Tooltip tooltipContent="Toggle workspace level search" isMobile={isMobile}>
+            <Tooltip label="Toggle workspace level search" disabled={isMobile}>
               <div
                 className={`flex flex-shrink-0 cursor-pointer items-center gap-1 text-11 ${
                   isWorkspaceLevel ? "text-primary" : "text-secondary"

--- a/apps/web/core/components/cycles/active-cycle/cycle-stats.tsx
+++ b/apps/web/core/components/cycles/active-cycle/cycle-stats.tsx
@@ -14,7 +14,7 @@ import { Tab } from "@headlessui/react";
 // plane imports
 import { useTranslation } from "@plane/i18n";
 import { PriorityIcon } from "@plane/propel/icons";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import type { TWorkItemFilterCondition } from "@plane/shared-state";
 import type { ICycle } from "@plane/types";
 import { EIssuesStoreType } from "@plane/types";
@@ -207,7 +207,7 @@ export const ActiveCycleStats = observer(function ActiveCycleStats(props: Active
                         >
                           <div className="flex w-full min-w-24 flex-grow items-center gap-1.5 truncate">
                             <IssueIdentifier issueId={issue.id} projectId={projectId} size="xs" variant="secondary" />
-                            <Tooltip position="top-start" tooltipHeading="Title" tooltipContent={issue.name}>
+                            <Tooltip label={`Title: ${issue.name}`} layout="stacked" align="start">
                               <span className="truncate text-13 text-primary">{issue.name}</span>
                             </Tooltip>
                           </div>
@@ -223,10 +223,7 @@ export const ActiveCycleStats = observer(function ActiveCycleStats(props: Active
                               showTooltip
                             />
                             {issue.target_date && (
-                              <Tooltip
-                                tooltipHeading="Target Date"
-                                tooltipContent={renderFormattedDate(issue.target_date)}
-                              >
+                              <Tooltip label={`Target Date: ${renderFormattedDate(issue.target_date) ?? ""}`}>
                                 <div className="flex h-full cursor-pointer items-center gap-1.5 truncate rounded-sm bg-layer-1 px-2 py-0.5 text-11 group-hover:bg-surface-1">
                                   <CalendarCheck className="h-3 w-3 flex-shrink-0" />
                                   <span className="truncate text-11">

--- a/apps/web/core/components/cycles/analytics-sidebar/sidebar-header.tsx
+++ b/apps/web/core/components/cycles/analytics-sidebar/sidebar-header.tsx
@@ -7,7 +7,6 @@
 import { useEffect } from "react";
 import { observer } from "mobx-react";
 import { Controller, useForm } from "react-hook-form";
-import { ArrowRight } from "lucide-react";
 // Plane Imports
 import { CYCLE_STATUS, EUserPermissions, EUserPermissionsLevel } from "@plane/constants";
 import { useTranslation } from "@plane/i18n";
@@ -176,13 +175,9 @@ export const CycleSidebarHeader = observer(function CycleSidebarHeader(props: Pr
                       to: t("project_cycles.end_date"),
                     }}
                     customTooltipHeading={t("project_cycles.in_your_timezone")}
-                    customTooltipContent={
-                      <span className="flex gap-1">
-                        {renderFormattedDateInUserTimezone(cycleDetails.start_date ?? "")}
-                        <ArrowRight className="my-auto h-3 w-3 flex-shrink-0" />
-                        {renderFormattedDateInUserTimezone(cycleDetails.end_date ?? "")}
-                      </span>
-                    }
+                    customTooltipContent={`${renderFormattedDateInUserTimezone(
+                      cycleDetails.start_date ?? ""
+                    )} → ${renderFormattedDateInUserTimezone(cycleDetails.end_date ?? "")}`}
                     mergeDates
                     showTooltip={!!cycleDetails.start_date && !!cycleDetails.end_date} // show tooltip only if both start and end date are present
                     required={cycleDetails.status !== "draft"}

--- a/apps/web/core/components/cycles/list/cycle-list-item-action.tsx
+++ b/apps/web/core/components/cycles/list/cycle-list-item-action.tsx
@@ -9,14 +9,14 @@ import React, { useEffect, useMemo, useState } from "react";
 import { observer } from "mobx-react";
 import { useParams, usePathname, useSearchParams } from "next/navigation";
 import { useForm } from "react-hook-form";
-import { Eye, ArrowRight, CalendarDays } from "lucide-react";
+import { Eye, CalendarDays } from "lucide-react";
 // plane imports
 import { EUserPermissions, EUserPermissionsLevel, IS_FAVORITE_MENU_OPEN } from "@plane/constants";
 import { useLocalStorage } from "@plane/hooks";
 import { useTranslation } from "@plane/i18n";
 import { TransferIcon, WorkItemsIcon, MembersPropertyIcon } from "@plane/propel/icons";
 import { setPromiseToast } from "@plane/propel/toast";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import type { ICycle, TCycleGroups } from "@plane/types";
 import { Avatar, AvatarGroup, FavoriteStar } from "@plane/ui";
 import { getDate, getFileURL, generateQueryParams } from "@plane/utils";
@@ -208,15 +208,11 @@ export const CycleListItemAction = observer(function CycleListItemAction(props: 
           <div className="flex gap-2">
             {/* Duration */}
             <Tooltip
-              tooltipContent={
-                <span className="flex gap-1">
-                  {renderFormattedDateInUserTimezone(cycleDetails.start_date ?? "")}
-                  <ArrowRight className="my-auto h-3 w-3 flex-shrink-0" />
-                  {renderFormattedDateInUserTimezone(cycleDetails.end_date ?? "")}
-                </span>
-              }
+              label={`${t("project_cycles.in_your_timezone")}: ${renderFormattedDateInUserTimezone(
+                cycleDetails.start_date ?? ""
+              )} → ${renderFormattedDateInUserTimezone(cycleDetails.end_date ?? "")}`}
+              layout="stacked"
               disabled={!isProjectTimeZoneDifferent()}
-              tooltipHeading={t("project_cycles.in_your_timezone")}
             >
               <div className="flex items-center gap-1 text-11 font-medium text-tertiary">
                 <CalendarDays className="my-auto h-3 w-3 flex-shrink-0" />
@@ -250,13 +246,9 @@ export const CycleListItemAction = observer(function CycleListItemAction(props: 
               }}
               showTooltip={isProjectTimeZoneDifferent()}
               customTooltipHeading={t("project_cycles.in_your_timezone")}
-              customTooltipContent={
-                <span className="flex gap-1">
-                  {renderFormattedDateInUserTimezone(cycleDetails.start_date ?? "")}
-                  <ArrowRight className="my-auto h-3 w-3 flex-shrink-0" />
-                  {renderFormattedDateInUserTimezone(cycleDetails.end_date ?? "")}
-                </span>
-              }
+              customTooltipContent={`${renderFormattedDateInUserTimezone(
+                cycleDetails.start_date ?? ""
+              )} → ${renderFormattedDateInUserTimezone(cycleDetails.end_date ?? "")}`}
               mergeDates
               required={cycleDetails.status !== "draft"}
               disabled
@@ -271,7 +263,7 @@ export const CycleListItemAction = observer(function CycleListItemAction(props: 
       {/* created by */}
       {createdByDetails && !isActive && <ButtonAvatars showTooltip={false} userIds={createdByDetails?.id} />}
       {!isActive && (
-        <Tooltip tooltipContent={`${cycleDetails.assignee_ids?.length} Members`} isMobile={isMobile}>
+        <Tooltip label={`${cycleDetails.assignee_ids?.length} Members`} layout="stacked" disabled={isMobile}>
           <div className="flex w-min cursor-default items-center justify-center">
             {cycleDetails.assignee_ids && cycleDetails.assignee_ids?.length > 0 ? (
               <AvatarGroup showTooltip={false}>

--- a/apps/web/core/components/dropdowns/buttons.tsx
+++ b/apps/web/core/components/dropdowns/buttons.tsx
@@ -7,7 +7,7 @@
 import React from "react";
 // helpers
 import { Button } from "@plane/propel/button";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import { cn } from "@plane/utils";
 // types
 import { usePlatformOS } from "@/hooks/use-platform-os";
@@ -18,7 +18,7 @@ export type DropdownButtonProps = {
   children: React.ReactNode;
   className?: string;
   isActive: boolean;
-  tooltipContent?: string | React.ReactNode | null;
+  tooltipContent?: string;
   tooltipHeading: string;
   showTooltip: boolean;
   variant: TButtonVariants;
@@ -29,7 +29,7 @@ type ButtonProps = {
   children: React.ReactNode;
   className?: string;
   isActive: boolean;
-  tooltipContent?: string | React.ReactNode | null;
+  tooltipContent?: string;
   tooltipHeading: string;
   showTooltip: boolean;
   renderToolTipByDefault?: boolean;
@@ -67,16 +67,14 @@ export function DropdownButton(props: DropdownButtonProps) {
 }
 
 function BorderButton(props: ButtonProps) {
-  const { children, className, isActive, tooltipContent, renderToolTipByDefault, tooltipHeading, showTooltip } = props;
+  const { children, className, isActive, tooltipContent, tooltipHeading, showTooltip } = props;
   const { isMobile } = usePlatformOS();
 
   return (
     <Tooltip
-      tooltipHeading={tooltipHeading}
-      tooltipContent={<>{tooltipContent}</>}
-      disabled={!showTooltip}
-      isMobile={isMobile}
-      renderByDefault={renderToolTipByDefault}
+      label={tooltipContent ? `${tooltipHeading}: ${tooltipContent}` : tooltipHeading}
+      layout="stacked"
+      disabled={!showTooltip || isMobile}
     >
       <Button
         variant="ghost"
@@ -96,15 +94,13 @@ function BorderButton(props: ButtonProps) {
 }
 
 function BackgroundButton(props: ButtonProps) {
-  const { children, className, tooltipContent, tooltipHeading, renderToolTipByDefault, showTooltip } = props;
+  const { children, className, tooltipContent, tooltipHeading, showTooltip } = props;
   const { isMobile } = usePlatformOS();
   return (
     <Tooltip
-      tooltipHeading={tooltipHeading}
-      tooltipContent={<>{tooltipContent}</>}
-      disabled={!showTooltip}
-      isMobile={isMobile}
-      renderByDefault={renderToolTipByDefault}
+      label={tooltipContent ? `${tooltipHeading}: ${tooltipContent}` : tooltipHeading}
+      layout="stacked"
+      disabled={!showTooltip || isMobile}
     >
       <Button
         variant="ghost"
@@ -121,15 +117,13 @@ function BackgroundButton(props: ButtonProps) {
 }
 
 function TransparentButton(props: ButtonProps) {
-  const { children, className, isActive, tooltipContent, tooltipHeading, renderToolTipByDefault, showTooltip } = props;
+  const { children, className, isActive, tooltipContent, tooltipHeading, showTooltip } = props;
   const { isMobile } = usePlatformOS();
   return (
     <Tooltip
-      tooltipHeading={tooltipHeading}
-      tooltipContent={<>{tooltipContent}</>}
-      disabled={!showTooltip}
-      isMobile={isMobile}
-      renderByDefault={renderToolTipByDefault}
+      label={tooltipContent ? `${tooltipHeading}: ${tooltipContent}` : tooltipHeading}
+      layout="stacked"
+      disabled={!showTooltip || isMobile}
     >
       <Button
         variant="ghost"

--- a/apps/web/core/components/dropdowns/date-range.tsx
+++ b/apps/web/core/components/dropdowns/date-range.tsx
@@ -64,7 +64,7 @@ type Props = {
   };
   renderByDefault?: boolean;
   renderPlaceholder?: boolean;
-  customTooltipContent?: React.ReactNode;
+  customTooltipContent?: string;
   customTooltipHeading?: string;
   defaultOpen?: boolean;
   renderInPortal?: boolean;
@@ -176,15 +176,10 @@ export const DateRangeDropdown = observer(function DateRangeDropdown(props: Prop
         isActive={isOpen}
         tooltipHeading={customTooltipHeading ?? t("project_cycles.date_range")}
         tooltipContent={
-          <>
-            {customTooltipContent ?? (
-              <>
-                {dateRange.from ? renderFormattedDate(dateRange.from) : ""}
-                {dateRange.from && dateRange.to ? " - " : ""}
-                {dateRange.to ? renderFormattedDate(dateRange.to) : ""}
-              </>
-            )}
-          </>
+          customTooltipContent ??
+          `${dateRange.from ? renderFormattedDate(dateRange.from) : ""}${
+            dateRange.from && dateRange.to ? " - " : ""
+          }${dateRange.to ? renderFormattedDate(dateRange.to) : ""}`
         }
         showTooltip={showTooltip}
         variant={buttonVariant}

--- a/apps/web/core/components/dropdowns/module/button-content.tsx
+++ b/apps/web/core/components/dropdowns/module/button-content.tsx
@@ -6,7 +6,7 @@
 
 // plane imports
 import { CloseIcon, ModuleIcon, ChevronDownIcon } from "@plane/propel/icons";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import { cn } from "@plane/utils";
 // hooks
 import { useModule } from "@/hooks/store/use-module";
@@ -75,22 +75,15 @@ export function ModuleButtonContent(props: ModuleButtonContentProps) {
                   {!hideIcon && <ModuleIcon className="h-2.5 w-2.5 flex-shrink-0" />}
                   {!hideText && (
                     <Tooltip
-                      tooltipHeading="Title"
-                      tooltipContent={moduleDetails?.name}
-                      disabled={!showTooltip}
-                      isMobile={isMobile}
-                      renderByDefault={false}
+                      label={`Title: ${moduleDetails?.name ?? ""}`}
+                      layout="stacked"
+                      disabled={!showTooltip || isMobile}
                     >
                       <span className="max-w-40 truncate text-11 font-medium">{moduleDetails?.name}</span>
                     </Tooltip>
                   )}
                   {!disabled && (
-                    <Tooltip
-                      tooltipContent="Remove"
-                      disabled={!showTooltip}
-                      isMobile={isMobile}
-                      renderByDefault={false}
-                    >
+                    <Tooltip label="Remove" disabled={!showTooltip || isMobile}>
                       <button
                         type="button"
                         className="flex-shrink-0"

--- a/apps/web/core/components/dropdowns/priority.tsx
+++ b/apps/web/core/components/dropdowns/priority.tsx
@@ -13,7 +13,7 @@ import { ISSUE_PRIORITIES } from "@plane/constants";
 import { useTranslation } from "@plane/i18n";
 // types
 import { CheckIcon, PriorityIcon, ChevronDownIcon, SearchIcon } from "@plane/propel/icons";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import type { TIssuePriorities } from "@plane/types";
 // ui
 import { ComboDropDown } from "@plane/ui";
@@ -63,7 +63,6 @@ function BorderButton(props: ButtonProps) {
     placeholder,
     priority,
     showTooltip,
-    renderToolTipByDefault = true,
   } = props;
 
   const priorityDetails = ISSUE_PRIORITIES.find((p) => p.key === priority);
@@ -81,11 +80,8 @@ function BorderButton(props: ButtonProps) {
 
   return (
     <Tooltip
-      tooltipHeading={t("priority")}
-      tooltipContent={priorityDetails?.title ?? t("common.none")}
-      disabled={!showTooltip}
-      isMobile={isMobile}
-      renderByDefault={renderToolTipByDefault}
+      label={`${t("priority")}: ${priorityDetails?.title ?? t("common.none")}`}
+      disabled={!showTooltip || isMobile}
     >
       <div
         className={cn(
@@ -154,7 +150,6 @@ function BackgroundButton(props: ButtonProps) {
     placeholder,
     priority,
     showTooltip,
-    renderToolTipByDefault = true,
   } = props;
 
   const priorityDetails = ISSUE_PRIORITIES.find((p) => p.key === priority);
@@ -171,13 +166,7 @@ function BackgroundButton(props: ButtonProps) {
   const { t } = useTranslation();
 
   return (
-    <Tooltip
-      tooltipHeading={t("priority")}
-      tooltipContent={t(priorityDetails?.key ?? "none")}
-      disabled={!showTooltip}
-      isMobile={isMobile}
-      renderByDefault={renderToolTipByDefault}
-    >
+    <Tooltip label={`${t("priority")}: ${t(priorityDetails?.key ?? "none")}`} disabled={!showTooltip || isMobile}>
       <div
         className={cn(
           "flex h-full items-center gap-1.5 rounded-sm px-2 py-0.5",
@@ -246,7 +235,6 @@ function TransparentButton(props: ButtonProps) {
     placeholder,
     priority,
     showTooltip,
-    renderToolTipByDefault = true,
   } = props;
 
   const priorityDetails = ISSUE_PRIORITIES.find((p) => p.key === priority);
@@ -256,11 +244,8 @@ function TransparentButton(props: ButtonProps) {
 
   return (
     <Tooltip
-      tooltipHeading={t("priority")}
-      tooltipContent={priorityDetails?.title ?? t("common.none")}
-      disabled={!showTooltip}
-      isMobile={isMobile}
-      renderByDefault={renderToolTipByDefault}
+      label={`${t("priority")}: ${priorityDetails?.title ?? t("common.none")}`}
+      disabled={!showTooltip || isMobile}
     >
       <div
         className={cn(

--- a/apps/web/core/components/editor/lite-text/toolbar.tsx
+++ b/apps/web/core/components/editor/lite-text/toolbar.tsx
@@ -16,7 +16,7 @@ import { useTranslation } from "@plane/i18n";
 import { Button } from "@plane/propel/button";
 import { GlobeIcon, LockIcon } from "@plane/propel/icons";
 import type { ISvgIcons } from "@plane/propel/icons";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 // constants
 import { cn } from "@plane/utils";
 import type { ToolbarMenuItem } from "@plane/editor";
@@ -110,7 +110,7 @@ export function IssueCommentToolbar(props: Props) {
             const isAccessActive = accessSpecifier === access.key;
 
             return (
-              <Tooltip key={access.key} tooltipContent={access.label}>
+              <Tooltip key={access.key} label={access.label} layout="stacked">
                 <button
                   type="button"
                   onClick={() => handleAccessChange?.(access.key)}
@@ -143,15 +143,7 @@ export function IssueCommentToolbar(props: Props) {
                 const isItemActive = activeStates[item.renderKey];
 
                 return (
-                  <Tooltip
-                    key={item.renderKey}
-                    tooltipContent={
-                      <p className="flex flex-col gap-1 text-center text-11">
-                        <span className="font-medium">{item.name}</span>
-                        {item.shortcut && <kbd className="text-placeholder">{item.shortcut.join(" + ")}</kbd>}
-                      </p>
-                    }
-                  >
+                  <Tooltip key={item.renderKey} label={item.name} shortcut={item.shortcut?.join(" + ")}>
                     <button
                       type="button"
                       onClick={() => executeCommand(item)}

--- a/apps/web/core/components/editor/sticky-editor/toolbar.tsx
+++ b/apps/web/core/components/editor/sticky-editor/toolbar.tsx
@@ -11,7 +11,7 @@ import type { EditorRefApi } from "@plane/editor";
 // ui
 import { useOutsideClickDetector } from "@plane/hooks";
 import { TrashIcon } from "@plane/propel/icons";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import type { TSticky } from "@plane/types";
 // constants
 import { cn } from "@plane/utils";
@@ -68,13 +68,7 @@ export function StickyEditorToolbar(props: Props) {
       <div className="my-auto flex gap-4" ref={colorPaletteRef}>
         {/* color palette */}
         {showColorPalette && <ColorPalette handleUpdate={handleColorChange} />}
-        <Tooltip
-          tooltipContent={
-            <p className="flex flex-col gap-1 text-center text-11">
-              <span className="font-medium">Background color</span>
-            </p>
-          }
-        >
+        <Tooltip label="Background color">
           <button type="button" onClick={() => setShowColorPalette(!showColorPalette)} className="flex text-primary/50">
             <Palette className="my-auto size-4" />
           </button>
@@ -88,15 +82,7 @@ export function StickyEditorToolbar(props: Props) {
                   const isItemActive = activeStates[item.renderKey];
 
                   return (
-                    <Tooltip
-                      key={item.renderKey}
-                      tooltipContent={
-                        <p className="flex flex-col gap-1 text-center text-11">
-                          <span className="font-medium">{item.name}</span>
-                          {item.shortcut && <kbd className="text-placeholder">{item.shortcut.join(" + ")}</kbd>}
-                        </p>
-                      }
-                    >
+                    <Tooltip key={item.renderKey} label={item.name} shortcut={item.shortcut?.join(" + ")}>
                       <button
                         type="button"
                         onClick={() => executeCommand(item)}
@@ -118,13 +104,7 @@ export function StickyEditorToolbar(props: Props) {
         </div>
       </div>
       {/* delete action */}
-      <Tooltip
-        tooltipContent={
-          <p className="flex flex-col gap-1 text-center text-11">
-            <span className="font-medium">Delete</span>
-          </p>
-        }
-      >
+      <Tooltip label="Delete">
         <button type="button" onClick={handleDelete} className="my-auto text-primary/50">
           <TrashIcon className="size-4" />
         </button>

--- a/apps/web/core/components/estimates/create/stage-one.tsx
+++ b/apps/web/core/components/estimates/create/stage-one.tsx
@@ -8,7 +8,7 @@ import { Info } from "lucide-react";
 // plane imports
 import { EEstimateSystem, ESTIMATE_SYSTEMS } from "@plane/constants";
 import { useTranslation } from "@plane/i18n";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import type { TEstimateSystemKeys } from "@plane/types";
 // helpers
 import { isEstimateSystemEnabled } from "./helper";
@@ -45,7 +45,7 @@ export function EstimateCreateStageOne(props: TEstimateCreateStageOne) {
                 label: !ESTIMATE_SYSTEMS[currentSystem]?.is_available ? (
                   <div className="relative flex cursor-no-drop items-center gap-2 text-tertiary">
                     {t(ESTIMATE_SYSTEMS[currentSystem]?.i18n_name)}
-                    <Tooltip tooltipContent={t("common.coming_soon")}>
+                    <Tooltip label={t("common.coming_soon")}>
                       <Info size={12} />
                     </Tooltip>
                   </div>

--- a/apps/web/core/components/estimates/points/create.tsx
+++ b/apps/web/core/components/estimates/points/create.tsx
@@ -12,7 +12,7 @@ import { EEstimateSystem, MAX_ESTIMATE_POINT_INPUT_LENGTH } from "@plane/constan
 import { useTranslation } from "@plane/i18n";
 import { CheckIcon, CloseIcon } from "@plane/propel/icons";
 import { TOAST_TYPE, setToast } from "@plane/propel/toast";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import type { TEstimatePointsObject, TEstimateSystemKeys, TEstimateTypeErrorObject } from "@plane/types";
 import { Spinner } from "@plane/ui";
 import { cn, isEstimatePointValuesRepeated } from "@plane/utils";
@@ -180,7 +180,7 @@ export const EstimatePointCreate = observer(function EstimatePointCreate(props: 
           value={estimateInputValue}
         />
         {estimatePointError?.message && (
-          <Tooltip tooltipContent={estimatePointError?.message} position="bottom">
+          <Tooltip label={estimatePointError?.message} layout="stacked" side="bottom">
             <div className="relative mr-3 flex h-3.5 w-3.5 flex-shrink-0 items-center justify-center overflow-hidden text-danger-primary">
               <Info size={14} />
             </div>

--- a/apps/web/core/components/estimates/points/update.tsx
+++ b/apps/web/core/components/estimates/points/update.tsx
@@ -12,7 +12,7 @@ import { EEstimateSystem, MAX_ESTIMATE_POINT_INPUT_LENGTH } from "@plane/constan
 import { useTranslation } from "@plane/i18n";
 import { CheckIcon, CloseIcon } from "@plane/propel/icons";
 import { TOAST_TYPE, setToast } from "@plane/propel/toast";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import type { TEstimatePointsObject, TEstimateSystemKeys, TEstimateTypeErrorObject } from "@plane/types";
 import { Spinner } from "@plane/ui";
 import { cn, isEstimatePointValuesRepeated } from "@plane/utils";
@@ -187,12 +187,13 @@ export const EstimatePointUpdate = observer(function EstimatePointUpdate(props: 
         {estimatePointError?.message && (
           <>
             <Tooltip
-              tooltipContent={
+              label={
                 (estimateInputValue || "")?.length >= 1
                   ? t("project_settings.estimates.validation.unsaved_changes")
                   : estimatePointError?.message
               }
-              position="bottom"
+              layout="stacked"
+              side="bottom"
             >
               <div className="relative mr-3 flex h-3.5 w-3.5 flex-shrink-0 items-center justify-center overflow-hidden text-danger-primary">
                 <Info size={14} />

--- a/apps/web/core/components/exporter/export-form.tsx
+++ b/apps/web/core/components/exporter/export-form.tsx
@@ -18,7 +18,7 @@ import {
 import { useTranslation } from "@plane/i18n";
 import { Button } from "@plane/propel/button";
 import { TOAST_TYPE, setToast } from "@plane/propel/toast";
-// import { Tooltip } from "@plane/propel/tooltip";
+// import { Tooltip } from "@makeplane/propel/components/tooltip";
 // import { EIssuesStoreType } from "@plane/types";
 import type { TWorkItemFilterExpression } from "@plane/types";
 import { CustomSearchSelect, CustomSelect } from "@plane/ui";
@@ -217,17 +217,7 @@ export const ExportForm = observer(function ExportForm(props: Props) {
       {/* <div className="w-full">
         <div className="flex items-center gap-2 mb-2">
           <div className="text-13 font-medium text-secondary leading-tight">{t("common.filters")}</div>
-          <Tooltip
-            tooltipContent={
-              <div className="max-w-[238px] flex gap-2">
-                <div className=" rounded-sm bg-layer-1 flex items-center justify-center p-1 h-5 aspect-square">
-                  <Info className="h-3 w-3" />
-                </div>
-                {t("workspace_settings.settings.exports.filters_info")}
-              </div>
-            }
-            position="top"
-          >
+          <Tooltip label={t("workspace_settings.settings.exports.filters_info")} layout="stacked">
             <button type="button" className="flex items-center justify-center">
               <Info className="h-3 w-3 text-tertiary" />
             </button>

--- a/apps/web/core/components/gantt-chart/helpers/add-block.tsx
+++ b/apps/web/core/components/gantt-chart/helpers/add-block.tsx
@@ -9,7 +9,7 @@ import { addDays } from "date-fns";
 import { observer } from "mobx-react";
 import { PlusIcon } from "@plane/propel/icons";
 // ui
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import type { IBlockUpdateData, IGanttBlock } from "@plane/types";
 // helpers
 import { renderFormattedDate, renderFormattedPayloadDate } from "@plane/utils";
@@ -88,7 +88,7 @@ export const ChartAddBlock = observer(function ChartAddBlock(props: Props) {
     >
       <div ref={containerRef} className="h-full w-full" />
       {isButtonVisible && (
-        <Tooltip tooltipContent={buttonStartDate && renderFormattedDate(buttonStartDate)} isMobile={isMobile}>
+        <Tooltip label={renderFormattedDate(buttonStartDate) ?? ""} disabled={isMobile}>
           <button
             type="button"
             className="absolute top-1/2 grid h-8 w-8 -translate-x-1/2 -translate-y-1/2 place-items-center rounded-sm border border-strong bg-layer-1 p-1.5 text-secondary hover:text-primary"

--- a/apps/web/core/components/home/widgets/recents/issue.tsx
+++ b/apps/web/core/components/home/widgets/recents/issue.tsx
@@ -7,7 +7,7 @@
 import { observer } from "mobx-react";
 // plane types
 import { PriorityIcon, StateGroupIcon, WorkItemsIcon } from "@plane/propel/icons";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import type { TActivityEntityData, TIssueEntityData } from "@plane/types";
 import { EIssueServiceType } from "@plane/types";
 // plane ui
@@ -98,7 +98,7 @@ export const RecentIssue = observer(function RecentIssue(props: BlockProps) {
       }
       quickActionElement={
         <div className="flex gap-4">
-          <Tooltip tooltipHeading="State" tooltipContent={state?.name ?? "State"}>
+          <Tooltip label={`State: ${state?.name ?? "State"}`} layout="stacked">
             <div>
               <StateGroupIcon
                 stateGroup={state?.group ?? "backlog"}
@@ -108,7 +108,7 @@ export const RecentIssue = observer(function RecentIssue(props: BlockProps) {
               />
             </div>
           </Tooltip>
-          <Tooltip tooltipHeading="Priority" tooltipContent={issueDetails?.priority ?? "Priority"}>
+          <Tooltip label={`Priority: ${issueDetails?.priority ?? "Priority"}`}>
             <div>
               <PriorityIcon priority={issueDetails?.priority} withContainer size={12} />
             </div>

--- a/apps/web/core/components/icons/locked-component.tsx
+++ b/apps/web/core/components/icons/locked-component.tsx
@@ -5,7 +5,7 @@
  */
 
 import { LockIcon } from "@plane/propel/icons";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 
 export function LockedComponent(props: { toolTipContent?: string }) {
   const { toolTipContent } = props;
@@ -18,7 +18,13 @@ export function LockedComponent(props: { toolTipContent?: string }) {
 
   return (
     <>
-      {toolTipContent ? <Tooltip tooltipContent={toolTipContent}>{lockedComponent}</Tooltip> : <>{lockedComponent}</>}
+      {toolTipContent ? (
+        <Tooltip label={toolTipContent} layout="stacked">
+          {lockedComponent}
+        </Tooltip>
+      ) : (
+        <>{lockedComponent}</>
+      )}
     </>
   );
 }

--- a/apps/web/core/components/inbox/content/issue-properties.tsx
+++ b/apps/web/core/components/inbox/content/issue-properties.tsx
@@ -13,7 +13,7 @@ import {
   LabelPropertyIcon,
   DuplicatePropertyIcon,
 } from "@plane/propel/icons";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import type { TInboxDuplicateIssueDetails, TIssue } from "@plane/types";
 import { ControlLink } from "@plane/ui";
 import { getDate, renderFormattedPayloadDate, generateWorkItemLink } from "@plane/utils";
@@ -199,7 +199,7 @@ export const InboxIssueContentProperties = observer(function InboxIssueContentPr
                   }}
                   target="_self"
                 >
-                  <Tooltip tooltipContent={`${duplicateIssueDetails?.name}`}>
+                  <Tooltip label={`${duplicateIssueDetails?.name}`} layout="stacked">
                     <span className="flex cursor-pointer items-center gap-1 rounded-sm bg-layer-1 px-1.5 py-1 pb-0.5 text-11 text-secondary">
                       {`${currentProjectDetails?.identifier}-${duplicateIssueDetails?.sequence_id}`}
                     </span>

--- a/apps/web/core/components/inbox/content/issue-properties.tsx
+++ b/apps/web/core/components/inbox/content/issue-properties.tsx
@@ -199,7 +199,7 @@ export const InboxIssueContentProperties = observer(function InboxIssueContentPr
                   }}
                   target="_self"
                 >
-                  <Tooltip label={`${duplicateIssueDetails?.name}`} layout="stacked">
+                  <Tooltip label={duplicateIssueDetails?.name ?? ""} layout="stacked">
                     <span className="flex cursor-pointer items-center gap-1 rounded-sm bg-layer-1 px-1.5 py-1 pb-0.5 text-11 text-secondary">
                       {`${currentProjectDetails?.identifier}-${duplicateIssueDetails?.sequence_id}`}
                     </span>

--- a/apps/web/core/components/inbox/sidebar/inbox-list-item.tsx
+++ b/apps/web/core/components/inbox/sidebar/inbox-list-item.tsx
@@ -10,7 +10,7 @@ import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 // plane imports
 import { PriorityIcon } from "@plane/propel/icons";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import { Row, Avatar } from "@plane/ui";
 import { cn, renderFormattedDate, getFileURL } from "@plane/utils";
 // components
@@ -81,18 +81,14 @@ export const InboxIssueListItem = observer(function InboxIssueListItem(props: In
 
           <div className="flex items-center justify-between">
             <div className="flex flex-wrap items-center gap-2">
-              <Tooltip
-                tooltipHeading="Created on"
-                tooltipContent={`${renderFormattedDate(issue.created_at ?? "")}`}
-                isMobile={isMobile}
-              >
+              <Tooltip label={`Created on: ${renderFormattedDate(issue.created_at ?? "") ?? ""}`} disabled={isMobile}>
                 <div className="text-11 text-secondary">{renderFormattedDate(issue.created_at ?? "")}</div>
               </Tooltip>
 
               <div className="rounded-full border-2 border-strong-1" />
 
               {issue.priority && (
-                <Tooltip tooltipHeading="Priority" tooltipContent={`${issue.priority ?? "None"}`}>
+                <Tooltip label={`Priority: ${issue.priority ?? "None"}`}>
                   <PriorityIcon priority={issue.priority} withContainer className="h-3 w-3" />
                 </Tooltip>
               )}

--- a/apps/web/core/components/integration/single-integration-card.tsx
+++ b/apps/web/core/components/integration/single-integration-card.tsx
@@ -12,7 +12,7 @@ import { CheckCircle } from "lucide-react";
 import { EUserPermissions, EUserPermissionsLevel } from "@plane/constants";
 import { Button } from "@plane/propel/button";
 import { TOAST_TYPE, setToast } from "@plane/propel/toast";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import type { IAppIntegration, IWorkspaceIntegration } from "@plane/types";
 // ui
 import { Loader } from "@plane/ui";
@@ -140,9 +140,9 @@ export const SingleIntegrationCard = observer(function SingleIntegrationCard({ i
       {workspaceIntegrations ? (
         isInstalled ? (
           <Tooltip
-            isMobile={isMobile}
-            disabled={isUserAdmin}
-            tooltipContent={!isUserAdmin ? "You don't have permission to perform this" : null}
+            label={!isUserAdmin ? "You don't have permission to perform this" : ""}
+            layout="stacked"
+            disabled={isUserAdmin || isMobile}
           >
             <Button
               className={`${!isUserAdmin ? "hover:cursor-not-allowed" : ""}`}
@@ -159,9 +159,9 @@ export const SingleIntegrationCard = observer(function SingleIntegrationCard({ i
           </Tooltip>
         ) : (
           <Tooltip
-            isMobile={isMobile}
-            disabled={isUserAdmin}
-            tooltipContent={!isUserAdmin ? "You don't have permission to perform this" : null}
+            label={!isUserAdmin ? "You don't have permission to perform this" : ""}
+            layout="stacked"
+            disabled={isUserAdmin || isMobile}
           >
             <Button
               className={`${!isUserAdmin ? "hover:cursor-not-allowed" : ""}`}

--- a/apps/web/core/components/issues/attachment/attachment-detail.tsx
+++ b/apps/web/core/components/issues/attachment/attachment-detail.tsx
@@ -10,7 +10,7 @@ import Link from "next/link";
 import { AlertCircle } from "lucide-react";
 import { CloseIcon } from "@plane/propel/icons";
 // ui
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import {
   convertBytesToSize,
   getFileExtension,
@@ -77,14 +77,15 @@ export const IssueAttachmentsDetail = observer(function IssueAttachmentsDetail(p
             <div className="h-7 w-7">{fileIcon}</div>
             <div className="flex flex-col gap-1">
               <div className="flex items-center gap-2">
-                <Tooltip tooltipContent={fileName} isMobile={isMobile}>
+                <Tooltip label={fileName} layout="stacked" disabled={isMobile}>
                   <span className="text-13">{truncateText(`${fileName}`, 10)}</span>
                 </Tooltip>
                 <Tooltip
-                  isMobile={isMobile}
-                  tooltipContent={`${
+                  label={`${
                     getUserDetails(attachment.updated_by)?.display_name ?? ""
                   } uploaded on ${renderFormattedDate(attachment.updated_at)}`}
+                  layout="stacked"
+                  disabled={isMobile}
                 >
                   <span>
                     <AlertCircle className="h-3 w-3" />

--- a/apps/web/core/components/issues/attachment/attachment-list-item.tsx
+++ b/apps/web/core/components/issues/attachment/attachment-list-item.tsx
@@ -8,7 +8,7 @@ import { observer } from "mobx-react";
 
 import { useTranslation } from "@plane/i18n";
 import { TrashIcon } from "@plane/propel/icons";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import type { TIssueServiceType } from "@plane/types";
 import { EIssueServiceType } from "@plane/types";
 // ui
@@ -63,7 +63,7 @@ export const IssueAttachmentsListItem = observer(function IssueAttachmentsListIt
         <div className="group flex h-11 items-center justify-between gap-3 pr-2 pl-9 hover:bg-surface-2">
           <div className="flex items-center gap-3 truncate text-13">
             <div className="flex items-center gap-3">{fileIcon}</div>
-            <Tooltip tooltipContent={`${fileName}.${fileExtension}`} isMobile={isMobile}>
+            <Tooltip label={`${fileName}.${fileExtension}`} layout="stacked" disabled={isMobile}>
               <p className="truncate font-medium text-secondary">{`${fileName}.${fileExtension}`}</p>
             </Tooltip>
             <span className="flex size-1.5 rounded-full bg-layer-1" />
@@ -74,10 +74,11 @@ export const IssueAttachmentsListItem = observer(function IssueAttachmentsListIt
             {attachment?.created_by && (
               <>
                 <Tooltip
-                  isMobile={isMobile}
-                  tooltipContent={`${
+                  label={`${
                     getUserDetails(attachment?.created_by)?.display_name ?? ""
                   } uploaded on ${renderFormattedDate(attachment.updated_at)}`}
+                  layout="stacked"
+                  disabled={isMobile}
                 >
                   <div className="flex items-center justify-center">
                     <ButtonAvatars showTooltip userIds={attachment?.created_by} />

--- a/apps/web/core/components/issues/attachment/attachment-list-upload-item.tsx
+++ b/apps/web/core/components/issues/attachment/attachment-list-upload-item.tsx
@@ -7,7 +7,7 @@
 import { observer } from "mobx-react";
 // ui
 import { CircularProgress } from "@makeplane/propel/components/circular-progress";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 // components
 import { getFileExtension } from "@plane/utils";
 import { getFileIcon } from "@/components/icons";
@@ -35,7 +35,7 @@ export const IssueAttachmentsUploadItem = observer(function IssueAttachmentsUplo
     <div className="pointer-events-none flex h-11 items-center justify-between gap-3 bg-surface-2 pr-2 pl-9">
       <div className="flex items-center gap-3 truncate text-13">
         <div className="flex-shrink-0">{fileIcon}</div>
-        <Tooltip tooltipContent={fileName} isMobile={isMobile}>
+        <Tooltip label={fileName} layout="stacked" disabled={isMobile}>
           <p className="truncate font-medium text-secondary">{fileName}</p>
         </Tooltip>
       </div>

--- a/apps/web/core/components/issues/attachment/attachment-upload-details.tsx
+++ b/apps/web/core/components/issues/attachment/attachment-upload-details.tsx
@@ -6,7 +6,7 @@
 
 import { observer } from "mobx-react";
 import { CircularProgress } from "@makeplane/propel/components/circular-progress";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import { getFileExtension, truncateText } from "@plane/utils";
 // ui
 // icons
@@ -37,7 +37,7 @@ export const IssueAttachmentsUploadDetails = observer(function IssueAttachmentsU
         <div className="h-7 w-7">{fileIcon}</div>
         <div className="flex flex-col gap-1">
           <div className="flex items-center gap-2">
-            <Tooltip tooltipContent={fileName} isMobile={isMobile}>
+            <Tooltip label={fileName} layout="stacked" disabled={isMobile}>
               <span className="text-13">{truncateText(`${fileName}`, 10)}</span>
             </Tooltip>
           </div>

--- a/apps/web/core/components/issues/header.tsx
+++ b/apps/web/core/components/issues/header.tsx
@@ -13,7 +13,7 @@ import { EUserPermissions, EUserPermissionsLevel, SPACE_BASE_PATH, SPACE_BASE_UR
 import { useTranslation } from "@plane/i18n";
 import { Button } from "@plane/propel/button";
 import { NewTabIcon, WorkItemsIcon } from "@plane/propel/icons";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import { EIssuesStoreType } from "@plane/types";
 import { Breadcrumbs, Header } from "@plane/ui";
 // components
@@ -80,9 +80,10 @@ export const IssuesHeader = observer(function IssuesHeader() {
           </Breadcrumbs>
           {issuesCount && issuesCount > 0 ? (
             <Tooltip
-              isMobile={isMobile}
-              tooltipContent={`There are ${issuesCount} ${issuesCount > 1 ? "work items" : "work item"} in this project`}
-              position="bottom"
+              label={`There are ${issuesCount} ${issuesCount > 1 ? "work items" : "work item"} in this project`}
+              layout="stacked"
+              side="bottom"
+              disabled={isMobile}
             >
               <CountChip count={issuesCount} />
             </Tooltip>

--- a/apps/web/core/components/issues/issue-detail-widgets/sub-issues/issues-list/list-item.tsx
+++ b/apps/web/core/components/issues/issue-detail-widgets/sub-issues/issues-list/list-item.tsx
@@ -9,7 +9,7 @@ import { Link as Loader } from "lucide-react";
 import { useTranslation } from "@plane/i18n";
 import { LinkIcon, EditIcon, TrashIcon, CloseIcon, ChevronRightIcon } from "@plane/propel/icons";
 // plane imports
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import type { TIssue, TIssueServiceType, TSubIssueOperations } from "@plane/types";
 import { EIssueServiceType, EIssuesStoreType } from "@plane/types";
 import { ControlLink, CustomMenu } from "@plane/ui";
@@ -165,7 +165,7 @@ export const SubIssuesListItem = observer(function SubIssuesListItem(props: Prop
                   )}
                 </div>
               </WithDisplayPropertiesHOC>
-              <Tooltip tooltipContent={issue.name} isMobile={isMobile}>
+              <Tooltip label={issue.name} layout="stacked" disabled={isMobile}>
                 <span className="w-0 flex-1 truncate text-13 text-primary">{issue.name}</span>
               </Tooltip>
             </div>

--- a/apps/web/core/components/issues/issue-detail/identifier-text.tsx
+++ b/apps/web/core/components/issues/issue-detail/identifier-text.tsx
@@ -5,7 +5,7 @@
  */
 
 import { setToast, TOAST_TYPE } from "@plane/propel/toast";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import type { TIdentifierTextProps, TIdentifierTextVariant, TIssueIdentifierSize } from "@plane/types";
 import { cn } from "@plane/utils";
 
@@ -49,7 +49,7 @@ export function IdentifierText(props: TIdentifierTextProps) {
   const variantClassName = VARIANT_MAP[variant];
 
   return (
-    <Tooltip tooltipContent="Click to copy" disabled={!enableClickToCopyIdentifier} position="top">
+    <Tooltip label="Click to copy" disabled={!enableClickToCopyIdentifier}>
       <button
         type="button"
         className={cn("text-12 font-medium whitespace-nowrap text-tertiary", textSizeClassName, variantClassName, {

--- a/apps/web/core/components/issues/issue-detail/issue-activity/activity/actions/helpers/activity-block.tsx
+++ b/apps/web/core/components/issues/issue-detail/issue-activity/activity/actions/helpers/activity-block.tsx
@@ -7,7 +7,7 @@
 import type { ReactNode } from "react";
 import { Network } from "lucide-react";
 // plane imports
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import { renderFormattedTime, renderFormattedDate, calculateTimeAgo } from "@plane/utils";
 import { useIssueDetail } from "@/hooks/store/use-issue-detail";
 import { usePlatformOS } from "@/hooks/use-platform-os";
@@ -52,8 +52,8 @@ export function IssueActivityBlockComponent(props: TIssueActivityBlockComponent)
         <span> {children} </span>
         <span>
           <Tooltip
-            isMobile={isMobile}
-            tooltipContent={`${renderFormattedDate(activity.created_at)}, ${renderFormattedTime(activity.created_at)}`}
+            label={`${renderFormattedDate(activity.created_at)}, ${renderFormattedTime(activity.created_at)}`}
+            disabled={isMobile}
           >
             <span className="whitespace-nowrap text-tertiary"> {calculateTimeAgo(activity.created_at)}</span>
           </Tooltip>

--- a/apps/web/core/components/issues/issue-detail/issue-activity/activity/actions/helpers/issue-link.tsx
+++ b/apps/web/core/components/issues/issue-detail/issue-activity/activity/actions/helpers/issue-link.tsx
@@ -4,7 +4,7 @@
  * See the LICENSE file for details.
  */
 
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import { generateWorkItemLink } from "@plane/utils";
 // hooks
 import { useIssueDetail } from "@/hooks/store/use-issue-detail";
@@ -34,8 +34,9 @@ export function IssueLink(props: TIssueLink) {
   });
   return (
     <Tooltip
-      tooltipContent={activity.issue_detail ? activity.issue_detail.name : "This work item has been deleted"}
-      isMobile={isMobile}
+      label={activity.issue_detail ? activity.issue_detail.name : "This work item has been deleted"}
+      layout="stacked"
+      disabled={isMobile}
     >
       <a
         aria-disabled={activity.issue === null}

--- a/apps/web/core/components/issues/issue-detail/issue-activity/activity/actions/label-activity-chip.tsx
+++ b/apps/web/core/components/issues/issue-detail/issue-activity/activity/actions/label-activity-chip.tsx
@@ -4,14 +4,14 @@
  * See the LICENSE file for details.
  */
 
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 
 type TIssueLabelPill = { name?: string; color?: string };
 
 export function LabelActivityChip(props: TIssueLabelPill) {
   const { name, color } = props;
   return (
-    <Tooltip tooltipContent={name}>
+    <Tooltip label={name ?? ""} layout="stacked">
       <span className="inline-flex w-min max-w-32 flex-shrink-0 cursor-default items-center gap-2 truncate rounded-full border border-strong px-2 py-0.5 text-11 whitespace-nowrap">
         <span
           className="h-1.5 w-1.5 flex-shrink-0 rounded-full"

--- a/apps/web/core/components/issues/issue-detail/issue-detail-quick-actions.tsx
+++ b/apps/web/core/components/issues/issue-detail/issue-detail-quick-actions.tsx
@@ -11,7 +11,7 @@ import { useTranslation } from "@plane/i18n";
 import { CopyLinkIcon } from "@plane/propel/icons";
 import { IconButton } from "@plane/propel/icon-button";
 import { TOAST_TYPE, setToast } from "@plane/propel/toast";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import { EIssuesStoreType } from "@plane/types";
 import { generateWorkItemLink, copyTextToClipboard } from "@plane/utils";
 // hooks
@@ -147,7 +147,7 @@ export const IssueDetailQuickActions = observer(function IssueDetailQuickActions
             <IssueSubscription workspaceSlug={workspaceSlug} projectId={projectId} issueId={issueId} />
           )}
           <div className="flex flex-wrap items-center gap-2 text-tertiary">
-            <Tooltip tooltipContent={t("common.actions.copy_link")} isMobile={isMobile}>
+            <Tooltip label={t("common.actions.copy_link")} disabled={isMobile}>
               <IconButton variant="secondary" size="lg" onClick={handleCopyText} icon={CopyLinkIcon} />
             </Tooltip>
             <WorkItemDetailQuickActions

--- a/apps/web/core/components/issues/issue-detail/links/link-detail.tsx
+++ b/apps/web/core/components/issues/issue-detail/links/link-detail.tsx
@@ -6,7 +6,7 @@
 
 import { NewTabIcon, EditIcon, TrashIcon } from "@plane/propel/icons";
 import { TOAST_TYPE, setToast } from "@plane/propel/toast";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import { getIconForLink, copyTextToClipboard, calculateTimeAgo } from "@plane/utils";
 // hooks
 import { useIssueDetail } from "@/hooks/store/use-issue-detail";
@@ -63,8 +63,9 @@ export function IssueLinkDetail(props: TIssueLinkDetail) {
               <Icon className="size-3 flex-shrink-0 stroke-2 text-tertiary group-hover:text-primary" />
             </span>
             <Tooltip
-              tooltipContent={linkDetail.title && linkDetail.title !== "" ? linkDetail.title : linkDetail.url}
-              isMobile={isMobile}
+              label={linkDetail.title && linkDetail.title !== "" ? linkDetail.title : linkDetail.url}
+              layout="stacked"
+              disabled={isMobile}
             >
               <span className="truncate text-11">
                 {linkDetail.title && linkDetail.title !== "" ? linkDetail.title : linkDetail.url}

--- a/apps/web/core/components/issues/issue-detail/links/link-item.tsx
+++ b/apps/web/core/components/issues/issue-detail/links/link-item.tsx
@@ -9,7 +9,7 @@ import { observer } from "mobx-react";
 import { useTranslation } from "@plane/i18n";
 import { LinkIcon, CopyIcon, EditIcon, TrashIcon } from "@plane/propel/icons";
 import { TOAST_TYPE, setToast } from "@plane/propel/toast";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import type { TIssueServiceType } from "@plane/types";
 import { EIssueServiceType } from "@plane/types";
 // ui
@@ -62,7 +62,7 @@ export const IssueLinkItem = observer(function IssueLinkItem(props: TIssueLinkIt
           ) : (
             <LinkIcon className="size-4 flex-shrink-0 text-tertiary group-hover:text-primary" />
           )}
-          <Tooltip tooltipContent={linkDetail.url} isMobile={isMobile}>
+          <Tooltip label={linkDetail.url} layout="stacked" disabled={isMobile}>
             <a
               href={linkDetail.url}
               target="_blank"

--- a/apps/web/core/components/issues/issue-detail/parent-select.tsx
+++ b/apps/web/core/components/issues/issue-detail/parent-select.tsx
@@ -11,7 +11,7 @@ import Link from "next/link";
 import { useTranslation } from "@plane/i18n";
 import { EditIcon, CloseIcon } from "@plane/propel/icons";
 // plane imports
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import { cn } from "@plane/utils";
 // hooks
 import { useIssueDetail } from "@/hooks/store/use-issue-detail";
@@ -91,7 +91,7 @@ export const IssueParentSelect = observer(function IssueParentSelect(props: TIss
       >
         {issue.parent_id && parentIssue ? (
           <div className="flex items-center gap-1.5">
-            <Tooltip tooltipHeading="Title" tooltipContent={parentIssue.name} isMobile={isMobile}>
+            <Tooltip label={`Title: ${parentIssue.name}`} layout="stacked" disabled={isMobile}>
               <Link href={workItemLink} target="_blank" rel="noopener noreferrer" onClick={(e) => e.stopPropagation()}>
                 {parentIssue?.project_id && parentIssueProjectDetails && (
                   <IssueIdentifier
@@ -107,7 +107,7 @@ export const IssueParentSelect = observer(function IssueParentSelect(props: TIss
             </Tooltip>
 
             {!disabled && (
-              <Tooltip tooltipContent={t("common.remove")} position="bottom" isMobile={isMobile}>
+              <Tooltip label={t("common.remove")} side="bottom" disabled={isMobile}>
                 <span
                   onClick={(e) => {
                     e.preventDefault();

--- a/apps/web/core/components/issues/issue-detail/relation-select.tsx
+++ b/apps/web/core/components/issues/issue-detail/relation-select.tsx
@@ -11,7 +11,7 @@ import Link from "next/link";
 import { EditIcon, CloseIcon } from "@plane/propel/icons";
 // Plane
 import { TOAST_TYPE, setToast } from "@plane/propel/toast";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import type { ISearchIssueResponse } from "@plane/types";
 import { cn, generateWorkItemLink } from "@plane/utils";
 // components
@@ -119,7 +119,7 @@ export const IssueRelationSelect = observer(function IssueRelationSelect(props: 
                     key={relationIssueId}
                     className={`group flex items-center gap-1 rounded-sm px-1.5 pt-1 pb-1 leading-3 hover:bg-surface-2 ${currRelationOption?.className}`}
                   >
-                    <Tooltip tooltipHeading="Title" tooltipContent={currentIssue.name} isMobile={isMobile}>
+                    <Tooltip label={`Title: ${currentIssue.name}`} layout="stacked" disabled={isMobile}>
                       <Link
                         href={generateWorkItemLink({
                           workspaceSlug,
@@ -137,7 +137,7 @@ export const IssueRelationSelect = observer(function IssueRelationSelect(props: 
                       </Link>
                     </Tooltip>
                     {!disabled && (
-                      <Tooltip tooltipContent="Remove" position="bottom" isMobile={isMobile}>
+                      <Tooltip label="Remove" side="bottom" disabled={isMobile}>
                         {/* eslint-disable-next-line jsx_a11y/click-events-have-key-events oxlint-disable-next-line jsx_a11y/no-static-element-interactions */}
                         <span
                           onClick={(e) => {

--- a/apps/web/core/components/issues/issue-layouts/filters/header/layout-selection.tsx
+++ b/apps/web/core/components/issues/issue-layouts/filters/header/layout-selection.tsx
@@ -7,7 +7,7 @@
 // plane imports
 import { ISSUE_LAYOUTS } from "@plane/constants";
 import { useTranslation } from "@plane/i18n";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import type { EIssueLayoutTypes } from "@plane/types";
 import { cn } from "@plane/utils";
 // components
@@ -34,7 +34,7 @@ export function LayoutSelection(props: Props) {
   return (
     <div className="flex items-center gap-1 rounded-md bg-layer-3 p-1">
       {ISSUE_LAYOUTS.filter((l) => layouts.includes(l.key)).map((layout) => (
-        <Tooltip key={layout.key} tooltipContent={t(layout.i18n_title)} isMobile={isMobile}>
+        <Tooltip key={layout.key} label={t(layout.i18n_title)} disabled={isMobile}>
           <button
             type="button"
             className={cn(

--- a/apps/web/core/components/issues/issue-layouts/filters/header/layout-selection.tsx
+++ b/apps/web/core/components/issues/issue-layouts/filters/header/layout-selection.tsx
@@ -33,27 +33,31 @@ export function LayoutSelection(props: Props) {
 
   return (
     <div className="flex items-center gap-1 rounded-md bg-layer-3 p-1">
-      {ISSUE_LAYOUTS.filter((l) => layouts.includes(l.key)).map((layout) => (
-        <Tooltip key={layout.key} label={t(layout.i18n_title)} disabled={isMobile}>
-          <button
-            type="button"
-            className={cn(
-              "group grid h-5.5 w-7 place-items-center overflow-hidden rounded-sm transition-all hover:bg-layer-transparent-hover",
-              {
-                "bg-layer-transparent-active hover:bg-layer-transparent-active": selectedLayout === layout.key,
-              }
-            )}
-            onClick={() => handleOnChange(layout.key)}
-          >
-            <IssueLayoutIcon
-              layout={layout.key}
-              size={14}
-              strokeWidth={2}
-              className={`size-3.5 ${selectedLayout == layout.key ? "text-primary" : "text-secondary"}`}
-            />
-          </button>
-        </Tooltip>
-      ))}
+      {ISSUE_LAYOUTS.map((layout) => {
+        if (!layouts.includes(layout.key)) return null;
+        return (
+          <Tooltip key={layout.key} label={t(layout.i18n_title)} disabled={isMobile}>
+            <button
+              type="button"
+              aria-label={t(layout.i18n_title)}
+              className={cn(
+                "group grid h-5.5 w-7 place-items-center overflow-hidden rounded-sm transition-all hover:bg-layer-transparent-hover",
+                {
+                  "bg-layer-transparent-active hover:bg-layer-transparent-active": selectedLayout === layout.key,
+                }
+              )}
+              onClick={() => handleOnChange(layout.key)}
+            >
+              <IssueLayoutIcon
+                layout={layout.key}
+                size={14}
+                strokeWidth={2}
+                className={`size-3.5 ${selectedLayout == layout.key ? "text-primary" : "text-secondary"}`}
+              />
+            </button>
+          </Tooltip>
+        );
+      })}
     </div>
   );
 }

--- a/apps/web/core/components/issues/issue-layouts/gantt/blocks.tsx
+++ b/apps/web/core/components/issues/issue-layouts/gantt/blocks.tsx
@@ -8,7 +8,7 @@ import { observer } from "mobx-react";
 import { useParams } from "next/navigation";
 // plane imports
 import { Popover } from "@plane/propel/popover";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import { ControlLink } from "@plane/ui";
 import { findTotalDaysInRange, generateWorkItemLink } from "@plane/utils";
 // components
@@ -151,7 +151,7 @@ export const IssueGanttSidebarBlock = observer(function IssueGanttSidebarBlock(p
             displayProperties={issuesFilter?.issueFilters?.displayProperties}
           />
         )}
-        <Tooltip tooltipContent={issueDetails?.name} isMobile={isMobile}>
+        <Tooltip label={issueDetails?.name ?? ""} layout="stacked" disabled={isMobile}>
           <span className="flex-grow truncate text-13 font-medium">{issueDetails?.name}</span>
         </Tooltip>
       </div>

--- a/apps/web/core/components/issues/issue-layouts/kanban/block.tsx
+++ b/apps/web/core/components/issues/issue-layouts/kanban/block.tsx
@@ -15,7 +15,7 @@ import { MoreHorizontal } from "lucide-react";
 import { useOutsideClickDetector } from "@plane/hooks";
 // types
 import { TOAST_TYPE, setToast } from "@plane/propel/toast";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import type { TIssue, IIssueDisplayProperties, IIssueMap } from "@plane/types";
 import { EIssueServiceType } from "@plane/types";
 // ui
@@ -120,7 +120,7 @@ const KanbanIssueDetailsBlock = observer(function KanbanIssueDetailsBlock(props:
         </div>
       </div>
 
-      <Tooltip tooltipContent={issue.name} isMobile={isMobile} renderByDefault={false}>
+      <Tooltip label={issue.name} layout="stacked" disabled={isMobile}>
         <div className="line-clamp-1 w-full text-body-sm-medium text-primary">
           <span>{issue.name}</span>
         </div>

--- a/apps/web/core/components/issues/issue-layouts/list/block.tsx
+++ b/apps/web/core/components/issues/issue-layouts/list/block.tsx
@@ -13,7 +13,7 @@ import { useParams } from "next/navigation";
 import { ChevronRightIcon } from "@plane/propel/icons";
 // types
 import { TOAST_TYPE, setToast } from "@plane/propel/toast";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import type { TIssue, IIssueDisplayProperties, TIssueMap } from "@plane/types";
 import { EIssueServiceType } from "@plane/types";
 // ui
@@ -208,13 +208,8 @@ export const IssueBlock = observer(function IssueBlock(props: IssueBlockProps) {
               {/* select checkbox */}
               {projectId && canSelectIssues && !isEpic && (
                 <Tooltip
-                  tooltipContent={
-                    <>
-                      Only work items within the current
-                      <br />
-                      project can be selected.
-                    </>
-                  }
+                  label="Only work items within the current project can be selected."
+                  layout="stacked"
                   disabled={issue.project_id === projectId}
                 >
                   <div className="absolute left-1 grid w-3.5 flex-shrink-0 place-items-center">
@@ -270,13 +265,7 @@ export const IssueBlock = observer(function IssueBlock(props: IssueBlockProps) {
               )}
             </div>
 
-            <Tooltip
-              tooltipContent={issue.name}
-              isMobile={isMobile}
-              position="top-start"
-              disabled={isCurrentBlockDragging}
-              renderByDefault={false}
-            >
+            <Tooltip label={issue.name} layout="stacked" align="start" disabled={isCurrentBlockDragging || isMobile}>
               <p className="cursor-pointer truncate text-body-xs-medium text-primary">{issue.name}</p>
             </Tooltip>
           </div>

--- a/apps/web/core/components/issues/issue-layouts/properties/all-properties.tsx
+++ b/apps/web/core/components/issues/issue-layouts/properties/all-properties.tsx
@@ -14,7 +14,7 @@ import { Paperclip } from "lucide-react";
 // i18n
 import { useTranslation } from "@plane/i18n";
 import { LinkIcon, StartDatePropertyIcon, ViewsIcon, DueDatePropertyIcon } from "@plane/propel/icons";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import type { TIssue, IIssueDisplayProperties, TIssuePriorities } from "@plane/types";
 // ui
 import {
@@ -410,12 +410,7 @@ export const IssueProperties = observer(function IssueProperties(props: IIssuePr
           displayPropertyKey="sub_issue_count"
           shouldRenderProperty={(properties) => !!properties.sub_issue_count && !!subIssueCount}
         >
-          <Tooltip
-            tooltipHeading={t("common.sub_work_items")}
-            tooltipContent={`${subIssueCount}`}
-            isMobile={isMobile}
-            renderByDefault={false}
-          >
+          <Tooltip label={`${t("common.sub_work_items")}: ${subIssueCount}`} disabled={isMobile}>
             {/* oxlint-disable-next-line jsx_a11y/click-events-have-key-events oxlint-disable-next-line jsx_a11y/no-static-element-interactions */}
             <div
               onFocus={handleEventPropagation}
@@ -444,12 +439,7 @@ export const IssueProperties = observer(function IssueProperties(props: IIssuePr
         displayPropertyKey="attachment_count"
         shouldRenderProperty={(properties) => !!properties.attachment_count && !!issue.attachment_count}
       >
-        <Tooltip
-          tooltipHeading={t("common.attachments")}
-          tooltipContent={`${issue.attachment_count}`}
-          isMobile={isMobile}
-          renderByDefault={false}
-        >
+        <Tooltip label={`${t("common.attachments")}: ${issue.attachment_count}`} disabled={isMobile}>
           {/* oxlint-disable-next-line jsx_a11y/click-events-have-key-events oxlint-disable-next-line jsx_a11y/no-static-element-interactions */}
           <div
             className="flex h-5 flex-shrink-0 items-center justify-center gap-2 overflow-hidden rounded-sm border-[0.5px] border-strong px-2.5 py-1"
@@ -468,12 +458,7 @@ export const IssueProperties = observer(function IssueProperties(props: IIssuePr
         displayPropertyKey="link"
         shouldRenderProperty={(properties) => !!properties.link && !!issue.link_count}
       >
-        <Tooltip
-          tooltipHeading={t("common.links")}
-          tooltipContent={`${issue.link_count}`}
-          isMobile={isMobile}
-          renderByDefault={false}
-        >
+        <Tooltip label={`${t("common.links")}: ${issue.link_count}`} disabled={isMobile}>
           {/* oxlint-disable-next-line jsx_a11y/click-events-have-key-events oxlint-disable-next-line jsx_a11y/no-static-element-interactions */}
           <div
             className="flex h-5 flex-shrink-0 items-center justify-center gap-2 overflow-hidden rounded-sm border-[0.5px] border-strong px-2.5 py-1"

--- a/apps/web/core/components/issues/issue-layouts/properties/labels.tsx
+++ b/apps/web/core/components/issues/issue-layouts/properties/labels.tsx
@@ -13,7 +13,7 @@ import { useOutsideClickDetector } from "@plane/hooks";
 import { useTranslation } from "@plane/i18n";
 import { LabelPropertyIcon } from "@plane/propel/icons";
 // types
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import type { IIssueLabel } from "@plane/types";
 // ui
 // hooks
@@ -53,13 +53,7 @@ const NoLabel = observer(function NoLabel({ isMobile, noLabelBorder, fullWidth, 
   const { t } = useTranslation();
 
   return (
-    <Tooltip
-      position="top"
-      tooltipHeading={t("common.labels")}
-      tooltipContent="None"
-      isMobile={isMobile}
-      renderByDefault={false}
-    >
+    <Tooltip label={`${t("common.labels")}: None`} disabled={isMobile}>
       <div
         className={cn(
           "flex h-full items-center justify-center gap-2 rounded-sm px-2.5 py-1 text-caption-sm-regular hover:bg-layer-1",
@@ -95,14 +89,14 @@ function LabelSummary({ isMobile, fullWidth, noLabelBorder, disabled, projectLab
       )}
     >
       <Tooltip
-        isMobile={isMobile}
-        position="top"
-        tooltipHeading={t("common.labels")}
-        tooltipContent={projectLabels
-          ?.filter((l) => value.includes(l?.id))
-          .map((l) => l?.name)
-          .join(", ")}
-        renderByDefault={false}
+        label={`${t("common.labels")}: ${
+          projectLabels
+            ?.filter((l) => value.includes(l?.id))
+            .map((l) => l?.name)
+            .join(", ") ?? ""
+        }`}
+        layout="stacked"
+        disabled={isMobile}
       >
         <div className="flex h-full items-center gap-1.5 text-secondary">
           <span className="h-2 w-2 flex-shrink-0 rounded-full bg-accent-primary" />
@@ -122,24 +116,11 @@ type LabelItemProps = {
   noLabelBorder: boolean;
 };
 
-const LabelItem = observer(function LabelItem({
-  label,
-  isMobile,
-  renderByDefault,
-  disabled,
-  fullWidth,
-  noLabelBorder,
-}: LabelItemProps) {
+const LabelItem = observer(function LabelItem({ label, isMobile, disabled, fullWidth, noLabelBorder }: LabelItemProps) {
   const { t } = useTranslation();
 
   return (
-    <Tooltip
-      position="top"
-      tooltipHeading={t("common.labels")}
-      tooltipContent={label?.name ?? ""}
-      isMobile={isMobile}
-      renderByDefault={renderByDefault}
-    >
+    <Tooltip label={`${t("common.labels")}: ${label?.name ?? ""}`} layout="stacked" disabled={isMobile}>
       <div
         className={cn(
           "flex h-full max-w-full flex-shrink-0 items-center justify-center overflow-hidden rounded-sm px-2.5 text-caption-sm-regular hover:bg-layer-1",

--- a/apps/web/core/components/issues/issue-layouts/properties/labels.tsx
+++ b/apps/web/core/components/issues/issue-layouts/properties/labels.tsx
@@ -79,6 +79,11 @@ type LabelSummaryProps = {
 
 function LabelSummary({ isMobile, fullWidth, noLabelBorder, disabled, projectLabels, value }: LabelSummaryProps) {
   const { t } = useTranslation();
+  // single pass: collect the selected label names instead of filter -> map -> join
+  const selectedLabelNames = projectLabels.reduce<string[]>((names, label) => {
+    if (value.includes(label?.id)) names.push(label?.name);
+    return names;
+  }, []);
   return (
     <div
       className={cn(
@@ -88,16 +93,7 @@ function LabelSummary({ isMobile, fullWidth, noLabelBorder, disabled, projectLab
         disabled ? "cursor-not-allowed" : "cursor-pointer"
       )}
     >
-      <Tooltip
-        label={`${t("common.labels")}: ${
-          projectLabels
-            ?.filter((l) => value.includes(l?.id))
-            .map((l) => l?.name)
-            .join(", ") ?? ""
-        }`}
-        layout="stacked"
-        disabled={isMobile}
-      >
+      <Tooltip label={`${t("common.labels")}: ${selectedLabelNames.join(", ")}`} layout="stacked" disabled={isMobile}>
         <div className="flex h-full items-center gap-1.5 text-secondary">
           <span className="h-2 w-2 flex-shrink-0 rounded-full bg-accent-primary" />
           {`${value.length} Labels`}

--- a/apps/web/core/components/issues/issue-layouts/spreadsheet/issue-row.tsx
+++ b/apps/web/core/components/issues/issue-layouts/spreadsheet/issue-row.tsx
@@ -14,7 +14,7 @@ import { SPREADSHEET_SELECT_GROUP } from "@plane/constants";
 import { useOutsideClickDetector } from "@plane/hooks";
 import { ChevronRightIcon } from "@plane/propel/icons";
 // types
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import type { IIssueDisplayProperties, TIssue } from "@plane/types";
 import { EIssueServiceType } from "@plane/types";
 // ui
@@ -308,13 +308,8 @@ const IssueRowDetails = observer(function IssueRowDetails(props: IssueRowDetails
               {/* select checkbox */}
               {projectId && canSelectIssues && (
                 <Tooltip
-                  tooltipContent={
-                    <>
-                      Only work items within the current
-                      <br />
-                      project can be selected.
-                    </>
-                  }
+                  label="Only work items within the current project can be selected."
+                  layout="stacked"
                   disabled={issueDetail.project_id === projectId}
                 >
                   <div className="absolute left-1 mr-1 grid w-3.5 flex-shrink-0 place-items-center">
@@ -358,7 +353,7 @@ const IssueRowDetails = observer(function IssueRowDetails(props: IssueRowDetails
               <div className="my-auto flex h-full w-full items-center justify-between gap-2 truncate">
                 <div className="line-clamp-1 w-full text-14 text-primary">
                   <div className="w-full overflow-hidden">
-                    <Tooltip tooltipContent={issueDetail.name} isMobile={isMobile}>
+                    <Tooltip label={issueDetail.name} layout="stacked" disabled={isMobile}>
                       <div
                         className="h-full w-full cursor-pointer truncate pr-4 text-left text-13 text-primary focus:outline-none"
                         tabIndex={-1}

--- a/apps/web/core/components/issues/label.tsx
+++ b/apps/web/core/components/issues/label.tsx
@@ -6,7 +6,7 @@
 
 import React from "react";
 // components
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import { usePlatformOS } from "@/hooks/use-platform-os";
 type Props = {
   labelDetails: any[];
@@ -25,7 +25,7 @@ export function ViewIssueLabel({ labelDetails, maxRender = 1 }: Props) {
                 key={label.id}
                 className="shadow-sm flex flex-shrink-0 cursor-default items-center rounded-md border border-strong px-2.5 py-1 text-11"
               >
-                <Tooltip position="top" tooltipHeading="Label" tooltipContent={label.name} isMobile={isMobile}>
+                <Tooltip label={`Label: ${label.name}`} layout="stacked" disabled={isMobile}>
                   <div className="flex items-center gap-1.5 text-secondary">
                     <span
                       className="h-2 w-2 flex-shrink-0 rounded-full"
@@ -42,10 +42,9 @@ export function ViewIssueLabel({ labelDetails, maxRender = 1 }: Props) {
         ) : (
           <div className="shadow-sm flex flex-shrink-0 cursor-default items-center rounded-md border border-strong px-2.5 py-1 text-11">
             <Tooltip
-              position="top"
-              tooltipHeading="Labels"
-              tooltipContent={labelDetails.map((l) => l.name).join(", ")}
-              isMobile={isMobile}
+              label={`Labels: ${labelDetails.map((l) => l.name).join(", ")}`}
+              layout="stacked"
+              disabled={isMobile}
             >
               <div className="flex items-center gap-1.5 text-secondary">
                 <span className="h-2 w-2 flex-shrink-0 rounded-full bg-accent-primary" />

--- a/apps/web/core/components/issues/peek-overview/error.tsx
+++ b/apps/web/core/components/issues/peek-overview/error.tsx
@@ -5,7 +5,7 @@
  */
 
 import { MoveRight } from "lucide-react";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 // assets
 import emptyIssue from "@/app/assets/empty-state/issue.svg?url";
 // components
@@ -25,7 +25,7 @@ export function IssuePeekOverviewError(props: TIssuePeekOverviewError) {
   return (
     <div className="relative flex h-full w-full flex-col overflow-hidden">
       <div className="flex flex-shrink-0 justify-start">
-        <Tooltip tooltipContent="Close the peek view" isMobile={isMobile}>
+        <Tooltip label="Close the peek view" disabled={isMobile}>
           <button onClick={removeRoutePeekId} className="m-5 h-5 w-5">
             <MoveRight className="h-4 w-4 text-tertiary hover:text-secondary" />
           </button>

--- a/apps/web/core/components/issues/peek-overview/header.tsx
+++ b/apps/web/core/components/issues/peek-overview/header.tsx
@@ -12,7 +12,7 @@ import { MoveDiagonal, MoveRight } from "lucide-react";
 import { useTranslation } from "@plane/i18n";
 import { CenterPanelIcon, CopyLinkIcon, FullScreenPanelIcon, SidePanelIcon } from "@plane/propel/icons";
 import { TOAST_TYPE, setToast } from "@plane/propel/toast";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import type { TNameDescriptionLoader } from "@plane/types";
 import { EIssuesStoreType } from "@plane/types";
 import { CustomSelect } from "@plane/ui";
@@ -159,13 +159,13 @@ export const IssuePeekOverviewHeader = observer(function IssuePeekOverviewHeader
       }`}
     >
       <div className="flex items-center gap-4">
-        <Tooltip tooltipContent={t("common.close_peek_view")} isMobile={isMobile}>
+        <Tooltip label={t("common.close_peek_view")} disabled={isMobile}>
           <button onClick={removeRoutePeekId}>
             <MoveRight className="h-4 w-4 text-tertiary hover:text-secondary" />
           </button>
         </Tooltip>
 
-        <Tooltip tooltipContent={t("issue.open_in_full_screen")} isMobile={isMobile}>
+        <Tooltip label={t("issue.open_in_full_screen")} disabled={isMobile}>
           <Link href={workItemLink} onClick={() => removeRoutePeekId()}>
             <MoveDiagonal className="h-4 w-4 text-tertiary hover:text-secondary" />
           </Link>
@@ -176,7 +176,7 @@ export const IssuePeekOverviewHeader = observer(function IssuePeekOverviewHeader
               value={currentMode}
               onChange={(val: any) => setPeekMode(val)}
               customButton={
-                <Tooltip tooltipContent={t("common.toggle_peek_view_layout")} isMobile={isMobile}>
+                <Tooltip label={t("common.toggle_peek_view_layout")} disabled={isMobile}>
                   <button type="button" className="">
                     <currentMode.icon className="h-4 w-4 text-tertiary hover:text-secondary" />
                   </button>
@@ -205,7 +205,7 @@ export const IssuePeekOverviewHeader = observer(function IssuePeekOverviewHeader
           {currentUser && !isArchived && (
             <IssueSubscription workspaceSlug={workspaceSlug} projectId={projectId} issueId={issueId} />
           )}
-          <Tooltip tooltipContent={t("common.actions.copy_link")} isMobile={isMobile}>
+          <Tooltip label={t("common.actions.copy_link")} disabled={isMobile}>
             <IconButton variant="secondary" size="lg" onClick={handleCopyText} icon={CopyLinkIcon} />
           </Tooltip>
           {issueDetails && (

--- a/apps/web/core/components/issues/peek-overview/loader.tsx
+++ b/apps/web/core/components/issues/peek-overview/loader.tsx
@@ -5,7 +5,7 @@
  */
 
 import { MoveRight } from "lucide-react";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import { Loader } from "@plane/ui";
 // hooks
 import { usePlatformOS } from "@/hooks/use-platform-os";
@@ -23,7 +23,7 @@ export function IssuePeekOverviewLoader(props: TIssuePeekOverviewLoader) {
     <Loader className="h-screen w-full space-y-6 overflow-hidden p-5">
       <div className="flex items-center justify-between gap-2">
         <div className="flex items-center gap-2">
-          <Tooltip tooltipContent="Close the peek view" isMobile={isMobile}>
+          <Tooltip label="Close the peek view" disabled={isMobile}>
             <button onClick={removeRoutePeekId}>
               <MoveRight className="h-4 w-4 text-tertiary hover:text-secondary" />
             </button>

--- a/apps/web/core/components/issues/relations/issue-list-item.tsx
+++ b/apps/web/core/components/issues/relations/issue-list-item.tsx
@@ -9,7 +9,7 @@ import { observer } from "mobx-react";
 import { useTranslation } from "@plane/i18n";
 import { LinkIcon, EditIcon, TrashIcon, CloseIcon } from "@plane/propel/icons";
 // plane imports
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import type { TIssueRelationTypes } from "@plane/types";
 import type { TIssue, TIssueServiceType } from "@plane/types";
 import { EIssueServiceType } from "@plane/types";
@@ -144,7 +144,7 @@ export const RelationIssueListItem = observer(function RelationIssueListItem(pro
                 )}
               </div>
 
-              <Tooltip tooltipContent={issue.name} isMobile={isMobile}>
+              <Tooltip label={issue.name} layout="stacked" disabled={isMobile}>
                 <span className="w-0 flex-1 truncate text-13 text-primary">{issue.name}</span>
               </Tooltip>
             </div>

--- a/apps/web/core/components/issues/workspace-draft/draft-issue-block.tsx
+++ b/apps/web/core/components/issues/workspace-draft/draft-issue-block.tsx
@@ -10,7 +10,7 @@ import { observer } from "mobx-react";
 import { SquareStackIcon } from "lucide-react";
 import { CopyIcon, EditIcon, TrashIcon } from "@plane/propel/icons";
 // plane utils
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import type { TWorkspaceDraftIssue } from "@plane/types";
 import { EIssuesStoreType } from "@plane/types";
 import type { TContextMenuItem } from "@plane/ui";
@@ -160,7 +160,7 @@ export const DraftIssueBlock = observer(function DraftIssueBlock(props: Props) {
                 <div className="grid size-4 flex-shrink-0 place-items-center" />
               </div>
 
-              <Tooltip tooltipContent={issue.name} position="top-start" renderByDefault={false}>
+              <Tooltip label={issue.name} layout="stacked" align="start">
                 <p className="w-full cursor-pointer truncate text-13 text-primary">{issue.name}</p>
               </Tooltip>
             </div>

--- a/apps/web/core/components/modules/gantt-chart/blocks.tsx
+++ b/apps/web/core/components/modules/gantt-chart/blocks.tsx
@@ -10,7 +10,7 @@ import { useParams } from "next/navigation";
 // ui
 import { MODULE_STATUS } from "@plane/constants";
 import { ModuleStatusIcon } from "@plane/propel/icons";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 // components
 import { SIDEBAR_WIDTH } from "@/components/gantt-chart/constants";
 import { getBlockViewDetails } from "@/components/issues/issue-layouts/utils";
@@ -43,14 +43,10 @@ export const ModuleGanttBlock = observer(function ModuleGanttBlock(props: Props)
 
   return (
     <Tooltip
-      isMobile={isMobile}
-      tooltipContent={
-        <div className="space-y-1">
-          <h5>{moduleDetails?.name}</h5>
-          <div>{message}</div>
-        </div>
-      }
-      position="top-start"
+      label={moduleDetails?.name ? `${moduleDetails.name}: ${message ?? ""}` : (message ?? "")}
+      layout="stacked"
+      align="start"
+      disabled={isMobile}
     >
       <div
         className="relative flex h-full w-full cursor-pointer items-center rounded-sm"

--- a/apps/web/core/components/modules/links/list-item.tsx
+++ b/apps/web/core/components/modules/links/list-item.tsx
@@ -9,7 +9,7 @@ import { observer } from "mobx-react";
 import { CopyIcon, EditIcon, TrashIcon } from "@plane/propel/icons";
 // plane types
 import { TOAST_TYPE, setToast } from "@plane/propel/toast";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import type { ILinkDetails } from "@plane/types";
 // plane ui
 import { getIconForLink, copyTextToClipboard, calculateTimeAgo } from "@plane/utils";
@@ -54,7 +54,7 @@ export const ModulesLinksListItem = observer(function ModulesLinksListItem(props
           <span className="py-1">
             <Icon className="size-3 shrink-0 stroke-2 text-tertiary group-hover:text-primary" />
           </span>
-          <Tooltip tooltipContent={link.title && link.title !== "" ? link.title : link.url} isMobile={isMobile}>
+          <Tooltip label={link.title && link.title !== "" ? link.title : link.url} layout="stacked" disabled={isMobile}>
             <a href={link.url} target="_blank" rel="noopener noreferrer" className="cursor-pointer truncate text-11">
               {link.title && link.title !== "" ? link.title : link.url}
             </a>

--- a/apps/web/core/components/modules/module-card-item.tsx
+++ b/apps/web/core/components/modules/module-card-item.tsx
@@ -16,7 +16,7 @@ import { useLocalStorage } from "@plane/hooks";
 import { LinearProgress } from "@makeplane/propel/components/linear-progress";
 import { WorkItemsIcon } from "@plane/propel/icons";
 import { TOAST_TYPE, setPromiseToast, setToast } from "@plane/propel/toast";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import type { IModule } from "@plane/types";
 import { Card, FavoriteStar } from "@plane/ui";
 import { getDate, renderFormattedPayloadDate, generateQueryParams } from "@plane/utils";
@@ -178,7 +178,7 @@ export const ModuleCardItem = observer(function ModuleCardItem(props: Props) {
         <Card>
           <div>
             <div className="flex items-center justify-between gap-2">
-              <Tooltip tooltipContent={moduleDetails.name} position="top" isMobile={isMobile}>
+              <Tooltip label={moduleDetails.name} layout="stacked" disabled={isMobile}>
                 <span className="truncate text-14 font-medium">{moduleDetails.name}</span>
               </Tooltip>
               <div className="flex items-center gap-2" onClick={handleEventPropagation}>
@@ -206,7 +206,7 @@ export const ModuleCardItem = observer(function ModuleCardItem(props: Props) {
                   <ButtonAvatars showTooltip={false} userIds={moduleLeadDetails?.id} />
                 </span>
               ) : (
-                <Tooltip tooltipContent="No lead">
+                <Tooltip label="No lead">
                   <SquareUser className="mx-1 h-4 w-4 text-tertiary" />
                 </Tooltip>
               )}

--- a/apps/web/core/components/modules/module-list-item-action.tsx
+++ b/apps/web/core/components/modules/module-list-item-action.tsx
@@ -13,7 +13,7 @@ import { MODULE_STATUS, EUserPermissions, EUserPermissionsLevel, IS_FAVORITE_MEN
 import { useLocalStorage } from "@plane/hooks";
 import { useTranslation } from "@plane/i18n";
 import { TOAST_TYPE, setPromiseToast, setToast } from "@plane/propel/toast";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import type { IModule } from "@plane/types";
 import { FavoriteStar } from "@plane/ui";
 import { renderFormattedPayloadDate, getDate } from "@plane/utils";
@@ -166,7 +166,7 @@ export const ModuleListItemAction = observer(function ModuleListItemAction(props
           <ButtonAvatars showTooltip={false} userIds={moduleLeadDetails?.id} />
         </span>
       ) : (
-        <Tooltip tooltipContent="No lead">
+        <Tooltip label="No lead">
           <SquareUser className="h-4 w-4 text-tertiary" />
         </Tooltip>
       )}

--- a/apps/web/core/components/modules/module-view-header.tsx
+++ b/apps/web/core/components/modules/module-view-header.tsx
@@ -14,7 +14,7 @@ import { useOutsideClickDetector } from "@plane/hooks";
 // types
 import { useTranslation } from "@plane/i18n";
 import { SearchIcon, CloseIcon } from "@plane/propel/icons";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import type { TModuleFilters } from "@plane/types";
 // ui
 import { cn, calculateTotalFilters } from "@plane/utils";
@@ -172,7 +172,7 @@ export const ModuleViewHeader = observer(function ModuleViewHeader() {
       </FiltersDropdown>
       <div className="hidden items-center gap-1 rounded-sm bg-layer-3 p-1 md:flex">
         {MODULE_VIEW_LAYOUTS.map((layout) => (
-          <Tooltip key={layout.key} tooltipContent={t(layout.i18n_title)} isMobile={isMobile}>
+          <Tooltip key={layout.key} label={t(layout.i18n_title)} disabled={isMobile}>
             <button
               type="button"
               className={cn(

--- a/apps/web/core/components/navigation/project-header-button.tsx
+++ b/apps/web/core/components/navigation/project-header-button.tsx
@@ -8,7 +8,7 @@ import type { TPartialProject } from "@plane/types";
 // plane propel imports
 import { Logo } from "@plane/propel/emoji-icon-picker";
 import { ChevronDownIcon } from "@plane/propel/icons";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 
 type TProjectHeaderButtonProps = {
   project: TPartialProject;
@@ -16,7 +16,7 @@ type TProjectHeaderButtonProps = {
 
 export function ProjectHeaderButton({ project }: TProjectHeaderButtonProps) {
   return (
-    <Tooltip tooltipContent={project.name} position="bottom">
+    <Tooltip label={project.name} layout="stacked" side="bottom">
       <div className="relative flex w-full max-w-48 items-center pr-1 text-left select-none">
         <div className="flex size-7 flex-shrink-0 items-center justify-center rounded-md bg-layer-1">
           <Logo logo={project.logo_props} size={16} />

--- a/apps/web/core/components/navigation/tab-navigation-overflow-menu.tsx
+++ b/apps/web/core/components/navigation/tab-navigation-overflow-menu.tsx
@@ -11,7 +11,7 @@ import { MoreHorizontal, Pin } from "lucide-react";
 import { useTranslation } from "@plane/i18n";
 import { SetAsDefaultIcon } from "@plane/propel/icons";
 import { Menu } from "@plane/propel/menu";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import { cn } from "@plane/utils";
 // local imports
 import type { TNavigationItem } from "./tab-navigation-root";
@@ -72,7 +72,7 @@ export function TabNavigationOverflowMenu({ overflowItems, isActive, tabPreferen
                     <Pin className="size-3" />
                   </button>
                 )}
-                <Tooltip tooltipContent={isDefault ? "Clear default" : "Set as default"}>
+                <Tooltip label={isDefault ? "Clear default" : "Set as default"}>
                   <button
                     onClick={(e) => {
                       e.stopPropagation();

--- a/apps/web/core/components/navigation/top-navigation-root.tsx
+++ b/apps/web/core/components/navigation/top-navigation-root.tsx
@@ -13,7 +13,7 @@ import { HelpMenuRoot } from "@/components/workspace/sidebar/help-section/root";
 import { UserMenuRoot } from "@/components/workspace/sidebar/user-menu-root";
 import { WorkspaceMenuRoot } from "@/components/workspace/sidebar/workspace-menu-root";
 import { useAppRailPreferences } from "@/hooks/use-navigation-preferences";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import { AppSidebarItem } from "@/components/sidebar/sidebar-item";
 import { InboxIcon } from "@plane/propel/icons";
 import useSWR from "swr";
@@ -60,7 +60,7 @@ export const TopNavigationRoot = observer(function TopNavigationRoot() {
       </div>
       {/* Additional Actions */}
       <div className="flex flex-1 shrink-0 items-center justify-end gap-1">
-        <Tooltip tooltipContent="Inbox" position="bottom">
+        <Tooltip label="Inbox" side="bottom">
           <AppSidebarItem
             variant="link"
             item={{

--- a/apps/web/core/components/onboarding/header.tsx
+++ b/apps/web/core/components/onboarding/header.tsx
@@ -7,7 +7,7 @@
 import { observer } from "mobx-react";
 // plane imports
 import { PlaneLockup, ChevronLeftIcon } from "@plane/propel/icons";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import type { TOnboardingStep } from "@plane/types";
 import { EOnboardingSteps } from "@plane/types";
 import { cn } from "@plane/utils";
@@ -69,7 +69,7 @@ export const OnboardingHeader = observer(function OnboardingHeader(props: Onboar
   return (
     <div className="sticky top-0 z-10 flex flex-col gap-4">
       <div className="h-1.5 w-full cursor-pointer overflow-hidden rounded-t-lg bg-surface-1">
-        <Tooltip tooltipContent={`${currentStepNumber}/${totalSteps}`} position="bottom-end">
+        <Tooltip label={`${currentStepNumber}/${totalSteps}`} side="bottom" align="end">
           <div
             className="h-full bg-accent-primary transition-all duration-700 ease-out"
             style={{ width: `${(currentStepNumber / totalSteps) * 100}%` }}

--- a/apps/web/core/components/pages/editor/ai/ask-pi-menu.tsx
+++ b/apps/web/core/components/pages/editor/ai/ask-pi-menu.tsx
@@ -7,7 +7,7 @@
 import { useState } from "react";
 import { CircleArrowUp, CornerDownRight, RefreshCcw, Sparkles } from "lucide-react";
 // ui
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 // components
 import { cn } from "@plane/utils";
 import { RichTextEditor } from "@/components/editor/rich-text";
@@ -64,7 +64,7 @@ export function AskPiMenu(props: Props) {
               >
                 Replace selection
               </button>
-              <Tooltip tooltipContent="Add to next line">
+              <Tooltip label="Add to next line">
                 <button
                   type="button"
                   className="grid size-6 flex-shrink-0 place-items-center rounded-sm outline-none hover:bg-layer-1"
@@ -73,7 +73,7 @@ export function AskPiMenu(props: Props) {
                   <CornerDownRight className="size-4 text-tertiary" />
                 </button>
               </Tooltip>
-              <Tooltip tooltipContent="Re-generate response">
+              <Tooltip label="Re-generate response">
                 <button
                   type="button"
                   className="grid size-6 flex-shrink-0 place-items-center rounded-sm outline-none hover:bg-layer-1"

--- a/apps/web/core/components/pages/editor/ai/menu.tsx
+++ b/apps/web/core/components/pages/editor/ai/menu.tsx
@@ -11,7 +11,7 @@ import { CornerDownRight, RefreshCcw, Sparkles, TriangleAlert } from "lucide-rea
 import type { EditorRefApi } from "@plane/editor";
 import { ChevronRightIcon } from "@plane/propel/icons";
 // plane ui
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 // components
 import { cn } from "@plane/utils";
 import { RichTextEditor } from "@/components/editor/rich-text";
@@ -234,7 +234,7 @@ export function EditorAIMenu(props: Props) {
                       >
                         Replace selection
                       </button>
-                      <Tooltip tooltipContent="Add to next line">
+                      <Tooltip label="Add to next line">
                         <button
                           type="button"
                           className="grid size-6 flex-shrink-0 place-items-center rounded-sm outline-none hover:bg-layer-1"
@@ -243,7 +243,7 @@ export function EditorAIMenu(props: Props) {
                           <CornerDownRight className="size-4 text-tertiary" />
                         </button>
                       </Tooltip>
-                      <Tooltip tooltipContent="Re-generate response">
+                      <Tooltip label="Re-generate response">
                         <button
                           type="button"
                           className="grid size-6 flex-shrink-0 place-items-center rounded-sm outline-none hover:bg-layer-1"

--- a/apps/web/core/components/pages/editor/toolbar/root.tsx
+++ b/apps/web/core/components/pages/editor/toolbar/root.tsx
@@ -8,7 +8,7 @@ import { observer } from "mobx-react";
 import { PanelRight } from "lucide-react";
 // plane imports
 import { useTranslation } from "@plane/i18n";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import { cn } from "@plane/utils";
 // components
 import { PageToolbar } from "@/components/pages/editor/toolbar";
@@ -72,7 +72,7 @@ export const PageEditorToolbarRoot = observer(function PageEditorToolbarRoot(pro
       {shouldHideToolbar && (
         <div className="absolute top-0 right-0 z-10 flex h-[52px] items-center px-page-x">
           {!isNavigationPaneOpen && (
-            <Tooltip tooltipContent={t("page_navigation_pane.open_button")}>
+            <Tooltip label={t("page_navigation_pane.open_button")}>
               <button
                 type="button"
                 className="grid size-6 shrink-0 place-items-center rounded-sm text-secondary transition-colors hover:bg-layer-transparent-hover hover:text-primary"

--- a/apps/web/core/components/pages/editor/toolbar/toolbar.tsx
+++ b/apps/web/core/components/pages/editor/toolbar/toolbar.tsx
@@ -8,7 +8,7 @@ import React, { useEffect, useState, useCallback } from "react";
 import type { EditorRefApi } from "@plane/editor";
 // plane imports
 import { CheckIcon, ChevronDownIcon } from "@plane/propel/icons";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import { CustomMenu } from "@plane/ui";
 import { cn } from "@plane/utils";
 // constants
@@ -31,14 +31,7 @@ const ToolbarButton = React.memo(function ToolbarButton(props: ToolbarButtonProp
   const { item, isActive, executeCommand } = props;
 
   return (
-    <Tooltip
-      tooltipContent={
-        <p className="flex flex-col gap-1 text-center text-11">
-          <span className="font-medium">{item.name}</span>
-          {item.shortcut && <kbd className="text-placeholder">{item.shortcut.join(" + ")}</kbd>}
-        </p>
-      }
-    >
+    <Tooltip label={item.name} shortcut={item.shortcut?.join(" + ")}>
       <button
         type="button"
         onClick={() =>

--- a/apps/web/core/components/pages/header/copy-link-control.tsx
+++ b/apps/web/core/components/pages/header/copy-link-control.tsx
@@ -9,7 +9,7 @@ import { observer } from "mobx-react";
 
 import { LinkIcon, CheckIcon } from "@plane/propel/icons";
 // plane imports
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import { IconButton } from "@plane/propel/icon-button";
 import { cn } from "@plane/utils";
 // hooks
@@ -57,7 +57,7 @@ export const PageCopyLinkControl = observer(function PageCopyLinkControl({ page 
   }, [pageOperations]);
 
   return (
-    <Tooltip tooltipContent={isCopied ? "Copied!" : "Copy link"} position="bottom">
+    <Tooltip label={isCopied ? "Copied!" : "Copy link"} side="bottom">
       <IconButton
         variant="ghost"
         size="lg"

--- a/apps/web/core/components/pages/header/lock-control.tsx
+++ b/apps/web/core/components/pages/header/lock-control.tsx
@@ -8,7 +8,7 @@ import { useState, useEffect, useRef } from "react";
 import { observer } from "mobx-react";
 import { LockKeyhole, LockKeyholeOpen } from "lucide-react";
 // plane imports
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 // hooks
 import { usePageOperations } from "@/hooks/use-page-operations";
 // store
@@ -78,7 +78,7 @@ export const PageLockControl = observer(function PageLockControl({ page }: Props
   return (
     <>
       {displayState === "neutral" && (
-        <Tooltip tooltipContent="Lock" position="bottom">
+        <Tooltip label="Lock" side="bottom">
           <button
             type="button"
             onClick={toggleLock}

--- a/apps/web/core/components/pages/header/offline-badge.tsx
+++ b/apps/web/core/components/pages/header/offline-badge.tsx
@@ -6,7 +6,7 @@
 
 import { observer } from "mobx-react";
 // plane imports
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 // hooks
 import useOnlineStatus from "@/hooks/use-online-status";
 // store
@@ -24,8 +24,8 @@ export const PageOfflineBadge = observer(function PageOfflineBadge({ page }: Pro
 
   return (
     <Tooltip
-      tooltipHeading="You are offline."
-      tooltipContent="You can continue making changes. They will be synced when you are back online."
+      label="You are offline. You can continue making changes. They will be synced when you are back online."
+      layout="stacked"
     >
       <div className="flex h-7 flex-shrink-0 items-center gap-2 rounded-full bg-layer-1 px-3 py-0.5 text-11 font-medium text-tertiary">
         <span className="size-1.5 flex-shrink-0 rounded-full bg-layer-1" />

--- a/apps/web/core/components/pages/header/syncing-badge.tsx
+++ b/apps/web/core/components/pages/header/syncing-badge.tsx
@@ -6,7 +6,7 @@
 
 import { useState, useEffect } from "react";
 import { CloudOff, Dot } from "lucide-react";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import { Badge } from "@plane/propel/badge";
 
 type Props = {
@@ -37,14 +37,12 @@ export function PageSyncingBadge({ syncStatus }: Props) {
   const badgeContent = {
     syncing: {
       label: "Syncing...",
-      tooltipHeading: "Syncing...",
-      tooltipContent: "Your changes are being synced with the server. You can continue making changes.",
+      tooltipLabel: "Syncing... Your changes are being synced with the server. You can continue making changes.",
     },
     error: {
       label: "Connection lost",
-      tooltipHeading: "Connection lost",
-      tooltipContent:
-        "We're having trouble connecting to the websocket server. Your changes will be synced and saved every 10 seconds.",
+      tooltipLabel:
+        "Connection lost. We're having trouble connecting to the websocket server. Your changes will be synced and saved every 10 seconds.",
     },
   };
 
@@ -52,7 +50,7 @@ export function PageSyncingBadge({ syncStatus }: Props) {
   const content = badgeContent[syncStatus];
 
   return (
-    <Tooltip tooltipHeading={content.tooltipHeading} tooltipContent={content.tooltipContent}>
+    <Tooltip label={content.tooltipLabel} layout="stacked">
       <span className="animate-quickFadeIn">
         <Badge
           variant={syncStatus === "syncing" ? "brand" : "danger"}

--- a/apps/web/core/components/pages/header/syncing-badge.tsx
+++ b/apps/web/core/components/pages/header/syncing-badge.tsx
@@ -13,6 +13,18 @@ type Props = {
   syncStatus: "syncing" | "synced" | "error";
 };
 
+const BADGE_CONTENT = {
+  syncing: {
+    label: "Syncing...",
+    tooltipLabel: "Syncing... Your changes are being synced with the server. You can continue making changes.",
+  },
+  error: {
+    label: "Connection lost",
+    tooltipLabel:
+      "Connection lost. We're having trouble connecting to the websocket server. Your changes will be synced and saved every 10 seconds.",
+  },
+};
+
 export function PageSyncingBadge({ syncStatus }: Props) {
   const [prevSyncStatus, setPrevSyncStatus] = useState<"syncing" | "synced" | "error" | null>(null);
   const [isVisible, setIsVisible] = useState(syncStatus !== "synced");
@@ -34,20 +46,8 @@ export function PageSyncingBadge({ syncStatus }: Props) {
 
   if (!isVisible || syncStatus === "synced") return null;
 
-  const badgeContent = {
-    syncing: {
-      label: "Syncing...",
-      tooltipLabel: "Syncing... Your changes are being synced with the server. You can continue making changes.",
-    },
-    error: {
-      label: "Connection lost",
-      tooltipLabel:
-        "Connection lost. We're having trouble connecting to the websocket server. Your changes will be synced and saved every 10 seconds.",
-    },
-  };
-
-  // This way we guarantee badgeContent is defined
-  const content = badgeContent[syncStatus];
+  // The synced early-return above guarantees this key exists
+  const content = BADGE_CONTENT[syncStatus];
 
   return (
     <Tooltip label={content.tooltipLabel} layout="stacked">

--- a/apps/web/core/components/pages/list/block-item-action.tsx
+++ b/apps/web/core/components/pages/list/block-item-action.tsx
@@ -8,7 +8,7 @@ import { observer } from "mobx-react";
 import { Earth, Info, Minus } from "lucide-react";
 // plane imports
 import { LockIcon } from "@plane/propel/icons";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import { Avatar, FavoriteStar } from "@plane/ui";
 import { renderFormattedDate, getFileURL } from "@plane/utils";
 // hooks
@@ -43,12 +43,12 @@ export const BlockItemAction = observer(function BlockItemAction(props: Props) {
     <>
       {/* page details */}
       <div className="cursor-default">
-        <Tooltip tooltipHeading="Owned by" tooltipContent={ownerDetails?.display_name}>
+        <Tooltip label={`Owned by: ${ownerDetails?.display_name ?? ""}`} layout="stacked">
           <Avatar src={getFileURL(ownerDetails?.avatar_url ?? "")} name={ownerDetails?.display_name} />
         </Tooltip>
       </div>
       <div className="cursor-default text-tertiary">
-        <Tooltip tooltipContent={access === 0 ? "Public" : "Private"}>
+        <Tooltip label={access === 0 ? "Public" : "Private"}>
           {access === 0 ? <Earth className="h-4 w-4" /> : <LockIcon className="h-4 w-4" />}
         </Tooltip>
       </div>
@@ -56,7 +56,7 @@ export const BlockItemAction = observer(function BlockItemAction(props: Props) {
       <Minus className="-mx-3 h-5 w-5 rotate-90 text-placeholder" strokeWidth={1} />
 
       {/* page info */}
-      <Tooltip tooltipContent={`Created on ${renderFormattedDate(created_at)}`}>
+      <Tooltip label={`Created on ${renderFormattedDate(created_at)}`} layout="stacked">
         <span className="grid h-4 w-4 cursor-default place-items-center">
           <Info className="h-4 w-4 text-tertiary" />
         </span>

--- a/apps/web/core/components/pages/navigation-pane/root.tsx
+++ b/apps/web/core/components/pages/navigation-pane/root.tsx
@@ -11,7 +11,7 @@ import { ArrowRightCircle } from "lucide-react";
 // plane imports
 import { useTranslation } from "@plane/i18n";
 import { Tabs } from "@plane/propel/tabs";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 // hooks
 import { useQueryParams } from "@/hooks/use-query-params";
 // plane web components
@@ -94,7 +94,7 @@ export const PageNavigationPaneRoot = observer(function PageNavigationPaneRoot(p
       }}
     >
       <div className="mb-3.5 px-3.5">
-        <Tooltip tooltipContent={t("page_navigation_pane.close_button")}>
+        <Tooltip label={t("page_navigation_pane.close_button")}>
           <button
             type="button"
             className="grid size-3.5 place-items-center text-secondary transition-colors hover:text-primary"

--- a/apps/web/core/components/profile/sidebar.tsx
+++ b/apps/web/core/components/profile/sidebar.tsx
@@ -14,7 +14,7 @@ import { useTranslation } from "@plane/i18n";
 import { Logo } from "@plane/propel/emoji-icon-picker";
 import { IconButton } from "@plane/propel/icon-button";
 import { EditIcon, ChevronDownIcon } from "@plane/propel/icons";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import type { IUserProfileProjectSegregation } from "@plane/types";
 import { Loader } from "@plane/ui";
 import { cn, renderFormattedDate, getFileURL } from "@plane/utils";
@@ -171,7 +171,7 @@ export const ProfileSidebar = observer(function ProfileSidebar(props: TProfileSi
                           </div>
                           <div className="flex flex-shrink-0 items-center gap-2">
                             {project.assigned_issues > 0 && (
-                              <Tooltip tooltipContent="Completion percentage" position="left" isMobile={isMobile}>
+                              <Tooltip label="Completion percentage" side="left" disabled={isMobile}>
                                 <div
                                   className={`rounded-sm px-1 py-0.5 text-11 font-medium ${
                                     completedIssuePercentage <= 35

--- a/apps/web/core/components/project-states/options/delete.tsx
+++ b/apps/web/core/components/project-states/options/delete.tsx
@@ -10,7 +10,7 @@ import { Loader } from "lucide-react";
 import { CloseIcon } from "@plane/propel/icons";
 // plane imports
 import { TOAST_TYPE, setToast } from "@plane/propel/toast";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import type { IState, TStateOperationsCallbacks } from "@plane/types";
 import { AlertModalCore } from "@plane/ui";
 import { cn } from "@plane/utils";
@@ -87,12 +87,11 @@ export const StateDelete = observer(function StateDelete(props: TStateDelete) {
         onClick={() => setIsDeleteModal(true)}
       >
         <Tooltip
-          tooltipContent={
+          label={
             state.default ? "Cannot delete the default state." : totalStates === 1 ? `Cannot have an empty group.` : ``
           }
-          isMobile={isMobile}
-          disabled={!isDeleteDisabled}
-          className="focus:outline-none"
+          layout="stacked"
+          disabled={!isDeleteDisabled || isMobile}
         >
           {isDelete ? <Loader className="h-3.5 w-3.5 text-secondary" /> : <CloseIcon className="h-3.5 w-3.5" />}
         </Tooltip>

--- a/apps/web/core/components/project/applied-filters/root.tsx
+++ b/apps/web/core/components/project/applied-filters/root.tsx
@@ -8,7 +8,7 @@ import { useTranslation } from "@plane/i18n";
 import { PillButton } from "@makeplane/propel/components/pill";
 import { CloseIcon } from "@plane/propel/icons";
 // plane imports
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import type { TProjectAppliedDisplayFilterKeys, TProjectFilters } from "@plane/types";
 import { EHeaderVariant, Header } from "@plane/ui";
 import { replaceUnderscoreIfSnakeCase } from "@plane/utils";
@@ -125,14 +125,7 @@ export function ProjectAppliedFiltersList(props: Props) {
         )}
       </Header.LeftItem>
       <Header.RightItem>
-        <Tooltip
-          tooltipContent={
-            <p>
-              <span className="font-semibold">{filteredProjects}</span> of{" "}
-              <span className="font-semibold">{totalProjects}</span> projects match the applied filters.
-            </p>
-          }
-        >
+        <Tooltip label={`${filteredProjects} of ${totalProjects} projects match the applied filters.`} layout="stacked">
           <span className="rounded-full bg-layer-1 px-2.5 py-1 text-13 font-medium">
             {filteredProjects}/{totalProjects}
           </span>

--- a/apps/web/core/components/project/card.tsx
+++ b/apps/web/core/components/project/card.tsx
@@ -16,7 +16,7 @@ import { Button } from "@plane/propel/button";
 import { Logo } from "@plane/propel/emoji-icon-picker";
 import { LinkIcon, LockIcon, NewTabIcon, TrashIcon, CheckIcon } from "@plane/propel/icons";
 import { setPromiseToast, setToast, TOAST_TYPE } from "@plane/propel/toast";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import type { IProject } from "@plane/types";
 import type { TContextMenuItem } from "@plane/ui";
 import { Avatar, AvatarGroup, ContextMenu, FavoriteStar } from "@plane/ui";
@@ -279,12 +279,9 @@ export const ProjectCard = observer(function ProjectCard(props: Props) {
           <div className="item-center flex justify-between">
             <div className="flex items-center justify-center gap-2">
               <Tooltip
-                isMobile={isMobile}
-                tooltipHeading="Members"
-                tooltipContent={
-                  project.members && project.members.length > 0 ? `${project.members.length} Members` : "No Member"
-                }
-                position="top"
+                label={project.members?.length ? `Members: ${project.members.length}` : "No members"}
+                layout="stacked"
+                disabled={isMobile}
               >
                 {projectMembersIds && projectMembersIds.length > 0 ? (
                   <div className="flex cursor-pointer items-center gap-2 text-secondary">

--- a/apps/web/core/components/project/create/common-attributes.tsx
+++ b/apps/web/core/components/project/create/common-attributes.tsx
@@ -15,7 +15,7 @@ import { ETabIndices } from "@plane/constants";
 import { useTranslation } from "@plane/i18n";
 import type { TProject } from "@plane/types";
 // ui
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import { TextArea } from "@plane/ui";
 import { cn, projectIdentifierSanitizer, getTabIndex } from "@plane/utils";
 
@@ -124,10 +124,11 @@ function ProjectCommonAttributes(props: Props) {
           )}
         />
         <Tooltip
-          isMobile={isMobile}
-          tooltipContent={t("project_id_tooltip_content")}
-          className="text-13"
-          position="right-start"
+          label={t("project_id_tooltip_content")}
+          layout="stacked"
+          side="right"
+          align="start"
+          disabled={isMobile}
         >
           <InfoIcon className="absolute top-2.5 right-2 h-3 w-3 text-placeholder" />
         </Tooltip>

--- a/apps/web/core/components/project/form.tsx
+++ b/apps/web/core/components/project/form.tsx
@@ -16,7 +16,7 @@ import { Button } from "@plane/propel/button";
 import { EmojiPicker, EmojiIconPickerTypes, Logo } from "@plane/propel/emoji-icon-picker";
 import { LockIcon } from "@plane/propel/icons";
 import { TOAST_TYPE, setToast } from "@plane/propel/toast";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import { EFileAssetType } from "@plane/types";
 import type { IProject, IWorkspace } from "@plane/types";
 import { CustomSelect, TextArea } from "@plane/ui";
@@ -365,10 +365,11 @@ export function ProjectDetailsForm(props: IProjectDetailsForm) {
                 )}
               />
               <Tooltip
-                isMobile={isMobile}
-                tooltipContent={t("project_id_tooltip_content")}
-                className="text-13"
-                position="right-start"
+                label={t("project_id_tooltip_content")}
+                layout="stacked"
+                side="right"
+                align="start"
+                disabled={isMobile}
               >
                 <Info className="absolute top-2.5 right-2 h-4 w-4 text-placeholder" />
               </Tooltip>

--- a/apps/web/core/components/project/settings/features-list.tsx
+++ b/apps/web/core/components/project/settings/features-list.tsx
@@ -8,7 +8,7 @@ import { observer } from "mobx-react";
 // plane imports
 import { useTranslation } from "@plane/i18n";
 import { setPromiseToast } from "@plane/propel/toast";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import type { IProject } from "@plane/types";
 import { CycleIcon, IntakeIcon, ModuleIcon, PageIcon, ViewsIcon } from "@plane/propel/icons";
 // components
@@ -120,7 +120,7 @@ export const ProjectFeaturesList = observer(function ProjectFeaturesList(props: 
                   <span className="flex items-center gap-2">
                     {t(featureItem.key)}
                     {featureItem.isPro && (
-                      <Tooltip tooltipContent="Pro feature" position="top">
+                      <Tooltip label="Pro feature">
                         <UpgradeBadge className="rounded-sm" />
                       </Tooltip>
                     )}

--- a/apps/web/core/components/readonly/labels.tsx
+++ b/apps/web/core/components/readonly/labels.tsx
@@ -7,7 +7,7 @@
 import { useEffect } from "react";
 import { observer } from "mobx-react";
 // plane imports
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import { cn } from "@plane/utils";
 // hooks
 import { useLabel } from "@/hooks/store/use-label";
@@ -42,11 +42,9 @@ export const ReadonlyLabels = observer(function ReadonlyLabels(props: TReadonlyL
       {labels && (
         <>
           <Tooltip
-            position="top"
-            tooltipHeading="Labels"
-            tooltipContent={labels.map((l) => l?.name).join(", ")}
-            isMobile={isMobile}
-            disabled={labels.length === 0}
+            label={`Labels: ${labels.map((l) => l?.name).join(", ")}`}
+            layout="stacked"
+            disabled={labels.length === 0 || isMobile}
           >
             <div className="flex h-full items-center gap-1 rounded-sm py-1 text-body-xs-bold">
               <span className="h-2 w-2 flex-shrink-0 rounded-full bg-accent-primary" />

--- a/apps/web/core/components/rich-filters/filter-item/container.tsx
+++ b/apps/web/core/components/rich-filters/filter-item/container.tsx
@@ -6,7 +6,7 @@
 
 import { useEffect, useRef } from "react";
 // plane imports
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import { cn } from "@plane/propel/utils";
 import type { SingleOrArray, TFilterValue } from "@plane/types";
 import { hasValidValue } from "@plane/utils";
@@ -16,7 +16,7 @@ interface FilterItemContainerProps {
   conditionValue: SingleOrArray<TFilterValue>;
   showTransition: boolean;
   variant?: "default" | "error";
-  tooltipContent?: React.ReactNode;
+  tooltipContent?: string;
 }
 
 export function FilterItemContainer(props: FilterItemContainerProps) {
@@ -55,7 +55,7 @@ export function FilterItemContainer(props: FilterItemContainerProps) {
   }, []);
 
   return (
-    <Tooltip tooltipContent={tooltipContent} position="bottom" disabled={!tooltipContent}>
+    <Tooltip label={tooltipContent ?? ""} layout="stacked" side="bottom" disabled={!tooltipContent}>
       <div
         ref={itemRef}
         className={cn("flex h-7 items-stretch overflow-hidden rounded-sm border transition-all duration-200", {

--- a/apps/web/core/components/rich-filters/filter-item/property.tsx
+++ b/apps/web/core/components/rich-filters/filter-item/property.tsx
@@ -6,7 +6,7 @@
 
 import { observer } from "mobx-react";
 // plane imports
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import { cn } from "@plane/propel/utils";
 import type { IFilterInstance } from "@plane/shared-state";
 import type { TExternalFilter, TFilterProperty, TSupportedOperators } from "@plane/types";
@@ -20,7 +20,7 @@ interface IFilterItemPropertyProps<P extends TFilterProperty, E extends TExterna
   isDisabled?: boolean;
   filter: IFilterInstance<P, E>;
   label: string;
-  tooltipContent?: React.ReactNode | undefined;
+  tooltipContent?: string;
 }
 
 export const FilterItemProperty = observer(function FilterItemProperty<
@@ -54,7 +54,7 @@ function PropertyButton<P extends TFilterProperty, E extends TExternalFilter>(pr
   const { icon: Icon, label, tooltipContent, className } = props;
 
   return (
-    <Tooltip tooltipContent={tooltipContent} position="bottom-start" disabled={!tooltipContent}>
+    <Tooltip label={tooltipContent ?? ""} layout="stacked" side="bottom" align="start" disabled={!tooltipContent}>
       <div
         className={cn(
           "flex h-full min-w-0 items-center gap-1 px-2 py-[5px] text-11 text-tertiary",

--- a/apps/web/core/components/rich-filters/filter-item/root.tsx
+++ b/apps/web/core/components/rich-filters/filter-item/root.tsx
@@ -92,7 +92,7 @@ export const FilterItem = observer(function FilterItem<P extends TFilterProperty
         icon={filterConfig.icon}
         isDisabled={isDisabled}
         label={filterConfig.label}
-        tooltipContent={filterConfig.tooltipContent}
+        tooltipContent={typeof filterConfig.tooltipContent === "string" ? filterConfig.tooltipContent : undefined}
       />
 
       {/* Operator section */}

--- a/apps/web/core/components/stickies/action-bar.tsx
+++ b/apps/web/core/components/stickies/action-bar.tsx
@@ -91,7 +91,7 @@ export const StickyActionBar = observer(function StickyActionBar() {
                   <StickyNote
                     className="w-full"
                     workspaceSlug={workspaceSlug.toString()}
-                    stickyId={newSticky ? activeStickyId : recentStickyId || ""}
+                    stickyId={newSticky ? activeStickyId : recentStickyId}
                   />
                   <div
                     className="absolute top-0 right-0 h-full w-full"
@@ -140,7 +140,7 @@ export const StickyActionBar = observer(function StickyActionBar() {
             className={"w-[290px]"}
             onClose={() => (newSticky ? setNewSticky(false) : setShowRecentSticky(false))}
             workspaceSlug={workspaceSlug.toString()}
-            stickyId={newSticky ? activeStickyId : recentStickyId || ""}
+            stickyId={newSticky ? activeStickyId : recentStickyId}
           />
         )}
       </div>

--- a/apps/web/core/components/stickies/action-bar.tsx
+++ b/apps/web/core/components/stickies/action-bar.tsx
@@ -13,7 +13,8 @@ import { StickyNote as StickyIcon } from "lucide-react";
 import { useOutsideClickDetector } from "@plane/hooks";
 // plane ui
 import { RecentStickyIcon, StickyNoteIcon, PlusIcon, CloseIcon } from "@plane/propel/icons";
-import { Tooltip } from "@plane/propel/tooltip";
+import { PreviewCard, PreviewCardContent, PreviewCardTrigger } from "@makeplane/propel/components/preview-card";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 // plane utils
 import { cn } from "@plane/utils";
 // hooks
@@ -53,6 +54,16 @@ export const StickyActionBar = observer(function StickyActionBar() {
     setIsExpanded(false);
   });
 
+  const recentStickyButton = (
+    <button
+      className="btn btn--icon shadow-sm flex h-10 w-10 items-center justify-center rounded-full bg-surface-1"
+      onClick={() => setShowRecentSticky(true)}
+      style={{ color: recentStickyBackgroundColor }}
+    >
+      <StickyNoteIcon className={cn("size-5 rotate-90")} color={recentStickyBackgroundColor} />
+    </button>
+  );
+
   return (
     <div
       ref={ref}
@@ -61,7 +72,7 @@ export const StickyActionBar = observer(function StickyActionBar() {
       <div
         className={`flex origin-bottom flex-col gap-2 transition-all duration-300 ease-in-out ${isExpanded ? "mb-2 scale-y-100 opacity-100 " : "h-0 scale-y-0 opacity-0"}`}
       >
-        <Tooltip tooltipContent="All stickies" isMobile={false} position="left">
+        <Tooltip label="All stickies" side="left">
           <button
             className="btn btn--icon shadow-sm flex h-10 w-10 items-center justify-center rounded-full bg-surface-1"
             onClick={() => toggleAllStickiesModal(true)}
@@ -69,38 +80,30 @@ export const StickyActionBar = observer(function StickyActionBar() {
             <RecentStickyIcon className="size-5 rotate-90 text-tertiary" />
           </button>
         </Tooltip>
-        {recentStickyId && (
-          <Tooltip
-            className="-mr-30 translate-x-10 scale-75"
-            tooltipContent={
-              <div className="-m-2 max-h-[150px]">
-                <StickyNote
-                  className={"w-[290px]"}
-                  workspaceSlug={workspaceSlug.toString()}
-                  stickyId={newSticky ? activeStickyId : recentStickyId || ""}
-                />
-                <div
-                  className="absolute top-0 right-0 h-full w-full"
-                  style={{
-                    background: `linear-gradient(to top, ${recentStickyBackgroundColor}, transparent)`,
-                  }}
-                />
-              </div>
-            }
-            isMobile={false}
-            position="left"
-            disabled={showRecentSticky}
-          >
-            <button
-              className="btn btn--icon shadow-sm flex h-10 w-10 items-center justify-center rounded-full bg-surface-1"
-              onClick={() => setShowRecentSticky(true)}
-              style={{ color: recentStickyBackgroundColor }}
-            >
-              <StickyNoteIcon className={cn("size-5 rotate-90")} color={recentStickyBackgroundColor} />
-            </button>
-          </Tooltip>
-        )}
-        <Tooltip tooltipContent="Add sticky" isMobile={false} position="left">
+        {recentStickyId &&
+          (showRecentSticky ? (
+            recentStickyButton
+          ) : (
+            <PreviewCard>
+              <PreviewCardTrigger render={recentStickyButton} />
+              <PreviewCardContent side="left">
+                <div className="relative max-h-[150px] overflow-hidden rounded-lg">
+                  <StickyNote
+                    className="w-full"
+                    workspaceSlug={workspaceSlug.toString()}
+                    stickyId={newSticky ? activeStickyId : recentStickyId || ""}
+                  />
+                  <div
+                    className="absolute top-0 right-0 h-full w-full"
+                    style={{
+                      background: `linear-gradient(to top, ${recentStickyBackgroundColor}, transparent)`,
+                    }}
+                  />
+                </div>
+              </PreviewCardContent>
+            </PreviewCard>
+          ))}
+        <Tooltip label="Add sticky" side="left">
           <button
             className="btn btn--icon shadow-sm flex h-10 w-10 items-center justify-center rounded-full bg-surface-1"
             onClick={() => {

--- a/apps/web/core/components/ui/labels-list.tsx
+++ b/apps/web/core/components/ui/labels-list.tsx
@@ -5,7 +5,7 @@
  */
 
 // ui
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import type { IIssueLabel } from "@plane/types";
 // types
 import { usePlatformOS } from "@/hooks/use-platform-os";
@@ -24,12 +24,7 @@ export function IssueLabelsList(props: IssueLabelsListProps) {
     <>
       {labels && (
         <>
-          <Tooltip
-            position="top"
-            tooltipHeading="Labels"
-            tooltipContent={labels.map((l) => l?.name).join(", ")}
-            isMobile={isMobile}
-          >
+          <Tooltip label={`Labels: ${labels.map((l) => l?.name).join(", ")}`} layout="stacked" disabled={isMobile}>
             <div className="flex h-full items-center gap-1 rounded-sm border-[0.5px] border-strong px-2 py-1 text-11 text-secondary">
               <span className="h-2 w-2 flex-shrink-0 rounded-full bg-accent-primary" />
               <span>{labels.length}</span>

--- a/apps/web/core/components/views/view-list-item-action.tsx
+++ b/apps/web/core/components/views/view-list-item-action.tsx
@@ -12,7 +12,7 @@ import { Earth } from "lucide-react";
 import { EUserPermissions, EUserPermissionsLevel, IS_FAVORITE_MENU_OPEN } from "@plane/constants";
 import { useLocalStorage } from "@plane/hooks";
 import { LockIcon } from "@plane/propel/icons";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import type { IProjectView } from "@plane/types";
 import { EViewAccess } from "@plane/types";
 import { FavoriteStar } from "@plane/ui";
@@ -91,7 +91,7 @@ export const ViewListItemAction = observer(function ViewListItemAction(props: Pr
       )}
       <DeleteProjectViewModal data={view} isOpen={deleteViewModal} onClose={() => setDeleteViewModal(false)} />
       <div className="cursor-default text-tertiary">
-        <Tooltip tooltipContent={access === EViewAccess.PUBLIC ? "Public" : "Private"}>
+        <Tooltip label={access === EViewAccess.PUBLIC ? "Public" : "Private"}>
           {access === EViewAccess.PUBLIC ? <Earth className="h-4 w-4" /> : <LockIcon className="h-4 w-4" />}
         </Tooltip>
       </div>

--- a/apps/web/core/components/web-hooks/form/secret-key.tsx
+++ b/apps/web/core/components/web-hooks/form/secret-key.tsx
@@ -14,7 +14,7 @@ import { useTranslation } from "@plane/i18n";
 import { Button } from "@plane/propel/button";
 import { CopyIcon } from "@plane/propel/icons";
 import { TOAST_TYPE, setToast } from "@plane/propel/toast";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import type { IWebhook } from "@plane/types";
 // ui
 import { csvDownload, copyTextToClipboard } from "@plane/utils";
@@ -122,7 +122,7 @@ export const WebhookSecretKey = observer(function WebhookSecretKey(props: Props)
               {webhookSecretKey && (
                 <div className="flex items-center gap-2">
                   {SECRET_KEY_OPTIONS.map((option) => (
-                    <Tooltip key={option.key} tooltipContent={option.label} isMobile={isMobile}>
+                    <Tooltip key={option.key} label={option.label} layout="stacked" disabled={isMobile}>
                       <button type="button" className="grid flex-shrink-0 place-items-center" onClick={option.onClick}>
                         <option.Icon className="h-3 w-3 text-placeholder" />
                       </button>

--- a/apps/web/core/components/workspace-notifications/sidebar/filters/menu/root.tsx
+++ b/apps/web/core/components/workspace-notifications/sidebar/filters/menu/root.tsx
@@ -10,7 +10,7 @@ import { ListFilter } from "lucide-react";
 import type { ENotificationFilterType } from "@plane/constants";
 import { FILTER_TYPE_OPTIONS } from "@plane/constants";
 import { useTranslation } from "@plane/i18n";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import { PopoverMenu } from "@plane/ui";
 // hooks
 import { usePlatformOS } from "@/hooks/use-platform-os";
@@ -32,7 +32,7 @@ export const NotificationFilter = observer(function NotificationFilter() {
     <PopoverMenu
       data={translatedFilterTypeOptions}
       button={
-        <Tooltip tooltipContent={t("notification.options.filters")} isMobile={isMobile} position="bottom">
+        <Tooltip label={t("notification.options.filters")} side="bottom" disabled={isMobile}>
           <IconButton size="base" variant="ghost" icon={ListFilter} />
         </Tooltip>
       }

--- a/apps/web/core/components/workspace-notifications/sidebar/header/options/root.tsx
+++ b/apps/web/core/components/workspace-notifications/sidebar/header/options/root.tsx
@@ -9,7 +9,7 @@ import { CheckCheck, RefreshCw } from "lucide-react";
 // plane imports
 import { ENotificationLoader, ENotificationQueryParamType } from "@plane/constants";
 import { useTranslation } from "@plane/i18n";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import { Spinner } from "@plane/ui";
 // hooks
 import { useWorkspaceNotifications } from "@/hooks/store/notifications";
@@ -54,7 +54,7 @@ export const NotificationSidebarHeaderOptions = observer(function NotificationSi
   return (
     <div className="relative flex items-center justify-center gap-2 text-body-xs-medium">
       {/* mark all notifications as read*/}
-      <Tooltip tooltipContent={t("notification.options.mark_all_as_read")} isMobile={isMobile} position="bottom">
+      <Tooltip label={t("notification.options.mark_all_as_read")} side="bottom" disabled={isMobile}>
         <IconButton
           size="base"
           variant="ghost"
@@ -66,7 +66,7 @@ export const NotificationSidebarHeaderOptions = observer(function NotificationSi
       </Tooltip>
 
       {/* refetch current notifications */}
-      <Tooltip tooltipContent={t("notification.options.refresh")} isMobile={isMobile} position="bottom">
+      <Tooltip label={t("notification.options.refresh")} side="bottom" disabled={isMobile}>
         <IconButton
           size="base"
           variant="ghost"

--- a/apps/web/core/components/workspace-notifications/sidebar/notification-card/options/button.tsx
+++ b/apps/web/core/components/workspace-notifications/sidebar/notification-card/options/button.tsx
@@ -5,7 +5,7 @@
  */
 
 import type { ReactNode } from "react";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 // helpers
 import { cn } from "@plane/utils";
 // hooks
@@ -24,7 +24,7 @@ export function NotificationItemOptionButton(props: TNotificationItemOptionButto
   const { isMobile } = usePlatformOS();
 
   return (
-    <Tooltip tooltipContent={tooltipContent} isMobile={isMobile}>
+    <Tooltip label={tooltipContent} layout="stacked" disabled={isMobile}>
       <button
         type="button"
         className={cn(

--- a/apps/web/core/components/workspace-notifications/sidebar/notification-card/options/snooze/root.tsx
+++ b/apps/web/core/components/workspace-notifications/sidebar/notification-card/options/snooze/root.tsx
@@ -13,7 +13,7 @@ import { Popover, Transition } from "@headlessui/react";
 import { NOTIFICATION_SNOOZE_OPTIONS } from "@plane/constants";
 import { useTranslation } from "@plane/i18n";
 import { TOAST_TYPE, setToast } from "@plane/propel/toast";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import { cn } from "@plane/utils";
 // hooks
 import { useWorkspaceNotifications } from "@/hooks/store/notifications";
@@ -97,10 +97,10 @@ export const NotificationItemSnoozeOption = observer(function NotificationItemSn
           return (
             <>
               <Tooltip
-                tooltipContent={
+                label={
                   data.snoozed_till ? t("notification.options.mark_unsnooze") : t("notification.options.mark_snooze")
                 }
-                isMobile={isMobile}
+                disabled={isMobile}
               >
                 <Popover.Button
                   className={cn(

--- a/apps/web/core/components/workspace/edition-badge.tsx
+++ b/apps/web/core/components/workspace/edition-badge.tsx
@@ -8,7 +8,7 @@ import { useState } from "react";
 import { observer } from "mobx-react";
 // ui
 import { useTranslation } from "@plane/i18n";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 // hooks
 import { usePlatformOS } from "@/hooks/use-platform-os";
 import packageJson from "package.json";
@@ -30,7 +30,7 @@ export const WorkspaceEditionBadge = observer(function WorkspaceEditionBadge() {
         isOpen={isPaidPlanPurchaseModalOpen}
         handleClose={() => setIsPaidPlanPurchaseModalOpen(false)}
       />
-      <Tooltip tooltipContent={`Version: v${packageJson.version}`} isMobile={isMobile}>
+      <Tooltip label={`Version: v${packageJson.version}`} disabled={isMobile}>
         <Button
           variant="tertiary"
           size="lg"

--- a/apps/web/core/components/workspace/sidebar/extended-sidebar-item.tsx
+++ b/apps/web/core/components/workspace/sidebar/extended-sidebar-item.tsx
@@ -16,7 +16,7 @@ import { Pin, PinOff } from "lucide-react";
 import type { IWorkspaceSidebarNavigationItem } from "@plane/constants";
 import { EUserPermissionsLevel } from "@plane/constants";
 import { useTranslation } from "@plane/i18n";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import { DragHandle, DropIndicator } from "@plane/ui";
 import { cn } from "@plane/utils";
 // components
@@ -172,12 +172,7 @@ export const ExtendedSidebarItem = observer(function ExtendedSidebarItem(props: 
         id={`${item.key}`}
       >
         {!disableDrag && (
-          <Tooltip
-            // isMobile={isMobile}
-            tooltipContent={t("drag_to_rearrange")}
-            position="top-start"
-            disabled={isDragging}
-          >
+          <Tooltip label={t("drag_to_rearrange")} align="start" disabled={isDragging}>
             <button
               type="button"
               className={cn(
@@ -207,14 +202,14 @@ export const ExtendedSidebarItem = observer(function ExtendedSidebarItem(props: 
               </div>
             )}
             {isPinned ? (
-              <Tooltip tooltipContent="Unpin">
+              <Tooltip label="Unpin">
                 <PinOff
                   className="size-3.5 flex-shrink-0 text-placeholder outline-none hover:text-tertiary"
                   onClick={() => unPinNavigationItem(item.key)}
                 />
               </Tooltip>
             ) : (
-              <Tooltip tooltipContent="Pin">
+              <Tooltip label="Pin">
                 <Pin
                   className="size-3.5 flex-shrink-0 text-placeholder outline-none hover:text-tertiary"
                   onClick={() => pinNavigationItem(item.key)}

--- a/apps/web/core/components/workspace/sidebar/favorites/favorite-folder.tsx
+++ b/apps/web/core/components/workspace/sidebar/favorites/favorite-folder.tsx
@@ -25,7 +25,7 @@ import { Disclosure, Transition } from "@headlessui/react";
 import { useOutsideClickDetector } from "@plane/hooks";
 import { useTranslation } from "@plane/i18n";
 import { DraftIcon, FavoriteFolderIcon, ChevronRightIcon } from "@plane/propel/icons";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import type { IFavorite, InstructionType } from "@plane/types";
 import { CustomMenu, DropIndicator, DragHandle } from "@plane/ui";
 // helpers
@@ -173,7 +173,7 @@ export function FavoriteFolder(props: Props) {
               </div>
 
               <>
-                <Tooltip tooltipContent={`${favorite.name}`} position="right" className="ml-8" isMobile={isMobile}>
+                <Tooltip label={`${favorite.name}`} layout="stacked" side="right" sideOffset={40} disabled={isMobile}>
                   <div className="flex flex-grow truncate">
                     <Disclosure.Button
                       as="button"
@@ -181,12 +181,9 @@ export function FavoriteFolder(props: Props) {
                       className="flex w-full flex-grow items-center gap-1.5 text-left select-none"
                     >
                       <Tooltip
-                        isMobile={isMobile}
-                        tooltipContent={
-                          favorite.sort_order === null ? "Join the project to rearrange" : "Drag to rearrange"
-                        }
-                        position="top-end"
-                        disabled={isDragging}
+                        label={favorite.sort_order === null ? "Join the project to rearrange" : "Drag to rearrange"}
+                        align="end"
+                        disabled={isDragging || isMobile}
                       >
                         <button
                           type="button"

--- a/apps/web/core/components/workspace/sidebar/favorites/favorite-items/common/favorite-item-drag-handle.tsx
+++ b/apps/web/core/components/workspace/sidebar/favorites/favorite-items/common/favorite-item-drag-handle.tsx
@@ -7,7 +7,7 @@
 import React from "react";
 import { observer } from "mobx-react";
 // ui
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import { DragHandle } from "@plane/ui";
 // helper
 import { cn } from "@plane/utils";
@@ -26,10 +26,9 @@ export const FavoriteItemDragHandle = observer(function FavoriteItemDragHandle(p
 
   return (
     <Tooltip
-      isMobile={isMobile}
-      tooltipContent={sort_order === null ? "Join the project to rearrange" : "Drag to rearrange"}
-      position="top-end"
-      disabled={isDragging}
+      label={sort_order === null ? "Join the project to rearrange" : "Drag to rearrange"}
+      align="end"
+      disabled={isDragging || isMobile}
     >
       <div
         className={cn(

--- a/apps/web/core/components/workspace/sidebar/favorites/favorite-items/common/favorite-item-title.tsx
+++ b/apps/web/core/components/workspace/sidebar/favorites/favorite-items/common/favorite-item-title.tsx
@@ -7,7 +7,7 @@
 import React from "react";
 import { observer } from "mobx-react";
 import Link from "next/link";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import { useAppTheme } from "@/hooks/store/use-app-theme";
 import { usePlatformOS } from "@/hooks/use-platform-os";
 
@@ -28,7 +28,7 @@ export const FavoriteItemTitle = observer(function FavoriteItemTitle(props: Prop
   };
 
   return (
-    <Tooltip tooltipContent={title} isMobile={isMobile} position="right" className="ml-8">
+    <Tooltip label={title} layout="stacked" side="right" sideOffset={40} disabled={isMobile}>
       <Link href={href} className="flex w-full items-center gap-1.5 truncate" draggable onClick={handleOnClick}>
         <span className="flex size-5 items-center justify-center">{icon}</span>
         <span className="flex-1 truncate text-13 leading-5 font-medium">{title}</span>

--- a/apps/web/core/components/workspace/sidebar/favorites/favorites-menu.tsx
+++ b/apps/web/core/components/workspace/sidebar/favorites/favorites-menu.tsx
@@ -22,7 +22,7 @@ import { useTranslation } from "@plane/i18n";
 import { ChevronRightIcon } from "@plane/propel/icons";
 // ui
 import { TOAST_TYPE, setToast } from "@plane/propel/toast";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import type { IFavorite } from "@plane/types";
 // helpers
 import { cn } from "@plane/utils";
@@ -206,7 +206,7 @@ export const SidebarFavoritesMenu = observer(function SidebarFavoritesMenu() {
             <span className="text-13 font-semibold">{t("favorites")}</span>
           </Disclosure.Button>
           <div className="pointer-events-none flex items-center opacity-0 group-hover/favorites-button:pointer-events-auto group-hover/favorites-button:opacity-100">
-            <Tooltip tooltipHeading={t("create_folder")} tooltipContent="">
+            <Tooltip label={t("create_folder")}>
               <IconButton
                 variant="ghost"
                 size="sm"

--- a/apps/web/core/components/workspace/sidebar/projects-list-item.tsx
+++ b/apps/web/core/components/workspace/sidebar/projects-list-item.tsx
@@ -23,7 +23,7 @@ import { useTranslation } from "@plane/i18n";
 import { Logo } from "@plane/propel/emoji-icon-picker";
 import { LinkIcon, ArchiveIcon, ChevronRightIcon } from "@plane/propel/icons";
 import { IconButton } from "@plane/propel/icon-button";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import { CustomMenu, DropIndicator, DragHandle, ControlLink } from "@plane/ui";
 import { cn } from "@plane/utils";
 // components
@@ -302,12 +302,9 @@ export const SidebarProjectsListItem = observer(function SidebarProjectsListItem
           >
             {!disableDrag && (
               <Tooltip
-                isMobile={isMobile}
-                tooltipContent={
-                  project.sort_order === null ? t("join_the_project_to_rearrange") : t("drag_to_rearrange")
-                }
-                position="top-end"
-                disabled={isDragging}
+                label={project.sort_order === null ? t("join_the_project_to_rearrange") : t("drag_to_rearrange")}
+                align="end"
+                disabled={isDragging || isMobile}
               >
                 <button
                   type="button"

--- a/apps/web/core/components/workspace/sidebar/projects-list.tsx
+++ b/apps/web/core/components/workspace/sidebar/projects-list.tsx
@@ -17,7 +17,7 @@ import { useTranslation } from "@plane/i18n";
 import { PlusIcon, ChevronRightIcon } from "@plane/propel/icons";
 import { IconButton } from "@plane/propel/icon-button";
 import { TOAST_TYPE, setToast } from "@plane/propel/toast";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import { Loader } from "@plane/ui";
 import { copyUrlToClipboard, cn, orderJoinedProjects } from "@plane/utils";
 // components
@@ -187,7 +187,7 @@ export const SidebarProjectsList = observer(function SidebarProjectsList() {
               </Disclosure.Button>
               <div className="flex items-center gap-1">
                 {isAuthorizedUser && (
-                  <Tooltip tooltipHeading={t("create_project")} tooltipContent="">
+                  <Tooltip label={t("create_project")}>
                     <IconButton
                       variant="ghost"
                       size="sm"

--- a/apps/web/core/layouts/auth-layout/workspace-wrapper.tsx
+++ b/apps/web/core/layouts/auth-layout/workspace-wrapper.tsx
@@ -15,7 +15,7 @@ import { EUserPermissions, EUserPermissionsLevel } from "@plane/constants";
 import { Button, getButtonStyling } from "@plane/propel/button";
 import { PlaneLogo } from "@plane/propel/icons";
 import { TOAST_TYPE, setToast } from "@plane/propel/toast";
-import { Tooltip } from "@plane/propel/tooltip";
+import { Tooltip } from "@makeplane/propel/components/tooltip";
 import { cn } from "@plane/utils";
 // assets
 import WorkSpaceNotAvailable from "@/app/assets/workspace/workspace-not-available.png?url";
@@ -163,7 +163,7 @@ export const WorkspaceAuthWrapper = observer(function WorkspaceAuthWrapper(props
                 className="relative flex h-6 w-6 flex-shrink-0 cursor-pointer items-center justify-center overflow-hidden rounded-sm hover:bg-layer-1"
                 onClick={handleSignOut}
               >
-                <Tooltip tooltipContent={"Sign out"} position="top" className="ml-2" isMobile={isMobile}>
+                <Tooltip label={"Sign out"} alignOffset={8} disabled={isMobile}>
                   <LogOut size={14} />
                 </Tooltip>
               </div>


### PR DESCRIPTION
### Description

Moves all **144 `<Tooltip>` call sites in `apps/web`** off the in-repo `@plane/propel/tooltip` and onto the published `@makeplane/propel/components/tooltip`. Part of the in-repo → published Propel wave (PR 3 in `docs/plane-propel-to-makeplane-plan.md`). No `@plane/ui` migration is mixed in, and `packages/propel` is untouched.

**Prop mapping, applied identically on every site:**

| In-repo | Published |
|---|---|
| `tooltipContent` | `label` (string) |
| `tooltipHeading` | folded into `label` + `layout="stacked"` |
| `position` | `side` / `align` — `top`/`center` omitted, it's the published default |
| `isMobile` | `disabled` (OR'd with any existing `disabled`) |
| `renderByDefault` | dropped — the in-repo Tooltip declared it but never read it |
| `className` | dropped, or mapped to `sideOffset` / `alignOffset` (3 sites) |

Resulting distribution: 144 `label`, 92 `disabled`, 71 `layout`, 26 `side`, 13 `align`, 3 `shortcut`, 2 `sideOffset`, 1 `alignOffset`, **0 `className`**.

**`layout` choice.** `single` is `whitespace-nowrap`, so a long label would render as one very wide chip and overflow the viewport — the in-repo tooltip wrapped at `max-w-xs`. So `single` is used only for short, bounded copy (39 sites); `stacked` wherever the label interpolates unbounded data such as work item names, page titles, URLs, or joined label lists.

**⚠️ Behavior change — tooltip open delay is now 600ms, was 200ms.** The in-repo component defaulted `openDelay = 200` and no call site overrode it. `delay` is deliberately not set per site, so every tooltip now takes Base UI's published `OPEN_DELAY` of 600ms. This is a deliberate move to the design-system default, but it is user-perceptible across the whole app. If we'd rather keep the old feel, a single `<TooltipProvider delay={200}>` in `apps/web/app/provider.tsx` covers all sites.

**ReactNode content (15 sites).** The published `label` is a `string`, so nothing was stuffed into it:
- **Editor toolbars (5)** — `item.name` + `<kbd>{shortcut}</kbd>` maps cleanly onto the published `shortcut` prop.
- **`<br/>` / fragment copy (6)** — folded into one wrapping `stacked` string.
- **`stickies/action-bar.tsx`** — this was never a tooltip; it rendered a full `<StickyNote>` hover preview. Moved to `PreviewCard` / `PreviewCardTrigger` / `PreviewCardContent`. **This is the one site worth a design review.**
- **`exporter/export-form.tsx`** — dead code inside a commented-out JSX block; updated so no stale `@plane/propel` reference is left behind.

**Type narrowing.** `DropdownButtonProps.tooltipContent`, date-range's `customTooltipContent`, and the two `rich-filters` components narrow from `ReactNode` to `string`. `rich-filters/root.tsx` guards `filterConfig.tooltipContent`, which stays `ReactNode` in `@plane/types` (out of scope for a web-only change).

**Nullable labels.** Folded labels use `?? ""` wherever the source expression is nullable, so they can't render the literal string `"undefined"` in places the in-repo tooltip rendered nothing.

**Known follow-ups (not in this PR):**
- `comments/card/display.tsx:130` keeps `delay={200}` — the one Tooltip already on `@makeplane/propel` before this PR, so it's now the only site at 200ms.
- `renderToolTipByDefault` / `renderByDefault` is now dead plumbing across ~15 dropdown files. Only the bindings that lint flagged were removed; ripping out the public dropdown prop belongs in its own PR.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [x] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)

<!-- Add screenshots here -->

Recipe verified by rendering the published `Tooltip` against this repo's own compiled token CSS in both themes — `single` and `stacked`, light and dark. Surface, border, and text all flip correctly via `bg-layer-2` / `border-subtle-1` / `text-primary`.

### Test Scenarios

- **Open delay:** hover any tooltip trigger (sidebar project item, issue list row) and confirm the ~600ms delay is acceptable, or flag it so we add a `TooltipProvider`.
- **Long labels wrap:** hover a work item with a long title in the list, kanban, spreadsheet, and gantt layouts — the tooltip should wrap at `max-w-60`, not stretch off-screen.
- **Folded headings:** hover a label chip (`Labels: bug, feature`), a priority dropdown (`Priority: Urgent`), and sub-work-item/attachment/link counts on an issue row — the heading should read as a prefix, not a dangling `"Heading: "`.
- **Keyboard shortcuts:** hover bold/italic in the comment editor, sticky editor, and page editor toolbars — the shortcut should render in the dimmed `shortcut` slot beside the name.
- **Sticky hover preview:** with a recent sticky present, hover the sticky action bar button — the `PreviewCard` should show the sticky with its gradient fade. Open the recent-sticky panel and confirm the preview no longer appears.
- **Mobile:** on a touch viewport, confirm tooltips do not open (`isMobile` now maps to `disabled`).
- **Light + dark:** toggle themes and confirm tooltip surfaces adapt on both.
- **Positioned tooltips:** hover the favorites sidebar items and the sign-out control — offsets previously done via `className` now come from `sideOffset` / `alignOffset`.

### References

- Plan: `docs/plane-propel-to-makeplane-plan.md` (PR 3 — Tooltip)
- Mapping: `docs/plane-propel-to-makeplane-mapping.md`
- Propel docs: https://propel.plane.so/components/tooltip

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Updated tooltips across the application for more consistent presentation, positioning, and alignment.
  * Tooltips now use clearer labels and improved stacked layouts.
  * Tooltips are automatically disabled on mobile devices when appropriate.
  * Added accessible labels to key controls, including layout and project actions.
  * Keyboard shortcuts are displayed more clearly in editor toolbar tooltips.
  * Recent-item previews now appear in a dedicated preview card.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->