### PR TITLE
fix(i18n): route remaining hardcoded zh-CN-visible strings in settings and issue detail through i18n keys

### DIFF
--- a/apps/web/core/components/issues/issue-detail/issue-activity/helper.tsx
+++ b/apps/web/core/components/issues/issue-detail/issue-activity/helper.tsx
@@ -162,15 +162,15 @@ export const useWorkItemCommentOperations = (
           if (!workspaceSlug || !projectId || !commentId) throw new Error("Missing fields");
           await createCommentReaction(workspaceSlug, projectId, commentId, reaction);
           setToast({
-            title: "Success!",
+            title: t("toast.success"),
             type: TOAST_TYPE.SUCCESS,
-            message: "Reaction created successfully",
+            message: t("reactions.toasts.created"),
           });
         } catch {
           setToast({
-            title: "Error!",
+            title: t("toast.error"),
             type: TOAST_TYPE.ERROR,
-            message: "Reaction creation failed",
+            message: t("reactions.toasts.creation_failed"),
           });
         }
       },
@@ -179,15 +179,15 @@ export const useWorkItemCommentOperations = (
           if (!workspaceSlug || !projectId || !commentId || !currentUser?.id) throw new Error("Missing fields");
           removeCommentReaction(workspaceSlug, projectId, commentId, reaction, currentUser.id);
           setToast({
-            title: "Success!",
+            title: t("toast.success"),
             type: TOAST_TYPE.SUCCESS,
-            message: "Reaction removed successfully",
+            message: t("reactions.toasts.removed"),
           });
         } catch {
           setToast({
-            title: "Error!",
+            title: t("toast.error"),
             type: TOAST_TYPE.ERROR,
-            message: "Reaction remove failed",
+            message: t("reactions.toasts.remove_failed"),
           });
         }
       },

--- a/apps/web/core/components/issues/issue-detail/links/root.tsx
+++ b/apps/web/core/components/issues/issue-detail/links/root.tsx
@@ -8,6 +8,7 @@ import { useCallback, useMemo, useState } from "react";
 
 import { PlusIcon } from "@plane/propel/icons";
 // plane imports
+import { useTranslation } from "@plane/i18n";
 import { TOAST_TYPE, setToast } from "@plane/propel/toast";
 import type { TIssueLink } from "@plane/types";
 import { EIssueServiceType } from "@plane/types";
@@ -33,6 +34,8 @@ export type TIssueLinkRoot = {
 export function IssueLinkRoot(props: TIssueLinkRoot) {
   // props
   const { workspaceSlug, projectId, issueId, disabled = false } = props;
+  // translation
+  const { t } = useTranslation();
   // hooks
   const { toggleIssueLinkModal: toggleIssueLinkModalStore, createLink, updateLink, removeLink } = useIssueDetail();
   // state
@@ -52,16 +55,16 @@ export function IssueLinkRoot(props: TIssueLinkRoot) {
           if (!workspaceSlug || !projectId || !issueId) throw new Error("Missing required fields");
           await createLink(workspaceSlug, projectId, issueId, data);
           setToast({
-            message: "The link has been successfully created",
+            message: t("links.toasts.created.message"),
             type: TOAST_TYPE.SUCCESS,
-            title: "Link created",
+            title: t("links.toasts.created.title"),
           });
           toggleIssueLinkModal(false);
         } catch (error: any) {
           setToast({
-            message: error?.data?.error ?? "The link could not be created",
+            message: error?.data?.error ?? t("links.toasts.not_created.message"),
             type: TOAST_TYPE.ERROR,
-            title: "Link not created",
+            title: t("links.toasts.not_created.title"),
           });
           throw error;
         }
@@ -71,16 +74,16 @@ export function IssueLinkRoot(props: TIssueLinkRoot) {
           if (!workspaceSlug || !projectId || !issueId) throw new Error("Missing required fields");
           await updateLink(workspaceSlug, projectId, issueId, linkId, data);
           setToast({
-            message: "The link has been successfully updated",
+            message: t("links.toasts.updated.message"),
             type: TOAST_TYPE.SUCCESS,
-            title: "Link updated",
+            title: t("links.toasts.updated.title"),
           });
           toggleIssueLinkModal(false);
         } catch (error) {
           setToast({
-            message: "The link could not be updated",
+            message: t("links.toasts.not_updated.message"),
             type: TOAST_TYPE.ERROR,
-            title: "Link not updated",
+            title: t("links.toasts.not_updated.title"),
           });
           throw error;
         }
@@ -90,21 +93,21 @@ export function IssueLinkRoot(props: TIssueLinkRoot) {
           if (!workspaceSlug || !projectId || !issueId) throw new Error("Missing required fields");
           await removeLink(workspaceSlug, projectId, issueId, linkId);
           setToast({
-            message: "The link has been successfully removed",
+            message: t("links.toasts.removed.message"),
             type: TOAST_TYPE.SUCCESS,
-            title: "Link removed",
+            title: t("links.toasts.removed.title"),
           });
           toggleIssueLinkModal(false);
         } catch {
           setToast({
-            message: "The link could not be removed",
+            message: t("links.toasts.not_removed.message"),
             type: TOAST_TYPE.ERROR,
-            title: "Link not removed",
+            title: t("links.toasts.not_removed.title"),
           });
         }
       },
     }),
