### PR TITLE
feat(editor): add language selector to code block node view

### DIFF
--- a/packages/editor/src/core/extensions/code/code-block-node-view.tsx
+++ b/packages/editor/src/core/extensions/code/code-block-node-view.tsx
@@ -4,12 +4,12 @@
  * See the LICENSE file for details.
  */
 
-import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
+import type { NodeViewProps } from "@tiptap/react";
 import { NodeViewWrapper, NodeViewContent } from "@tiptap/react";
 import ts from "highlight.js/lib/languages/typescript";
 import { common, createLowlight } from "lowlight";
 import { CheckIcon } from "lucide-react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { CopyIcon } from "@plane/propel/icons";
 // ui
 import { Tooltip } from "@plane/propel/tooltip";
@@ -23,14 +23,27 @@ import { ECodeBlockAttributeNames } from "./types";
 const lowlight = createLowlight(common);
 lowlight.register("ts", ts);
 
-type Props = {
-  node: ProseMirrorNode;
-};
-
-export function CodeBlockComponent({ node }: Props) {
+export function CodeBlockComponent(props: NodeViewProps) {
+  const { node, editor, updateAttributes } = props;
   const [copied, setCopied] = useState(false);
   // derived values
   const attrs = node.attrs as TCodeBlockAttributes;
+  const currentLanguage = attrs[ECodeBlockAttributeNames.LANGUAGE] ?? "";
+
+  // languages supported by the registered lowlight grammars
+  const languageOptions = useMemo(() => {
+    const options = lowlight.listLanguages().toSorted((a, b) => a.localeCompare(b));
+    // keep an explicitly set but unregistered language selectable instead of blanking the picker
+    if (currentLanguage && !options.includes(currentLanguage)) {
+      options.push(currentLanguage);
+    }
+    return options;
+  }, [currentLanguage]);
+
+  const handleLanguageChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const language = e.target.value;
+    updateAttributes({ [ECodeBlockAttributeNames.LANGUAGE]: language === "" ? null : language });
+  };
 
   const copyToClipboard = async (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     try {
@@ -46,6 +59,28 @@ export function CodeBlockComponent({ node }: Props) {
 
   return (
     <NodeViewWrapper key={attrs[ECodeBlockAttributeNames.ID]} className="code-block group/code relative">
+      {editor.isEditable && (
+        <div
+          contentEditable={false}
+          role="presentation"
+          className="absolute top-2 left-2 z-10"
+          onMouseDown={(e) => e.stopPropagation()}
+        >
+          <select
+            value={currentLanguage}
+            onChange={handleLanguageChange}
+            aria-label="Code language"
+            className="h-8 cursor-pointer rounded-md border border-subtle bg-layer-1 px-2 text-11 text-secondary backdrop-blur-sm outline-none hover:text-primary"
+          >
+            <option value="">Plain text</option>
+            {languageOptions.map((language) => (
+              <option key={language} value={language}>
+                {language}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
       <Tooltip tooltipContent="Copy code">
         <button
           type="button"
@@ -65,7 +100,7 @@ export function CodeBlockComponent({ node }: Props) {
         </button>
       </Tooltip>
 
-      <pre className="my-2 rounded-lg bg-layer-3 p-4 text-primary">
+      <pre className={cn("my-2 rounded-lg bg-layer-3 p-4 text-primary", { "pt-10": editor.isEditable })}>
         <NodeViewContent as="code" className="whitespace-pre-wrap" />
       </pre>
     </NodeViewWrapper>


### PR DESCRIPTION
### Description

Adds a language selector dropdown to the code block node view, closing #9799.

In CE, code blocks created via slash command / paste / import get `language: null` and there is no UI to set or change the language afterwards — the only workaround is retyping the ` ```lang ` fence. This PR renders a compact `<select>` at the top-left of code blocks (editable mode only):

- Options come from the extension's own lowlight instance (`listLanguages()`), so the list always matches the registered grammars, plus a "Plain text" (null) option.
- Selecting a language calls `updateAttributes({ language })`, so lowlight highlighting updates in place.
- A language that is set on the node but not registered in lowlight stays selectable instead of blanking the picker.
- The selector is inside a `contentEditable={false}` wrapper with mousedown propagation stopped, so it doesn't disturb the editor selection; the `<pre>` gets extra top padding in editable mode so the control never overlaps the first line of code.

Read-only rendering is unchanged (no selector, no extra padding).

### Type of Change

- [x] New feature (non-breaking change which adds functionality)

### Screenshots and Media (if applicable)

Tested locally on the CE dev server: created code blocks via slash command, ` ```ts ` fence, and plain paste; switched languages via the selector and confirmed highlighting follows the selection; verified the selector is hidden in read-only mode.

### Test Scenarios

- `pnpm turbo run check:types --filter=@plane/editor` passes
- `oxlint` on the changed file: 0 warnings, 0 errors

### References

Closes #9799
