### PR TITLE
chore: bump @makeplane/propel to 0.3.0

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -23,7 +23,7 @@
     "@fontsource/ibm-plex-mono": "catalog:",
     "@fontsource/material-symbols-rounded": "catalog:",
     "@headlessui/react": "catalog:",
-    "@makeplane/propel": "0.2.0",
+    "@makeplane/propel": "catalog:",
     "@plane/constants": "workspace:*",
     "@plane/hooks": "workspace:*",
     "@plane/services": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,8 +73,8 @@ catalogs:
       specifier: ^0.7.1
       version: 0.7.1
     '@makeplane/propel':
-      specifier: 0.2.0
-      version: 0.2.0
+      specifier: 0.3.0
+      version: 0.3.0
     '@popperjs/core':
       specifier: ^2.11.8
       version: 2.11.8
@@ -612,8 +612,8 @@ importers:
         specifier: 'catalog:'
         version: 2.2.10(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@makeplane/propel':
-        specifier: 0.2.0
-        version: 0.2.0(@date-fns/tz@1.4.1)(@types/react@19.2.17)(date-fns@4.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(tailwindcss@4.1.17)
+        specifier: 'catalog:'
+        version: 0.3.0(@date-fns/tz@1.4.1)(@types/react@19.2.17)(date-fns@4.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(tailwindcss@4.1.17)
       '@plane/constants':
         specifier: workspace:*
         version: link:../../packages/constants
@@ -1030,7 +1030,7 @@ importers:
         version: 2.2.10(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@makeplane/propel':
         specifier: 'catalog:'
-        version: 0.2.0(@date-fns/tz@1.4.1)(@types/react@19.2.17)(date-fns@4.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(tailwindcss@4.1.17)
+        version: 0.3.0(@date-fns/tz@1.4.1)(@types/react@19.2.17)(date-fns@4.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(tailwindcss@4.1.17)
       '@plane/constants':
         specifier: workspace:*
         version: link:../../packages/constants
@@ -1705,7 +1705,7 @@ importers:
     dependencies:
       '@makeplane/propel':
         specifier: 'catalog:'
-        version: 0.2.0(@date-fns/tz@1.4.1)(@types/react@19.2.17)(date-fns@4.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(tailwindcss@4.1.17)
+        version: 0.3.0(@date-fns/tz@1.4.1)(@types/react@19.2.17)(date-fns@4.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(tailwindcss@4.1.17)
       '@tailwindcss/postcss':
         specifier: 'catalog:'
         version: 4.1.17
@@ -2868,8 +2868,8 @@ packages:
     peerDependencies:
       '@types/react': 19.2.17
 
-  '@makeplane/propel@0.2.0':
-    resolution: {integrity: sha512-a4gd9m9gTMbc2NOrpb1jrSkM/OtocVBTf2bmnaAdU8K8Xw3OoTgvMLM3nRtfUbSFNLl1OjG7SCXeg2x/7lYvSA==}
+  '@makeplane/propel@0.3.0':
+    resolution: {integrity: sha512-nGhiE42vLQVvv7NZOcQYKARJiTXyKDSSTcHOzPdtFpa+WkSz9B91jw6i+3Ikz5cpkv/aEKjOTJF+cByw2zv5ZQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       react: 19.2.8
@@ -10586,7 +10586,7 @@ snapshots:
     dependencies:
       '@types/react': 19.2.17
 
-  '@makeplane/propel@0.2.0(@date-fns/tz@1.4.1)(@types/react@19.2.17)(date-fns@4.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(tailwindcss@4.1.17)':
+  '@makeplane/propel@0.3.0(@date-fns/tz@1.4.1)(@types/react@19.2.17)(date-fns@4.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(tailwindcss@4.1.17)':
     dependencies:
       '@base-ui/react': 1.7.0(@date-fns/tz@1.4.1)(@types/react@19.2.17)(date-fns@4.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       class-variance-authority: 0.7.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -27,7 +27,7 @@ catalog:
   "@hocuspocus/server": "2.15.2"
   "@hocuspocus/transformer": "2.15.2"
   "@hypermod/utils": "^0.7.1"
-  "@makeplane/propel": "0.2.0"
+  "@makeplane/propel": "0.3.0"
   "@popperjs/core": "^2.11.8"
   "@radix-ui/react-scroll-area": "^1.2.3"
   "@react-pdf/renderer": "^4.8.1"
@@ -279,6 +279,7 @@ minimumReleaseAgeExclude:
   - "@storybook/react-vite@10.4.6"
   - "@storybook/react@10.4.6"
   - storybook@10.4.6
+  - "@makeplane/propel@0.3.0"
 
 patchedDependencies:
   react-color@2.19.3: patches/react-color@2.19.3.patch


### PR DESCRIPTION
### Description

Bumps `@makeplane/propel` from `0.2.0` to `0.3.0` (npm latest).

The catalog pin is now the single source of truth: `apps/web` and `packages/tailwind-config` already used `catalog:`, and `apps/admin` is switched from a hardcoded `0.2.0` to `catalog:` so the three consumers stay aligned.

`0.3.0` is additive (Avatar tooltip, Collapsible trailing slot, Toast action `href`, TextArea `autoResize`). No call-site changes in this PR.

`@makeplane/propel@0.3.0` is added to `minimumReleaseAgeExclude` so install succeeds while the package is still under the supply-chain age floor.

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

Dependency bump (chore). None of the boxes above apply.

### Screenshots and Media (if applicable)
<!-- Add screenshots here -->

### Test Scenarios
- `pnpm install` on a clean checkout resolves `@makeplane/propel@0.3.0` for web, admin, and `@plane/tailwind-config`.
- `pnpm turbo run check:types --filter=web --filter=admin` passes.
- Smoke admin: sign-in, dashboard switches/buttons, toast (close action still a button).
- Smoke web: a surface that already uses `@makeplane/propel` Avatar, Input, and Switch still renders in light and dark.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated internal application packages to newer managed versions.
  - No user-facing functionality or behavior changes are included in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->