-    [workspaceSlug, projectId, issueId, createLink, updateLink, removeLink, toggleIssueLinkModal]
+    [workspaceSlug, projectId, issueId, createLink, updateLink, removeLink, toggleIssueLinkModal, t]
   );
 
   const handleOnClose = () => {

--- a/apps/web/core/components/issues/issue-detail/reactions/issue-comment.tsx
+++ b/apps/web/core/components/issues/issue-detail/reactions/issue-comment.tsx
@@ -9,6 +9,7 @@ import { observer } from "mobx-react";
 import { stringToEmoji } from "@plane/propel/emoji-icon-picker";
 import { EmojiReactionGroup, EmojiReactionPicker } from "@plane/propel/emoji-reaction";
 import type { EmojiReactionType } from "@plane/propel/emoji-reaction";
+import { useTranslation } from "@plane/i18n";
 import { TOAST_TYPE, setToast } from "@plane/propel/toast";
 import type { IUser } from "@plane/types";
 // hooks
@@ -34,6 +35,8 @@ export const IssueCommentReaction = observer(function IssueCommentReaction(props
     removeCommentReaction,
   } = useIssueDetail();
   const { getUserDetails } = useMember();
+  // translation
+  const { t } = useTranslation();
 
   const reactionIds = getCommentReactionsByCommentId(commentId);
   const userReactions = commentReactionsByUser(commentId, currentUser.id).map((r) => r.reaction);
@@ -45,15 +48,15 @@ export const IssueCommentReaction = observer(function IssueCommentReaction(props
           if (!workspaceSlug || !projectId || !commentId) throw new Error("Missing fields");
           await createCommentReaction(workspaceSlug, projectId, commentId, reaction);
           setToast({
-            title: "Success!",
+            title: t("toast.success"),
             type: TOAST_TYPE.SUCCESS,
-            message: "Reaction created successfully",
+            message: t("reactions.toasts.created"),
           });
         } catch (_error) {
           setToast({
-            title: "Error!",
+            title: t("toast.error"),
             type: TOAST_TYPE.ERROR,
-            message: "Reaction creation failed",
+            message: t("reactions.toasts.creation_failed"),
           });
         }
       },
@@ -62,15 +65,15 @@ export const IssueCommentReaction = observer(function IssueCommentReaction(props
           if (!workspaceSlug || !projectId || !commentId || !currentUser?.id) throw new Error("Missing fields");
           removeCommentReaction(workspaceSlug, projectId, commentId, reaction, currentUser.id);
           setToast({
-            title: "Success!",
+            title: t("toast.success"),
             type: TOAST_TYPE.SUCCESS,
-            message: "Reaction removed successfully",
+            message: t("reactions.toasts.removed"),
           });
         } catch (_error) {
           setToast({
-            title: "Error!",
+            title: t("toast.error"),
             type: TOAST_TYPE.ERROR,
-            message: "Reaction remove failed",
+            message: t("reactions.toasts.remove_failed"),
           });
         }
       },
@@ -79,7 +82,7 @@ export const IssueCommentReaction = observer(function IssueCommentReaction(props
         else await issueCommentReactionOperations.create(reaction);
       },
     }),
-    [workspaceSlug, projectId, commentId, currentUser, createCommentReaction, removeCommentReaction, userReactions]
+    [workspaceSlug, projectId, commentId, currentUser, createCommentReaction, removeCommentReaction, userReactions, t]
   );
 
   const getReactionUsers = (reaction: string): string[] => {

--- a/apps/web/core/components/issues/issue-detail/reactions/issue.tsx
+++ b/apps/web/core/components/issues/issue-detail/reactions/issue.tsx
@@ -9,6 +9,7 @@ import { observer } from "mobx-react";
 import { stringToEmoji } from "@plane/propel/emoji-icon-picker";
 import { EmojiReactionGroup, EmojiReactionPicker } from "@plane/propel/emoji-reaction";
 import type { EmojiReactionType } from "@plane/propel/emoji-reaction";
+import { useTranslation } from "@plane/i18n";
 import { TOAST_TYPE, setToast } from "@plane/propel/toast";
 import type { IUser } from "@plane/types";
 // hooks
@@ -39,6 +40,8 @@ export const IssueReaction = observer(function IssueReaction(props: TIssueReacti
     removeReaction,
   } = useIssueDetail();
   const { getUserDetails } = useMember();
+  // translation
+  const { t } = useTranslation();
 
   const reactionIds = getReactionsByIssueId(issueId);
   const userReactions = reactionsByUser(issueId, currentUser.id).map((r) => r.reaction);
@@ -50,15 +53,15 @@ export const IssueReaction = observer(function IssueReaction(props: TIssueReacti
           if (!workspaceSlug || !projectId || !issueId) throw new Error("Missing fields");
           await createReaction(workspaceSlug, projectId, issueId, reaction);
           setToast({
-            title: "Success!",
+            title: t("toast.success"),
             type: TOAST_TYPE.SUCCESS,
-            message: "Reaction created successfully",
+            message: t("reactions.toasts.created"),
           });
         } catch (_error) {
           setToast({
-            title: "Error!",
+            title: t("toast.error"),
             type: TOAST_TYPE.ERROR,
-            message: "Reaction creation failed",
+            message: t("reactions.toasts.creation_failed"),
           });
         }
       },
@@ -67,15 +70,15 @@ export const IssueReaction = observer(function IssueReaction(props: TIssueReacti
           if (!workspaceSlug || !projectId || !issueId || !currentUser?.id) throw new Error("Missing fields");
           await removeReaction(workspaceSlug, projectId, issueId, reaction, currentUser.id);
           setToast({
-            title: "Success!",
+            title: t("toast.success"),
             type: TOAST_TYPE.SUCCESS,
-            message: "Reaction removed successfully",
+            message: t("reactions.toasts.removed"),
           });
         } catch (_error) {
           setToast({
-            title: "Error!",
+            title: t("toast.error"),
             type: TOAST_TYPE.ERROR,
-            message: "Reaction remove failed",
+            message: t("reactions.toasts.remove_failed"),
           });
         }
       },
@@ -84,7 +87,7 @@ export const IssueReaction = observer(function IssueReaction(props: TIssueReacti
         else await issueReactionOperations.create(reaction);
       },
     }),
-    [workspaceSlug, projectId, issueId, currentUser, createReaction, removeReaction, userReactions]
+    [workspaceSlug, projectId, issueId, currentUser, createReaction, removeReaction, userReactions, t]
   );
 
   const getReactionUsers = (reaction: string): string[] => {

--- a/apps/web/core/components/issues/issue-detail/relation-select.tsx
+++ b/apps/web/core/components/issues/issue-detail/relation-select.tsx
@@ -10,6 +10,7 @@ import Link from "next/link";
 
 import { EditIcon, CloseIcon } from "@plane/propel/icons";
 // Plane
+import { useTranslation } from "@plane/i18n";
 import { TOAST_TYPE, setToast } from "@plane/propel/toast";
 import { Tooltip } from "@plane/propel/tooltip";
 import type { ISearchIssueResponse } from "@plane/types";
@@ -48,6 +49,8 @@ export const IssueRelationSelect = observer(function IssueRelationSelect(props: 
   } = useIssueDetail();
   const { issueMap } = useIssues();
   const { isMobile } = usePlatformOS();
+  // translation
+  const { t } = useTranslation();
   const relationIssueIds = getRelationByIssueIdRelationType(issueId, relationKey);
   const ISSUE_RELATION_OPTIONS = useTimeLineRelationOptions();
 
@@ -55,8 +58,8 @@ export const IssueRelationSelect = observer(function IssueRelationSelect(props: 
     if (data.length === 0) {
       setToast({
         type: TOAST_TYPE.ERROR,
-        title: "Error!",
-        message: "Please select at least one work item.",
+        title: t("toast.error"),
+        message: t("please_select_at_least_one_work_item"),
       });
       return;
     }
@@ -119,7 +122,7 @@ export const IssueRelationSelect = observer(function IssueRelationSelect(props: 
                     key={relationIssueId}
                     className={`group flex items-center gap-1 rounded-sm px-1.5 pt-1 pb-1 leading-3 hover:bg-surface-2 ${currRelationOption?.className}`}
                   >
-                    <Tooltip tooltipHeading="Title" tooltipContent={currentIssue.name} isMobile={isMobile}>
+                    <Tooltip tooltipHeading={t("title")} tooltipContent={currentIssue.name} isMobile={isMobile}>
                       <Link
                         href={generateWorkItemLink({
                           workspaceSlug,
@@ -137,7 +140,7 @@ export const IssueRelationSelect = observer(function IssueRelationSelect(props: 
                       </Link>
                     </Tooltip>
                     {!disabled && (
-                      <Tooltip tooltipContent="Remove" position="bottom" isMobile={isMobile}>
+                      <Tooltip tooltipContent={t("remove")} position="bottom" isMobile={isMobile}>
                         {/* eslint-disable-next-line jsx_a11y/click-events-have-key-events oxlint-disable-next-line jsx_a11y/no-static-element-interactions */}
                         <span
                           onClick={(e) => {

--- a/apps/web/core/components/profile/start-of-week-preference.tsx
+++ b/apps/web/core/components/profile/start-of-week-preference.tsx
@@ -7,6 +7,7 @@
 import { observer } from "mobx-react";
 // plane imports
 import { START_OF_THE_WEEK_OPTIONS } from "@plane/constants";
+import { useTranslation } from "@plane/i18n";
 import { TOAST_TYPE, setToast } from "@plane/propel/toast";
 import type { EStartOfTheWeek } from "@plane/types";
 import { CustomSelect } from "@plane/ui";
@@ -23,13 +24,23 @@ export const StartOfWeekPreference = observer(function StartOfWeekPreference(pro
 }) {
   // hooks
   const { data: userProfile, updateUserProfile } = useUserProfile();
+  // translation
+  const { t } = useTranslation();
 
   const handleStartOfWeekChange = async (val: number) => {
     try {
       await updateUserProfile({ start_of_the_week: val });
-      setToast({ type: TOAST_TYPE.SUCCESS, title: "Success", message: "First day of the week updated successfully" });
+      setToast({
+        type: TOAST_TYPE.SUCCESS,
+        title: t("toast.success"),
+        message: t("account_settings.preferences.toasts.start_of_week_updated"),
+      });
     } catch (_error) {
-      setToast({ type: TOAST_TYPE.ERROR, title: "Update failed", message: "Please try again later." });
+      setToast({
+        type: TOAST_TYPE.ERROR,
+        title: t("toast.error"),
+        message: t("account_settings.preferences.toasts.start_of_week_update_failed"),
+      });
     }
   };
 

--- a/apps/web/core/components/settings/profile/content/pages/general/form.tsx
+++ b/apps/web/core/components/settings/profile/content/pages/general/form.tsx
@@ -98,8 +98,8 @@ export const GeneralProfileSettingsForm = observer(function GeneralProfileSettin
       .then(() => {
         setToast({
           type: TOAST_TYPE.SUCCESS,
-          title: "Success!",
-          message: "Profile picture deleted successfully.",
+          title: t("toast.success"),
+          message: t("account_settings.profile.general.toasts.picture_deleted"),
         });
         setValue("avatar_url", "");
         return;
@@ -107,8 +107,8 @@ export const GeneralProfileSettingsForm = observer(function GeneralProfileSettin
       .catch(() => {
         setToast({
           type: TOAST_TYPE.ERROR,
-          title: "Error!",
-          message: "There was some error in deleting your profile picture. Please try again.",
+          title: t("toast.error"),
+          message: t("account_settings.profile.general.toasts.picture_delete_failed"),
         });
       })
       .finally(() => {
@@ -176,14 +176,14 @@ export const GeneralProfileSettingsForm = observer(function GeneralProfileSettin
       .finally(() => setIsLoading(false));
 
     setPromiseToast(updatePromise, {
-      loading: "Updating...",
+      loading: t("account_settings.profile.general.toasts.updating"),
       success: {
-        title: "Success!",
-        message: () => `Profile updated successfully.`,
+        title: t("toast.success"),
+        message: () => t("account_settings.profile.general.toasts.updated"),
       },
       error: {
-        title: "Error!",
-        message: () => `There was some error in updating your profile. Please try again.`,
+        title: t("toast.error"),
+        message: () => t("account_settings.profile.general.toasts.update_failed"),
       },
     });
   };
@@ -275,7 +275,7 @@ export const GeneralProfileSettingsForm = observer(function GeneralProfileSettin
                   control={control}
                   name="first_name"
                   rules={{
-                    required: "Please enter first name",
+                    required: t("account_settings.profile.general.form.errors.first_name_required"),
                     validate: validatePersonName,
                   }}
                   render={({ field: { value, onChange, ref } }) => (
@@ -287,7 +287,7 @@ export const GeneralProfileSettingsForm = observer(function GeneralProfileSettin
                       onChange={onChange}
                       ref={ref}
                       hasError={Boolean(errors.first_name)}
-                      placeholder="Enter your first name"
+                      placeholder={t("account_settings.profile.general.form.first_name_placeholder")}
                       className={`w-full rounded-md ${errors.first_name ? "border-danger-strong" : ""}`}
                       maxLength={50}
                       autoComplete="on"
@@ -313,7 +313,7 @@ export const GeneralProfileSettingsForm = observer(function GeneralProfileSettin
                       onChange={onChange}
                       ref={ref}
                       hasError={Boolean(errors.last_name)}
-                      placeholder="Enter your last name"
+                      placeholder={t("account_settings.profile.general.form.last_name_placeholder")}
                       className="w-full rounded-md"
                       maxLength={50}
                       autoComplete="on"
@@ -331,7 +331,7 @@ export const GeneralProfileSettingsForm = observer(function GeneralProfileSettin
                   control={control}
                   name="display_name"
                   rules={{
-                    required: "Display name is required.",
+                    required: t("account_settings.profile.general.form.errors.display_name_required"),
                     validate: validateDisplayName,
                   }}
                   render={({ field: { value, onChange, ref } }) => (
@@ -343,7 +343,7 @@ export const GeneralProfileSettingsForm = observer(function GeneralProfileSettin
                       onChange={onChange}
                       ref={ref}
                       hasError={Boolean(errors?.display_name)}
-                      placeholder="Enter your display name"
+                      placeholder={t("account_settings.profile.general.form.display_name_placeholder")}
                       className={`w-full ${errors?.display_name ? "border-danger-strong" : ""}`}
                       maxLength={50}
                     />
@@ -362,7 +362,7 @@ export const GeneralProfileSettingsForm = observer(function GeneralProfileSettin
                   control={control}
                   name="email"
                   rules={{
-                    required: "Email is required.",
+                    required: t("account_settings.profile.general.form.errors.email_required"),
                   }}
                   render={({ field: { value, ref } }) => (
                     <Input
@@ -372,7 +372,7 @@ export const GeneralProfileSettingsForm = observer(function GeneralProfileSettin
                       value={value}
                       ref={ref}
                       hasError={Boolean(errors.email)}
-                      placeholder="Enter your email"
+                      placeholder={t("account_settings.profile.general.form.email_placeholder")}
                       className={`w-full cursor-not-allowed rounded-md !bg-surface-2 ${
                         errors.email ? "border-danger-strong" : ""
                       }`}

--- a/apps/web/core/components/settings/profile/content/pages/preferences/language-and-timezone-list.tsx
+++ b/apps/web/core/components/settings/profile/content/pages/preferences/language-and-timezone-list.tsx
@@ -32,14 +32,14 @@ export const ProfileSettingsLanguageAndTimezonePreferencesList = observer(
       try {
         await updateCurrentUser({ user_timezone: value });
         setToast({
-          title: "Success!",
-          message: "Timezone updated successfully",
+          title: t("toast.success"),
+          message: t("account_settings.preferences.toasts.timezone_updated"),
           type: TOAST_TYPE.SUCCESS,
         });
       } catch (_error) {
         setToast({
-          title: "Error!",
-          message: "Failed to update timezone",
+          title: t("toast.error"),
+          message: t("account_settings.preferences.toasts.timezone_update_failed"),
           type: TOAST_TYPE.ERROR,
         });
       }
@@ -49,14 +49,14 @@ export const ProfileSettingsLanguageAndTimezonePreferencesList = observer(
       try {
         await updateUserProfile({ language: value });
         setToast({
-          title: "Success!",
-          message: "Language updated successfully",
+          title: t("toast.success"),
+          message: t("account_settings.preferences.toasts.language_updated"),
           type: TOAST_TYPE.SUCCESS,
         });
       } catch (_error) {
         setToast({
-          title: "Error!",
-          message: "Failed to update language",
+          title: t("toast.error"),
+          message: t("account_settings.preferences.toasts.language_update_failed"),
           type: TOAST_TYPE.ERROR,
         });
       }
@@ -81,7 +81,11 @@ export const ProfileSettingsLanguageAndTimezonePreferencesList = observer(
           control={
             <CustomSelect
               value={profile?.language}
-              label={profile?.language ? getLanguageLabel(profile?.language) : "Select a language"}
+              label={
+                profile?.language
+                  ? getLanguageLabel(profile?.language)
+                  : t("account_settings.preferences.select_a_language")
+              }
               onChange={handleLanguageChange}
               buttonClassName="border border-subtle-1"
               className="rounded-md"
@@ -98,8 +102,8 @@ export const ProfileSettingsLanguageAndTimezonePreferencesList = observer(
         />
         <StartOfWeekPreference
           option={{
-            title: "First day of the week",
-            description: "This will change how all calendars in your app look.",
+            title: t("account_settings.preferences.start_of_week.title"),
+            description: t("account_settings.preferences.start_of_week.description"),
           }}
         />
       </div>

--- a/apps/web/core/components/settings/project/content/feature-control-item.tsx
+++ b/apps/web/core/components/settings/project/content/feature-control-item.tsx
@@ -6,6 +6,7 @@
 
 import { observer } from "mobx-react";
 // plane imports
+import { useTranslation } from "@plane/i18n";
 import { setPromiseToast } from "@plane/propel/toast";
 import type { IProject } from "@plane/types";
 import { ToggleSwitch } from "@plane/ui";
@@ -28,6 +29,8 @@ export const ProjectSettingsFeatureControlItem = observer(function ProjectSettin
   const { description, disabled, featureProperty, projectId, title, value, workspaceSlug } = props;
   // store hooks
   const { getProjectById, updateProject } = useProject();
+  // translation
+  const { t } = useTranslation();
   // derived values
   const currentProjectDetails = getProjectById(projectId);
 
@@ -41,14 +44,14 @@ export const ProjectSettingsFeatureControlItem = observer(function ProjectSettin
     const updateProjectPromise = updateProject(workspaceSlug, projectId, settingsPayload);
 
     setPromiseToast(updateProjectPromise, {
-      loading: "Updating project feature...",
+      loading: t("project_settings.feature_toasts.updating"),
       success: {
-        title: "Success!",
-        message: () => "Project feature updated successfully.",
+        title: t("toast.success"),
+        message: () => t("project_settings.feature_toasts.updated"),
       },
       error: {
-        title: "Error!",
-        message: () => "Something went wrong while updating project feature. Please try again.",
+        title: t("toast.error"),
+        message: () => t("project_settings.feature_toasts.update_failed"),
       },
     });
     void updateProjectPromise.then(() => {

--- a/apps/web/core/components/settings/project/sidebar/header.tsx
+++ b/apps/web/core/components/settings/project/sidebar/header.tsx
@@ -48,7 +48,7 @@ export const ProjectSettingsSidebarHeader = observer(function ProjectSettingsSid
           icon={ArrowLeft}
           onClick={() => router.push(`/${currentWorkspace?.slug}/projects/${projectId}/issues/`)}
         />
-        <p>Project settings</p>
+        <p>{t("project_settings.label")}</p>
       </div>
       <div className="mt-1.5 flex items-center gap-2 truncate px-5 py-0.5">
         <div className="grid size-8 shrink-0 place-items-center rounded bg-layer-2">

--- a/apps/web/core/components/settings/workspace/sidebar/header.tsx
+++ b/apps/web/core/components/settings/workspace/sidebar/header.tsx
@@ -41,7 +41,7 @@ export const WorkspaceSettingsSidebarHeader = observer(function WorkspaceSetting
           icon={ArrowLeft}
           onClick={() => router.push(`/${currentWorkspace?.slug}/`)}
         />
-        <p>Workspace settings</p>
+        <p>{t("workspace_settings.label")}</p>
       </div>
       <div className="mt-1.5 flex items-center justify-between gap-2 px-5 py-0.5">
         <div className="flex items-center gap-2 truncate">

--- a/apps/web/core/components/workspace/settings/workspace-details.tsx
+++ b/apps/web/core/components/workspace/settings/workspace-details.tsx
@@ -69,9 +69,9 @@ export const WorkspaceDetails = observer(function WorkspaceDetails() {
     try {
       await updateWorkspace(currentWorkspace.slug, payload);
       setToast({
-        title: "Success!",
+        title: t("toast.success"),
         type: TOAST_TYPE.SUCCESS,
-        message: "Workspace updated successfully",
+        message: t("workspace_settings.toasts.updated"),
       });
     } catch (err: unknown) {
       console.error(err);
@@ -91,14 +91,14 @@ export const WorkspaceDetails = observer(function WorkspaceDetails() {
       });
       setToast({
         type: TOAST_TYPE.SUCCESS,
-        title: "Success!",
-        message: "Workspace picture removed successfully.",
+        title: t("toast.success"),
+        message: t("workspace_settings.toasts.picture_removed"),
       });
     } catch {
       setToast({
         type: TOAST_TYPE.ERROR,
-        title: "Error!",
-        message: "There was some error in deleting your profile picture. Please try again.",
+        title: t("toast.error"),
+        message: t("workspace_settings.toasts.picture_remove_failed"),
       });
     }
   };
@@ -110,7 +110,7 @@ export const WorkspaceDetails = observer(function WorkspaceDetails() {
       .then(() => {
         setToast({
           type: TOAST_TYPE.SUCCESS,
-          title: "Workspace URL copied to the clipboard.",
+          title: t("workspace_settings.toasts.url_copied"),
         });
         return undefined;
       })

--- a/packages/i18n/src/locales/cs/common.json
+++ b/packages/i18n/src/locales/cs/common.json
@@ -867,5 +867,14 @@
       "description": "Exportujte položky do JSON.",
       "short_description": "Exportovat jako JSON"
     }
-  }
+  },
+  "reactions": {
+    "toasts": {
+      "created": "Reaction created successfully",
+      "creation_failed": "Reaction creation failed",
+      "removed": "Reaction removed successfully",
+      "remove_failed": "Reaction remove failed"
+    }
+  },
+  "please_select_at_least_one_work_item": "Please select at least one work item."
 }

--- a/packages/i18n/src/locales/cs/project-settings.json
+++ b/packages/i18n/src/locales/cs/project-settings.json
@@ -521,6 +521,12 @@
           }
         }
       }
+    },
+    "label": "Project settings",
+    "feature_toasts": {
+      "updating": "Updating project feature...",
+      "updated": "Project feature updated successfully.",
+      "update_failed": "Something went wrong while updating project feature. Please try again."
     }
   }
 }

--- a/packages/i18n/src/locales/cs/settings.json
+++ b/packages/i18n/src/locales/cs/settings.json
@@ -37,11 +37,44 @@
         "states": {
           "sending": "Odesílání…"
         }
+      },
+      "general": {
+        "form": {
+          "first_name_placeholder": "Enter your first name",
+          "last_name_placeholder": "Enter your last name",
+          "display_name_placeholder": "Enter your display name",
+          "email_placeholder": "Enter your email",
+          "errors": {
+            "first_name_required": "Please enter first name",
+            "display_name_required": "Display name is required.",
+            "email_required": "Email is required."
+          }
+        },
+        "toasts": {
+          "picture_deleted": "Profile picture deleted successfully.",
+          "picture_delete_failed": "There was some error in deleting your profile picture. Please try again.",
+          "updating": "Updating...",
+          "updated": "Profile updated successfully.",
+          "update_failed": "There was some error in updating your profile. Please try again."
+        }
       }
     },
     "preferences": {
       "heading": "Předvolby",
-      "description": "Přizpůsobte si prostředí aplikace podle toho, jak pracujete"
+      "description": "Přizpůsobte si prostředí aplikace podle toho, jak pracujete",
+      "select_a_language": "Select a language",
+      "start_of_week": {
+        "title": "First day of the week",
+        "description": "This will change how all calendars in your app look."
+      },
+      "toasts": {
+        "timezone_updated": "Timezone updated successfully",
+        "timezone_update_failed": "Failed to update timezone",
+        "language_updated": "Language updated successfully",
+        "language_update_failed": "Failed to update language",
+        "start_of_week_updated": "First day of the week updated successfully",
+        "start_of_week_update_failed": "Please try again later."
+      }
     },
     "notifications": {
       "heading": "E-mailová oznámení",

--- a/packages/i18n/src/locales/cs/workspace-settings.json
+++ b/packages/i18n/src/locales/cs/workspace-settings.json
@@ -503,6 +503,12 @@
         "title": "Žádné importy",
         "description": "Zde najdete historii importů."
       }
+    },
+    "toasts": {
+      "updated": "Workspace updated successfully",
+      "picture_removed": "Workspace picture removed successfully.",
+      "picture_remove_failed": "There was some error in deleting your profile picture. Please try again.",
+      "url_copied": "Workspace URL copied to the clipboard."
     }
   }
 }

--- a/packages/i18n/src/locales/de/common.json
+++ b/packages/i18n/src/locales/de/common.json
@@ -867,5 +867,14 @@
       "description": "Arbeitselemente in JSON exportieren.",
       "short_description": "Als JSON exportieren"
     }
-  }
+  },
+  "reactions": {
+    "toasts": {
+      "created": "Reaction created successfully",
+      "creation_failed": "Reaction creation failed",
+      "removed": "Reaction removed successfully",
+      "remove_failed": "Reaction remove failed"
+    }
+  },
+  "please_select_at_least_one_work_item": "Please select at least one work item."
 }

--- a/packages/i18n/src/locales/de/project-settings.json
+++ b/packages/i18n/src/locales/de/project-settings.json
@@ -521,6 +521,12 @@
           }
         }
       }
+    },
+    "label": "Project settings",
+    "feature_toasts": {
+      "updating": "Updating project feature...",
+      "updated": "Project feature updated successfully.",
+      "update_failed": "Something went wrong while updating project feature. Please try again."
     }
   }
 }

--- a/packages/i18n/src/locales/de/settings.json
+++ b/packages/i18n/src/locales/de/settings.json
@@ -37,11 +37,44 @@
         "states": {
           "sending": "Wird gesendet…"
         }
+      },
+      "general": {
+        "form": {
+          "first_name_placeholder": "Enter your first name",
+          "last_name_placeholder": "Enter your last name",
+          "display_name_placeholder": "Enter your display name",
+          "email_placeholder": "Enter your email",
+          "errors": {
+            "first_name_required": "Please enter first name",
+            "display_name_required": "Display name is required.",
+            "email_required": "Email is required."
+          }
+        },
+        "toasts": {
+          "picture_deleted": "Profile picture deleted successfully.",
+          "picture_delete_failed": "There was some error in deleting your profile picture. Please try again.",
+          "updating": "Updating...",
+          "updated": "Profile updated successfully.",
+          "update_failed": "There was some error in updating your profile. Please try again."
+        }
       }
     },
     "preferences": {
       "heading": "Einstellungen",
-      "description": "Passen Sie Ihre App-Erfahrung an Ihre Arbeitsweise an"
+      "description": "Passen Sie Ihre App-Erfahrung an Ihre Arbeitsweise an",
+      "select_a_language": "Select a language",
+      "start_of_week": {
+        "title": "First day of the week",
+        "description": "This will change how all calendars in your app look."
+      },
+      "toasts": {
+        "timezone_updated": "Timezone updated successfully",
+        "timezone_update_failed": "Failed to update timezone",
+        "language_updated": "Language updated successfully",
+        "language_update_failed": "Failed to update language",
+        "start_of_week_updated": "First day of the week updated successfully",
+        "start_of_week_update_failed": "Please try again later."
+      }
     },
     "notifications": {
       "heading": "E-Mail-Benachrichtigungen",

--- a/packages/i18n/src/locales/de/workspace-settings.json
+++ b/packages/i18n/src/locales/de/workspace-settings.json
@@ -503,6 +503,12 @@
         "title": "Keine Importe",
         "description": "Hier finden Sie Ihre Importhistorie."
       }
+    },
+    "toasts": {
+      "updated": "Workspace updated successfully",
+      "picture_removed": "Workspace picture removed successfully.",
+      "picture_remove_failed": "There was some error in deleting your profile picture. Please try again.",
+      "url_copied": "Workspace URL copied to the clipboard."
     }
   }
 }

--- a/packages/i18n/src/locales/en/common.json
+++ b/packages/i18n/src/locales/en/common.json
@@ -374,6 +374,15 @@
     "success": "Success!",
     "error": "Error!"
   },
+  "reactions": {
+    "toasts": {
+      "created": "Reaction created successfully",
+      "creation_failed": "Reaction creation failed",
+      "removed": "Reaction removed successfully",
+      "remove_failed": "Reaction remove failed"
+    }
+  },
+  "please_select_at_least_one_work_item": "Please select at least one work item.",
   "links": {
     "toasts": {
       "created": {

--- a/packages/i18n/src/locales/en/project-settings.json
+++ b/packages/i18n/src/locales/en/project-settings.json
@@ -1,5 +1,11 @@
 {
   "project_settings": {
+    "label": "Project settings",
+    "feature_toasts": {
+      "updating": "Updating project feature...",
+      "updated": "Project feature updated successfully.",
+      "update_failed": "Something went wrong while updating project feature. Please try again."
+    },
     "general": {
       "enter_project_id": "Enter project ID",
       "please_select_a_timezone": "Please select a timezone",

--- a/packages/i18n/src/locales/en/settings.json
+++ b/packages/i18n/src/locales/en/settings.json
@@ -37,11 +37,44 @@
         "states": {
           "sending": "Sending"
         }
+      },
+      "general": {
+        "form": {
+          "first_name_placeholder": "Enter your first name",
+          "last_name_placeholder": "Enter your last name",
+          "display_name_placeholder": "Enter your display name",
+          "email_placeholder": "Enter your email",
+          "errors": {
+            "first_name_required": "Please enter first name",
+            "display_name_required": "Display name is required.",
+            "email_required": "Email is required."
+          }
+        },
+        "toasts": {
+          "picture_deleted": "Profile picture deleted successfully.",
+          "picture_delete_failed": "There was some error in deleting your profile picture. Please try again.",
+          "updating": "Updating...",
+          "updated": "Profile updated successfully.",
+          "update_failed": "There was some error in updating your profile. Please try again."
+        }
       }
     },
     "preferences": {
       "heading": "Preferences",
-      "description": "Customize your app experience the way you work"
+      "description": "Customize your app experience the way you work",
+      "select_a_language": "Select a language",
+      "start_of_week": {
+        "title": "First day of the week",
+        "description": "This will change how all calendars in your app look."
+      },
+      "toasts": {
+        "timezone_updated": "Timezone updated successfully",
+        "timezone_update_failed": "Failed to update timezone",
+        "language_updated": "Language updated successfully",
+        "language_update_failed": "Failed to update language",
+        "start_of_week_updated": "First day of the week updated successfully",
+        "start_of_week_update_failed": "Please try again later."
+      }
     },
     "notifications": {
       "heading": "Email notifications",

--- a/packages/i18n/src/locales/en/workspace-settings.json
+++ b/packages/i18n/src/locales/en/workspace-settings.json
@@ -1,6 +1,12 @@
 {
   "workspace_settings": {
     "label": "Workspace settings",
+    "toasts": {
+      "updated": "Workspace updated successfully",
+      "picture_removed": "Workspace picture removed successfully.",
+      "picture_remove_failed": "There was some error in deleting your profile picture. Please try again.",
+      "url_copied": "Workspace URL copied to the clipboard."
+    },
     "page_label": "{workspace} - General settings",
     "key_created": "Key created",
     "copy_key": "Copy and save this secret key in Plane Pages. You can't see this key after you hit Close. A CSV file containing the key has been downloaded.",

--- a/packages/i18n/src/locales/es/common.json
+++ b/packages/i18n/src/locales/es/common.json
@@ -867,5 +867,14 @@
       "description": "Exporta elementos de trabajo a un archivo JSON.",
       "short_description": "Exportar como json"
     }
-  }
+  },
+  "reactions": {
+    "toasts": {
+      "created": "Reaction created successfully",
+      "creation_failed": "Reaction creation failed",
+      "removed": "Reaction removed successfully",
+      "remove_failed": "Reaction remove failed"
+    }
+  },
+  "please_select_at_least_one_work_item": "Please select at least one work item."
 }

--- a/packages/i18n/src/locales/es/project-settings.json
+++ b/packages/i18n/src/locales/es/project-settings.json
@@ -521,6 +521,12 @@
           }
         }
       }
+    },
+    "label": "Project settings",
+    "feature_toasts": {
+      "updating": "Updating project feature...",
+      "updated": "Project feature updated successfully.",
+      "update_failed": "Something went wrong while updating project feature. Please try again."
     }
   }
 }

--- a/packages/i18n/src/locales/es/settings.json
+++ b/packages/i18n/src/locales/es/settings.json
@@ -37,11 +37,44 @@
         "states": {
           "sending": "Enviando…"
         }
+      },
+      "general": {
+        "form": {
+          "first_name_placeholder": "Enter your first name",
+          "last_name_placeholder": "Enter your last name",
+          "display_name_placeholder": "Enter your display name",
+          "email_placeholder": "Enter your email",
+          "errors": {
+            "first_name_required": "Please enter first name",
+            "display_name_required": "Display name is required.",
+            "email_required": "Email is required."
+          }
+        },
+        "toasts": {
+          "picture_deleted": "Profile picture deleted successfully.",
+          "picture_delete_failed": "There was some error in deleting your profile picture. Please try again.",
+          "updating": "Updating...",
+          "updated": "Profile updated successfully.",
+          "update_failed": "There was some error in updating your profile. Please try again."
+        }
       }
     },
     "preferences": {
       "heading": "Preferencias",
-      "description": "Personaliza tu experiencia de la aplicación según tu forma de trabajar"
+      "description": "Personaliza tu experiencia de la aplicación según tu forma de trabajar",
+      "select_a_language": "Select a language",
+      "start_of_week": {
+        "title": "First day of the week",
+        "description": "This will change how all calendars in your app look."
+      },
+      "toasts": {
+        "timezone_updated": "Timezone updated successfully",
+        "timezone_update_failed": "Failed to update timezone",
+        "language_updated": "Language updated successfully",
+        "language_update_failed": "Failed to update language",
+        "start_of_week_updated": "First day of the week updated successfully",
+        "start_of_week_update_failed": "Please try again later."
+      }
     },
     "notifications": {
       "heading": "Notificaciones por correo electrónico",

--- a/packages/i18n/src/locales/es/workspace-settings.json
+++ b/packages/i18n/src/locales/es/workspace-settings.json
@@ -503,6 +503,12 @@
         "title": "No hay importaciones aún",
         "description": "Encuentra todas tus importaciones anteriores aquí y descárgalas."
       }
+    },
+    "toasts": {
+      "updated": "Workspace updated successfully",
+      "picture_removed": "Workspace picture removed successfully.",
+      "picture_remove_failed": "There was some error in deleting your profile picture. Please try again.",
+      "url_copied": "Workspace URL copied to the clipboard."
     }
   }
 }

--- a/packages/i18n/src/locales/fr/common.json
+++ b/packages/i18n/src/locales/fr/common.json
@@ -867,5 +867,14 @@
       "description": "Exportez les éléments de travail vers un fichier JSON.",
       "short_description": "Exporter en json"
     }
-  }
+  },
+  "reactions": {
+    "toasts": {
+      "created": "Reaction created successfully",
+      "creation_failed": "Reaction creation failed",
+      "removed": "Reaction removed successfully",
+      "remove_failed": "Reaction remove failed"
+    }
+  },
+  "please_select_at_least_one_work_item": "Please select at least one work item."
 }

--- a/packages/i18n/src/locales/fr/project-settings.json
+++ b/packages/i18n/src/locales/fr/project-settings.json
@@ -521,6 +521,12 @@
           }
         }
       }
+    },
+    "label": "Project settings",
+    "feature_toasts": {
+      "updating": "Updating project feature...",
+      "updated": "Project feature updated successfully.",
+      "update_failed": "Something went wrong while updating project feature. Please try again."
     }
   }
 }

