### PR TITLE
feat(api): add KEY_PREFIX to redis cache and make clear_cache optional on startup - [WEB-9759]

### DIFF
--- a/apps/api/bin/docker-entrypoint-api-local.sh
+++ b/apps/api/bin/docker-entrypoint-api-local.sh
@@ -28,7 +28,12 @@ python manage.py configure_instance
 # Create the default bucket
 python manage.py create_bucket
 
-# Clear Cache before starting to remove stale values
-python manage.py clear_cache
+# Clear Cache before starting to remove stale values unless skipped
+if [ "$PLANE_SKIP_CACHE_CLEAR" != "1" ] && [ "$PLANE_SKIP_CACHE_CLEAR" != "true" ]; then
+    python manage.py clear_cache
+else
+    echo "Skipping cache clear on startup (PLANE_SKIP_CACHE_CLEAR is set)"
+fi
+
 
 python manage.py runserver 0.0.0.0:8000 --settings=plane.settings.local

--- a/apps/api/bin/docker-entrypoint-api.sh
+++ b/apps/api/bin/docker-entrypoint-api.sh
@@ -29,8 +29,13 @@ python manage.py configure_instance
 # Create the default bucket
 python manage.py create_bucket
 
-# Clear Cache before starting to remove stale values
-python manage.py clear_cache
+# Clear Cache before starting to remove stale values unless skipped
+if [ "$PLANE_SKIP_CACHE_CLEAR" != "1" ] && [ "$PLANE_SKIP_CACHE_CLEAR" != "true" ]; then
+    python manage.py clear_cache
+else
+    echo "Skipping cache clear on startup (PLANE_SKIP_CACHE_CLEAR is set)"
+fi
+
 
 # Collect static files
 python manage.py collectstatic --noinput

--- a/apps/api/plane/db/management/commands/clear_cache.py
+++ b/apps/api/plane/db/management/commands/clear_cache.py
@@ -3,6 +3,7 @@
 # See the LICENSE file for details.
 
 # Django imports
+from django.conf import settings
 from django.core.cache import cache
 from django.core.management import BaseCommand
 
@@ -13,18 +14,38 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         # Positional argument
         parser.add_argument("--key", type=str, nargs="?", help="Key to clear cache")
+        parser.add_argument(
+            "--all",
+            action="store_true",
+            help="Flush the entire cache database (FLUSHDB) instead of only scoped prefix keys",
+        )
 
     def handle(self, *args, **options):
         try:
-            if options["key"]:
+            if options.get("key"):
                 cache.delete(options["key"])
                 self.stdout.write(self.style.SUCCESS(f"Cache Cleared for key: {options['key']}"))
                 return
 
+            # If user explicitly requests flushing the entire DB
+            if options.get("all"):
+                cache.clear()
+                self.stdout.write(self.style.SUCCESS("Entire cache database cleared (FLUSHDB)"))
+                return
+
+            # Scoped cache clear using KEY_PREFIX
+            key_prefix = getattr(cache, "key_prefix", None) or getattr(settings, "REDIS_KEY_PREFIX", None)
+
+            if key_prefix and hasattr(cache, "delete_pattern"):
+                pattern = f"{key_prefix}:*"
+                cache.delete_pattern(pattern)
+                self.stdout.write(self.style.SUCCESS(f"Cache Cleared for pattern: {pattern}"))
+                return
+
+            # Fallback to cache.clear() if no prefix or if cache backend doesn't support delete_pattern (e.g. LocMemCache)
             cache.clear()
             self.stdout.write(self.style.SUCCESS("Cache Cleared"))
             return
-        except Exception:
-            # Another ClientError occurred
-            self.stdout.write(self.style.ERROR("Failed to clear cache"))
+        except Exception as e:
+            self.stdout.write(self.style.ERROR(f"Failed to clear cache: {e}"))
             return

--- a/apps/api/plane/db/management/commands/clear_cache.py
+++ b/apps/api/plane/db/management/commands/clear_cache.py
@@ -36,15 +36,27 @@ class Command(BaseCommand):
             # Scoped cache clear using KEY_PREFIX
             key_prefix = getattr(cache, "key_prefix", None) or getattr(settings, "REDIS_KEY_PREFIX", None)
 
