### PR TITLE
fix(api): resolve description asset URLs to workspace scope without a project

### DIFF
--- a/apps/api/plane/db/models/asset.py
+++ b/apps/api/plane/db/models/asset.py
@@ -98,6 +98,15 @@ class FileAsset(BaseModel):
             self.EntityTypeContext.PAGE_DESCRIPTION,
             self.EntityTypeContext.DRAFT_ISSUE_DESCRIPTION,
         ]:
+            # Description assets are not always project-bound. Workspace-level
+            # pages have no project (Page relates to projects through a M2M),
+            # and WorkspaceFileAssetEndpoint never sets project_id, so the
+            # column is NULL for those assets. Interpolating it would emit
+            # `projects/None/`, which 404s. Fall back to the workspace-scoped
+            # route instead, mirroring the two branches the clients' own URL
+            # builder (`getEditorAssetSrc`) already picks between.
+            if self.project_id is None:
+                return f"/api/assets/v2/workspaces/{self.workspace.slug}/{self.id}/"
             return f"/api/assets/v2/workspaces/{self.workspace.slug}/projects/{self.project_id}/{self.id}/"
 
         return None

--- a/apps/api/plane/tests/unit/models/test_file_asset_url.py
+++ b/apps/api/plane/tests/unit/models/test_file_asset_url.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""Unit tests for ``FileAsset.asset_url``.
+
+Regression coverage for #9564: description assets uploaded through
+``WorkspaceFileAssetEndpoint`` are created without a ``project_id`` (the
+endpoint only maps the entity id, and workspace-level pages have no project at
+all), so ``asset_url`` used to build ``.../projects/None/<id>/``, which 404s.
+Those assets must fall back to the workspace-scoped route.
+"""
+
+import pytest
+
+from plane.db.models import FileAsset, Project
+
+DESCRIPTION_ENTITY_TYPES = [
+    FileAsset.EntityTypeContext.ISSUE_DESCRIPTION,
+    FileAsset.EntityTypeContext.COMMENT_DESCRIPTION,
+    FileAsset.EntityTypeContext.PAGE_DESCRIPTION,
+    FileAsset.EntityTypeContext.DRAFT_ISSUE_DESCRIPTION,
+]
+
+
+@pytest.fixture
+def project(workspace, create_user):
+    """A project inside the fixture workspace."""
+    return Project.objects.create(
+        name="Test Project",
+        identifier="TP",
+        workspace=workspace,
+        created_by=create_user,
+    )
+
+
+@pytest.mark.unit
+class TestFileAssetUrl:
+    """Test the ``asset_url`` property of the FileAsset model"""
+
+    @pytest.mark.django_db
+    @pytest.mark.parametrize("entity_type", DESCRIPTION_ENTITY_TYPES)
+    def test_description_asset_without_project_uses_workspace_route(self, workspace, entity_type):
+        """Description assets with no project resolve to the workspace-scoped route"""
+        asset = FileAsset.objects.create(
+            attributes={"name": "image.png", "type": "image/png", "size": 1024},
+            asset=f"{workspace.id}/image.png",
+            size=1024,
+            workspace=workspace,
+            entity_type=entity_type,
+        )
+
+        assert asset.project_id is None
+        assert asset.asset_url == f"/api/assets/v2/workspaces/{workspace.slug}/{asset.id}/"
+        assert "None" not in asset.asset_url
+
+    @pytest.mark.django_db
+    @pytest.mark.parametrize("entity_type", DESCRIPTION_ENTITY_TYPES)
+    def test_description_asset_with_project_uses_project_route(self, workspace, project, entity_type):
+        """Description assets bound to a project keep the project-scoped route"""
+        asset = FileAsset.objects.create(
+            attributes={"name": "image.png", "type": "image/png", "size": 1024},
+            asset=f"{workspace.id}/image.png",
+            size=1024,
+            workspace=workspace,
+            project=project,
+            entity_type=entity_type,
+        )
+
+        assert asset.asset_url == f"/api/assets/v2/workspaces/{workspace.slug}/projects/{project.id}/{asset.id}/"
+
+    @pytest.mark.django_db
+    def test_workspace_level_asset_uses_static_route(self, workspace):
+        """Workspace-level assets are unaffected by the project fallback"""
+        asset = FileAsset.objects.create(
+            attributes={"name": "logo.png", "type": "image/png", "size": 1024},
+            asset=f"{workspace.id}/logo.png",
+            size=1024,
+            workspace=workspace,
+            entity_type=FileAsset.EntityTypeContext.WORKSPACE_LOGO,
+        )
+
+        assert asset.asset_url == f"/api/assets/v2/static/{asset.id}/"


### PR DESCRIPTION
### Description

`FileAsset.asset_url` always interpolated `project_id` into the URL for the description entity types (`ISSUE_DESCRIPTION`, `COMMENT_DESCRIPTION`, `PAGE_DESCRIPTION`, `DRAFT_ISSUE_DESCRIPTION`), so an asset with no project resolved to `/api/assets/v2/workspaces/<slug>/projects/None/<id>/`, which 404s. The upload itself succeeds, so the file is in storage but the returned URL never resolves.

Those assets are not always project-bound:

- `WorkspaceFileAssetEndpoint.get_entity_id_field` maps only `issue_id` / `page_id` / `comment_id`, never `project_id`, so the column stays NULL for assets created through `POST /api/assets/v2/workspaces/{slug}/`.
- Workspace-level pages have no project at all — `Page` relates to projects through a M2M (`db.ProjectPage`), so there is nothing to derive.

This falls back to the workspace-scoped route when `project_id` is NULL, mirroring the two branches `getEditorAssetSrc` (`packages/utils/src/editor/common.ts`) already picks between on the client. Project-bound assets keep the project-scoped URL, and every other branch of the property is untouched.

Both routes already exist and both enforce access control (`has_project_asset_access` on `WorkspaceFileAssetEndpoint`), so this only makes the URL the API reports match the route the clients already use — it does not widen access.

#### Approaches considered and rejected

- **Reading `project_id` from the request body**, as the public API's `GenericAssetEndpoint` does. `WorkspaceFileAssetEndpoint` is authorized at workspace level, so accepting a client-supplied `project_id` there would let any workspace member stamp an arbitrary project onto an asset.
- **Deriving `project_id` from the related entity.** Not possible for pages: workspace-level pages belong to zero projects.

#### Note for maintainers (not addressed here)

`ISSUE_ATTACHMENT` interpolates `project_id` the same way, and `DuplicateAssetEndpoint.post` accepts `entity_type` and `project_id` independently, so an attachment can also end up with a NULL `project_id`. I left it alone because there is no workspace-scoped attachment route to fall back to, so the right behaviour there is a design call rather than a mechanical fix. Happy to follow up in a separate PR if you want it covered.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)

N/A — the change is a URL-building fix in a model property.

### Test Scenarios

New unit tests in `apps/api/plane/tests/unit/models/test_file_asset_url.py` (9 cases, run with `pytest plane/tests/unit/models/test_file_asset_url.py`):

- Each of the four description entity types with `project_id` NULL resolves to `/api/assets/v2/workspaces/{slug}/{id}/`, and the URL contains no `None`.
- Each of the four description entity types bound to a project keeps `/api/assets/v2/workspaces/{slug}/projects/{project_id}/{id}/`.
- `WORKSPACE_LOGO` still resolves to the `/api/assets/v2/static/{id}/` route, guarding the branch above the change.

Verified the tests fail without the fix (the 4 project-less cases go red with `projects/None/` in the actual value) and pass with it. `ruff check` and `ruff format --check` both pass on the two files.

### References

Fixes #9564

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed asset links for workspace-level descriptions so they no longer contain invalid project paths.
  * Preserved project-specific links for descriptions associated with a project.
  * Ensured workspace-level assets continue using the appropriate static links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->