--- a/packages/i18n/src/locales/fr/settings.json
+++ b/packages/i18n/src/locales/fr/settings.json
@@ -37,11 +37,44 @@
         "states": {
           "sending": "Envoi…"
         }
+      },
+      "general": {
+        "form": {
+          "first_name_placeholder": "Enter your first name",
+          "last_name_placeholder": "Enter your last name",
+          "display_name_placeholder": "Enter your display name",
+          "email_placeholder": "Enter your email",
+          "errors": {
+            "first_name_required": "Please enter first name",
+            "display_name_required": "Display name is required.",
+            "email_required": "Email is required."
+          }
+        },
+        "toasts": {
+          "picture_deleted": "Profile picture deleted successfully.",
+          "picture_delete_failed": "There was some error in deleting your profile picture. Please try again.",
+          "updating": "Updating...",
+          "updated": "Profile updated successfully.",
+          "update_failed": "There was some error in updating your profile. Please try again."
+        }
       }
     },
     "preferences": {
       "heading": "Préférences",
-      "description": "Personnalisez votre expérience de l’application selon votre façon de travailler"
+      "description": "Personnalisez votre expérience de l’application selon votre façon de travailler",
+      "select_a_language": "Select a language",
+      "start_of_week": {
+        "title": "First day of the week",
+        "description": "This will change how all calendars in your app look."
+      },
+      "toasts": {
+        "timezone_updated": "Timezone updated successfully",
+        "timezone_update_failed": "Failed to update timezone",
+        "language_updated": "Language updated successfully",
+        "language_update_failed": "Failed to update language",
+        "start_of_week_updated": "First day of the week updated successfully",
+        "start_of_week_update_failed": "Please try again later."
+      }
     },
     "notifications": {
       "heading": "Notifications par e-mail",

--- a/packages/i18n/src/locales/fr/workspace-settings.json
+++ b/packages/i18n/src/locales/fr/workspace-settings.json
@@ -503,6 +503,12 @@
         "title": "Aucune importation pour le moment",
         "description": "Trouvez toutes vos importations précédentes ici et téléchargez-les."
       }
