### PR TITLE
fix: restore dropdown positioning after Headless UI v2 upgrade

### DIFF
--- a/apps/space/components/issues/filters/helpers/dropdown.tsx
+++ b/apps/space/components/issues/filters/helpers/dropdown.tsx
@@ -52,6 +52,7 @@ export function FiltersDropdown(props: Props) {
               leaveTo="opacity-0 translate-y-1"
             >
               <Popover.Panel
+                className="z-30"
                 ref={setPopperElement}
                 style={styles.popper}
                 {...attributes.popper}

--- a/apps/space/components/issues/filters/helpers/dropdown.tsx
+++ b/apps/space/components/issues/filters/helpers/dropdown.tsx
@@ -21,9 +21,10 @@ export function FiltersDropdown(props: Props) {
   const { children, title = "Dropdown", placement } = props;
 
   const [referenceElement, setReferenceElement] = useState<HTMLButtonElement | null>(null);
-  const [popperElement, setPopperElement] = useState<HTMLDivElement | null>(null);
+  const [popperElement, setPopperElement] = useState<HTMLElement | null>(null);
 
   const { styles, attributes } = usePopper(referenceElement, popperElement, {
+    strategy: "fixed",
     placement: placement ?? "auto",
   });
 
@@ -50,13 +51,12 @@ export function FiltersDropdown(props: Props) {
               leaveFrom="opacity-100 translate-y-0"
               leaveTo="opacity-0 translate-y-1"
             >
-              <Popover.Panel>
-                <div
-                  className="z-10 overflow-hidden rounded-sm border border-subtle bg-surface-1 shadow-raised-200"
-                  ref={setPopperElement}
-                  style={styles.popper}
-                  {...attributes.popper}
-                >
+              <Popover.Panel
+                ref={setPopperElement}
+                style={styles.popper}
+                {...attributes.popper}
+              >
+                <div className="z-10 overflow-hidden rounded-sm border border-subtle bg-surface-1 shadow-raised-200">
                   <div className="flex max-h-[37.5rem] w-[18.75rem] flex-col overflow-hidden">{children}</div>
                 </div>
               </Popover.Panel>

--- a/apps/space/components/issues/navbar/user-avatar.tsx
+++ b/apps/space/components/issues/navbar/user-avatar.tsx
@@ -38,7 +38,7 @@ export const UserAvatar = observer(function UserAvatar() {
   // states
   const [csrfToken, setCsrfToken] = useState<string | undefined>(undefined);
   const [referenceElement, setReferenceElement] = useState<HTMLButtonElement | null>(null);
-  const [popperElement, setPopperElement] = useState<HTMLDivElement | null>(null);
+  const [popperElement, setPopperElement] = useState<HTMLElement | null>(null);
 
   useEffect(() => {
     if (csrfToken === undefined)
@@ -46,6 +46,7 @@ export const UserAvatar = observer(function UserAvatar() {
   }, [csrfToken]);
 
   const { styles, attributes } = usePopper(referenceElement, popperElement, {
+    strategy: "fixed",
     placement: "bottom-end",
     modifiers: [
       {
@@ -91,13 +92,12 @@ export const UserAvatar = observer(function UserAvatar() {
               leaveFrom="opacity-100 translate-y-0"
               leaveTo="opacity-0 translate-y-1"
             >
-              <Popover.Panel>
-                <div
-                  className="z-10 overflow-hidden rounded-sm border border-subtle bg-surface-1 p-1 shadow-raised-200"
-                  ref={setPopperElement}
-                  style={styles.popper}
-                  {...attributes.popper}
-                >
+              <Popover.Panel
+                ref={setPopperElement}
+                style={styles.popper}
+                {...attributes.popper}
+              >
+                <div className="z-10 overflow-hidden rounded-sm border border-subtle bg-surface-1 p-1 shadow-raised-200">
                   {csrfToken && (
                     <form method="POST" action={`${API_BASE_URL}/auth/spaces/sign-out/`} onSubmit={signOut}>
                       <input type="hidden" name="csrfmiddlewaretoken" value={csrfToken} />

--- a/apps/space/components/issues/navbar/user-avatar.tsx
+++ b/apps/space/components/issues/navbar/user-avatar.tsx
@@ -93,6 +93,7 @@ export const UserAvatar = observer(function UserAvatar() {
               leaveTo="opacity-0 translate-y-1"
             >
               <Popover.Panel
+                className="z-30"
                 ref={setPopperElement}
                 style={styles.popper}
                 {...attributes.popper}

--- a/apps/space/components/issues/peek-overview/header.tsx
+++ b/apps/space/components/issues/peek-overview/header.tsx
@@ -99,6 +99,7 @@ export const PeekOverviewHeader = observer(function PeekOverviewHeader(props: Pr
             >
               <Listbox.Options
                 as="ul"
+                modal={false}
                 className="shadow-lg absolute left-0 z-10 mt-1 min-w-[12rem] origin-top-left overflow-y-auto rounded-md border border-strong bg-surface-2 text-11 whitespace-nowrap focus:outline-none"
               >
                 <div className="space-y-1 p-2">

--- a/apps/web/core/components/account/auth-forms/forgot-password-popover.tsx
+++ b/apps/web/core/components/account/auth-forms/forgot-password-popover.tsx
@@ -14,9 +14,10 @@ import { CloseOutline } from "@makeplane/propel/icons";
 export function ForgotPasswordPopover() {
   // popper-js refs
   const [referenceElement, setReferenceElement] = useState<HTMLButtonElement | null>(null);
-  const [popperElement, setPopperElement] = useState<HTMLDivElement | null>(null);
+  const [popperElement, setPopperElement] = useState<HTMLElement | null>(null);
   // popper-js init
   const { styles, attributes } = usePopper(referenceElement, popperElement, {
+    strategy: "fixed",
     placement: "right-start",
     modifiers: [
       {
@@ -41,14 +42,14 @@ export function ForgotPasswordPopover() {
           {t("auth.common.forgot_password")}
         </button>
       </Popover.Button>
-      <Popover.Panel className="fixed z-10">
+      <Popover.Panel
+        className="fixed z-10"
+        ref={setPopperElement}
+        style={styles.popper}
+        {...attributes.popper}
+      >
         {({ close }) => (
-          <div
-            className="z-10 ml-3 flex w-64 items-start gap-3 rounded-sm border border-strong bg-surface-1 px-2 py-1 text-left break-words"
-            ref={setPopperElement}
-            style={styles.popper}
-            {...attributes.popper}
-          >
+          <div className="z-10 ml-3 flex w-64 items-start gap-3 rounded-sm border border-strong bg-surface-1 px-2 py-1 text-left break-words">
             <span className="flex-shrink-0">🤥</span>
             <p className="text-11">{t("auth.forgot_password.errors.smtp_not_enabled")}</p>
             <button

--- a/apps/web/core/components/core/modals/bulk-delete-issues-modal.tsx
+++ b/apps/web/core/components/core/modals/bulk-delete-issues-modal.tsx
@@ -183,7 +183,7 @@ export const BulkDeleteIssuesModal = observer(function BulkDeleteIssuesModal(pro
             />
           </div>
 
-          <Combobox.Options as="ul" static className="max-h-80 scroll-py-2 divide-y divide-subtle-1 overflow-y-auto">
+          <Combobox.Options as="ul" static modal={false} className="max-h-80 scroll-py-2 divide-y divide-subtle-1 overflow-y-auto">
             {isSearching ? (
               <Loader className="space-y-3 p-3">
                 <Loader.Item height="40px" />

--- a/apps/web/core/components/core/modals/existing-issues-list-modal.tsx
+++ b/apps/web/core/components/core/modals/existing-issues-list-modal.tsx
@@ -219,6 +219,7 @@ export function ExistingIssuesListModal(props: Props) {
         <Combobox.Options
           as="ul"
           static
+          modal={false}
           className="vertical-scrollbar scrollbar-md max-h-80 scroll-py-2 overflow-y-auto"
         >
           {/* TODO: Translate here */}

--- a/apps/web/core/components/core/modals/gpt-assistant-popover.tsx
+++ b/apps/web/core/components/core/modals/gpt-assistant-popover.tsx
@@ -4,7 +4,6 @@
  * See the LICENSE file for details.
  */
 
-import type { Ref } from "react";
 import React, { useEffect, useState, useRef, Fragment } from "react";
 import type { Placement } from "@popperjs/core";
 import { Controller, useForm } from "react-hook-form"; // services
@@ -217,7 +216,7 @@ export function GptAssistantPopover(props: Props) {
         <Popover.Panel
           as="div"
           className={`shadow fixed z-10 flex w-full max-w-full min-w-[50rem] flex-col space-y-4 overflow-hidden rounded-[10px] border border-subtle bg-surface-1 p-4 ${className}`}
-          ref={setPopperElement as Ref<HTMLDivElement>}
+          ref={setPopperElement}
           style={styles.popper}
           {...attributes.popper}
         >

--- a/apps/web/core/components/core/modals/gpt-assistant-popover.tsx
+++ b/apps/web/core/components/core/modals/gpt-assistant-popover.tsx
@@ -60,12 +60,13 @@ export function GptAssistantPopover(props: Props) {
   const [response, setResponse] = useState("");
   const [invalidResponse, setInvalidResponse] = useState(false);
   const [referenceElement, setReferenceElement] = useState<HTMLButtonElement | null>(null);
-  const [popperElement, setPopperElement] = useState<HTMLDivElement | null>(null);
+  const [popperElement, setPopperElement] = useState<HTMLElement | null>(null);
   // refs
   const editorRef = useRef<EditorRefApi>(null);
   const responseRef = useRef<EditorRefApi>(null);
   // popper
   const { styles, attributes } = usePopper(referenceElement, popperElement, {
+    strategy: "fixed",
     placement: placement ?? "auto",
   });
   // form

--- a/apps/web/core/components/dropdowns/cycle/cycle-options.tsx
+++ b/apps/web/core/components/dropdowns/cycle/cycle-options.tsx
@@ -46,7 +46,7 @@ export const CycleOptions = observer(function CycleOptions(props: CycleOptionsPr
   const { t } = useTranslation();
   //state hooks
   const [query, setQuery] = useState("");
-  const [popperElement, setPopperElement] = useState<HTMLDivElement | null>(null);
+  const [popperElement, setPopperElement] = useState<HTMLElement | null>(null);
   const inputRef = useRef<HTMLInputElement | null>(null);
   // store hooks
   const { workspaceSlug } = useParams();
@@ -65,6 +65,7 @@ export const CycleOptions = observer(function CycleOptions(props: CycleOptionsPr
   // popper-js init
   const { styles, attributes } = usePopper(referenceElement, popperElement, {
     placement: placement ?? "bottom-start",
+    strategy: "fixed",
     modifiers: [
       {
         name: "preventOverflow",
@@ -125,13 +126,16 @@ export const CycleOptions = observer(function CycleOptions(props: CycleOptionsPr
     query === "" ? options : options?.filter((o) => o.query.toLowerCase().includes(query.toLowerCase()));
 
   return (
-    <Combobox.Options as="ul" className="fixed z-10" static>
-      <div
-        className="my-1 w-48 rounded-sm border-[0.5px] border-strong bg-surface-1 px-2 py-2.5 text-11 shadow-raised-200 focus:outline-none"
-        ref={setPopperElement}
-        style={styles.popper}
-        {...attributes.popper}
-      >
+    <Combobox.Options
+      as="ul"
+      className="fixed z-10"
+      static
+      modal={false}
+      ref={setPopperElement}
+      style={styles.popper}
+      {...attributes.popper}
+    >
+      <div className="my-1 w-48 rounded-sm border-[0.5px] border-strong bg-surface-1 px-2 py-2.5 text-11 shadow-raised-200 focus:outline-none">
         <div className="flex items-center gap-1.5 rounded-sm border border-subtle bg-surface-2 px-2">
           <SearchOutline className="h-3.5 w-3.5 text-placeholder" />
           <Combobox.Input

--- a/apps/web/core/components/dropdowns/date-range.tsx
+++ b/apps/web/core/components/dropdowns/date-range.tsx
@@ -114,10 +114,11 @@ export const DateRangeDropdown = observer(function DateRangeDropdown(props: Prop
   const dropdownRef = useRef<HTMLDivElement | null>(null);
   // popper-js refs
   const [referenceElement, setReferenceElement] = useState<HTMLButtonElement | null>(null);
-  const [popperElement, setPopperElement] = useState<HTMLDivElement | null>(null);
+  const [popperElement, setPopperElement] = useState<HTMLElement | null>(null);
   // popper-js init
   const { styles, attributes } = usePopper(referenceElement, popperElement, {
     placement: placement ?? "bottom-start",
+    strategy: "fixed",
     modifiers: [
       {
         name: "preventOverflow",
@@ -255,13 +256,17 @@ export const DateRangeDropdown = observer(function DateRangeDropdown(props: Prop
   );
 
   const comboOptions = (
-    <Combobox.Options as="ul" data-prevent-outside-click static>
-      <div
-        className="z-30 my-1 overflow-hidden rounded-md border-[0.5px] border-subtle-1 bg-surface-1"
-        ref={setPopperElement}
-        style={styles.popper}
-        {...attributes.popper}
-      >
+    <Combobox.Options
+      as="ul"
+      className="z-30"
+      data-prevent-outside-click
+      static
+      modal={false}
+      ref={setPopperElement}
+      style={styles.popper}
+      {...attributes.popper}
+    >
+      <div className="z-30 my-1 overflow-hidden rounded-md border-[0.5px] border-subtle-1 bg-surface-1">
         <Calendar
           className="rounded-md border border-subtle p-3 text-12"
           captionLayout="dropdown"

--- a/apps/web/core/components/dropdowns/date.tsx
+++ b/apps/web/core/components/dropdowns/date.tsx
@@ -79,10 +79,11 @@ export const DateDropdown = observer(function DateDropdown(props: Props) {
   const startOfWeek = data?.start_of_the_week;
   // popper-js refs
   const [referenceElement, setReferenceElement] = useState<HTMLButtonElement | null>(null);
-  const [popperElement, setPopperElement] = useState<HTMLDivElement | null>(null);
+  const [popperElement, setPopperElement] = useState<HTMLElement | null>(null);
   // popper-js init
   const { styles, attributes } = usePopper(referenceElement, popperElement, {
     placement: placement ?? "bottom-start",
+    strategy: "fixed",
     modifiers: [
       {
         name: "preventOverflow",
@@ -180,15 +181,21 @@ export const DateDropdown = observer(function DateDropdown(props: Props) {
     >
       {isOpen &&
         createPortal(
-          <Combobox.Options as="ul" data-prevent-outside-click static>
+          <Combobox.Options
+            as="ul"
+            className="z-30"
+            data-prevent-outside-click
+            static
+            modal={false}
+            ref={setPopperElement}
+            style={styles.popper}
+            {...attributes.popper}
+          >
             <div
               className={cn(
                 "z-30 my-1 overflow-hidden rounded-md border-[0.5px] border-strong bg-surface-1 shadow-raised-200",
                 optionsClassName
               )}
-              ref={setPopperElement}
-              style={styles.popper}
-              {...attributes.popper}
             >
               <Calendar
                 className="rounded-md border border-subtle p-3"

--- a/apps/web/core/components/dropdowns/estimate.tsx
+++ b/apps/web/core/components/dropdowns/estimate.tsx
@@ -76,10 +76,11 @@ export const EstimateDropdown = observer(function EstimateDropdown(props: Props)
   const inputRef = useRef<HTMLInputElement | null>(null);
   // popper-js refs
   const [referenceElement, setReferenceElement] = useState<HTMLButtonElement | null>(null);
-  const [popperElement, setPopperElement] = useState<HTMLDivElement | null>(null);
+  const [popperElement, setPopperElement] = useState<HTMLElement | null>(null);
   // popper-js init
   const { styles, attributes } = usePopper(referenceElement, popperElement, {
     placement: placement ?? "bottom-start",
+    strategy: "fixed",
     modifiers: [
       {
         name: "preventOverflow",
@@ -228,13 +229,16 @@ export const EstimateDropdown = observer(function EstimateDropdown(props: Props)
       renderByDefault={renderByDefault}
     >
       {isOpen && (
-        <Combobox.Options as="ul" className="fixed z-10" static>
-          <div
-            className="my-1 w-48 rounded-sm border-[0.5px] border-strong bg-surface-1 px-2 py-2.5 text-11 shadow-raised-200 focus:outline-none"
-            ref={setPopperElement}
-            style={styles.popper}
-            {...attributes.popper}
-          >
+        <Combobox.Options
+          as="ul"
+          className="fixed z-10"
+          static
+          modal={false}
+          ref={setPopperElement}
+          style={styles.popper}
+          {...attributes.popper}
+        >
+          <div className="my-1 w-48 rounded-sm border-[0.5px] border-strong bg-surface-1 px-2 py-2.5 text-11 shadow-raised-200 focus:outline-none">
             <div className="flex items-center gap-1.5 rounded-sm border border-subtle bg-surface-2 px-2">
               <SearchOutline className="h-3.5 w-3.5 text-placeholder" />
               <Combobox.Input

--- a/apps/web/core/components/dropdowns/intake-state/base.tsx
+++ b/apps/web/core/components/dropdowns/intake-state/base.tsx
@@ -77,7 +77,7 @@ export const WorkItemStateDropdownBase = observer(function WorkItemStateDropdown
   const inputRef = useRef<HTMLInputElement | null>(null);
   // popper-js refs
   const [referenceElement, setReferenceElement] = useState<HTMLButtonElement | null>(null);
-  const [popperElement, setPopperElement] = useState<HTMLDivElement | null>(null);
+  const [popperElement, setPopperElement] = useState<HTMLElement | null>(null);
   // states
   const [query, setQuery] = useState("");
   const [isOpen, setIsOpen] = useState(false);
@@ -89,6 +89,7 @@ export const WorkItemStateDropdownBase = observer(function WorkItemStateDropdown
   // popper-js init
   const { styles, attributes } = usePopper(referenceElement, popperElement, {
     placement: placement ?? "bottom-start",
+    strategy: "fixed",
     modifiers: [
       {
         name: "preventOverflow",
@@ -212,13 +213,16 @@ export const WorkItemStateDropdownBase = observer(function WorkItemStateDropdown
       renderByDefault={renderByDefault}
     >
       {isOpen && (
-        <Combobox.Options as="ul" className="fixed z-10" static>
-          <div
-            className="my-1 w-48 rounded-sm border-[0.5px] border-strong bg-surface-1 px-2 py-2.5 text-11 shadow-raised-200 focus:outline-none"
-            ref={setPopperElement}
-            style={styles.popper}
-            {...attributes.popper}
-          >
+        <Combobox.Options
+          as="ul"
+          className="fixed z-10"
+          static
+          modal={false}
+          ref={setPopperElement}
+          style={styles.popper}
+          {...attributes.popper}
+        >
+          <div className="my-1 w-48 rounded-sm border-[0.5px] border-strong bg-surface-1 px-2 py-2.5 text-11 shadow-raised-200 focus:outline-none">
             <div className="flex items-center gap-1.5 rounded-sm border border-subtle bg-surface-2 px-2">
               <SearchOutline className="h-3.5 w-3.5 text-placeholder" />
               <Combobox.Input

--- a/apps/web/core/components/dropdowns/member/member-options.tsx
+++ b/apps/web/core/components/dropdowns/member/member-options.tsx
@@ -52,7 +52,7 @@ export const MemberOptions = observer(function MemberOptions(props: Props) {
   const inputRef = useRef<HTMLInputElement | null>(null);
   // states
   const [query, setQuery] = useState("");
-  const [popperElement, setPopperElement] = useState<HTMLDivElement | null>(null);
+  const [popperElement, setPopperElement] = useState<HTMLElement | null>(null);
   // plane hooks
   const { t } = useTranslation();
   // store hooks
@@ -64,6 +64,7 @@ export const MemberOptions = observer(function MemberOptions(props: Props) {
   // popper-js init
   const { styles, attributes } = usePopper(referenceElement, popperElement, {
     placement: placement ?? "bottom-start",
+    strategy: "fixed",
     modifiers: [
       {
         name: "preventOverflow",
@@ -131,17 +132,23 @@ export const MemberOptions = observer(function MemberOptions(props: Props) {
   );
 
   return createPortal(
-    <Combobox.Options as="ul" data-prevent-outside-click static>
+    <Combobox.Options
+      as="ul"
+      className="z-30"
+      data-prevent-outside-click
+      static
+      modal={false}
+      ref={setPopperElement}
+      style={{
+        ...styles.popper,
+      }}
+      {...attributes.popper}
+    >
       <div
         className={cn(
           "z-30 my-1 w-48 rounded-sm border-[0.5px] border-strong bg-surface-1 px-2 py-2.5 text-11 shadow-raised-200 focus:outline-none",
           optionsClassName
         )}
-        ref={setPopperElement}
-        style={{
-          ...styles.popper,
-        }}
-        {...attributes.popper}
       >
         <div className="flex items-center gap-1.5 rounded-sm border border-subtle bg-surface-2 px-2">
           <SearchOutline className="h-3.5 w-3.5 text-placeholder" />

--- a/apps/web/core/components/dropdowns/module/module-options.tsx
+++ b/apps/web/core/components/dropdowns/module/module-options.tsx
@@ -42,7 +42,7 @@ export const ModuleOptions = observer(function ModuleOptions(props: Props) {
   const inputRef = useRef<HTMLInputElement | null>(null);
   // states
   const [query, setQuery] = useState("");
-  const [popperElement, setPopperElement] = useState<HTMLDivElement | null>(null);
+  const [popperElement, setPopperElement] = useState<HTMLElement | null>(null);
   // plane hooks
   const { t } = useTranslation();
   // store hooks
@@ -61,6 +61,7 @@ export const ModuleOptions = observer(function ModuleOptions(props: Props) {
   // popper-js init
   const { styles, attributes } = usePopper(referenceElement, popperElement, {
     placement: placement ?? "bottom-start",
+    strategy: "fixed",
     modifiers: [
       {
         name: "preventOverflow",
@@ -113,13 +114,16 @@ export const ModuleOptions = observer(function ModuleOptions(props: Props) {
   );
 
   return (
-    <Combobox.Options as="ul" className="fixed z-10" static>
-      <div
-        className="my-1 w-48 rounded-sm border-[0.5px] border-strong bg-surface-1 px-2 py-2.5 text-11 shadow-raised-200 focus:outline-none"
-        ref={setPopperElement}
-        style={styles.popper}
-        {...attributes.popper}
-      >
+    <Combobox.Options
+      as="ul"
+      className="fixed z-10"
+      static
+      modal={false}
+      ref={setPopperElement}
+      style={styles.popper}
+      {...attributes.popper}
+    >
+      <div className="my-1 w-48 rounded-sm border-[0.5px] border-strong bg-surface-1 px-2 py-2.5 text-11 shadow-raised-200 focus:outline-none">
         <div className="flex items-center gap-1.5 rounded-sm border border-subtle bg-surface-2 px-2">
           <SearchOutline className="h-3.5 w-3.5 text-placeholder" />
           <Combobox.Input

--- a/apps/web/core/components/dropdowns/priority.tsx
+++ b/apps/web/core/components/dropdowns/priority.tsx
@@ -335,10 +335,11 @@ export function PriorityDropdown(props: Props) {
   const inputRef = useRef<HTMLInputElement | null>(null);
   // popper-js refs
   const [referenceElement, setReferenceElement] = useState<HTMLButtonElement | null>(null);
-  const [popperElement, setPopperElement] = useState<HTMLDivElement | null>(null);
+  const [popperElement, setPopperElement] = useState<HTMLElement | null>(null);
   // popper-js init
   const { styles, attributes } = usePopper(referenceElement, popperElement, {
     placement: placement ?? "bottom-start",
+    strategy: "fixed",
     modifiers: [
       {
         name: "preventOverflow",
@@ -445,13 +446,16 @@ export function PriorityDropdown(props: Props) {
       renderByDefault={renderByDefault}
     >
       {isOpen && (
-        <Combobox.Options as="ul" className="fixed z-10" static>
-          <div
-            className="my-1 w-48 rounded-sm border-[0.5px] border-strong bg-surface-1 px-2 py-2.5 text-11 shadow-raised-200 focus:outline-none"
-            ref={setPopperElement}
-            style={styles.popper}
-            {...attributes.popper}
-          >
+        <Combobox.Options
+          as="ul"
+          className="fixed z-10"
+          static
+          modal={false}
+          ref={setPopperElement}
+          style={styles.popper}
+          {...attributes.popper}
+        >
+          <div className="my-1 w-48 rounded-sm border-[0.5px] border-strong bg-surface-1 px-2 py-2.5 text-11 shadow-raised-200 focus:outline-none">
             <div className="flex items-center gap-1.5 rounded-sm border border-subtle bg-surface-2 px-2">
               <SearchOutline className="h-3.5 w-3.5 text-placeholder" />
               <Combobox.Input

--- a/apps/web/core/components/dropdowns/project/base.tsx
+++ b/apps/web/core/components/dropdowns/project/base.tsx
@@ -78,7 +78,7 @@ export const ProjectDropdownBase = observer(function ProjectDropdownBase(props: 
   const inputRef = useRef<HTMLInputElement | null>(null);
   // popper-js refs
   const [referenceElement, setReferenceElement] = useState<HTMLButtonElement | null>(null);
-  const [popperElement, setPopperElement] = useState<HTMLDivElement | null>(null);
+  const [popperElement, setPopperElement] = useState<HTMLElement | null>(null);
   // states
   const [query, setQuery] = useState("");
   const [isOpen, setIsOpen] = useState(false);
@@ -87,6 +87,7 @@ export const ProjectDropdownBase = observer(function ProjectDropdownBase(props: 
   // popper-js init
   const { styles, attributes } = usePopper(referenceElement, popperElement, {
     placement: placement ?? "bottom-start",
+    strategy: "fixed",
     modifiers: [
       {
         name: "preventOverflow",
@@ -234,13 +235,16 @@ export const ProjectDropdownBase = observer(function ProjectDropdownBase(props: 
       multiple={multiple}
     >
       {isOpen && (
-        <Combobox.Options as="ul" className="fixed z-10" static>
-          <div
-            className="my-1 w-48 rounded-sm border-[0.5px] border-strong bg-surface-1 px-2 py-2.5 text-11 shadow-raised-200 focus:outline-none"
-            ref={setPopperElement}
-            style={styles.popper}
-            {...attributes.popper}
-          >
+        <Combobox.Options
+          as="ul"
+          className="fixed z-10"
+          static
+          modal={false}
+          ref={setPopperElement}
+          style={styles.popper}
+          {...attributes.popper}
+        >
+          <div className="my-1 w-48 rounded-sm border-[0.5px] border-strong bg-surface-1 px-2 py-2.5 text-11 shadow-raised-200 focus:outline-none">
             <div className="flex items-center gap-1.5 rounded-sm border border-subtle bg-surface-2 px-2">
               <SearchOutline className="h-3.5 w-3.5 text-placeholder" />
               <Combobox.Input

--- a/apps/web/core/components/dropdowns/state/base.tsx
+++ b/apps/web/core/components/dropdowns/state/base.tsx
@@ -77,7 +77,7 @@ export const WorkItemStateDropdownBase = observer(function WorkItemStateDropdown
   const inputRef = useRef<HTMLInputElement | null>(null);
   // popper-js refs
   const [referenceElement, setReferenceElement] = useState<HTMLButtonElement | null>(null);
-  const [popperElement, setPopperElement] = useState<HTMLDivElement | null>(null);
+  const [popperElement, setPopperElement] = useState<HTMLElement | null>(null);
   // states
   const [query, setQuery] = useState("");
   const [isOpen, setIsOpen] = useState(false);
@@ -89,6 +89,7 @@ export const WorkItemStateDropdownBase = observer(function WorkItemStateDropdown
   // popper-js init
   const { styles, attributes } = usePopper(referenceElement, popperElement, {
     placement: placement ?? "bottom-start",
+    strategy: "fixed",
     modifiers: [
       {
         name: "preventOverflow",
@@ -214,13 +215,16 @@ export const WorkItemStateDropdownBase = observer(function WorkItemStateDropdown
       renderByDefault={renderByDefault}
     >
       {isOpen && (
-        <Combobox.Options as="ul" className="fixed z-10" static>
-          <div
-            className="my-1 w-48 rounded-sm border-[0.5px] border-strong bg-surface-1 px-2 py-2.5 text-11 shadow-raised-200 focus:outline-none"
-            ref={setPopperElement}
-            style={styles.popper}
-            {...attributes.popper}
-          >
+        <Combobox.Options
+          as="ul"
+          className="fixed z-10"
+          static
+          modal={false}
+          ref={setPopperElement}
+          style={styles.popper}
+          {...attributes.popper}
+        >
+          <div className="my-1 w-48 rounded-sm border-[0.5px] border-strong bg-surface-1 px-2 py-2.5 text-11 shadow-raised-200 focus:outline-none">
             <div className="flex items-center gap-1.5 rounded-sm border border-subtle bg-surface-2 px-2">
               <SearchOutline className="h-3.5 w-3.5 text-placeholder" />
               <Combobox.Input

--- a/apps/web/core/components/empty-state/comic-box-button.tsx
+++ b/apps/web/core/components/empty-state/comic-box-button.tsx
@@ -4,7 +4,6 @@
  * See the LICENSE file for details.
  */
 
-import type { Ref } from "react";
 import { Fragment, useState } from "react";
 import { usePopper } from "react-popper";
 import { Popover } from "@headlessui/react";
@@ -33,8 +32,9 @@ export function ComicBoxButton(props: Props) {
   };
 
   const [referenceElement, setReferenceElement] = useState<HTMLButtonElement | null>(null);
-  const [popperElement, setPopperElement] = useState<HTMLDivElement | null>();
+  const [popperElement, setPopperElement] = useState<HTMLElement | null>(null);
   const { styles, attributes } = usePopper(referenceElement, popperElement, {
+    strategy: "fixed",
     placement: "right-end",
     modifiers: [
       {
@@ -63,13 +63,14 @@ export function ComicBoxButton(props: Props) {
         </Button>
       </Popover.Button>
       {isHovered && (
-        <Popover.Panel className="fixed z-10" static>
-          <div
-            className="relative flex w-52 flex-col overflow-hidden rounded-sm rounded-xl border border-subtle bg-layer-1 p-5 hover:bg-layer-1-hover lg:w-60 xl:w-80"
-            ref={setPopperElement as Ref<HTMLDivElement>}
-            style={styles.popper}
-            {...attributes.popper}
-          >
+        <Popover.Panel
+          className="fixed z-10"
+          static
+          ref={setPopperElement}
+          style={styles.popper}
+          {...attributes.popper}
+        >
+          <div className="relative flex w-52 flex-col overflow-hidden rounded-sm rounded-xl border border-subtle bg-layer-1 p-5 hover:bg-layer-1-hover lg:w-60 xl:w-80">
             <div className="rounded-lb-sm absolute bottom-2 -left-[5px] h-2 w-2 rotate-45 transform border border-t-0 border-r-0 border-subtle bg-surface-1" />
             <h3 className="w-full text-16 font-semibold">{title}</h3>
             <h4 className="mt-1 text-13">{description}</h4>

--- a/apps/web/core/components/inbox/modals/select-duplicate.tsx
+++ b/apps/web/core/components/inbox/modals/select-duplicate.tsx
@@ -151,7 +151,7 @@ export function SelectDuplicateInboxIssueModal(props: Props) {
           />
         </div>
 
-        <Combobox.Options as="ul" static className="max-h-80 scroll-py-2 divide-y divide-subtle-1 overflow-y-auto">
+        <Combobox.Options as="ul" static modal={false} className="max-h-80 scroll-py-2 divide-y divide-subtle-1 overflow-y-auto">
           {isSearching ? (
             <Loader className="space-y-3 p-3">
               <Loader.Item height="40px" />

--- a/apps/web/core/components/issues/issue-detail/label/create-label.tsx
+++ b/apps/web/core/components/issues/issue-detail/label/create-label.tsx
@@ -39,7 +39,7 @@ export function LabelCreate(props: ILabelCreate) {
   const [isCreateToggle, setIsCreateToggle] = useState(false);
   const handleIsCreateToggle = () => setIsCreateToggle(!isCreateToggle);
   const [referenceElement, setReferenceElement] = useState<HTMLButtonElement | null>(null);
-  const [popperElement, setPopperElement] = useState<HTMLDivElement | null>(null);
+  const [popperElement, setPopperElement] = useState<HTMLElement | null>(null);
   // react hook form
   const {
     handleSubmit,
@@ -52,6 +52,7 @@ export function LabelCreate(props: ILabelCreate) {
   });
 
   const { styles, attributes } = usePopper(referenceElement, popperElement, {
+    strategy: "fixed",
     placement: "bottom-start",
     modifiers: [
       {
@@ -113,13 +114,13 @@ export function LabelCreate(props: ILabelCreate) {
                         )}
                       </button>
                     </Popover.Button>
-                    <Popover.Panel className="fixed z-10">
-                      <div
-                        className="max-w-xs p-2 sm:px-0"
-                        ref={setPopperElement}
-                        style={styles.popper}
-                        {...attributes.popper}
-                      >
+                    <Popover.Panel
+                      className="fixed z-10"
+                      ref={setPopperElement}
+                      style={styles.popper}
+                      {...attributes.popper}
+                    >
+                      <div className="max-w-xs p-2 sm:px-0">
                         <TwitterPicker triangle={"hide"} color={value} onChange={(value) => onChange(value.hex)} />
                       </div>
                     </Popover.Panel>

--- a/apps/web/core/components/issues/issue-detail/label/select/label-select.tsx
+++ b/apps/web/core/components/issues/issue-detail/label/select/label-select.tsx
@@ -40,7 +40,7 @@ export const IssueLabelSelect = observer(function IssueLabelSelect(props: IIssue
   const { allowPermissions } = useUserPermissions();
   // states
   const [referenceElement, setReferenceElement] = useState<HTMLButtonElement | null>(null);
-  const [popperElement, setPopperElement] = useState<HTMLDivElement | null>(null);
+  const [popperElement, setPopperElement] = useState<HTMLElement | null>(null);
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [query, setQuery] = useState("");
   const [submitting, setSubmitting] = useState<boolean>(false);
@@ -78,6 +78,7 @@ export const IssueLabelSelect = observer(function IssueLabelSelect(props: IIssue
     query === "" ? options : options?.filter((option) => option.query.toLowerCase().includes(query.toLowerCase()));
 
   const { styles, attributes } = usePopper(referenceElement, popperElement, {
+    strategy: "fixed",
     placement: "bottom-start",
     modifiers: [
       {
@@ -138,13 +139,15 @@ export const IssueLabelSelect = observer(function IssueLabelSelect(props: IIssue
           </Button>
         </Combobox.Button>
 
-        <Combobox.Options as="ul" className="fixed z-10">
-          <div
-            className={`z-10 my-1 w-48 rounded-sm border border-strong bg-surface-1 py-2.5 text-11 whitespace-nowrap shadow-raised-200 focus:outline-none`}
-            ref={setPopperElement}
-            style={styles.popper}
-            {...attributes.popper}
-          >
+        <Combobox.Options
+          as="ul"
+          className="fixed z-10"
+          modal={false}
+          ref={setPopperElement}
+          style={styles.popper}
+          {...attributes.popper}
+        >
+          <div className={`z-10 my-1 w-48 rounded-sm border border-strong bg-surface-1 py-2.5 text-11 whitespace-nowrap shadow-raised-200 focus:outline-none`}>
             <div className="px-2">
               <div className="flex w-full items-center justify-start rounded-sm border border-subtle bg-surface-2 px-2">
                 <SearchOutline className="h-3.5 w-3.5 text-tertiary" />

--- a/apps/web/core/components/issues/issue-layouts/calendar/dropdowns/months-dropdown.tsx
+++ b/apps/web/core/components/issues/issue-layouts/calendar/dropdowns/months-dropdown.tsx
@@ -32,9 +32,10 @@ export const CalendarMonthsDropdown = observer(function CalendarMonthsDropdown(p
   const calendarLayout = issuesFilterStore.issueFilters?.displayFilters?.calendar?.layout ?? "month";
 
   const [referenceElement, setReferenceElement] = useState<HTMLButtonElement | null>(null);
-  const [popperElement, setPopperElement] = useState<HTMLDivElement | null>(null);
+  const [popperElement, setPopperElement] = useState<HTMLElement | null>(null);
 
   const { styles, attributes } = usePopper(referenceElement, popperElement, {
+    strategy: "fixed",
     placement: "auto",
     modifiers: [
       {
@@ -102,13 +103,13 @@ export const CalendarMonthsDropdown = observer(function CalendarMonthsDropdown(p
         leaveFrom="opacity-100 translate-y-0"
         leaveTo="opacity-0 translate-y-1"
       >
-        <Popover.Panel className="fixed z-50">
-          <div
-            ref={setPopperElement}
-            style={styles.popper}
-            {...attributes.popper}
-            className="w-56 divide-y divide-subtle-1 rounded-sm border border-subtle bg-surface-1 p-3 shadow-raised-200"
-          >
+        <Popover.Panel
+          className="fixed z-50"
+          ref={setPopperElement}
+          style={styles.popper}
+          {...attributes.popper}
+        >
+          <div className="w-56 divide-y divide-subtle-1 rounded-sm border border-subtle bg-surface-1 p-3 shadow-raised-200">
             <div className="flex items-center justify-between gap-2 pb-3">
               <button
                 type="button"

--- a/apps/web/core/components/issues/issue-layouts/calendar/dropdowns/options-dropdown.tsx
+++ b/apps/web/core/components/issues/issue-layouts/calendar/dropdowns/options-dropdown.tsx
@@ -48,9 +48,10 @@ export const CalendarOptionsDropdown = observer(function CalendarOptionsDropdown
   const [windowWidth] = useSize();
 
   const [referenceElement, setReferenceElement] = useState<HTMLButtonElement | null>(null);
-  const [popperElement, setPopperElement] = useState<HTMLDivElement | null>(null);
+  const [popperElement, setPopperElement] = useState<HTMLElement | null>(null);
 
   const { styles, attributes } = usePopper(referenceElement, popperElement, {
+    strategy: "fixed",
     placement: "auto",
     modifiers: [
       {
@@ -128,13 +129,13 @@ export const CalendarOptionsDropdown = observer(function CalendarOptionsDropdown
             leaveFrom="opacity-100 translate-y-0"
             leaveTo="opacity-0 translate-y-1"
           >
-            <Popover.Panel className="fixed z-50">
-              <div
-                ref={setPopperElement}
-                style={styles.popper}
-                {...attributes.popper}
-                className="absolute right-0 z-10 mt-1 min-w-[12rem] overflow-hidden rounded-sm border border-subtle bg-surface-1 p-1 shadow-raised-200"
-              >
+            <Popover.Panel
+              className="fixed z-50"
+              ref={setPopperElement}
+              style={styles.popper}
+              {...attributes.popper}
+            >
+              <div className="z-10 mt-1 min-w-[12rem] overflow-hidden rounded-sm border border-subtle bg-surface-1 p-1 shadow-raised-200">
                 <div>
                   {Object.entries(CALENDAR_LAYOUTS).map(([layout, layoutDetails]) => (
                     <button

--- a/apps/web/core/components/issues/issue-layouts/filters/header/helpers/dropdown.tsx
+++ b/apps/web/core/components/issues/issue-layouts/filters/header/helpers/dropdown.tsx
@@ -38,9 +38,10 @@ export function FiltersDropdown(props: Props) {
   } = props;
 
   const [referenceElement, setReferenceElement] = useState<HTMLButtonElement | HTMLDivElement | null>(null);
-  const [popperElement, setPopperElement] = useState<HTMLDivElement | null>(null);
+  const [popperElement, setPopperElement] = useState<HTMLElement | null>(null);
 
   const { styles, attributes } = usePopper(referenceElement, popperElement, {
+    strategy: "fixed",
     placement: placement ?? "auto",
   });
 
@@ -98,13 +99,13 @@ export function FiltersDropdown(props: Props) {
             leaveTo="opacity-0 translate-y-1"
           >
             {/** translate-y-0 is a hack to create new stacking context. Required for safari  */}
-            <Popover.Panel className="fixed z-10 translate-y-0">
-              <div
-                className="my-1 overflow-hidden rounded-sm border border-subtle bg-surface-1 shadow-raised-100"
-                ref={setPopperElement}
-                style={styles.popper}
-                {...attributes.popper}
-              >
+            <Popover.Panel
+              className="fixed z-10 translate-y-0"
+              ref={setPopperElement}
+              style={styles.popper}
+              {...attributes.popper}
+            >
+              <div className="my-1 overflow-hidden rounded-sm border border-subtle bg-surface-1 shadow-raised-100">
                 <div className="flex max-h-[30rem] w-[18.75rem] flex-col overflow-hidden lg:max-h-[37.5rem]">
                   {children}
                 </div>

--- a/apps/web/core/components/issues/issue-layouts/properties/label-dropdown.tsx
+++ b/apps/web/core/components/issues/issue-layouts/properties/label-dropdown.tsx
@@ -82,7 +82,7 @@ export function LabelDropdown(props: ILabelDropdownProps) {
 
   // popper-js refs
   const [referenceElement, setReferenceElement] = useState<HTMLButtonElement | null>(null);
-  const [popperElement, setPopperElement] = useState<HTMLDivElement | null>(null);
+  const [popperElement, setPopperElement] = useState<HTMLElement | null>(null);
 
   //hooks
   const { fetchProjectLabels, getProjectLabels, createLabel } = useLabel();
@@ -127,6 +127,7 @@ export function LabelDropdown(props: ILabelDropdownProps) {
 
   const { styles, attributes } = usePopper(referenceElement, popperElement, {
     placement: placement ?? "bottom-start",
+    strategy: "fixed",
     modifiers: [
       {
         name: "preventOverflow",
@@ -251,12 +252,17 @@ export function LabelDropdown(props: ILabelDropdownProps) {
         multiple
       >
         {isOpen && (
-          <Combobox.Options as="ul" className="fixed z-10" static>
+          <Combobox.Options
+            as="ul"
+            className="fixed z-10"
+            static
+            modal={false}
+            ref={setPopperElement}
+            style={styles.popper}
+            {...attributes.popper}
+          >
             <div
               className={`z-10 my-1 h-auto w-48 rounded-sm border border-strong bg-surface-1 px-2 py-2.5 text-caption-sm-regular whitespace-nowrap shadow-raised-200 focus:outline-none ${optionsClassName}`}
-              ref={setPopperElement}
-              style={styles.popper}
-              {...attributes.popper}
             >
               <div className="flex w-full items-center justify-start rounded-sm border border-subtle bg-surface-2 px-2">
                 <SearchOutline className="h-3.5 w-3.5 text-tertiary" />

--- a/apps/web/core/components/issues/parent-issues-list-modal.tsx
+++ b/apps/web/core/components/issues/parent-issues-list-modal.tsx
@@ -114,6 +114,7 @@ export function ParentIssuesListModal({
         <Combobox.Options
           as="ul"
           static
+          modal={false}
           className="vertical-scrollbar scrollbar-md max-h-80 scroll-py-2 overflow-y-auto"
         >
           {searchTerm !== "" && (

--- a/apps/web/core/components/issues/select/base.tsx
+++ b/apps/web/core/components/issues/select/base.tsx
@@ -60,7 +60,7 @@ export const WorkItemLabelSelectBase = observer(function WorkItemLabelSelectBase
   // states
   const [query, setQuery] = useState("");
   const [referenceElement, setReferenceElement] = useState<HTMLButtonElement | null>(null);
-  const [popperElement, setPopperElement] = useState<HTMLDivElement | null>(null);
+  const [popperElement, setPopperElement] = useState<HTMLElement | null>(null);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [submitting, setSubmitting] = useState<boolean>(false);
   // plane hooks
@@ -70,6 +70,7 @@ export const WorkItemLabelSelectBase = observer(function WorkItemLabelSelectBase
   // popper-js init
   const { styles, attributes } = usePopper(referenceElement, popperElement, {
     placement: placement ?? "bottom-start",
+    strategy: "fixed",
   });
   // derived values
   const labelsList = labelIds.map((labelId) => getLabelById(labelId)).filter((label) => !!label);
@@ -190,13 +191,16 @@ export const WorkItemLabelSelectBase = observer(function WorkItemLabelSelectBase
         )}
       </button>
       {isDropdownOpen && (
-        <Combobox.Options as="ul" className="fixed z-10" static>
-          <div
-            className="my-1 w-48 rounded-sm border-[0.5px] border-strong bg-surface-1 px-2 py-2.5 text-11 shadow-raised-200 focus:outline-none"
-            ref={setPopperElement}
-            style={styles.popper}
-            {...attributes.popper}
-          >
+        <Combobox.Options
+          as="ul"
+          className="fixed z-10"
+          static
+          modal={false}
+          ref={setPopperElement}
+          style={styles.popper}
+          {...attributes.popper}
+        >
+          <div className="my-1 w-48 rounded-sm border-[0.5px] border-strong bg-surface-1 px-2 py-2.5 text-11 shadow-raised-200 focus:outline-none">
             <div className="flex items-center gap-1.5 rounded-sm border border-subtle bg-surface-2 px-2">
               <SearchOutline className="h-3.5 w-3.5 text-placeholder" />
               <Combobox.Input

--- a/apps/web/core/components/onboarding/invite-members.tsx
+++ b/apps/web/core/components/onboarding/invite-members.tsx
@@ -98,7 +98,7 @@ const InviteMemberInput = observer(function InviteMemberInput(props: InviteMembe
   } = props;
 
   const [referenceElement, setReferenceElement] = useState<HTMLButtonElement | null>(null);
-  const [popperElement, setPopperElement] = useState<HTMLDivElement | null>(null);
+  const [popperElement, setPopperElement] = useState<HTMLElement | null>(null);
 
   const { t } = useTranslation();
 
@@ -129,6 +129,7 @@ const InviteMemberInput = observer(function InviteMemberInput(props: InviteMembe
   };
 
   const { styles, attributes } = usePopper(referenceElement, popperElement, {
+    strategy: "fixed",
     placement: "bottom-end",
     modifiers: [
       {
@@ -210,13 +211,14 @@ const InviteMemberInput = observer(function InviteMemberInput(props: InviteMembe
                   />
                 </Listbox.Button>
 
-                <Listbox.Options as="div">
-                  <div
-                    className="shadow-sm absolute z-10 mt-1 h-fit w-48 space-y-1 rounded-md border border-strong bg-surface-1 p-2 focus:outline-none sm:w-60"
-                    ref={setPopperElement}
-                    style={styles.popper}
-                    {...attributes.popper}
-                  >
+                <Listbox.Options
+                  as="div"
+                  modal={false}
+                  ref={setPopperElement}
+                  style={styles.popper}
+                  {...attributes.popper}
+                >
+                  <div className="shadow-sm z-10 mt-1 h-fit w-48 space-y-1 rounded-md border border-strong bg-surface-1 p-2 focus:outline-none sm:w-60">
                     {Object.entries(ROLE_DETAILS).map(([key, value]) => (
                       <Listbox.Option
                         as="div"

--- a/apps/web/core/components/onboarding/invite-members.tsx
+++ b/apps/web/core/components/onboarding/invite-members.tsx
@@ -213,6 +213,7 @@ const InviteMemberInput = observer(function InviteMemberInput(props: InviteMembe
 
                 <Listbox.Options
                   as="div"
+                  className="z-30"
                   modal={false}
                   ref={setPopperElement}
                   style={styles.popper}

--- a/apps/web/core/components/onboarding/steps/team/root.tsx
+++ b/apps/web/core/components/onboarding/steps/team/root.tsx
@@ -209,6 +209,7 @@ const InviteMemberInput = observer(function InviteMemberInput(props: InviteMembe
 
                 <Listbox.Options
                   as="div"
+                  className="z-30"
                   modal={false}
                   ref={setPopperElement}
                   style={styles.popper}

--- a/apps/web/core/components/onboarding/steps/team/root.tsx
+++ b/apps/web/core/components/onboarding/steps/team/root.tsx
@@ -94,7 +94,7 @@ const InviteMemberInput = observer(function InviteMemberInput(props: InviteMembe
   } = props;
 
   const [referenceElement, setReferenceElement] = useState<HTMLButtonElement | null>(null);
-  const [popperElement, setPopperElement] = useState<HTMLDivElement | null>(null);
+  const [popperElement, setPopperElement] = useState<HTMLElement | null>(null);
 
   const { t } = useTranslation();
 
@@ -125,6 +125,7 @@ const InviteMemberInput = observer(function InviteMemberInput(props: InviteMembe
   };
 
   const { styles, attributes } = usePopper(referenceElement, popperElement, {
+    strategy: "fixed",
     placement: "bottom-end",
     modifiers: [
       {
@@ -206,13 +207,14 @@ const InviteMemberInput = observer(function InviteMemberInput(props: InviteMembe
                   />
                 </Listbox.Button>
 
-                <Listbox.Options as="div">
-                  <div
-                    className="shadow-sm absolute z-10 mt-1 h-fit w-48 space-y-1 rounded-md border border-strong bg-surface-1 p-2 focus:outline-none sm:w-60"
-                    ref={setPopperElement}
-                    style={styles.popper}
-                    {...attributes.popper}
-                  >
+                <Listbox.Options
+                  as="div"
+                  modal={false}
+                  ref={setPopperElement}
+                  style={styles.popper}
+                  {...attributes.popper}
+                >
+                  <div className="shadow-sm z-10 mt-1 h-fit w-48 space-y-1 rounded-md border border-strong bg-surface-1 p-2 focus:outline-none sm:w-60">
                     {Object.entries(ROLE_DETAILS).map(([key, value]) => (
                       <Listbox.Option
                         as="div"

--- a/apps/web/core/components/project/multi-select-modal.tsx
+++ b/apps/web/core/components/project/multi-select-modal.tsx
@@ -126,6 +126,7 @@ export const ProjectMultiSelectModal = observer(function ProjectMultiSelectModal
         <Combobox.Options
           as="ul"
           static
+          modal={false}
           className="vertical-scrollbar scrollbar-md max-h-80 scroll-py-2 overflow-y-auto py-2 transition-[height] duration-200 ease-in-out"
         >
           {filteredProjectIds.length === 0 ? (

--- a/apps/web/core/hooks/use-extended-sidebar-overview-outside-click.tsx
+++ b/apps/web/core/hooks/use-extended-sidebar-overview-outside-click.tsx
@@ -16,33 +16,22 @@ const useExtendedSidebarOutsideClickDetector = (
     (event: MouseEvent) => {
       if (!(event.target instanceof HTMLElement)) return;
       // Headless UI v2 selects on mousedown and unmounts the list in the same event.
-      // After unmount, target is detached so contains() is false — use the event path.
-      if (ref.current && event.composedPath().includes(ref.current)) return;
+      // After unmount, target is detached so contains()/closest() miss — use the event path.
+      const path = event.composedPath();
+      if (ref.current && path.includes(ref.current)) return;
       if (ref.current && !ref.current.contains(event.target)) {
-        // check for the closest element with attribute name data-prevent-outside-click
-        const preventOutsideClickElement = event.target.closest("[data-prevent-outside-click]");
-        // if the closest element with attribute name data-prevent-outside-click is found, return
-        if (preventOutsideClickElement) {
+        if (path.some((node) => node instanceof Element && node.hasAttribute("data-prevent-outside-click"))) {
           return;
         }
-        // check if the click target is the current issue element or its children
-        let targetElement: HTMLElement | null = event.target;
-        while (targetElement) {
-          if (targetElement.id === targetId) {
-            // if the click target is the current issue element, return
-            return;
-          }
-          targetElement = targetElement.parentElement;
+        if (path.some((node) => node instanceof Element && node.id === targetId)) {
+          return;
         }
-        const delayOutsideClickElement = event.target.closest("[data-delay-outside-click]");
-        if (delayOutsideClickElement) {
-          // if the click target is the closest element with attribute name data-delay-outside-click, delay the callback
+        if (path.some((node) => node instanceof Element && node.hasAttribute("data-delay-outside-click"))) {
           setTimeout(() => {
             callback();
           }, 0);
           return;
         }
-        // else, call the callback immediately
         callback();
       }
     },

--- a/apps/web/core/hooks/use-extended-sidebar-overview-outside-click.tsx
+++ b/apps/web/core/hooks/use-extended-sidebar-overview-outside-click.tsx
@@ -14,7 +14,7 @@ const useExtendedSidebarOutsideClickDetector = (
 ) => {
   const handleClick = useCallback(
     (event: MouseEvent) => {
-      if (!(event.target instanceof HTMLElement)) return;
+      if (!(event.target instanceof Node)) return;
       // Headless UI v2 selects on mousedown and unmounts the list in the same event.
       // After unmount, target is detached so contains()/closest() miss — use the event path.
       const path = event.composedPath();

--- a/apps/web/core/hooks/use-extended-sidebar-overview-outside-click.tsx
+++ b/apps/web/core/hooks/use-extended-sidebar-overview-outside-click.tsx
@@ -15,6 +15,9 @@ const useExtendedSidebarOutsideClickDetector = (
   const handleClick = useCallback(
     (event: MouseEvent) => {
       if (!(event.target instanceof HTMLElement)) return;
+      // Headless UI v2 selects on mousedown and unmounts the list in the same event.
+      // After unmount, target is detached so contains() is false — use the event path.
+      if (ref.current && event.composedPath().includes(ref.current)) return;
       if (ref.current && !ref.current.contains(event.target)) {
         // check for the closest element with attribute name data-prevent-outside-click
         const preventOutsideClickElement = event.target.closest("[data-prevent-outside-click]");

--- a/apps/web/core/hooks/use-peek-overview-outside-click.tsx
+++ b/apps/web/core/hooks/use-peek-overview-outside-click.tsx
@@ -16,6 +16,9 @@ const usePeekOverviewOutsideClickDetector = (
   const handleClick = useCallback(
     (event: MouseEvent) => {
       if (!(event.target instanceof HTMLElement)) return;
+      // Headless UI v2 selects on mousedown and unmounts the list in the same event.
+      // After unmount, target is detached so contains() is false — use the event path.
+      if (ref.current && event.composedPath().includes(ref.current)) return;
       if (ref.current && !ref.current.contains(event.target)) {
         // check for the closest element with attribute name data-prevent-outside-click
         const preventOutsideClickElement = event.target.closest("[data-prevent-outside-click]");

--- a/apps/web/core/hooks/use-peek-overview-outside-click.tsx
+++ b/apps/web/core/hooks/use-peek-overview-outside-click.tsx
@@ -15,7 +15,7 @@ const usePeekOverviewOutsideClickDetector = (
 ) => {
   const handleClick = useCallback(
     (event: MouseEvent) => {
-      if (!(event.target instanceof HTMLElement)) return;
+      if (!(event.target instanceof Node)) return;
       // Headless UI v2 selects on mousedown and unmounts the list in the same event.
       // After unmount, target is detached so contains()/closest() miss — use the event path.
       const path = event.composedPath();

--- a/apps/web/core/hooks/use-peek-overview-outside-click.tsx
+++ b/apps/web/core/hooks/use-peek-overview-outside-click.tsx
@@ -17,14 +17,14 @@ const usePeekOverviewOutsideClickDetector = (
     (event: MouseEvent) => {
       if (!(event.target instanceof HTMLElement)) return;
       // Headless UI v2 selects on mousedown and unmounts the list in the same event.
-      // After unmount, target is detached so contains() is false — use the event path.
-      if (ref.current && event.composedPath().includes(ref.current)) return;
+      // After unmount, target is detached so contains()/closest() miss — use the event path.
+      const path = event.composedPath();
+      if (ref.current && path.includes(ref.current)) return;
       if (ref.current && !ref.current.contains(event.target)) {
-        // check for the closest element with attribute name data-prevent-outside-click
-        const preventOutsideClickElement = event.target.closest("[data-prevent-outside-click]");
-        // if the closest element with attribute name data-prevent-outside-click is found
+        const preventOutsideClickElement = path.find(
+          (node): node is Element => node instanceof Element && node.hasAttribute("data-prevent-outside-click")
+        );
         if (preventOutsideClickElement) {
-          // Check if this element's ID is in the exclusion list
           const elementId = preventOutsideClickElement.id;
           const shouldExcludePrevention =
             excludePreventionElementIds && elementId && excludePreventionElementIds.includes(elementId);
@@ -35,24 +35,15 @@ const usePeekOverviewOutsideClickDetector = (
             return;
           }
         }
-        // check if the click target is the current issue element or its children
-        let targetElement: HTMLElement | null = event.target;
-        while (targetElement) {
-          if (targetElement.id === `issue-${issueId}`) {
-            // if the click target is the current issue element, return
-            return;
-          }
-          targetElement = targetElement.parentElement;
+        if (path.some((node) => node instanceof Element && node.id === `issue-${issueId}`)) {
+          return;
         }
-        const delayOutsideClickElement = event.target.closest("[data-delay-outside-click]");
-        if (delayOutsideClickElement) {
-          // if the click target is the closest element with attribute name data-delay-outside-click, delay the callback
+        if (path.some((node) => node instanceof Element && node.hasAttribute("data-delay-outside-click"))) {
           setTimeout(() => {
             callback();
           }, 0);
           return;
         }
-        // else, call the callback immediately
         callback();
       }
     },

--- a/packages/hooks/src/use-outside-click-detector.tsx
+++ b/packages/hooks/src/use-outside-click-detector.tsx
@@ -13,6 +13,7 @@ export const useOutsideClickDetector = (
   useCapture = false
 ) => {
   const handleClick = (event: MouseEvent) => {
+    if (ref.current && event.composedPath().includes(ref.current)) return;
     if (ref.current && !ref.current.contains(event.target as any)) {
       // check for the closest element with attribute name data-prevent-outside-click
       const preventOutsideClickElement = (event.target as unknown as HTMLElement | undefined)?.closest(

--- a/packages/hooks/src/use-outside-click-detector.tsx
+++ b/packages/hooks/src/use-outside-click-detector.tsx
@@ -13,17 +13,12 @@ export const useOutsideClickDetector = (
   useCapture = false
 ) => {
   const handleClick = (event: MouseEvent) => {
-    if (ref.current && event.composedPath().includes(ref.current)) return;
+    const path = event.composedPath();
+    if (ref.current && path.includes(ref.current)) return;
     if (ref.current && !ref.current.contains(event.target as any)) {
-      // check for the closest element with attribute name data-prevent-outside-click
-      const preventOutsideClickElement = (event.target as unknown as HTMLElement | undefined)?.closest(
-        "[data-prevent-outside-click]"
-      );
-      // if the closest element with attribute name data-prevent-outside-click is found, return
-      if (preventOutsideClickElement) {
+      if (path.some((node) => node instanceof Element && node.hasAttribute("data-prevent-outside-click"))) {
         return;
       }
-      // else call the callback
       callback();
     }
   };

--- a/packages/ui/src/dropdown/single-select.tsx
+++ b/packages/ui/src/dropdown/single-select.tsx
@@ -49,7 +49,7 @@ export function Dropdown(props: ISingleSelectDropdown) {
   // states
   const [isOpen, setIsOpen] = useState(false);
   const [query, setQuery] = useState("");
-  const [popperElement, setPopperElement] = useState<HTMLDivElement | null>(null);
+  const [popperElement, setPopperElement] = useState<HTMLElement | null>(null);
   // refs
   const dropdownRef = useRef<HTMLDivElement | null>(null);
   // popper-js refs
@@ -58,6 +58,7 @@ export function Dropdown(props: ISingleSelectDropdown) {
   // popper-js init
   const { styles, attributes } = usePopper(referenceElement, popperElement, {
     placement: placement ?? "bottom-start",
+    strategy: "fixed",
     modifiers: [
       {
         name: "preventOverflow",
@@ -142,15 +143,20 @@ export function Dropdown(props: ISingleSelectDropdown) {
         disabled={disabled}
       />
       {isOpen && (
-        <Combobox.Options as="ul" className="fixed z-10" static>
+        <Combobox.Options
+          as="ul"
+          className="fixed z-10"
+          static
+          modal={false}
+          ref={setPopperElement}
+          style={styles.popper}
+          {...attributes.popper}
+        >
           <div
             className={cn(
               "my-1 w-48 rounded-sm border-[0.5px] border-strong bg-surface-1 px-2 py-2 text-11 shadow-raised-200 focus:outline-none",
               optionsContainerClassName
             )}
-            ref={setPopperElement}
-            style={styles.popper}
-            {...attributes.popper}
           >
             <DropdownOptions
               isOpen={isOpen}

--- a/packages/ui/src/dropdowns/custom-menu.tsx
+++ b/packages/ui/src/dropdowns/custom-menu.tsx
@@ -86,7 +86,7 @@ function CustomMenu(props: ICustomMenuDropdownProps) {
   } = props;
 
   const [referenceElement, setReferenceElement] = React.useState<HTMLButtonElement | null>(null);
-  const [popperElement, setPopperElement] = React.useState<HTMLDivElement | null>(null);
+  const [popperElement, setPopperElement] = React.useState<HTMLElement | null>(null);
   const [isOpen, setIsOpen] = React.useState(false);
   // refs
   const dropdownRef = React.useRef<HTMLDivElement | null>(null);
@@ -94,6 +94,7 @@ function CustomMenu(props: ICustomMenuDropdownProps) {
 
   const { styles, attributes } = usePopper(referenceElement, popperElement, {
     placement: placement ?? "auto",
+    strategy: "fixed",
   });
 
   const closeAllSubmenus = React.useCallback(() => {
@@ -201,6 +202,10 @@ function CustomMenu(props: ICustomMenuDropdownProps) {
         menuItemsClassName
       )} /** translate-y-0 is a hack to create new stacking context. Required for safari  */
       static
+      modal={false}
+      ref={setPopperElement}
+      style={styles.popper}
+      {...attributes.popper}
     >
       <div
         className={cn(
@@ -213,9 +218,6 @@ function CustomMenu(props: ICustomMenuDropdownProps) {
           },
           optionsClassName
         )}
-        ref={setPopperElement}
-        style={styles.popper}
-        {...attributes.popper}
       >
         <MenuContext.Provider value={menuContextValue}>{children}</MenuContext.Provider>
       </div>

--- a/packages/ui/src/dropdowns/custom-search-select.tsx
+++ b/packages/ui/src/dropdowns/custom-search-select.tsx
@@ -45,13 +45,14 @@ export function CustomSearchSelect(props: ICustomSearchSelectProps) {
   const [query, setQuery] = useState("");
 
   const [referenceElement, setReferenceElement] = useState<HTMLButtonElement | null>(null);
-  const [popperElement, setPopperElement] = useState<HTMLDivElement | null>(null);
+  const [popperElement, setPopperElement] = useState<HTMLElement | null>(null);
   const [isOpen, setIsOpen] = useState(defaultOpen);
   // refs
   const dropdownRef = useRef<HTMLDivElement | null>(null);
 
   const { styles, attributes } = usePopper(referenceElement, popperElement, {
     placement: placement ?? "bottom-start",
+    strategy: "fixed",
   });
 
   const filteredOptions =
@@ -142,15 +143,21 @@ export function CustomSearchSelect(props: ICustomSearchSelectProps) {
             )}
             {isOpen &&
               createPortal(
-                <Combobox.Options as="ul" data-prevent-outside-click static>
+                <Combobox.Options
+                  as="ul"
+                  className="z-30"
+                  data-prevent-outside-click
+                  static
+                  modal={false}
+                  ref={setPopperElement}
+                  style={styles.popper}
+                  {...attributes.popper}
+                >
                   <div
                     className={cn(
                       "z-30 my-1 min-w-48 overflow-y-scroll rounded-md border-[0.5px] border-subtle-1 bg-surface-1 py-2.5 text-11 whitespace-nowrap focus:outline-none",
                       optionsClassName
                     )}
-                    ref={setPopperElement}
-                    style={styles.popper}
-                    {...attributes.popper}
                   >
                     <div className="mx-2 flex items-center gap-1.5 rounded-sm border border-subtle px-2">
                       <SearchOutline className="h-3.5 w-3.5 text-placeholder" />

--- a/packages/ui/src/dropdowns/custom-select.tsx
+++ b/packages/ui/src/dropdowns/custom-select.tsx
@@ -42,13 +42,14 @@ function CustomSelect(props: ICustomSelectProps) {
   } = props;
   // states
   const [referenceElement, setReferenceElement] = useState<HTMLButtonElement | null>(null);
-  const [popperElement, setPopperElement] = useState<HTMLDivElement | null>(null);
+  const [popperElement, setPopperElement] = useState<HTMLElement | null>(null);
   const [isOpen, setIsOpen] = useState(false);
   // refs
   const dropdownRef = useRef<HTMLDivElement | null>(null);
 
   const { styles, attributes } = usePopper(referenceElement, popperElement, {
     placement: placement ?? "bottom-start",
+    strategy: "fixed",
   });
 
   const openDropdown = useCallback(() => {
@@ -119,15 +120,20 @@ function CustomSelect(props: ICustomSelectProps) {
         </>
         {isOpen &&
           createPortal(
-            <Combobox.Options as="ul" data-prevent-outside-click>
+            <Combobox.Options
+              as="ul"
+              className="z-30"
+              data-prevent-outside-click
+              modal={false}
+              ref={setPopperElement}
+              style={styles.popper}
+              {...attributes.popper}
+            >
               <div
                 className={cn(
                   "z-30 my-1 min-w-48 overflow-y-scroll rounded-md border-[0.5px] border-subtle-1 bg-surface-1 px-2 py-2.5 text-11 whitespace-nowrap focus:outline-none",
                   optionsClassName
                 )}
-                ref={setPopperElement}
-                style={styles.popper}
-                {...attributes.popper}
               >
                 <div
                   className={cn("space-y-1 overflow-y-scroll", {

--- a/packages/ui/src/form-fields/input-color-picker.tsx
+++ b/packages/ui/src/form-fields/input-color-picker.tsx
@@ -29,10 +29,11 @@ export function InputColorPicker(props: InputColorPickerProps) {
   const { value, hasError, onChange, name, className, style, placeholder } = props;
 
   const [referenceElement, setReferenceElement] = React.useState<HTMLButtonElement | null>(null);
-  const [popperElement, setPopperElement] = React.useState<HTMLDivElement | null>(null);
+  const [popperElement, setPopperElement] = React.useState<HTMLElement | null>(null);
 
   const { styles, attributes } = usePopper(referenceElement, popperElement, {
     placement: "auto",
+    strategy: "fixed",
   });
 
   const handleColorChange = (newColor: ColorResult) => {
@@ -92,13 +93,12 @@ export function InputColorPicker(props: InputColorPickerProps) {
               leaveFrom="opacity-100 translate-y-0"
               leaveTo="opacity-0 translate-y-1"
             >
-              <Popover.Panel>
-                <div
-                  className="z-10 overflow-hidden rounded-sm border border-subtle bg-surface-1 shadow-raised-200"
-                  ref={setPopperElement}
-                  style={styles.popper}
-                  {...attributes.popper}
-                >
+              <Popover.Panel
+                ref={setPopperElement}
+                style={styles.popper}
+                {...attributes.popper}
+              >
+                <div className="z-10 overflow-hidden rounded-sm border border-subtle bg-surface-1 shadow-raised-200">
                   <ColorPicker.SketchPicker color={value} onChange={handleColorChange} />
                 </div>
               </Popover.Panel>

--- a/packages/ui/src/form-fields/input-color-picker.tsx
+++ b/packages/ui/src/form-fields/input-color-picker.tsx
@@ -94,6 +94,7 @@ export function InputColorPicker(props: InputColorPickerProps) {
               leaveTo="opacity-0 translate-y-1"
             >
               <Popover.Panel
+                className="z-30"
                 ref={setPopperElement}
                 style={styles.popper}
                 {...attributes.popper}

--- a/packages/ui/src/popovers/popover.tsx
+++ b/packages/ui/src/popovers/popover.tsx
@@ -35,6 +35,7 @@ export function Popover(props: TPopover) {
   // react-popper derived values
   const { styles, attributes } = usePopper(referenceElement, popperElement, {
     placement: popperPosition,
+    strategy: "fixed",
     modifiers: [
       {
         name: "preventOverflow",


### PR DESCRIPTION
### Description

Headless UI v2 (`Frozen` + default `modal={true}` Combobox) broke dropdowns after the React 19 upgrade: menus opened at the viewport origin, option clicks did nothing, peek closed on select, and portaled date pickers sat behind peek.

This keeps public Headless APIs only (no vendor patch) and:

- Puts popper `ref` / `style` / attributes on the Options/Items/Panel host so Frozen `cloneElement` cannot clobber the popper node
- Uses `strategy: "fixed"` and `modal={false}` on searchable / in-peek lists
- Puts `z-30` (and `data-prevent-outside-click` where needed) on portaled hosts
- Uses `composedPath()` in peek/sidebar/outside-click hooks so a detached mousedown after Headless v2 select is not treated as an outside click

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

### Screenshots and Media (if applicable)

This section covers only a subset of the affected dropdowns. There are many instances across web, space, onboarding, modals, and settings, so the table below is a representative sample rather than a full inventory.

| Surface | Result | Screenshot |
| --- | --- | --- |
| State dropdown (browse) | PASS | <img width="3840" height="2160" alt="state-dropdown--browse-test-1--open" src="https://github.com/user-attachments/assets/11124503-94eb-4d17-a5e0-bdbe8b9ea1a6" /> |
| Due date calendar (browse) | PASS | <img width="3840" height="2160" alt="date-dropdown--browse-test-1--due-date-open" src="https://github.com/user-attachments/assets/2f67400d-63b3-4fad-8915-31820c57b740" /> |
| Peek state dropdown | PASS | <img width="1264" height="1756" alt="state-dropdown--peek-test-1--open" src="https://github.com/user-attachments/assets/09e29d18-e621-466f-887a-c84b5d838bcb" /> |
| Display filters | PASS | <img width="3840" height="2160" alt="display-dropdown--issues-list--open" src="https://github.com/user-attachments/assets/9d2cab07-874f-4d8f-9513-c69ba3ccaba5" /> |
| DateDropdown | PASS | <img width="1264" height="1756" alt="date-dropdown--harness--open" src="https://github.com/user-attachments/assets/b0afcb16-f228-473f-9800-3cbe4adbe7de" /> |
| DateRangeDropdown | PASS | <img width="3840" height="2160" alt="date-range-dropdown--harness--open" src="https://github.com/user-attachments/assets/d8fc6fa5-387e-4cbe-88fa-894678a0fcd3" /> |
| PriorityDropdown | PASS | <img width="3840" height="2160" alt="priority-dropdown--harness--open" src="https://github.com/user-attachments/assets/daaf527a-93f6-4677-9f5f-98ee1d0f8237" /> |
| StateDropdown | PASS | <img width="1264" height="1756" alt="state-dropdown--harness--open" src="https://github.com/user-attachments/assets/4c98d974-68f5-4aa3-964e-f1fb4a586d8e" /> |
| IntakeStateDropdown | PASS | <img width="3840" height="2160" alt="intake-state-dropdown--harness--open" src="https://github.com/user-attachments/assets/fb42384d-5baf-467b-a860-de42169745aa" /> |
| MemberDropdown | PASS | <img width="3840" height="2160" alt="member-dropdown--harness--open" src="https://github.com/user-attachments/assets/0468684c-d134-435a-9d55-337ff94ec3fb" /> |

### Test Scenarios

- Open state / priority / assignees on a full work item page: menu is next to the trigger, search works, selecting an option updates the property.
- Open start / due date on the same page: calendar is `position: fixed` and visible (not behind the panel).
- From the project work-item list, open peek, change state/priority: peek stays open.
- Open Display on the work-item list: panel is anchored to Display, not the viewport origin.
- Confirm no leftover `ref={setPopperElement}` on a Frozen inner `div`.

### References

- Headless UI Frozen + popper ref: Headless UI v2 `cloneElement(child, { ref })`
- Related: #9530 (upgrade)