### PR TITLE
fix(web): fall back to workspace timezone for time displays

### DIFF
--- a/apps/web/core/components/home/user-greetings.tsx
+++ b/apps/web/core/components/home/user-greetings.tsx
@@ -4,40 +4,49 @@
  * See the LICENSE file for details.
  */
 
+import { observer } from "mobx-react";
 // plane types
 import { useTranslation } from "@plane/i18n";
 import type { IUser } from "@plane/types";
 // plane ui
 // hooks
 import { useCurrentTime } from "@/hooks/use-current-time";
+import { useDisplayTimezone } from "@/hooks/use-display-timezone";
 
 export interface IUserGreetingsView {
   user: IUser;
 }
 
-export function UserGreetingsView(props: IUserGreetingsView) {
+export const UserGreetingsView = observer(function UserGreetingsView(props: IUserGreetingsView) {
   const { user } = props;
   // current time hook
   const { currentTime } = useCurrentTime();
   // store hooks
   const { t } = useTranslation();
+  // resolved display timezone: user preference (UTC treated as unset) -> workspace timezone -> browser local
+  const timeZone = useDisplayTimezone(user?.user_timezone);
 
+  // all fields below must use the same timezone, otherwise the greeting and
+  // the displayed time can belong to different timezones
   const hour = new Intl.DateTimeFormat("en-US", {
+    timeZone,
     hour12: false,
     hour: "numeric",
   }).format(currentTime);
 
   const date = new Intl.DateTimeFormat("en-US", {
+    timeZone,
     month: "short",
     day: "numeric",
   }).format(currentTime);
 
   const weekDay = new Intl.DateTimeFormat("en-US", {
+    timeZone,
     weekday: "long",
   }).format(currentTime);
 
   const timeString = new Intl.DateTimeFormat("en-US", {
-    timeZone: user?.user_timezone,
+    timeZone,
     hour12: false, // Use 24-hour format
     hour: "2-digit",
     minute: "2-digit",
@@ -58,4 +67,4 @@ export function UserGreetingsView(props: IUserGreetingsView) {
       </h5>
     </div>
   );
-}
+});

--- a/apps/web/core/components/profile/time.tsx
+++ b/apps/web/core/components/profile/time.tsx
@@ -4,21 +4,27 @@
  * See the LICENSE file for details.
  */
 
+import { observer } from "mobx-react";
 // hooks
 import { useCurrentTime } from "@/hooks/use-current-time";
+import { useDisplayTimezone } from "@/hooks/use-display-timezone";
 
 type Props = {
   timeZone: string | undefined;
 };
 
-export function ProfileSidebarTime(props: Props) {
+export const ProfileSidebarTime = observer(function ProfileSidebarTime(props: Props) {
   const { timeZone } = props;
   // current time hook
   const { currentTime } = useCurrentTime();
+  // resolved display timezone: user preference (UTC treated as unset) -> workspace timezone -> browser local
+  const resolvedTimeZone = useDisplayTimezone(timeZone);
+  // when both are unset the browser's local timezone is used; resolve its name for display
+  const displayTimeZone = resolvedTimeZone ?? Intl.DateTimeFormat().resolvedOptions().timeZone;
 
   // Create a date object for the current time in the specified timezone
   const formatter = new Intl.DateTimeFormat("en-US", {
-    timeZone: timeZone,
+    timeZone: displayTimeZone,
     hour12: false, // Use 24-hour format
     hour: "2-digit",
     minute: "2-digit",
@@ -27,7 +33,7 @@ export function ProfileSidebarTime(props: Props) {
 
   return (
     <span>
-      {timeString} <span className="text-secondary">{timeZone}</span>
+      {timeString} <span className="text-secondary">{displayTimeZone}</span>
     </span>
   );
-}
+});

--- a/apps/web/core/components/user/user-greetings.tsx
+++ b/apps/web/core/components/user/user-greetings.tsx
@@ -4,40 +4,49 @@
  * See the LICENSE file for details.
  */
 
+import { observer } from "mobx-react";
 // plane types
 import { useTranslation } from "@plane/i18n";
 // hooks
 import type { IUser } from "@plane/types";
 import { useCurrentTime } from "@/hooks/use-current-time";
+import { useDisplayTimezone } from "@/hooks/use-display-timezone";
 // types
 
 export interface IUserGreetingsView {
   user: IUser;
 }
 
-export function UserGreetingsView(props: IUserGreetingsView) {
+export const UserGreetingsView = observer(function UserGreetingsView(props: IUserGreetingsView) {
   const { user } = props;
   // current time hook
   const { currentTime } = useCurrentTime();
   // store hooks
   const { t } = useTranslation();
+  // resolved display timezone: user preference (UTC treated as unset) -> workspace timezone -> browser local
+  const timeZone = useDisplayTimezone(user?.user_timezone);
 
+  // all fields below must use the same timezone, otherwise the greeting and
+  // the displayed time can belong to different timezones
   const hour = new Intl.DateTimeFormat("en-US", {
+    timeZone,
     hour12: false,
     hour: "numeric",
   }).format(currentTime);
 
   const date = new Intl.DateTimeFormat("en-US", {
+    timeZone,
     month: "short",
     day: "numeric",
   }).format(currentTime);
 
   const weekDay = new Intl.DateTimeFormat("en-US", {
+    timeZone,
     weekday: "long",
   }).format(currentTime);
 
   const timeString = new Intl.DateTimeFormat("en-US", {
-    timeZone: user?.user_timezone,
+    timeZone,
     hour12: false, // Use 24-hour format
     hour: "2-digit",
     minute: "2-digit",
@@ -58,4 +67,4 @@ export function UserGreetingsView(props: IUserGreetingsView) {
       </h5>
     </div>
   );
-}
+});

--- a/apps/web/core/hooks/use-display-timezone.ts
+++ b/apps/web/core/hooks/use-display-timezone.ts
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2023-present Plane Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+// hooks
+import { useWorkspace } from "@/hooks/store/use-workspace";
+
+/**
+ * Resolve the timezone to use when displaying times in the UI.
+ *
+ * Resolution order:
+ * 1. The user's preferred timezone (`user_timezone`). `"UTC"` is treated as
+ *    "not set": it is the database default for users who never picked a
+ *    timezone, and we cannot distinguish that from a user who deliberately
+ *    chose UTC. The workspace timezone is the better fallback for those users.
+ * 2. The current workspace's timezone, which the organization has explicitly
+ *    declared in workspace settings.
+ * 3. `undefined`, which makes the Intl APIs fall back to the browser's local
+ *    timezone.
+ */
+export const resolveDisplayTimezone = (
+  userTimezone: string | undefined,
+  workspaceTimezone: string | undefined
+): string | undefined => {
+  if (userTimezone && userTimezone !== "UTC") return userTimezone;
+  if (workspaceTimezone) return workspaceTimezone;
+  return undefined;
+};
+
+/**
+ * Hook variant of `resolveDisplayTimezone` that reads the current workspace
+ * from the store.
+ */
+export const useDisplayTimezone = (userTimezone: string | undefined): string | undefined => {
+  const { currentWorkspace } = useWorkspace();
+  return resolveDisplayTimezone(userTimezone, currentWorkspace?.timezone);
+};


### PR DESCRIPTION
### Description

Time displays in the web app ignored the workspace timezone and mixed two different timezones on a single row:

- `home/user-greetings.tsx` and `user/user-greetings.tsx`: the clock time used `user.user_timezone` (DB default `UTC` for anyone who never picked one) while the greeting word, weekday and date used the browser timezone.
- `profile/time.tsx` (`ProfileSidebarTime`): used only the profile `user_timezone`.
- `workspaces.timezone` was only referenced by the settings page itself.

This PR adds a shared resolver in `apps/web/core/hooks/use-display-timezone.ts` and applies it to all three components. Resolution order:

1. The user's profile timezone, with `UTC` treated as "unset" — it is the database default, so a user who never chose a timezone is indistinguishable from one who deliberately picked UTC; the organization-declared workspace timezone is the better fallback for the common case (documented in code comments).
2. The current workspace's timezone (`useWorkspace().currentWorkspace.timezone`).
3. `undefined`, which makes the Intl APIs use the browser's local timezone.

All fields on the greeting row (`hour` used for the morning/afternoon/evening decision, `date`, `weekDay`, `timeString`) now share the same resolved timezone, fixing the inconsistency where the greeting word and the clock time could belong to different timezones. The three components are wrapped in `observer` since they now read from the MobX workspace store. `useTimeZoneConverter` (project-vs-user comparison for scheduling views) was intentionally left untouched as its semantics differ.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### Test Scenarios

- Workspace timezone = `Asia/Hong_Kong`, profile timezone unset (DB default `UTC`): home greeting shows `12:33` (workspace tz) instead of `04:33` (UTC), and the greeting word matches the displayed time.
- Profile timezone explicitly set to a non-UTC value: displays continue to use the profile timezone (unchanged behavior).
- Neither set: displays fall back to the browser's local timezone; the profile sidebar shows the browser timezone name instead of `undefined`.
- `pnpm turbo run check:types --filter=web`, `pnpm check:lint` and oxfmt all pass.

### References

Closes #9795