+    },
+    "toasts": {
+      "updated": "Workspace updated successfully",
+      "picture_removed": "Workspace picture removed successfully.",
+      "picture_remove_failed": "There was some error in deleting your profile picture. Please try again.",
+      "url_copied": "Workspace URL copied to the clipboard."
     }
   }
 }

--- a/packages/i18n/src/locales/id/common.json
+++ b/packages/i18n/src/locales/id/common.json
@@ -867,5 +867,14 @@
       "description": "Ekspor item kerja ke file JSON.",
       "short_description": "Ekspor sebagai json"
     }
-  }
+  },
+  "reactions": {
+    "toasts": {
+      "created": "Reaction created successfully",
+      "creation_failed": "Reaction creation failed",
+      "removed": "Reaction removed successfully",
+      "remove_failed": "Reaction remove failed"
+    }
+  },
+  "please_select_at_least_one_work_item": "Please select at least one work item."
 }

--- a/packages/i18n/src/locales/id/project-settings.json
+++ b/packages/i18n/src/locales/id/project-settings.json
@@ -521,6 +521,12 @@
           }
         }
       }
+    },
+    "label": "Project settings",
+    "feature_toasts": {
+      "updating": "Updating project feature...",
+      "updated": "Project feature updated successfully.",
+      "update_failed": "Something went wrong while updating project feature. Please try again."
     }
   }
 }

--- a/packages/i18n/src/locales/id/settings.json
+++ b/packages/i18n/src/locales/id/settings.json
@@ -37,11 +37,44 @@
         "states": {
           "sending": "Mengirim…"
         }
