### PR TITLE
fix(web): merge duplicate settings entries in user menu

### DIFF
--- a/apps/web/core/components/workspace/sidebar/user-menu-root.tsx
+++ b/apps/web/core/components/workspace/sidebar/user-menu-root.tsx
@@ -7,7 +7,7 @@
 import { useState, useEffect } from "react";
 import { observer } from "mobx-react";
 import { useRouter } from "next/navigation";
-import { LogOut, Settings, Settings2 } from "lucide-react";
+import { LogOut, Settings } from "lucide-react";
 // plane imports
 import { GOD_MODE_URL } from "@plane/constants";
 import { useTranslation } from "@plane/i18n";
@@ -119,18 +119,6 @@ export const UserMenuRoot = observer(function UserMenuRoot() {
         >
           <Settings className="size-3.5 shrink-0" />
           {t("settings")}
-        </CustomMenu.MenuItem>
-        <CustomMenu.MenuItem
-          onClick={() =>
-            toggleProfileSettingsModal({
-              activeTab: "preferences",
-              isOpen: true,
-            })
-          }
-          className="flex items-center gap-2"
-        >
-          <Settings2 className="size-3.5 shrink-0" />
-          {t("preferences")}
         </CustomMenu.MenuItem>
       </div>
       <CustomMenu.MenuItem onClick={handleSignOut} className="flex items-center gap-2">

--- a/packages/i18n/src/locales/cs/common.json
+++ b/packages/i18n/src/locales/cs/common.json
@@ -57,7 +57,6 @@
     "no_worklogs": "Zatím žádné záznamy práce",
     "no_history": "Zatím žádná historie"
   },
-  "preferences": "Předvolby",
   "language_and_time": "Jazyk a čas",
   "notifications": "Oznámení",
   "workspaces": "Pracovní prostory",

--- a/packages/i18n/src/locales/de/common.json
+++ b/packages/i18n/src/locales/de/common.json
@@ -57,7 +57,6 @@
     "no_worklogs": "Noch keine Arbeitszeiten",
     "no_history": "Noch kein Verlauf"
   },
-  "preferences": "Einstellungen",
   "language_and_time": "Sprache und Zeit",
   "notifications": "Benachrichtigungen",
   "workspaces": "Arbeitsbereiche",

--- a/packages/i18n/src/locales/en/common.json
+++ b/packages/i18n/src/locales/en/common.json
@@ -57,7 +57,6 @@
     "no_worklogs": "No worklogs yet",
     "no_history": "No history yet"
   },
-  "preferences": "Preferences",
   "language_and_time": "Language & Time",
   "notifications": "Notifications",
   "workspaces": "Workspaces",

--- a/packages/i18n/src/locales/es/common.json
+++ b/packages/i18n/src/locales/es/common.json
@@ -57,7 +57,6 @@
     "no_worklogs": "Sin registros de trabajo aún",
     "no_history": "Sin historial aún"
   },
-  "preferences": "Preferencias",
   "language_and_time": "Idioma y hora",
   "notifications": "Notificaciones",
   "workspaces": "Espacios de trabajo",

--- a/packages/i18n/src/locales/fr/common.json
+++ b/packages/i18n/src/locales/fr/common.json
@@ -57,7 +57,6 @@
     "no_worklogs": "Aucun journal de travail pour l'instant",
     "no_history": "Aucun historique pour l'instant"
   },
-  "preferences": "Préférences",
   "language_and_time": "Langue et heure",
   "notifications": "Notifications",
   "workspaces": "Espaces de travail",

--- a/packages/i18n/src/locales/id/common.json
+++ b/packages/i18n/src/locales/id/common.json
@@ -57,7 +57,6 @@
     "no_worklogs": "Belum ada catatan kerja",
     "no_history": "Belum ada riwayat"
   },
-  "preferences": "Preferensi",
   "language_and_time": "Bahasa & Waktu",
   "notifications": "Notifikasi",
   "workspaces": "Ruang kerja",

--- a/packages/i18n/src/locales/it/common.json
+++ b/packages/i18n/src/locales/it/common.json
@@ -57,7 +57,6 @@
     "no_worklogs": "Nessun registro di lavoro ancora",
     "no_history": "Nessuna cronologia ancora"
   },
-  "preferences": "Preferenze",
   "language_and_time": "Lingua e ora",
   "notifications": "Notifiche",
   "workspaces": "Spazi di lavoro",

--- a/packages/i18n/src/locales/ja/common.json
+++ b/packages/i18n/src/locales/ja/common.json
@@ -57,7 +57,6 @@
     "no_worklogs": "作業ログはまだありません",
     "no_history": "履歴はまだありません"
   },
-  "preferences": "環境設定",
   "language_and_time": "言語と時刻",
   "notifications": "通知",
   "workspaces": "ワークスペース",

--- a/packages/i18n/src/locales/ko/common.json
+++ b/packages/i18n/src/locales/ko/common.json
@@ -57,7 +57,6 @@
     "no_worklogs": "아직 작업 기록이 없습니다",
     "no_history": "아직 기록이 없습니다"
   },
-  "preferences": "환경 설정",
   "language_and_time": "언어 및 시간",
   "notifications": "알림",
   "workspaces": "작업 공간",