-            if key_prefix and hasattr(cache, "delete_pattern"):
-                pattern = f"{key_prefix}:*"
-                cache.delete_pattern(pattern)
-                self.stdout.write(self.style.SUCCESS(f"Cache Cleared for pattern: {pattern}"))
+            if not key_prefix:
+                self.stdout.write(
+                    self.style.ERROR(
+                        "Cannot clear cache: KEY_PREFIX is not configured. "
+                        "Use --all if you explicitly wish to flush the entire database."
+                    )
+                )
                 return
 
-            # Fallback to cache.clear() if no prefix or if cache backend doesn't support delete_pattern (e.g. LocMemCache)
-            cache.clear()
-            self.stdout.write(self.style.SUCCESS("Cache Cleared"))
+            if not hasattr(cache, "delete_pattern"):
+                self.stdout.write(
+                    self.style.ERROR(
+                        "Cannot clear cache: Cache backend does not support delete_pattern(). "
+                        "Use --all if you explicitly wish to flush the entire database."
+                    )
+                )
+                return
+
+            pattern = f"{key_prefix}:*"
+            cache.delete_pattern(pattern)
+            self.stdout.write(self.style.SUCCESS(f"Cache Cleared for pattern: {pattern}"))
             return
         except Exception as e:
             self.stdout.write(self.style.ERROR(f"Failed to clear cache: {e}"))

--- a/apps/api/plane/settings/common.py
+++ b/apps/api/plane/settings/common.py
@@ -241,12 +241,14 @@ if os.environ.get("ENABLE_READ_REPLICA", "0") == "1":
 # Redis Config
 REDIS_URL = os.environ.get("REDIS_URL")
 REDIS_SSL = REDIS_URL and "rediss" in REDIS_URL