+      },
+      "general": {
+        "form": {
+          "first_name_placeholder": "Enter your first name",
+          "last_name_placeholder": "Enter your last name",
+          "display_name_placeholder": "Enter your display name",
+          "email_placeholder": "Enter your email",
+          "errors": {
+            "first_name_required": "Please enter first name",
+            "display_name_required": "Display name is required.",
+            "email_required": "Email is required."
+          }
+        },
+        "toasts": {
+          "picture_deleted": "Profile picture deleted successfully.",
+          "picture_delete_failed": "There was some error in deleting your profile picture. Please try again.",
+          "updating": "Updating...",
+          "updated": "Profile updated successfully.",
+          "update_failed": "There was some error in updating your profile. Please try again."
+        }
       }
     },
     "preferences": {
       "heading": "Preferensi",
-      "description": "Sesuaikan pengalaman aplikasi Anda dengan cara kerja Anda"
+      "description": "Sesuaikan pengalaman aplikasi Anda dengan cara kerja Anda",
+      "select_a_language": "Select a language",
+      "start_of_week": {
+        "title": "First day of the week",
+        "description": "This will change how all calendars in your app look."
+      },
+      "toasts": {
+        "timezone_updated": "Timezone updated successfully",
+        "timezone_update_failed": "Failed to update timezone",
+        "language_updated": "Language updated successfully",
+        "language_update_failed": "Failed to update language",
+        "start_of_week_updated": "First day of the week updated successfully",
+        "start_of_week_update_failed": "Please try again later."
+      }
     },
     "notifications": {
       "heading": "Notifikasi email",

--- a/packages/i18n/src/locales/id/workspace-settings.json
+++ b/packages/i18n/src/locales/id/workspace-settings.json
@@ -503,6 +503,12 @@
         "title": "Belum ada impor",
         "description": "Temukan semua impor Anda sebelumnya di sini dan unduh."
       }
+    },
+    "toasts": {
+      "updated": "Workspace updated successfully",
+      "picture_removed": "Workspace picture removed successfully.",
+      "picture_remove_failed": "There was some error in deleting your profile picture. Please try again.",
+      "url_copied": "Workspace URL copied to the clipboard."
     }
   }
 }

--- a/packages/i18n/src/locales/it/common.json
+++ b/packages/i18n/src/locales/it/common.json
@@ -867,5 +867,14 @@
       "description": "Esporta elementi di lavoro in un file JSON.",
       "short_description": "Esporta come JSON"
     }
-  }
+  },
+  "reactions": {
+    "toasts": {
+      "created": "Reaction created successfully",
+      "creation_failed": "Reaction creation failed",
+      "removed": "Reaction removed successfully",
+      "remove_failed": "Reaction remove failed"
+    }
+  },
+  "please_select_at_least_one_work_item": "Please select at least one work item."
 }

--- a/packages/i18n/src/locales/it/project-settings.json
+++ b/packages/i18n/src/locales/it/project-settings.json
@@ -521,6 +521,12 @@
           }
         }
       }
+    },
+    "label": "Project settings",
+    "feature_toasts": {
+      "updating": "Updating project feature...",
+      "updated": "Project feature updated successfully.",
+      "update_failed": "Something went wrong while updating project feature. Please try again."
     }
   }
 }

--- a/packages/i18n/src/locales/it/settings.json
+++ b/packages/i18n/src/locales/it/settings.json
@@ -37,11 +37,44 @@
         "states": {
           "sending": "Invio…"
         }
+      },
+      "general": {
+        "form": {
+          "first_name_placeholder": "Enter your first name",
+          "last_name_placeholder": "Enter your last name",
+          "display_name_placeholder": "Enter your display name",
+          "email_placeholder": "Enter your email",
+          "errors": {
+            "first_name_required": "Please enter first name",
+            "display_name_required": "Display name is required.",
+            "email_required": "Email is required."
+          }
+        },
+        "toasts": {
+          "picture_deleted": "Profile picture deleted successfully.",
+          "picture_delete_failed": "There was some error in deleting your profile picture. Please try again.",
+          "updating": "Updating...",
+          "updated": "Profile updated successfully.",
+          "update_failed": "There was some error in updating your profile. Please try again."
+        }
       }
     },
     "preferences": {
       "heading": "Preferenze",
-      "description": "Personalizza la tua esperienza dell'app al modo in cui lavori"
+      "description": "Personalizza la tua esperienza dell'app al modo in cui lavori",
+      "select_a_language": "Select a language",
+      "start_of_week": {
+        "title": "First day of the week",
+        "description": "This will change how all calendars in your app look."
+      },
+      "toasts": {
+        "timezone_updated": "Timezone updated successfully",
+        "timezone_update_failed": "Failed to update timezone",
+        "language_updated": "Language updated successfully",
+        "language_update_failed": "Failed to update language",
+        "start_of_week_updated": "First day of the week updated successfully",
+        "start_of_week_update_failed": "Please try again later."
+      }
     },
     "notifications": {
       "heading": "Notifiche via email",

--- a/packages/i18n/src/locales/it/workspace-settings.json
+++ b/packages/i18n/src/locales/it/workspace-settings.json
@@ -503,6 +503,12 @@
         "title": "Nessuna importazione ancora",
         "description": "Trova qui tutte le tue importazioni precedenti e scaricale."
       }
+    },
+    "toasts": {
+      "updated": "Workspace updated successfully",
+      "picture_removed": "Workspace picture removed successfully.",
+      "picture_remove_failed": "There was some error in deleting your profile picture. Please try again.",
+      "url_copied": "Workspace URL copied to the clipboard."
     }
   }
 }

--- a/packages/i18n/src/locales/ja/common.json
+++ b/packages/i18n/src/locales/ja/common.json
@@ -867,5 +867,14 @@
       "description": "作業項目をJSONファイルにエクスポートします。",
       "short_description": "JSONとしてエクスポート"
     }
-  }
+  },
+  "reactions": {
+    "toasts": {
+      "created": "Reaction created successfully",
+      "creation_failed": "Reaction creation failed",
+      "removed": "Reaction removed successfully",
+      "remove_failed": "Reaction remove failed"
+    }
+  },
+  "please_select_at_least_one_work_item": "Please select at least one work item."
 }

--- a/packages/i18n/src/locales/ja/project-settings.json
+++ b/packages/i18n/src/locales/ja/project-settings.json
@@ -521,6 +521,12 @@
           }
         }
       }
+    },
+    "label": "Project settings",
+    "feature_toasts": {
+      "updating": "Updating project feature...",
+      "updated": "Project feature updated successfully.",
+      "update_failed": "Something went wrong while updating project feature. Please try again."
     }
   }
 }

--- a/packages/i18n/src/locales/ja/settings.json
+++ b/packages/i18n/src/locales/ja/settings.json
@@ -37,11 +37,44 @@
         "states": {
           "sending": "送信中…"
         }
+      },
+      "general": {
+        "form": {
+          "first_name_placeholder": "Enter your first name",
+          "last_name_placeholder": "Enter your last name",
+          "display_name_placeholder": "Enter your display name",
+          "email_placeholder": "Enter your email",
+          "errors": {
+            "first_name_required": "Please enter first name",
+            "display_name_required": "Display name is required.",
+            "email_required": "Email is required."
+          }
+        },
+        "toasts": {
+          "picture_deleted": "Profile picture deleted successfully.",
+          "picture_delete_failed": "There was some error in deleting your profile picture. Please try again.",
+          "updating": "Updating...",
+          "updated": "Profile updated successfully.",
+          "update_failed": "There was some error in updating your profile. Please try again."
+        }
       }
     },
     "preferences": {
       "heading": "環境設定",
-      "description": "あなたの働き方に合わせてアプリの体験をカスタマイズします"
+      "description": "あなたの働き方に合わせてアプリの体験をカスタマイズします",
+      "select_a_language": "Select a language",
+      "start_of_week": {
+        "title": "First day of the week",
+        "description": "This will change how all calendars in your app look."
+      },
+      "toasts": {
+        "timezone_updated": "Timezone updated successfully",
+        "timezone_update_failed": "Failed to update timezone",
+        "language_updated": "Language updated successfully",
+        "language_update_failed": "Failed to update language",
+        "start_of_week_updated": "First day of the week updated successfully",
+        "start_of_week_update_failed": "Please try again later."
+      }
     },
     "notifications": {
       "heading": "メール通知",

--- a/packages/i18n/src/locales/ja/workspace-settings.json
+++ b/packages/i18n/src/locales/ja/workspace-settings.json
@@ -503,6 +503,12 @@
         "title": "インポートがまだありません",
         "description": "過去のインポートをここで確認し、ダウンロードできます。"
       }
+    },
+    "toasts": {
+      "updated": "Workspace updated successfully",
+      "picture_removed": "Workspace picture removed successfully.",
+      "picture_remove_failed": "There was some error in deleting your profile picture. Please try again.",
+      "url_copied": "Workspace URL copied to the clipboard."
     }
   }
 }

--- a/packages/i18n/src/locales/ko/common.json
+++ b/packages/i18n/src/locales/ko/common.json
@@ -867,5 +867,14 @@
       "description": "작업 항목을 JSON 파일로 내보냅니다.",
       "short_description": "JSON으로 내보내기"
     }
-  }
+  },
+  "reactions": {
+    "toasts": {
+      "created": "Reaction created successfully",
+      "creation_failed": "Reaction creation failed",
+      "removed": "Reaction removed successfully",
+      "remove_failed": "Reaction remove failed"
+    }
+  },
+  "please_select_at_least_one_work_item": "Please select at least one work item."
 }

--- a/packages/i18n/src/locales/ko/project-settings.json
+++ b/packages/i18n/src/locales/ko/project-settings.json
@@ -521,6 +521,12 @@
           }
         }
       }
+    },
+    "label": "Project settings",
+    "feature_toasts": {
+      "updating": "Updating project feature...",
+      "updated": "Project feature updated successfully.",
+      "update_failed": "Something went wrong while updating project feature. Please try again."
     }
   }
 }

--- a/packages/i18n/src/locales/ko/settings.json
+++ b/packages/i18n/src/locales/ko/settings.json
@@ -37,11 +37,44 @@
         "states": {
           "sending": "전송 중…"
         }
+      },
+      "general": {
+        "form": {
+          "first_name_placeholder": "Enter your first name",
+          "last_name_placeholder": "Enter your last name",
+          "display_name_placeholder": "Enter your display name",
+          "email_placeholder": "Enter your email",
+          "errors": {
+            "first_name_required": "Please enter first name",
+            "display_name_required": "Display name is required.",
+            "email_required": "Email is required."
+          }
+        },
+        "toasts": {
+          "picture_deleted": "Profile picture deleted successfully.",
+          "picture_delete_failed": "There was some error in deleting your profile picture. Please try again.",
+          "updating": "Updating...",
+          "updated": "Profile updated successfully.",
+          "update_failed": "There was some error in updating your profile. Please try again."
+        }
       }
     },
     "preferences": {
       "heading": "환경 설정",
-      "description": "작업 방식에 맞게 앱 환경을 사용자 정의하세요"
+      "description": "작업 방식에 맞게 앱 환경을 사용자 정의하세요",
+      "select_a_language": "Select a language",
+      "start_of_week": {
+        "title": "First day of the week",
+        "description": "This will change how all calendars in your app look."
+      },
+      "toasts": {
+        "timezone_updated": "Timezone updated successfully",
+        "timezone_update_failed": "Failed to update timezone",
+        "language_updated": "Language updated successfully",
+        "language_update_failed": "Failed to update language",
+        "start_of_week_updated": "First day of the week updated successfully",
+        "start_of_week_update_failed": "Please try again later."
+      }
     },
     "notifications": {
       "heading": "이메일 알림",

--- a/packages/i18n/src/locales/ko/workspace-settings.json
+++ b/packages/i18n/src/locales/ko/workspace-settings.json
@@ -503,6 +503,12 @@
         "title": "아직 가져오기 없음",
         "description": "이전 가져오기를 모두 여기에서 찾고 다운로드하세요."
       }
+    },
+    "toasts": {
+      "updated": "Workspace updated successfully",
+      "picture_removed": "Workspace picture removed successfully.",
+      "picture_remove_failed": "There was some error in deleting your profile picture. Please try again.",
+      "url_copied": "Workspace URL copied to the clipboard."
     }
   }
 }

--- a/packages/i18n/src/locales/pl/common.json
+++ b/packages/i18n/src/locales/pl/common.json
@@ -867,5 +867,14 @@
       "description": "Eksportuj elementy do pliku JSON.",
       "short_description": "Eksportuj jako JSON"
     }
