### PR TITLE
fix(web): build absolute cover_image URL on same-origin deployments (error toast on successful cover save)

### DIFF
--- a/apps/web/helpers/cover-image.helper.ts
+++ b/apps/web/helpers/cover-image.helper.ts
@@ -4,6 +4,7 @@
  * See the LICENSE file for details.
  */
 
+import { API_BASE_URL } from "@plane/constants";
 import type { EFileAssetType } from "@plane/types";
 import { getFileURL } from "@plane/utils";
 
@@ -252,6 +253,21 @@ export const uploadCoverImage = async (
 };
 
 /**
+ * Converts an asset path/URL to an absolute URL.
+ * The backend `cover_image` field is a Django URLField and rejects relative paths, so when the
+ * API is served same-origin (self-hosted setups with an empty API_BASE_URL) the current origin
+ * is used to build the absolute URL.
+ */
+const toAbsoluteCoverURL = (path: string): string => {
+  if (path.startsWith("http")) return path;
+  try {
+    return new URL(path, API_BASE_URL || window.location.origin).href;
+  } catch {
+    return getFileURL(path) || path;
+  }
+};
+
+/**
  * Main utility to handle cover image changes with upload
  */
 export const handleCoverImageChange = async (
@@ -274,11 +290,11 @@ export const handleCoverImageChange = async (
   if (analysis.needsUpload) {
     const assetUrl = await uploadCoverImage(newImage, uploadConfig);
     // cover_image requires an absolute URL; cover_image_url is relative (matches GET /api/users/me/ format)
-    return { cover_image: getFileURL(assetUrl) || assetUrl, cover_image_url: assetUrl };
+    return { cover_image: toAbsoluteCoverURL(assetUrl), cover_image_url: assetUrl };
   }
 
-  // cover_image requires an absolute URL; getFileURL converts relative paths from the Upload tab
-  return { cover_image: getFileURL(newImage) || newImage, cover_image_url: newImage };
+  // cover_image requires an absolute URL; converts relative paths from the Upload tab
+  return { cover_image: toAbsoluteCoverURL(newImage), cover_image_url: newImage };
 };
 
 /**


### PR DESCRIPTION
### Description

Fixes #9283: saving a profile (or project) cover image shows an error toast even though the cover was actually saved.

Root cause: on same-origin self-hosted deployments `API_BASE_URL` is empty, so `getFileURL()` returns the asset path as a **relative** URL (`/api/assets/v2/static/<id>/`). The follow-up `PATCH /api/users/me/` then fails validation (`cover_image` is a Django `URLField` → 400 "Enter a valid URL."), which surfaces as the error toast — while the cover was already linked server-side via `cover_image_asset_id`, so the image appears saved after a reload.

Fix: new `toAbsoluteCoverURL()` in `cover-image.helper.ts` builds an absolute URL from `API_BASE_URL || window.location.origin` when given a relative path; both `cover_image` assignments in `handleCoverImageChange` use it. Project covers share this helper and are fixed too.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### Test Scenarios

- [x] Reproduced against a live self-hosted CE 1.4.2 API: `PATCH /api/users/me/` with relative `cover_image` → 400; with the absolute URL produced by the fix → 200.
- [x] `check:types` / `check:lint` for web pass.

### References

- Closes #9283