+REDIS_KEY_PREFIX = os.environ.get("REDIS_KEY_PREFIX", "plane")
 
 if REDIS_SSL:
     CACHES = {
         "default": {
             "BACKEND": "django_redis.cache.RedisCache",
             "LOCATION": REDIS_URL,
+            "KEY_PREFIX": REDIS_KEY_PREFIX,
             "OPTIONS": {
                 "CLIENT_CLASS": "django_redis.client.DefaultClient",
                 "CONNECTION_POOL_KWARGS": {"ssl_cert_reqs": False},
@@ -258,6 +260,7 @@ else:
         "default": {
             "BACKEND": "django_redis.cache.RedisCache",
             "LOCATION": REDIS_URL,
+            "KEY_PREFIX": REDIS_KEY_PREFIX,
             "OPTIONS": {"CLIENT_CLASS": "django_redis.client.DefaultClient"},
         }
     }

--- a/apps/api/plane/settings/local.py
+++ b/apps/api/plane/settings/local.py
@@ -23,6 +23,7 @@ CACHES = {
     "default": {
         "BACKEND": "django_redis.cache.RedisCache",
         "LOCATION": REDIS_URL,  # noqa
+        "KEY_PREFIX": REDIS_KEY_PREFIX, # noqa
         "OPTIONS": {"CLIENT_CLASS": "django_redis.client.DefaultClient"},
     }
 }

--- a/apps/api/plane/tests/unit/settings/test_clear_cache.py
+++ b/apps/api/plane/tests/unit/settings/test_clear_cache.py
@@ -1,0 +1,61 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Unit tests for the clear_cache management command and Redis KEY_PREFIX."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.core.management import call_command
+
+
+@pytest.mark.unit
+class TestClearCacheCommand:
+    @patch("plane.db.management.commands.clear_cache.cache")
+    def test_clear_cache_with_specific_key(self, mock_cache):
+        """Test clearing a single key deletes only that key."""
+        call_command("clear_cache", key="user_session_123")
+        mock_cache.delete.assert_called_once_with("user_session_123")
+        mock_cache.clear.assert_not_called()
+
+    @patch("plane.db.management.commands.clear_cache.cache")
+    def test_clear_cache_scoped_by_key_prefix(self, mock_cache):
+        """Test default clear_cache only deletes keys matching the prefix pattern."""
+        mock_cache.key_prefix = "plane"
+        mock_cache.delete_pattern = MagicMock()
+
+        call_command("clear_cache")
+
+        mock_cache.delete_pattern.assert_called_once_with("plane:*")
+        # Ensure full database flush was NOT called
+        mock_cache.clear.assert_not_called()
+
+    @patch("plane.db.management.commands.clear_cache.cache")
+    def test_clear_cache_with_all_flag_calls_flushdb(self, mock_cache):
+        """Test --all flag explicitly forces a full cache.clear() / FLUSHDB."""
+        mock_cache.key_prefix = "plane"
+        mock_cache.delete_pattern = MagicMock()
+
+        call_command("clear_cache", all=True)
+
+        mock_cache.clear.assert_called_once()
+        mock_cache.delete_pattern.assert_not_called()
+
+    @patch("plane.db.management.commands.clear_cache.cache")
+    def test_clear_cache_fallback_when_no_delete_pattern(self, mock_cache):
+        """Test graceful fallback to cache.clear() if backend does not support delete_pattern."""
+        mock_cache.key_prefix = "plane"
+        del mock_cache.delete_pattern  # Simulate backend without delete_pattern (e.g. LocMemCache)
+
+        call_command("clear_cache")
+
+        mock_cache.clear.assert_called_once()
+
+
+@pytest.mark.unit
+class TestRedisKeyPrefixSetting:
+    def test_redis_key_prefix_configured_in_caches(self, settings):
+        """Test that default CACHES setting includes KEY_PREFIX."""
+        assert "KEY_PREFIX" in settings.CACHES["default"]
+        assert settings.CACHES["default"]["KEY_PREFIX"] == getattr(settings, "REDIS_KEY_PREFIX", "plane")

--- a/apps/api/plane/tests/unit/settings/test_clear_cache.py
+++ b/apps/api/plane/tests/unit/settings/test_clear_cache.py
@@ -43,14 +43,27 @@ class TestClearCacheCommand:
         mock_cache.delete_pattern.assert_not_called()
 
     @patch("plane.db.management.commands.clear_cache.cache")
-    def test_clear_cache_fallback_when_no_delete_pattern(self, mock_cache):
-        """Test graceful fallback to cache.clear() if backend does not support delete_pattern."""
+    def test_clear_cache_errors_when_no_delete_pattern(self, mock_cache):
+        """Test that missing delete_pattern does NOT fall back to flushdb."""
         mock_cache.key_prefix = "plane"
-        del mock_cache.delete_pattern  # Simulate backend without delete_pattern (e.g. LocMemCache)
+        del mock_cache.delete_pattern
 
         call_command("clear_cache")
 
-        mock_cache.clear.assert_called_once()
+        # Crucial safeguard: FLUSHDB must NOT be called
+        mock_cache.clear.assert_not_called()
+
+    @patch("plane.db.management.commands.clear_cache.cache")
+    def test_clear_cache_errors_when_prefix_is_empty(self, mock_cache):
+        """Test that an empty prefix does NOT fall back to flushdb."""
+        mock_cache.key_prefix = ""
+        mock_cache.delete_pattern = MagicMock()
+
+        call_command("clear_cache")
+
+        # Crucial safeguard: FLUSHDB must NOT be called
+        mock_cache.clear.assert_not_called()
+        mock_cache.delete_pattern.assert_not_called()
 
 
 @pytest.mark.unit


### PR DESCRIPTION
### Description
Prevents accidental database-wide data loss when Plane is deployed alongside other services on a shared Redis database:
1. Makes startup cache flushing optional via `PLANE_SKIP_CACHE_CLEAR` in Docker entrypoint scripts.
2. Introduces `KEY_PREFIX` support to Django's Redis `CACHES` configuration (configurable via `REDIS_KEY_PREFIX`, defaulting to `"plane"`).
3. Updates the `clear_cache` management command to utilize `cache.delete_pattern(f"{prefix}:*")` scoped to the prefix rather than executing an unconditional `cache.clear()` (`FLUSHDB`). Adds `--all` flag for administrators who explicitly wish to flush the entire database.

### Test Scenarios
Added comprehensive unit tests in `apps/api/plane/tests/unit/settings/test_clear_cache.py`:
- `test_clear_cache_with_specific_key`
- `test_clear_cache_scoped_by_key_prefix` (verifies `FLUSHDB` is never called)
- `test_clear_cache_with_all_flag_calls_flushdb`
- `test_clear_cache_fallback_when_no_delete_pattern`
- `test_redis_key_prefix_configured_in_caches`

### References
Fixes #9759


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for conditionally skipping cache clearing during API startup with `PLANE_SKIP_CACHE_CLEAR`.
  - Cache clearing now targets application-specific keys by default, helping preserve unrelated cached data.
  - Added an option to flush the entire cache when needed.
  - Added configurable Redis key prefixes across environments.

- **Bug Fixes**
  - Prevented unsafe fallback to clearing the entire cache when targeted clearing is unavailable or unconfigured.
  - Startup and cache-clearing errors now include more actionable details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->