-  }
+  },
+  "reactions": {
+    "toasts": {
+      "created": "Reaction created successfully",
+      "creation_failed": "Reaction creation failed",
+      "removed": "Reaction removed successfully",
+      "remove_failed": "Reaction remove failed"
+    }
+  },
+  "please_select_at_least_one_work_item": "Please select at least one work item."
 }

--- a/packages/i18n/src/locales/pl/project-settings.json
+++ b/packages/i18n/src/locales/pl/project-settings.json
@@ -521,6 +521,12 @@
           }
         }
       }
+    },
+    "label": "Project settings",
+    "feature_toasts": {
+      "updating": "Updating project feature...",
+      "updated": "Project feature updated successfully.",
+      "update_failed": "Something went wrong while updating project feature. Please try again."
     }
   }
 }

--- a/packages/i18n/src/locales/pl/settings.json
+++ b/packages/i18n/src/locales/pl/settings.json
@@ -37,11 +37,44 @@
         "states": {
           "sending": "Wysyłanie…"
         }
+      },
+      "general": {
+        "form": {
+          "first_name_placeholder": "Enter your first name",
+          "last_name_placeholder": "Enter your last name",
+          "display_name_placeholder": "Enter your display name",
+          "email_placeholder": "Enter your email",
+          "errors": {
+            "first_name_required": "Please enter first name",
+            "display_name_required": "Display name is required.",
+            "email_required": "Email is required."
+          }
+        },
+        "toasts": {
+          "picture_deleted": "Profile picture deleted successfully.",
+          "picture_delete_failed": "There was some error in deleting your profile picture. Please try again.",
+          "updating": "Updating...",
+          "updated": "Profile updated successfully.",
+          "update_failed": "There was some error in updating your profile. Please try again."
+        }
       }
     },
     "preferences": {
       "heading": "Preferencje",
-      "description": "Dostosuj sposób korzystania z aplikacji do swojego stylu pracy"
+      "description": "Dostosuj sposób korzystania z aplikacji do swojego stylu pracy",
+      "select_a_language": "Select a language",
+      "start_of_week": {
+        "title": "First day of the week",
+        "description": "This will change how all calendars in your app look."
+      },
+      "toasts": {
+        "timezone_updated": "Timezone updated successfully",
+        "timezone_update_failed": "Failed to update timezone",
+        "language_updated": "Language updated successfully",
+        "language_update_failed": "Failed to update language",
+        "start_of_week_updated": "First day of the week updated successfully",
+        "start_of_week_update_failed": "Please try again later."
+      }
     },
     "notifications": {
       "heading": "Powiadomienia e-mail",

--- a/packages/i18n/src/locales/pl/workspace-settings.json
+++ b/packages/i18n/src/locales/pl/workspace-settings.json
@@ -503,6 +503,12 @@
         "title": "Brak importów",
         "description": "Znajdziesz tu historię swoich importów."
       }
+    },
+    "toasts": {
+      "updated": "Workspace updated successfully",
+      "picture_removed": "Workspace picture removed successfully.",
+      "picture_remove_failed": "There was some error in deleting your profile picture. Please try again.",
+      "url_copied": "Workspace URL copied to the clipboard."
     }
   }
 }

--- a/packages/i18n/src/locales/pt-BR/common.json
+++ b/packages/i18n/src/locales/pt-BR/common.json
@@ -867,5 +867,14 @@
       "description": "Exporte itens de trabalho para um arquivo JSON.",
       "short_description": "Exportar como JSON"
     }
-  }
+  },
+  "reactions": {
+    "toasts": {
+      "created": "Reaction created successfully",
+      "creation_failed": "Reaction creation failed",
+      "removed": "Reaction removed successfully",
+      "remove_failed": "Reaction remove failed"
+    }
+  },
+  "please_select_at_least_one_work_item": "Please select at least one work item."
 }

--- a/packages/i18n/src/locales/pt-BR/project-settings.json
+++ b/packages/i18n/src/locales/pt-BR/project-settings.json
@@ -521,6 +521,12 @@
           }
         }
       }
+    },
+    "label": "Project settings",
+    "feature_toasts": {
+      "updating": "Updating project feature...",
+      "updated": "Project feature updated successfully.",
+      "update_failed": "Something went wrong while updating project feature. Please try again."
     }
   }
 }

--- a/packages/i18n/src/locales/pt-BR/settings.json
+++ b/packages/i18n/src/locales/pt-BR/settings.json
@@ -37,11 +37,44 @@
         "states": {
           "sending": "Enviando…"
         }
+      },
+      "general": {
+        "form": {
+          "first_name_placeholder": "Enter your first name",
+          "last_name_placeholder": "Enter your last name",
+          "display_name_placeholder": "Enter your display name",
+          "email_placeholder": "Enter your email",
+          "errors": {
+            "first_name_required": "Please enter first name",
+            "display_name_required": "Display name is required.",
+            "email_required": "Email is required."
+          }
+        },
+        "toasts": {
+          "picture_deleted": "Profile picture deleted successfully.",
+          "picture_delete_failed": "There was some error in deleting your profile picture. Please try again.",
+          "updating": "Updating...",
+          "updated": "Profile updated successfully.",
+          "update_failed": "There was some error in updating your profile. Please try again."
+        }
       }
     },
     "preferences": {
       "heading": "Preferências",
-      "description": "Personalize sua experiência no aplicativo do jeito que você trabalha"
+      "description": "Personalize sua experiência no aplicativo do jeito que você trabalha",
+      "select_a_language": "Select a language",
+      "start_of_week": {
+        "title": "First day of the week",
+        "description": "This will change how all calendars in your app look."
+      },
+      "toasts": {
+        "timezone_updated": "Timezone updated successfully",
+        "timezone_update_failed": "Failed to update timezone",
+        "language_updated": "Language updated successfully",
+        "language_update_failed": "Failed to update language",
+        "start_of_week_updated": "First day of the week updated successfully",
+        "start_of_week_update_failed": "Please try again later."
+      }
     },
     "notifications": {
       "heading": "Notificações por e-mail",

--- a/packages/i18n/src/locales/pt-BR/workspace-settings.json
+++ b/packages/i18n/src/locales/pt-BR/workspace-settings.json
@@ -503,6 +503,12 @@
         "title": "Nenhuma importação ainda",
         "description": "Encontre todas as suas importações anteriores aqui e baixe-as."
       }
+    },
+    "toasts": {
+      "updated": "Workspace updated successfully",
+      "picture_removed": "Workspace picture removed successfully.",
+      "picture_remove_failed": "There was some error in deleting your profile picture. Please try again.",
+      "url_copied": "Workspace URL copied to the clipboard."
     }
   }
 }

--- a/packages/i18n/src/locales/ro/common.json
+++ b/packages/i18n/src/locales/ro/common.json
@@ -867,5 +867,14 @@
       "description": "Exportă activitățile într-un fișier JSON.",
       "short_description": "Exportă ca JSON"
     }
-  }
+  },
+  "reactions": {
+    "toasts": {
+      "created": "Reaction created successfully",
+      "creation_failed": "Reaction creation failed",
+      "removed": "Reaction removed successfully",
+      "remove_failed": "Reaction remove failed"
+    }
+  },
+  "please_select_at_least_one_work_item": "Please select at least one work item."
 }

--- a/packages/i18n/src/locales/ro/project-settings.json
+++ b/packages/i18n/src/locales/ro/project-settings.json
@@ -521,6 +521,12 @@
           }
         }
       }
+    },
+    "label": "Project settings",
+    "feature_toasts": {
+      "updating": "Updating project feature...",
+      "updated": "Project feature updated successfully.",
+      "update_failed": "Something went wrong while updating project feature. Please try again."
     }
   }
 }

--- a/packages/i18n/src/locales/ro/settings.json
+++ b/packages/i18n/src/locales/ro/settings.json
@@ -37,11 +37,44 @@
         "states": {
           "sending": "Se trimite…"
         }
+      },
+      "general": {
+        "form": {
+          "first_name_placeholder": "Enter your first name",
+          "last_name_placeholder": "Enter your last name",
+          "display_name_placeholder": "Enter your display name",
+          "email_placeholder": "Enter your email",
+          "errors": {
+            "first_name_required": "Please enter first name",
+            "display_name_required": "Display name is required.",
+            "email_required": "Email is required."
+          }
+        },
+        "toasts": {
+          "picture_deleted": "Profile picture deleted successfully.",
+          "picture_delete_failed": "There was some error in deleting your profile picture. Please try again.",
+          "updating": "Updating...",
+          "updated": "Profile updated successfully.",
+          "update_failed": "There was some error in updating your profile. Please try again."
+        }
       }
     },
     "preferences": {
       "heading": "Preferințe",
-      "description": "Personalizează experiența aplicației așa cum lucrezi"
+      "description": "Personalizează experiența aplicației așa cum lucrezi",
+      "select_a_language": "Select a language",
+      "start_of_week": {
+        "title": "First day of the week",
+        "description": "This will change how all calendars in your app look."
+      },
+      "toasts": {
+        "timezone_updated": "Timezone updated successfully",
+        "timezone_update_failed": "Failed to update timezone",
+        "language_updated": "Language updated successfully",
+        "language_update_failed": "Failed to update language",
+        "start_of_week_updated": "First day of the week updated successfully",
+        "start_of_week_update_failed": "Please try again later."
+      }
     },
     "notifications": {
       "heading": "Notificări prin e-mail",

--- a/packages/i18n/src/locales/ro/workspace-settings.json
+++ b/packages/i18n/src/locales/ro/workspace-settings.json
@@ -503,6 +503,12 @@
         "title": "Niciun import efectuat",
         "description": "Găsește aici toate importurile anterioare și descarcă-le."
       }
+    },
+    "toasts": {
+      "updated": "Workspace updated successfully",
+      "picture_removed": "Workspace picture removed successfully.",
+      "picture_remove_failed": "There was some error in deleting your profile picture. Please try again.",
+      "url_copied": "Workspace URL copied to the clipboard."
     }
   }
 }

--- a/packages/i18n/src/locales/ru/common.json
+++ b/packages/i18n/src/locales/ru/common.json
@@ -867,5 +867,14 @@
       "description": "Экспорт рабочих элементов в JSON-файл.",
       "short_description": "Экспорт в json"
     }
-  }
+  },
+  "reactions": {
+    "toasts": {
+      "created": "Reaction created successfully",
+      "creation_failed": "Reaction creation failed",
+      "removed": "Reaction removed successfully",
+      "remove_failed": "Reaction remove failed"
+    }
+  },
+  "please_select_at_least_one_work_item": "Please select at least one work item."
 }

--- a/packages/i18n/src/locales/ru/project-settings.json
+++ b/packages/i18n/src/locales/ru/project-settings.json
@@ -521,6 +521,12 @@
           }
         }
       }
+    },
+    "label": "Project settings",
+    "feature_toasts": {
+      "updating": "Updating project feature...",
+      "updated": "Project feature updated successfully.",
+      "update_failed": "Something went wrong while updating project feature. Please try again."
     }
   }
 }

--- a/packages/i18n/src/locales/ru/settings.json
+++ b/packages/i18n/src/locales/ru/settings.json
@@ -37,11 +37,44 @@
         "states": {
           "sending": "Отправка…"
         }