--- a/packages/i18n/src/locales/pl/common.json
+++ b/packages/i18n/src/locales/pl/common.json
@@ -57,7 +57,6 @@
     "no_worklogs": "Brak dzienników pracy",
     "no_history": "Brak historii"
   },
-  "preferences": "Preferencje",
   "language_and_time": "Język i czas",
   "notifications": "Powiadomienia",
   "workspaces": "Przestrzenie robocze",

--- a/packages/i18n/src/locales/pt-BR/common.json
+++ b/packages/i18n/src/locales/pt-BR/common.json
@@ -57,7 +57,6 @@
     "no_worklogs": "Nenhum registro de trabalho ainda",
     "no_history": "Nenhum histórico ainda"
   },
-  "preferences": "Preferências",
   "language_and_time": "Idioma e Hora",
   "notifications": "Notificações",
   "workspaces": "Espaços de trabalho",

--- a/packages/i18n/src/locales/ro/common.json
+++ b/packages/i18n/src/locales/ro/common.json
@@ -57,7 +57,6 @@
     "no_worklogs": "Niciun jurnal de lucru încă",
     "no_history": "Niciun istoric încă"
   },
-  "preferences": "Preferințe",
   "language_and_time": "Limbă și oră",
   "notifications": "Notificări",
   "workspaces": "Spații de lucru",

--- a/packages/i18n/src/locales/ru/common.json
+++ b/packages/i18n/src/locales/ru/common.json
@@ -57,7 +57,6 @@
     "no_worklogs": "Записей о работе пока нет",
     "no_history": "Истории пока нет"
   },
-  "preferences": "Настройки",
   "language_and_time": "Язык и время",
   "notifications": "Уведомления",
   "workspaces": "Рабочие пространства",

--- a/packages/i18n/src/locales/sk/common.json
+++ b/packages/i18n/src/locales/sk/common.json
@@ -57,7 +57,6 @@
     "no_worklogs": "Zatiaľ žiadne záznamy práce",
     "no_history": "Zatiaľ žiadna história"
   },
-  "preferences": "Predvoľby",
   "language_and_time": "Jazyk a čas",
   "notifications": "Oznámenia",
   "workspaces": "Pracovné priestory",

--- a/packages/i18n/src/locales/tr-TR/common.json
+++ b/packages/i18n/src/locales/tr-TR/common.json
@@ -57,7 +57,6 @@
     "no_worklogs": "Henüz çalışma kaydı yok",
     "no_history": "Henüz geçmiş yok"
   },
-  "preferences": "Tercihler",
   "language_and_time": "Dil ve Saat",
   "notifications": "Bildirimler",
   "workspaces": "Çalışma Alanları",

--- a/packages/i18n/src/locales/ua/common.json
+++ b/packages/i18n/src/locales/ua/common.json
@@ -57,7 +57,6 @@
     "no_worklogs": "Записів роботи ще немає",
     "no_history": "Історії ще немає"
   },
-  "preferences": "Налаштування",
   "language_and_time": "Мова та час",
   "notifications": "Сповіщення",
   "workspaces": "Робочі простори",

--- a/packages/i18n/src/locales/vi-VN/common.json
+++ b/packages/i18n/src/locales/vi-VN/common.json
@@ -57,7 +57,6 @@
     "no_worklogs": "Chưa có nhật ký công việc",
     "no_history": "Chưa có lịch sử"
   },
-  "preferences": "Tùy chọn",
   "language_and_time": "Ngôn ngữ và thời gian",
   "notifications": "Thông báo",
   "workspaces": "Không gian làm việc",

--- a/packages/i18n/src/locales/zh-CN/common.json
+++ b/packages/i18n/src/locales/zh-CN/common.json
@@ -57,7 +57,6 @@
     "no_worklogs": "暂无工时记录",
     "no_history": "暂无历史记录"
   },
-  "preferences": "偏好设置",
   "language_and_time": "语言和时间",
   "notifications": "通知",
   "workspaces": "工作区",

--- a/packages/i18n/src/locales/zh-TW/common.json
+++ b/packages/i18n/src/locales/zh-TW/common.json
@@ -57,7 +57,6 @@
     "no_worklogs": "尚無工時紀錄",
     "no_history": "尚無歷史紀錄"
   },
-  "preferences": "偏好設定",
   "language_and_time": "語言與時間",
   "notifications": "通知",
   "workspaces": "工作區",


### PR DESCRIPTION
### Description

The user avatar dropdown in the workspace sidebar listed two visually duplicate entries — **Settings** and **Preferences** — both opening the same profile settings modal (`toggleProfileSettingsModal`) with only the initial tab differing (`general` vs `preferences`).

This PR removes the **Preferences** menu item and keeps a single **Settings** entry that opens the modal on the `general` tab. Preferences are still reachable via the Preferences tab inside the modal.

Also cleaned up the now-unused top-level `preferences` translation key from `common.json` in all locales, since this menu item was its only reference.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Test Scenarios

- Open the user avatar dropdown in the sidebar: only one **Settings** entry (gear icon) is shown.
- Clicking it opens the profile settings modal on the **General** tab.
- Switching to the **Preferences** tab inside the modal still works.
- `check:types` passes for `web` and `@plane/i18n`; oxlint/oxfmt clean on changed files.

### References

Closes #9793