### PR TITLE
fix: scope un-themed editor color fallback so dark-mode ramp wins

### DIFF
--- a/apps/space/styles/globals.css
+++ b/apps/space/styles/globals.css
@@ -8,8 +8,10 @@
  * @plane/editor/styles (imported above), which is their single source of truth.
  * Only the un-themed :root fallback below is kept: the editor package declares
  * background colors solely under [data-theme*="light"] / [data-theme*="dark"],
- * so without this they are undefined until a theme lands on the element. */
-:root {
+ * so without this they are undefined until a theme lands on the element.
+ * Scoped with :not() so it never overrides the themed ramps — as a plain :root
+ * rule later in the bundle it would win over them regardless of theme. */
+:root:not([data-theme*="light"]):not([data-theme*="dark"]) {
   --editor-colors-gray-background: #d6d6d8;
   --editor-colors-peach-background: #ffd5d7;
   --editor-colors-pink-background: #fdd4e3;

--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -10,8 +10,10 @@
  * @plane/editor/styles (imported above), which is their single source of truth.
  * Only the un-themed :root fallback below is kept: the editor package declares
  * background colors solely under [data-theme*="light"] / [data-theme*="dark"],
- * so without this they are undefined until a theme lands on the element. */
-:root {
+ * so without this they are undefined until a theme lands on the element.
+ * Scoped with :not() so it never overrides the themed ramps — as a plain :root
+ * rule later in the bundle it would win over them regardless of theme. */
+:root:not([data-theme*="light"]):not([data-theme*="dark"]) {
   --editor-colors-gray-background: #d6d6d8;
   --editor-colors-peach-background: #ffd5d7;
   --editor-colors-pink-background: #fdd4e3;


### PR DESCRIPTION
### Description

Fixes stickies (and any other consumer of `--editor-colors-*-background`) rendering with light pastel backgrounds in dark mode, making their light text unreadable.

Both `apps/web/styles/globals.css` and `apps/space/styles/globals.css` keep an un-scoped `:root` fallback block of editor color variables (light values) for the pre-theme window. In the bundled CSS these blocks are ordered after `@plane/editor`'s `[data-theme*="dark"]` ramp; at equal specificity the later rule wins, so the light fallback overrode the dark ramp in every theme.

The fix scopes the fallback with `:not([data-theme*="light"]):not([data-theme*="dark"])`, so it only applies before a theme lands and for `custom` themes (next-themes ships a `custom` theme matching neither selector — deleting the block outright would leave those variables undefined there).

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### Test Scenarios

- Rebuilt the web and space images from this branch on a self-hosted instance and verified in dark mode: sticky card backgrounds now compute to the dark ramp (`rgb(88, 62, 42)` for orange, `rgb(31, 73, 92)` for light-blue) with light, readable text.
- Light mode unchanged: computed values identical to before (`rgb(255, 227, 205)` for orange + dark text) — the fallback block's values are value-identical to the editor package's `[data-theme*="light"]` ramp, and the `:not()` scoping never matches once a theme is applied.
- `npx oxfmt --check` passes on both modified files.

### References

Closes #9753


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed themed editor colors being overridden by unthemed fallback styles.
  * Light and dark editor themes now display the intended background color ramps consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->