+      },
+      "general": {
+        "form": {
+          "first_name_placeholder": "Enter your first name",
+          "last_name_placeholder": "Enter your last name",
+          "display_name_placeholder": "Enter your display name",
+          "email_placeholder": "Enter your email",
+          "errors": {
+            "first_name_required": "Please enter first name",
+            "display_name_required": "Display name is required.",
+            "email_required": "Email is required."
+          }
+        },
+        "toasts": {
+          "picture_deleted": "Profile picture deleted successfully.",
+          "picture_delete_failed": "There was some error in deleting your profile picture. Please try again.",
+          "updating": "Updating...",
+          "updated": "Profile updated successfully.",
+          "update_failed": "There was some error in updating your profile. Please try again."
+        }
       }
     },
     "preferences": {
       "heading": "Настройки",
-      "description": "Настройте работу с приложением так, как вам удобно"
+      "description": "Настройте работу с приложением так, как вам удобно",
+      "select_a_language": "Select a language",
+      "start_of_week": {
+        "title": "First day of the week",
+        "description": "This will change how all calendars in your app look."
+      },
+      "toasts": {
+        "timezone_updated": "Timezone updated successfully",
+        "timezone_update_failed": "Failed to update timezone",
+        "language_updated": "Language updated successfully",
+        "language_update_failed": "Failed to update language",
+        "start_of_week_updated": "First day of the week updated successfully",
+        "start_of_week_update_failed": "Please try again later."
+      }
     },
     "notifications": {
       "heading": "Email-уведомления",

--- a/packages/i18n/src/locales/ru/workspace-settings.json
+++ b/packages/i18n/src/locales/ru/workspace-settings.json
@@ -503,6 +503,12 @@
         "title": "Нет импортов",
         "description": "Здесь отображаются все предыдущие импорты."
       }
+    },
+    "toasts": {
+      "updated": "Workspace updated successfully",
+      "picture_removed": "Workspace picture removed successfully.",
+      "picture_remove_failed": "There was some error in deleting your profile picture. Please try again.",
+      "url_copied": "Workspace URL copied to the clipboard."
     }
   }
 }

--- a/packages/i18n/src/locales/sk/common.json
+++ b/packages/i18n/src/locales/sk/common.json
@@ -867,5 +867,14 @@
       "description": "Exportujte položky do JSON.",
       "short_description": "Exportovať ako JSON"
     }
-  }
+  },
+  "reactions": {
+    "toasts": {
+      "created": "Reaction created successfully",
+      "creation_failed": "Reaction creation failed",
+      "removed": "Reaction removed successfully",
+      "remove_failed": "Reaction remove failed"
+    }
+  },
+  "please_select_at_least_one_work_item": "Please select at least one work item."
 }

--- a/packages/i18n/src/locales/sk/project-settings.json
+++ b/packages/i18n/src/locales/sk/project-settings.json
@@ -521,6 +521,12 @@
           }
         }
       }
+    },
+    "label": "Project settings",
+    "feature_toasts": {
+      "updating": "Updating project feature...",
+      "updated": "Project feature updated successfully.",
+      "update_failed": "Something went wrong while updating project feature. Please try again."
     }
   }
 }

--- a/packages/i18n/src/locales/sk/settings.json
+++ b/packages/i18n/src/locales/sk/settings.json
@@ -37,11 +37,44 @@
         "states": {
           "sending": "Odosielanie…"
         }
+      },
+      "general": {
+        "form": {
+          "first_name_placeholder": "Enter your first name",
+          "last_name_placeholder": "Enter your last name",
+          "display_name_placeholder": "Enter your display name",
+          "email_placeholder": "Enter your email",
+          "errors": {
+            "first_name_required": "Please enter first name",
+            "display_name_required": "Display name is required.",
+            "email_required": "Email is required."
+          }
+        },
+        "toasts": {
+          "picture_deleted": "Profile picture deleted successfully.",
+          "picture_delete_failed": "There was some error in deleting your profile picture. Please try again.",
+          "updating": "Updating...",
+          "updated": "Profile updated successfully.",
+          "update_failed": "There was some error in updating your profile. Please try again."
+        }
       }
     },
     "preferences": {
       "heading": "Predvoľby",
-      "description": "Prispôsobte si aplikáciu spôsobu, akým pracujete"
+      "description": "Prispôsobte si aplikáciu spôsobu, akým pracujete",
+      "select_a_language": "Select a language",
+      "start_of_week": {
+        "title": "First day of the week",
+        "description": "This will change how all calendars in your app look."
+      },
+      "toasts": {
+        "timezone_updated": "Timezone updated successfully",
+        "timezone_update_failed": "Failed to update timezone",
+        "language_updated": "Language updated successfully",
+        "language_update_failed": "Failed to update language",
+        "start_of_week_updated": "First day of the week updated successfully",
+        "start_of_week_update_failed": "Please try again later."
+      }
     },
     "notifications": {
       "heading": "E-mailové oznámenia",

--- a/packages/i18n/src/locales/sk/workspace-settings.json
+++ b/packages/i18n/src/locales/sk/workspace-settings.json
@@ -503,6 +503,12 @@
         "title": "Žiadne importy",
         "description": "Tu nájdete históriu importov."
       }
+    },
+    "toasts": {
+      "updated": "Workspace updated successfully",
+      "picture_removed": "Workspace picture removed successfully.",
+      "picture_remove_failed": "There was some error in deleting your profile picture. Please try again.",
+      "url_copied": "Workspace URL copied to the clipboard."
     }
   }
 }

--- a/packages/i18n/src/locales/tr-TR/common.json
+++ b/packages/i18n/src/locales/tr-TR/common.json
@@ -867,5 +867,14 @@
       "description": "İş öğelerini JSON dosyasına aktarın.",
       "short_description": "JSON olarak aktar"
     }
-  }
+  },
+  "reactions": {
+    "toasts": {
+      "created": "Reaction created successfully",
+      "creation_failed": "Reaction creation failed",
+      "removed": "Reaction removed successfully",
+      "remove_failed": "Reaction remove failed"
+    }
+  },
+  "please_select_at_least_one_work_item": "Please select at least one work item."
 }

--- a/packages/i18n/src/locales/tr-TR/project-settings.json
+++ b/packages/i18n/src/locales/tr-TR/project-settings.json
@@ -521,6 +521,12 @@
           }
         }
       }
+    },
+    "label": "Project settings",
+    "feature_toasts": {
+      "updating": "Updating project feature...",
+      "updated": "Project feature updated successfully.",
+      "update_failed": "Something went wrong while updating project feature. Please try again."
     }
   }
 }

--- a/packages/i18n/src/locales/tr-TR/settings.json
+++ b/packages/i18n/src/locales/tr-TR/settings.json
@@ -37,11 +37,44 @@
         "states": {
           "sending": "Gönderiliyor…"
         }
+      },
+      "general": {
+        "form": {
+          "first_name_placeholder": "Enter your first name",
+          "last_name_placeholder": "Enter your last name",
+          "display_name_placeholder": "Enter your display name",
+          "email_placeholder": "Enter your email",
+          "errors": {
+            "first_name_required": "Please enter first name",
+            "display_name_required": "Display name is required.",
+            "email_required": "Email is required."
+          }
+        },
+        "toasts": {
+          "picture_deleted": "Profile picture deleted successfully.",
+          "picture_delete_failed": "There was some error in deleting your profile picture. Please try again.",
+          "updating": "Updating...",
+          "updated": "Profile updated successfully.",
+          "update_failed": "There was some error in updating your profile. Please try again."
+        }
       }
     },
     "preferences": {
       "heading": "Tercihler",
-      "description": "Uygulama deneyiminizi çalışma şeklinize göre özelleştirin"
+      "description": "Uygulama deneyiminizi çalışma şeklinize göre özelleştirin",
+      "select_a_language": "Select a language",
+      "start_of_week": {
+        "title": "First day of the week",
+        "description": "This will change how all calendars in your app look."
+      },
+      "toasts": {
+        "timezone_updated": "Timezone updated successfully",
+        "timezone_update_failed": "Failed to update timezone",
+        "language_updated": "Language updated successfully",
+        "language_update_failed": "Failed to update language",
+        "start_of_week_updated": "First day of the week updated successfully",
+        "start_of_week_update_failed": "Please try again later."
+      }
     },
     "notifications": {
       "heading": "E-posta bildirimleri",

--- a/packages/i18n/src/locales/tr-TR/workspace-settings.json
+++ b/packages/i18n/src/locales/tr-TR/workspace-settings.json
@@ -503,6 +503,12 @@
         "title": "Henüz içe aktarma yok",
         "description": "Tüm önceki içe aktarmalarınızı burada bulabilir ve indirebilirsiniz."
       }
+    },
+    "toasts": {
+      "updated": "Workspace updated successfully",
+      "picture_removed": "Workspace picture removed successfully.",
+      "picture_remove_failed": "There was some error in deleting your profile picture. Please try again.",
+      "url_copied": "Workspace URL copied to the clipboard."
     }
   }
 }

--- a/packages/i18n/src/locales/ua/common.json
+++ b/packages/i18n/src/locales/ua/common.json
@@ -867,5 +867,14 @@
       "description": "Експортуйте одиниці у формат JSON.",
       "short_description": "Експортувати як JSON"
     }
-  }
+  },
+  "reactions": {
+    "toasts": {
+      "created": "Reaction created successfully",
+      "creation_failed": "Reaction creation failed",
+      "removed": "Reaction removed successfully",
+      "remove_failed": "Reaction remove failed"
+    }
+  },
+  "please_select_at_least_one_work_item": "Please select at least one work item."
 }

--- a/packages/i18n/src/locales/ua/project-settings.json
+++ b/packages/i18n/src/locales/ua/project-settings.json
@@ -521,6 +521,12 @@
           }
         }
       }
+    },
+    "label": "Project settings",
+    "feature_toasts": {
+      "updating": "Updating project feature...",
+      "updated": "Project feature updated successfully.",
+      "update_failed": "Something went wrong while updating project feature. Please try again."
     }
   }
 }

--- a/packages/i18n/src/locales/ua/settings.json
+++ b/packages/i18n/src/locales/ua/settings.json
@@ -37,11 +37,44 @@
         "states": {
           "sending": "Надсилання…"
         }
+      },
+      "general": {
+        "form": {
+          "first_name_placeholder": "Enter your first name",
+          "last_name_placeholder": "Enter your last name",
+          "display_name_placeholder": "Enter your display name",
+          "email_placeholder": "Enter your email",
+          "errors": {
+            "first_name_required": "Please enter first name",
+            "display_name_required": "Display name is required.",
+            "email_required": "Email is required."
+          }
+        },
+        "toasts": {
+          "picture_deleted": "Profile picture deleted successfully.",
+          "picture_delete_failed": "There was some error in deleting your profile picture. Please try again.",
+          "updating": "Updating...",
+          "updated": "Profile updated successfully.",
+          "update_failed": "There was some error in updating your profile. Please try again."
+        }
       }
     },
     "preferences": {
       "heading": "Налаштування",
-      "description": "Налаштуйте роботу застосунку так, як вам зручно"
+      "description": "Налаштуйте роботу застосунку так, як вам зручно",
+      "select_a_language": "Select a language",
+      "start_of_week": {
+        "title": "First day of the week",
+        "description": "This will change how all calendars in your app look."
+      },
+      "toasts": {
+        "timezone_updated": "Timezone updated successfully",
+        "timezone_update_failed": "Failed to update timezone",
+        "language_updated": "Language updated successfully",
+        "language_update_failed": "Failed to update language",
+        "start_of_week_updated": "First day of the week updated successfully",
+        "start_of_week_update_failed": "Please try again later."
+      }
     },
     "notifications": {
       "heading": "Сповіщення електронною поштою",

--- a/packages/i18n/src/locales/ua/workspace-settings.json
+++ b/packages/i18n/src/locales/ua/workspace-settings.json
@@ -503,6 +503,12 @@
         "title": "Немає імпортів",
         "description": "Історія імпортів з'явиться тут."
       }
