### PR TITLE
[INFRA-804] fix(airgapped): harden community restore-airgapped.sh script

### DIFF
--- a/deployments/cli/community/restore-airgapped.sh
+++ b/deployments/cli/community/restore-airgapped.sh
@@ -1,20 +1,20 @@
 #!/bin/bash
-+set -euo pipefail
+set -euo pipefail
 
 function print_header() {
 clear
 
 cat <<"EOF"
---------------------------------------------
- ____  _                          ///////// 
-|  _ \| | __ _ _ __   ___         ///////// 
-| |_) | |/ _` | '_ \ / _ \   /////    ///// 
-|  __/| | (_| | | | |  __/   /////    ///// 
-|_|   |_|\__,_|_| |_|\___|        ////      
-                                  ////      
---------------------------------------------
-Project management tool from the future
---------------------------------------------
+##+.    ##+    .##-
+ ######+.######-.######.
+ #######.   -###    +#####+.
+ #######.      +       +######.
+ #######.              .#######
+ #######.              .#######
+  #######       +      .#######
+    .+#####+    ###-   .#######
+        .######.-#####+.+######
+            -##.    -##    .+##
 EOF
 }
 
@@ -27,7 +27,7 @@ function restoreData() {
     echo ""
 
     # set the backup folder path
-    BACKUP_FOLDER=${1}
+    BACKUP_FOLDER="${1:-}"
 
     if [ -z "$BACKUP_FOLDER" ]; then
         BACKUP_FOLDER="$PWD/backup"
@@ -78,12 +78,12 @@ function restoreData() {
 
     local dockerServiceStatus
     if command -v jq &> /dev/null; then
-        dockerServiceStatus=$($COMPOSE_CMD ls --filter name=plane-airgapped --format=json | jq -r .[0].Status)
+        dockerServiceStatus=$($COMPOSE_CMD ls --filter name=plane-airgapped --format=json | jq -r '.[0].Status // empty')
     else
-        dockerServiceStatus=$($COMPOSE_CMD ls --filter name=plane-airgapped | grep -o "running" | head -n 1)
+        dockerServiceStatus=$($COMPOSE_CMD ls --filter name=plane-airgapped | grep -o "running" | head -n 1 || true)
     fi
 
-    if [[ $dockerServiceStatus == "running" ]]; then
+    if [[ "$dockerServiceStatus" == running* ]]; then
         echo "Plane Airgapped is running. Please STOP the Plane Airgapped before restoring data."
         exit 1
     fi
@@ -97,24 +97,14 @@ function restoreData() {
         chown -R $CURRENT_USER_ID:$CURRENT_GROUP_ID "$AIRGAPPED_INSTALL_PATH/data"
     fi
 
-    for BACKUP_FILE in "$BACKUP_FOLDER/*.tar.gz"; do
+    # Extract all backup tar files
+    for BACKUP_FILE in "$BACKUP_FOLDER"/*.tar.gz; do
         if [ -e "$BACKUP_FILE" ]; then
-
-            # get the basefilename without the extension
             BASE_FILE_NAME=$(basename "$BACKUP_FILE" ".tar.gz")
-
-            # extract the restoreFile to the airgapped instance install path
-            echo "Restoring $BASE_FILE_NAME"
-            rm -rf "$AIRGAPPED_INSTALL_PATH/data/$BASE_FILE_NAME" || true
-            
-            tar -xvzf "$BACKUP_FILE" -C "$AIRGAPPED_INSTALL_PATH/data/"
+            echo "Extracting $BASE_FILE_NAME"
+            tar -xzvf "$BACKUP_FILE" -C "$AIRGAPPED_INSTALL_PATH/data/"
             if [ $? -ne 0 ]; then
                 echo "Error: Failed to extract $BACKUP_FILE"
-                exit 1
-            fi
-            chown -R $CURRENT_USER_ID:$CURRENT_GROUP_ID "$AIRGAPPED_INSTALL_PATH/data/$BASE_FILE_NAME"
-            if [ $? -ne 0 ]; then
-                echo "Error: Failed to change ownership of $AIRGAPPED_INSTALL_PATH/data/$BASE_FILE_NAME"
                 exit 1
             fi
         else
@@ -122,10 +112,44 @@ function restoreData() {
             echo ""
             echo "Please provide the path to the backup file."
             echo ""
-            echo "Usage: $0 /path/to/backup"  
+            echo "Usage: $0 /path/to/backup"
             exit 1
         fi
     done
+
+    DATA_DIR="$AIRGAPPED_INSTALL_PATH/data"
+
+    # Rename extracted directories to match docker-compose volume paths
+    # Backup tars: pgdata, redisdata, uploads, rabbitmq_data
+    # Docker-compose expects: db, redis, minio/uploads, mq
+
+    if [ -d "$DATA_DIR/pgdata" ]; then
+        rm -rf "$DATA_DIR/db"
+        mv "$DATA_DIR/pgdata" "$DATA_DIR/db"
+        echo "Renamed pgdata -> db"
+    fi
+
+    if [ -d "$DATA_DIR/redisdata" ]; then
+        rm -rf "$DATA_DIR/redis"
+        mv "$DATA_DIR/redisdata" "$DATA_DIR/redis"
+        echo "Renamed redisdata -> redis"
+    fi
+
+    if [ -d "$DATA_DIR/uploads" ]; then
+        mkdir -p "$DATA_DIR/minio"
+        rm -rf "$DATA_DIR/minio/uploads"
+        mv "$DATA_DIR/uploads" "$DATA_DIR/minio/uploads"
+        echo "Renamed uploads -> minio/uploads"
+    fi
+
+    if [ -d "$DATA_DIR/rabbitmq_data" ]; then
+        rm -rf "$DATA_DIR/mq"
+        mv "$DATA_DIR/rabbitmq_data" "$DATA_DIR/mq"
+        echo "Renamed rabbitmq_data -> mq"
+    fi
+
+    # Fix ownership on all restored data
+    chown -R $CURRENT_USER_ID:$CURRENT_GROUP_ID "$DATA_DIR"
 
     echo ""
     echo "Restore completed successfully."

--- a/deployments/cli/community/restore-airgapped.sh
+++ b/deployments/cli/community/restore-airgapped.sh
@@ -18,6 +18,28 @@ cat <<"EOF"
 EOF
 }
 
+# Replace $2 (dest) with $1 (src), keeping the old dest recoverable until the
+# swap succeeds. Rolls the old data back if the move fails.
+function replaceDir() {
+    local src="$1" dest="$2" label="$3"
+    local old="${dest}.old.$$"
+
+    if [ -d "$dest" ]; then
+        mv "$dest" "$old"
+    fi
+
+    if mv "$src" "$dest"; then
+        rm -rf "$old"
+        echo "Renamed $label"
+    else
+        echo "Error: Failed to install $label; restoring previous data"
+        if [ -d "$old" ]; then
+            mv "$old" "$dest"
+        fi
+        exit 1
+    fi
+}
+
 function restoreData() {
 
     echo ""
@@ -46,6 +68,8 @@ function restoreData() {
     # check if there are any .tar.gz files in the backup folder
     if ! ls "$BACKUP_FOLDER"/*.tar.gz 1> /dev/null 2>&1; then
         echo "Error: Backup folder does not contain .tar.gz files"
+        echo ""
+        echo "Usage: $0 /path/to/backup"
         exit 1
     fi
 
@@ -76,11 +100,19 @@ function restoreData() {
         exit 1
     fi
 
-    local dockerServiceStatus
+    local dockerServiceStatus compose_output
     if command -v jq &> /dev/null; then
-        dockerServiceStatus=$($COMPOSE_CMD ls --filter name=plane-airgapped --format=json | jq -r '.[0].Status // empty')
+        if ! compose_output=$($COMPOSE_CMD ls --filter name=plane-airgapped --format=json); then
+            echo "Error: Failed to query Docker Compose services"
+            exit 1
+        fi
+        dockerServiceStatus=$(printf '%s\n' "$compose_output" | jq -r '.[0].Status // empty')
     else
-        dockerServiceStatus=$($COMPOSE_CMD ls --filter name=plane-airgapped | grep -o "running" | head -n 1 || true)
+        if ! compose_output=$($COMPOSE_CMD ls --filter name=plane-airgapped); then
+            echo "Error: Failed to query Docker Compose services"
+            exit 1
+        fi
+        dockerServiceStatus=$(printf '%s\n' "$compose_output" | grep -o "running" | head -n 1 || true)
     fi
 
     if [[ "$dockerServiceStatus" == running* ]]; then
@@ -91,61 +123,47 @@ function restoreData() {
     CURRENT_USER_ID=$(id -u)
     CURRENT_GROUP_ID=$(id -g)
 
+    DATA_DIR="$AIRGAPPED_INSTALL_PATH/data"
+
     # if the data folder not exists, create it
-    if [ ! -d "$AIRGAPPED_INSTALL_PATH/data" ]; then
-        mkdir -p "$AIRGAPPED_INSTALL_PATH/data"
-        chown -R $CURRENT_USER_ID:$CURRENT_GROUP_ID "$AIRGAPPED_INSTALL_PATH/data"
+    if [ ! -d "$DATA_DIR" ]; then
+        mkdir -p "$DATA_DIR"
+        chown -R $CURRENT_USER_ID:$CURRENT_GROUP_ID "$DATA_DIR"
     fi
+
+    # Remove stale extracted source directories from a previous run so tar
+    # does not merge new files into old data
+    rm -rf "$DATA_DIR/pgdata" "$DATA_DIR/redisdata" "$DATA_DIR/uploads" "$DATA_DIR/rabbitmq_data"
 
     # Extract all backup tar files
     for BACKUP_FILE in "$BACKUP_FOLDER"/*.tar.gz; do
-        if [ -e "$BACKUP_FILE" ]; then
-            BASE_FILE_NAME=$(basename "$BACKUP_FILE" ".tar.gz")
-            echo "Extracting $BASE_FILE_NAME"
-            tar -xzvf "$BACKUP_FILE" -C "$AIRGAPPED_INSTALL_PATH/data/"
-            if [ $? -ne 0 ]; then
-                echo "Error: Failed to extract $BACKUP_FILE"
-                exit 1
-            fi
-        else
-            echo "No .tar.gz files found in the current directory."
-            echo ""
-            echo "Please provide the path to the backup file."
-            echo ""
-            echo "Usage: $0 /path/to/backup"
+        BASE_FILE_NAME=$(basename "$BACKUP_FILE" ".tar.gz")
+        echo "Extracting $BASE_FILE_NAME"
+        if ! tar -xzvf "$BACKUP_FILE" -C "$DATA_DIR/"; then
+            echo "Error: Failed to extract $BACKUP_FILE"
             exit 1
         fi
     done
-
-    DATA_DIR="$AIRGAPPED_INSTALL_PATH/data"
 
     # Rename extracted directories to match docker-compose volume paths
     # Backup tars: pgdata, redisdata, uploads, rabbitmq_data
     # Docker-compose expects: db, redis, minio/uploads, mq
 
     if [ -d "$DATA_DIR/pgdata" ]; then
-        rm -rf "$DATA_DIR/db"
-        mv "$DATA_DIR/pgdata" "$DATA_DIR/db"
-        echo "Renamed pgdata -> db"
+        replaceDir "$DATA_DIR/pgdata" "$DATA_DIR/db" "pgdata -> db"
     fi
 
     if [ -d "$DATA_DIR/redisdata" ]; then
-        rm -rf "$DATA_DIR/redis"
-        mv "$DATA_DIR/redisdata" "$DATA_DIR/redis"
-        echo "Renamed redisdata -> redis"
+        replaceDir "$DATA_DIR/redisdata" "$DATA_DIR/redis" "redisdata -> redis"
     fi
 
     if [ -d "$DATA_DIR/uploads" ]; then
         mkdir -p "$DATA_DIR/minio"
-        rm -rf "$DATA_DIR/minio/uploads"
-        mv "$DATA_DIR/uploads" "$DATA_DIR/minio/uploads"
-        echo "Renamed uploads -> minio/uploads"
+        replaceDir "$DATA_DIR/uploads" "$DATA_DIR/minio/uploads" "uploads -> minio/uploads"
     fi
 
     if [ -d "$DATA_DIR/rabbitmq_data" ]; then
-        rm -rf "$DATA_DIR/mq"
-        mv "$DATA_DIR/rabbitmq_data" "$DATA_DIR/mq"
-        echo "Renamed rabbitmq_data -> mq"
+        replaceDir "$DATA_DIR/rabbitmq_data" "$DATA_DIR/mq" "rabbitmq_data -> mq"
     fi
 
     # Fix ownership on all restored data

--- a/deployments/cli/community/restore-airgapped.sh
+++ b/deployments/cli/community/restore-airgapped.sh
@@ -26,12 +26,16 @@ function replaceDir() {
 
     if [ -d "$dest" ]; then
         mv "$dest" "$old"
+        # Restore the old data if we are interrupted mid-swap
+        trap "mv \"$old\" \"$dest\" 2>/dev/null || true; exit 1" INT TERM HUP
     fi
 
     if mv "$src" "$dest"; then
+        trap - INT TERM HUP
         rm -rf "$old"
         echo "Renamed $label"
     else
+        trap - INT TERM HUP
         echo "Error: Failed to install $label; restoring previous data"
         if [ -d "$old" ]; then
             mv "$old" "$dest"


### PR DESCRIPTION
## Summary
- Fix stray `+` before `set -euo pipefail` that broke the script on the first line
- Allow no-argument invocation under `set -u` (`BACKUP_FOLDER="${1:-}"`) so the interactive prompt is reachable
- Don't exit under `pipefail` when no compose project matches, and recognize `running(N)` statuses when checking whether the airgapped instance is running
- Fix unquoted glob in the backup extraction loop (`"$BACKUP_FOLDER"/*.tar.gz`)
- Rename extracted backup dirs (`pgdata`/`redisdata`/`uploads`/`rabbitmq_data`) to the volume paths the airgapped docker-compose expects (`db`/`redis`/`minio/uploads`/`mq`), then fix ownership once at the end
- Update ASCII header to the current logo

This keeps the shipped script in sync with the version now embedded in the developer docs (makeplane/developer-docs#321).

## Test plan
- [ ] `bash -n` syntax check passes (verified locally)
- [ ] Run a Community → Airgapped migration: `setup.sh backup` on CE, transfer, `sudo bash restore-airgapped.sh ./<backup-dir>`, verify data dirs land at `data/db`, `data/redis`, `data/minio/uploads`, `data/mq` and the instance starts
- [ ] Run script with no args — verify it prompts instead of exiting with "unbound variable"
- [ ] Run script while the airgapped instance is up — verify it refuses to restore

🧙 Built with [WOZCODE](https://wozcode.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved air-gapped backup restoration when no backup folder is specified.
  * Restores multiple backup archives more reliably and places database, cache, upload, and messaging data correctly.
  * Preserves existing data until replacement succeeds, with safer recovery if restoration is interrupted.
  * Better handles unavailable service status details and recognizes extended “running” statuses.
  * Applies data permissions consistently after extraction.
  * Added clearer guidance when no backup files are found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->