### PR TITLE
fix(web): restore password-manager autofill on auth forms via autocomplete tokens

### DIFF
--- a/apps/web/core/components/account/auth-forms/email.tsx
+++ b/apps/web/core/components/account/auth-forms/email.tsx
@@ -74,7 +74,7 @@ export const AuthEmailForm = observer(function AuthEmailForm(props: TAuthEmailFo
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               placeholder={t("auth.common.email.placeholder")}
-              autoComplete="off"
+              autoComplete="username"
               autoFocus
               ref={inputRef}
             />

--- a/apps/web/core/components/account/auth-forms/password.tsx
+++ b/apps/web/core/components/account/auth-forms/password.tsx
@@ -213,7 +213,7 @@ export const AuthPasswordForm = observer(function AuthPasswordForm(props: Props)
               placeholder={t("auth.common.password.placeholder")}
               onFocus={() => setIsPasswordInputFocused(true)}
               onBlur={() => setIsPasswordInputFocused(false)}
-              autoComplete="off"
+              autoComplete={mode === EAuthModes.SIGN_IN ? "current-password" : "new-password"}
               autoFocus
             />
             <button
@@ -250,7 +250,7 @@ export const AuthPasswordForm = observer(function AuthPasswordForm(props: Props)
                 placeholder={t("auth.common.password.confirm_password.placeholder")}
                 onFocus={() => setIsRetryPasswordInputFocused(true)}
                 onBlur={() => setIsRetryPasswordInputFocused(false)}
-                autoComplete="off"
+                autoComplete="new-password"
               />
               <button
                 type="button"


### PR DESCRIPTION
### Description
PR #8517 ([VPAT-27]) set `autoComplete="off"` on the auth email/password inputs. On the sign-in screen this stops Bitwarden and 1Password from offering to autofill the password, and it also fails **WCAG 2.1 SC 1.3.5 Identify Input Purpose** — which requires these fields to expose their purpose through the autocomplete tokens (`username`, `current-password`, `new-password`), not `off`.

This restores autofill by using the correct purpose tokens instead of disabling autocomplete. The sign-in password input is shared between sign-in and sign-up via the `mode` prop, so its token is conditional.

Scope of this PR: the `apps/web` sign-in/sign-up forms (the login-critical path). The same tokens should be mirrored to the admin/space auth forms and the `packages/ui` auth-form / password-input components that #8517 also touched — happy to extend this PR or follow up.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes

- `email.tsx`: email field `autoComplete="off"` → `"username"`
- `password.tsx`: password field `autoComplete="off"` → `mode === EAuthModes.SIGN_IN ? "current-password" : "new-password"`
- `password.tsx`: confirm_password field `autoComplete="off"` → `"new-password"`

### Test Scenarios

- Sign-in page with a saved login in Bitwarden/1Password: autofill suggestion now appears on the password field and fills email + password.
- Sign-up: password + confirm are treated as new-password (no stale-credential suggestion).

### References

- Regresses autofill introduced by #8517
Fixes: #9739 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved browser and password-manager autofill support for email and password fields during sign-in and sign-up.
  * Password fields now use context-appropriate autofill behavior, including separate handling for current and newly created passwords.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->