+    },
+    "toasts": {
+      "updated": "Workspace updated successfully",
+      "picture_removed": "Workspace picture removed successfully.",
+      "picture_remove_failed": "There was some error in deleting your profile picture. Please try again.",
+      "url_copied": "Workspace URL copied to the clipboard."
     }
   }
 }

--- a/packages/i18n/src/locales/vi-VN/common.json
+++ b/packages/i18n/src/locales/vi-VN/common.json
@@ -867,5 +867,14 @@
       "description": "Xuất mục công việc thành tệp JSON.",
       "short_description": "Xuất sang JSON"
     }
-  }
+  },
+  "reactions": {
+    "toasts": {
+      "created": "Reaction created successfully",
+      "creation_failed": "Reaction creation failed",
+      "removed": "Reaction removed successfully",
+      "remove_failed": "Reaction remove failed"
+    }
+  },
+  "please_select_at_least_one_work_item": "Please select at least one work item."
 }

--- a/packages/i18n/src/locales/vi-VN/project-settings.json
+++ b/packages/i18n/src/locales/vi-VN/project-settings.json
@@ -521,6 +521,12 @@
           }
         }
       }
+    },
+    "label": "Project settings",
+    "feature_toasts": {
+      "updating": "Updating project feature...",
+      "updated": "Project feature updated successfully.",
+      "update_failed": "Something went wrong while updating project feature. Please try again."
     }
   }
 }

--- a/packages/i18n/src/locales/vi-VN/settings.json
+++ b/packages/i18n/src/locales/vi-VN/settings.json
@@ -37,11 +37,44 @@
         "states": {
           "sending": "Đang gửi…"
         }
+      },
+      "general": {
+        "form": {
+          "first_name_placeholder": "Enter your first name",
+          "last_name_placeholder": "Enter your last name",
+          "display_name_placeholder": "Enter your display name",
+          "email_placeholder": "Enter your email",
+          "errors": {
+            "first_name_required": "Please enter first name",
+            "display_name_required": "Display name is required.",
+            "email_required": "Email is required."
+          }
+        },
+        "toasts": {
+          "picture_deleted": "Profile picture deleted successfully.",
+          "picture_delete_failed": "There was some error in deleting your profile picture. Please try again.",
+          "updating": "Updating...",
+          "updated": "Profile updated successfully.",
+          "update_failed": "There was some error in updating your profile. Please try again."
+        }
       }
     },
     "preferences": {
       "heading": "Tùy chọn",
-      "description": "Tùy chỉnh trải nghiệm ứng dụng theo cách bạn làm việc"
+      "description": "Tùy chỉnh trải nghiệm ứng dụng theo cách bạn làm việc",
+      "select_a_language": "Select a language",
+      "start_of_week": {
+        "title": "First day of the week",
+        "description": "This will change how all calendars in your app look."
+      },
+      "toasts": {
+        "timezone_updated": "Timezone updated successfully",
+        "timezone_update_failed": "Failed to update timezone",
+        "language_updated": "Language updated successfully",
+        "language_update_failed": "Failed to update language",
+        "start_of_week_updated": "First day of the week updated successfully",
+        "start_of_week_update_failed": "Please try again later."
+      }
     },
     "notifications": {
       "heading": "Thông báo qua email",

--- a/packages/i18n/src/locales/vi-VN/workspace-settings.json
+++ b/packages/i18n/src/locales/vi-VN/workspace-settings.json
@@ -503,6 +503,12 @@
         "title": "Chưa có nhập dữ liệu",
         "description": "Tìm tất cả các lần nhập trước đây và tải xuống chúng tại đây."
       }
+    },
+    "toasts": {
+      "updated": "Workspace updated successfully",
+      "picture_removed": "Workspace picture removed successfully.",
+      "picture_remove_failed": "There was some error in deleting your profile picture. Please try again.",
+      "url_copied": "Workspace URL copied to the clipboard."
     }
   }
 }

--- a/packages/i18n/src/locales/zh-CN/common.json
+++ b/packages/i18n/src/locales/zh-CN/common.json
@@ -374,6 +374,15 @@
     "success": "成功！",
     "error": "错误！"
   },
+  "reactions": {
+    "toasts": {
+      "created": "表情回应创建成功",
+      "creation_failed": "表情回应创建失败",
+      "removed": "表情回应移除成功",
+      "remove_failed": "表情回应移除失败"
+    }
+  },
+  "please_select_at_least_one_work_item": "请至少选择一个工作项。",
   "links": {
     "toasts": {
       "created": {

--- a/packages/i18n/src/locales/zh-CN/project-settings.json
+++ b/packages/i18n/src/locales/zh-CN/project-settings.json
@@ -1,5 +1,11 @@
 {
   "project_settings": {
+    "label": "项目设置",
+    "feature_toasts": {
+      "updating": "正在更新项目功能…",
+      "updated": "项目功能更新成功。",
+      "update_failed": "更新项目功能时出错，请重试。"
+    },
     "general": {
       "enter_project_id": "输入项目 ID",
       "please_select_a_timezone": "请选择时区",

--- a/packages/i18n/src/locales/zh-CN/settings.json
+++ b/packages/i18n/src/locales/zh-CN/settings.json
@@ -37,11 +37,44 @@
         "states": {
           "sending": "发送中…"
         }
+      },
+      "general": {
+        "form": {
+          "first_name_placeholder": "请输入名字",
+          "last_name_placeholder": "请输入姓氏",
+          "display_name_placeholder": "请输入显示名称",
+          "email_placeholder": "请输入邮箱",
+          "errors": {
+            "first_name_required": "请输入名字",
+            "display_name_required": "显示名称为必填项。",
+            "email_required": "邮箱为必填项。"
+          }
+        },
+        "toasts": {
+          "picture_deleted": "个人头像删除成功。",
+          "picture_delete_failed": "删除个人头像时出错，请重试。",
+          "updating": "更新中…",
+          "updated": "个人资料更新成功。",
+          "update_failed": "更新个人资料时出错，请重试。"
+        }
       }
     },
     "preferences": {
       "heading": "偏好设置",
-      "description": "按照您的工作方式自定义您的应用体验"
+      "description": "按照您的工作方式自定义您的应用体验",
+      "select_a_language": "选择语言",
+      "start_of_week": {
+        "title": "每周第一天",
+        "description": "这将改变应用中所有日历的显示方式。"
+      },
+      "toasts": {
+        "timezone_updated": "时区更新成功",
+        "timezone_update_failed": "时区更新失败",
+        "language_updated": "语言更新成功",
+        "language_update_failed": "语言更新失败",
+        "start_of_week_updated": "每周第一天设置更新成功",
+        "start_of_week_update_failed": "更新失败，请稍后重试。"
+      }
     },
     "notifications": {
       "heading": "邮件通知",

--- a/packages/i18n/src/locales/zh-CN/workspace-settings.json
+++ b/packages/i18n/src/locales/zh-CN/workspace-settings.json
@@ -1,6 +1,12 @@
 {
   "workspace_settings": {
     "label": "工作区设置",
+    "toasts": {
+      "updated": "工作区更新成功",
+      "picture_removed": "工作区图标移除成功。",
+      "picture_remove_failed": "删除工作区图标时出错，请重试。",
+      "url_copied": "工作区 URL 已复制到剪贴板。"
+    },
     "page_label": "{workspace} - 常规设置",
     "key_created": "密钥已创建",
     "copy_key": "复制并将此密钥保存在 Plane Pages 中。关闭后您将无法看到此密钥。包含密钥的 CSV 文件已下载。",

--- a/packages/i18n/src/locales/zh-TW/common.json
+++ b/packages/i18n/src/locales/zh-TW/common.json
@@ -867,5 +867,14 @@
       "description": "將工作事項匯出為 JSON 檔案。",
       "short_description": "匯出為 JSON"
     }
-  }
+  },
+  "reactions": {
+    "toasts": {
+      "created": "Reaction created successfully",
+      "creation_failed": "Reaction creation failed",
+      "removed": "Reaction removed successfully",
+      "remove_failed": "Reaction remove failed"
+    }
+  },
+  "please_select_at_least_one_work_item": "Please select at least one work item."
 }

--- a/packages/i18n/src/locales/zh-TW/project-settings.json
+++ b/packages/i18n/src/locales/zh-TW/project-settings.json
@@ -521,6 +521,12 @@
           }
         }
       }
+    },
+    "label": "Project settings",
+    "feature_toasts": {
+      "updating": "Updating project feature...",
+      "updated": "Project feature updated successfully.",
+      "update_failed": "Something went wrong while updating project feature. Please try again."
     }
   }
 }

--- a/packages/i18n/src/locales/zh-TW/settings.json
+++ b/packages/i18n/src/locales/zh-TW/settings.json
@@ -37,11 +37,44 @@
         "states": {
           "sending": "傳送中…"
         }
+      },
+      "general": {
+        "form": {
+          "first_name_placeholder": "Enter your first name",
+          "last_name_placeholder": "Enter your last name",
+          "display_name_placeholder": "Enter your display name",
+          "email_placeholder": "Enter your email",
+          "errors": {
+            "first_name_required": "Please enter first name",
+            "display_name_required": "Display name is required.",
+            "email_required": "Email is required."
+          }
+        },
+        "toasts": {
+          "picture_deleted": "Profile picture deleted successfully.",
+          "picture_delete_failed": "There was some error in deleting your profile picture. Please try again.",
+          "updating": "Updating...",
+          "updated": "Profile updated successfully.",
+          "update_failed": "There was some error in updating your profile. Please try again."
+        }
       }
     },
     "preferences": {
       "heading": "偏好設定",
-      "description": "以您工作的方式自訂您的應用程式體驗"
+      "description": "以您工作的方式自訂您的應用程式體驗",
+      "select_a_language": "Select a language",
+      "start_of_week": {
+        "title": "First day of the week",
+        "description": "This will change how all calendars in your app look."
+      },
+      "toasts": {
+        "timezone_updated": "Timezone updated successfully",
+        "timezone_update_failed": "Failed to update timezone",
+        "language_updated": "Language updated successfully",
+        "language_update_failed": "Failed to update language",
+        "start_of_week_updated": "First day of the week updated successfully",
+        "start_of_week_update_failed": "Please try again later."
+      }
     },
     "notifications": {
       "heading": "電子郵件通知",

--- a/packages/i18n/src/locales/zh-TW/workspace-settings.json
+++ b/packages/i18n/src/locales/zh-TW/workspace-settings.json
@@ -503,6 +503,12 @@
         "title": "尚無匯入",
         "description": "在這裡找到所有您先前的匯入並下載它們。"
       }
+    },
+    "toasts": {
+      "updated": "Workspace updated successfully",
+      "picture_removed": "Workspace picture removed successfully.",
+      "picture_remove_failed": "There was some error in deleting your profile picture. Please try again.",
+      "url_copied": "Workspace URL copied to the clipboard."
     }
   }
 }


### PR DESCRIPTION
### Description

Follow-up to the zh-CN translation pass — routes ~50 remaining hardcoded English strings through i18n keys (34 new keys with en + zh-CN translations; other locales synced with English values to keep `i18n-sync-check` green).

Covered surfaces:

- Settings sidebar headers (workspace + project)
- Profile "General" form: placeholders, validation errors, avatar/profile toasts
- Preferences: language/timezone/start-of-week labels and toasts
- Project feature toggles and workspace general settings toasts
- Issue detail: link add/remove toasts (reusing existing `links.toasts.*` keys), reaction toasts, relation picker error and tooltip

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### Test Scenarios

- [x] `pnpm --filter @plane/i18n check:types` + `check:sync` (18 locales 100% aligned)
- [x] `turbo run check:types --filter=web` 11/11
- [x] oxfmt/oxlint clean on touched files

### References

- Closes #9781
