### PR TITLE
fix(web): guard parent-issues search against out-of-order responses

### DIFF
--- a/apps/web/core/components/issues/parent-issues-list-modal.tsx
+++ b/apps/web/core/components/issues/parent-issues-list-modal.tsx
@@ -71,6 +71,8 @@ export function ParentIssuesListModal({
   useEffect(() => {
     if (!isOpen || !workspaceSlug || !projectId) return;
 
+    let ignore = false;
+
     setIsSearching(true);
     setIsLoading(true);
 
@@ -82,11 +84,18 @@ export function ParentIssuesListModal({
         workspace_search: false,
         epic: searchEpic ? true : undefined,
       })
-      .then((res) => setIssues(res))
+      .then((res) => {
+        if (!ignore) setIssues(res);
+      })
       .finally(() => {
+        if (ignore) return;
         setIsSearching(false);
         setIsLoading(false);
       });
+
+    return () => {
+      ignore = true;
+    };
   }, [debouncedSearchTerm, isOpen, issueId, projectId, workspaceSlug]);
 
   return (


### PR DESCRIPTION
### Problem

The parent-issues search effect writes the response directly into state with no cleanup:

```js
projectService
  .projectIssuesSearch(workspaceSlug, projectId, { search: debouncedSearchTerm, ... })
  .then((res) => setIssues(res))
```

`debouncedSearchTerm` is reactive, so a new request starts whenever the term changes. Debouncing narrows the window but doesn't close it — if an earlier, slower request resolves after a later one, the older response calls `setIssues` last and the list shows results for a query the user has already moved past. It stays wrong until the next keystroke, with no error.

The `.finally` has the same issue: a stale response can clear `isSearching`/`isLoading` while a newer request is still in flight.

`react-hooks/exhaustive-deps` is satisfied by this code, which is part of why it's easy to miss in review.

### Fix

Standard cleanup-scoped ignore flag. The effect's cleanup marks in-flight responses stale, and both continuations no-op for superseded requests.

```js
let ignore = false;
// ...
.then((res) => { if (!ignore) setIssues(res); })
.finally(() => { if (ignore) return; setIsSearching(false); setIsLoading(false); });

return () => { ignore = true; };
```

No behaviour change for the common path — only stale responses are dropped.

### Reproduction

Open the parent-issue selector and type a query that returns slowly, then quickly refine it. With network throttling the earlier response can land last, leaving results that don't match the input.

### Notes

- Scoped to one file; no API or type changes.
- I wasn't able to run the full local stack (it needs Docker + Postgres + Redis per CONTRIBUTING), so this is verified by inspection and parse-checked only — I'm relying on the PR build/lint workflow. Happy to adjust if you'd prefer a different guard style, or to open an issue first if that's the process you'd rather follow.
- Found while testing a static-analysis rule I'm building for this class of effect bug.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved issue search reliability by ignoring outdated results from previous searches.
  * Prevented loading indicators and results from updating after the search view is closed or refreshed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->