### PR TITLE
fix(web): hide work item IDs when Display → IDs is off

### DIFF
--- a/apps/web/core/components/issues/issue-detail/issue-identifier.tsx
+++ b/apps/web/core/components/issues/issue-detail/issue-identifier.tsx
@@ -7,6 +7,7 @@
 import { observer } from "mobx-react";
 // plane imports
 import type { TIssueIdentifierProps } from "@plane/types";
+import { shouldDisplayWorkItemId } from "@plane/utils";
 // hooks
 import { useIssueDetail } from "@/hooks/store/use-issue-detail";
 import { useProject } from "@/hooks/store/use-project";
@@ -25,9 +26,8 @@ export const IssueIdentifier = observer(function IssueIdentifier(props: TIssueId
   const issue = isUsingStoreData ? getIssueById(props.issueId) : null;
   const projectIdentifier = isUsingStoreData ? getProjectIdentifierById(projectId) : props.projectIdentifier;
   const issueSequenceId = isUsingStoreData ? issue?.sequence_id : props.issueSequenceId;
-  const shouldRenderIssueID = displayProperties ? displayProperties.key : true;
 
-  if (!shouldRenderIssueID) return null;
+  if (!shouldDisplayWorkItemId(displayProperties)) return null;
 
   return (
     <div className="flex shrink-0 items-center space-x-2">

--- a/apps/web/core/components/issues/issue-layouts/calendar/issue-block.tsx
+++ b/apps/web/core/components/issues/issue-layouts/calendar/issue-block.tsx
@@ -24,6 +24,7 @@ import useIssuePeekOverviewRedirection from "@/hooks/use-issue-peek-overview-red
 import { usePlatformOS } from "@/hooks/use-platform-os";
 // components
 import { IssueIdentifier } from "@/components/issues/issue-detail/issue-identifier";
+import { WithDisplayPropertiesHOC } from "@/components/issues/issue-layouts/properties/with-display-properties-HOC";
 // local components
 import { WorkItemPreviewCard } from "../../preview-card";
 import type { TRenderQuickActions } from "../list/list-view-types";
@@ -132,13 +133,18 @@ export const CalendarIssueBlock = observer(
                       }}
                     />
                     {issue.project_id && (
-                      <IssueIdentifier
-                        issueId={issue.id}
-                        projectId={issue.project_id}
-                        size="xs"
-                        variant="tertiary"
-                        displayProperties={issuesFilter?.issueFilters?.displayProperties}
-                      />
+                      <WithDisplayPropertiesHOC
+                        displayProperties={issuesFilter?.issueFilters?.displayProperties || {}}
+                        displayPropertyKey="key"
+                      >
+                        <IssueIdentifier
+                          issueId={issue.id}
+                          projectId={issue.project_id}
+                          size="xs"
+                          variant="tertiary"
+                          displayProperties={issuesFilter?.issueFilters?.displayProperties}
+                        />
+                      </WithDisplayPropertiesHOC>
                     )}
                     <div className="truncate text-13 font-medium md:text-11 md:font-regular">{issue.name}</div>
                   </div>

--- a/apps/web/core/components/issues/issue-layouts/gantt/blocks.tsx
+++ b/apps/web/core/components/issues/issue-layouts/gantt/blocks.tsx
@@ -10,10 +10,11 @@ import { useParams } from "next/navigation";
 import { Popover } from "@plane/propel/popover";
 import { Tooltip } from "@makeplane/propel/components/tooltip";
 import { ControlLink } from "@plane/ui";
-import { findTotalDaysInRange, generateWorkItemLink } from "@plane/utils";
+import { generateWorkItemLink } from "@plane/utils";
 // components
 import { SIDEBAR_WIDTH } from "@/components/gantt-chart/constants";
 import { IssueIdentifier } from "@/components/issues/issue-detail/issue-identifier";
+import { WithDisplayPropertiesHOC } from "@/components/issues/issue-layouts/properties/with-display-properties-HOC";
 // hooks
 import { useIssueDetail } from "@/hooks/store/use-issue-detail";
 import { useIssues } from "@/hooks/store/use-issues";
@@ -54,8 +55,6 @@ export const IssueGanttBlock = observer(function IssueGanttBlock(props: Props) {
   const { blockStyle } = getBlockViewDetails(issueDetails, stateDetails?.color ?? "");
 
   const handleIssuePeekOverview = () => handleRedirection(workspaceSlug, issueDetails, isMobile);
-
-  const duration = findTotalDaysInRange(issueDetails?.start_date, issueDetails?.target_date) || 0;
 
   return (
     <Popover delay={100} openOnHover>
@@ -143,13 +142,18 @@ export const IssueGanttSidebarBlock = observer(function IssueGanttSidebarBlock(p
     >
       <div className="relative flex h-full w-full cursor-pointer items-center gap-2">
         {issueDetails?.project_id && (
-          <IssueIdentifier
-            issueId={issueDetails.id}
-            projectId={issueDetails.project_id}
-            size="xs"
-            variant="tertiary"
-            displayProperties={issuesFilter?.issueFilters?.displayProperties}
-          />
+          <WithDisplayPropertiesHOC
+            displayProperties={issuesFilter?.issueFilters?.displayProperties || {}}
+            displayPropertyKey="key"
+          >
+            <IssueIdentifier
+              issueId={issueDetails.id}
+              projectId={issueDetails.project_id}
+              size="xs"
+              variant="tertiary"
+              displayProperties={issuesFilter?.issueFilters?.displayProperties}
+            />
+          </WithDisplayPropertiesHOC>
         )}
         <Tooltip label={issueDetails?.name ?? ""} layout="stacked" disabled={isMobile}>
           <span className="flex-grow truncate text-13 font-medium">{issueDetails?.name}</span>

--- a/apps/web/core/components/issues/issue-layouts/kanban/block.tsx
+++ b/apps/web/core/components/issues/issue-layouts/kanban/block.tsx
@@ -25,6 +25,7 @@ import { cn, generateWorkItemLink } from "@plane/utils";
 import RenderIfVisible from "@/components/core/render-if-visible-HOC";
 import { HIGHLIGHT_CLASS, getIssueBlockId } from "@/components/issues/issue-layouts/utils";
 import { IssueIdentifier } from "@/components/issues/issue-detail/issue-identifier";
+import { WithDisplayPropertiesHOC } from "@/components/issues/issue-layouts/properties/with-display-properties-HOC";
 // hooks
 import { useIssueDetail } from "@/hooks/store/use-issue-detail";
 import { useKanbanView } from "@/hooks/store/use-kanban-view";
@@ -96,13 +97,15 @@ const KanbanIssueDetailsBlock = observer(function KanbanIssueDetailsBlock(props:
     <>
       <div className="relative">
         {issue.project_id && (
-          <IssueIdentifier
-            issueId={issue.id}
-            projectId={issue.project_id}
-            size="xs"
-            variant="tertiary"
-            displayProperties={displayProperties}
-          />
+          <WithDisplayPropertiesHOC displayProperties={displayProperties || {}} displayPropertyKey="key">
+            <IssueIdentifier
+              issueId={issue.id}
+              projectId={issue.project_id}
+              size="xs"
+              variant="tertiary"
+              displayProperties={displayProperties}
+            />
+          </WithDisplayPropertiesHOC>
         )}
         {/* oxlint-disable-next-line jsx_a11y/click-events-have-key-events oxlint-disable-next-line jsx_a11y/no-static-element-interactions */}
         <div

--- a/apps/web/core/components/issues/issue-layouts/list/block.tsx
+++ b/apps/web/core/components/issues/issue-layouts/list/block.tsx
@@ -21,8 +21,9 @@ import { Spinner, ControlLink, Row } from "@plane/ui";
 import { cn, generateWorkItemLink } from "@plane/utils";
 // components
 import { MultipleSelectEntityAction } from "@/components/core/multiple-select";
-import { IssueProperties } from "@/components/issues/issue-layouts/properties";
 import { IssueIdentifier } from "@/components/issues/issue-detail/issue-identifier";
+import { IssueProperties } from "@/components/issues/issue-layouts/properties";
+import { WithDisplayPropertiesHOC } from "@/components/issues/issue-layouts/properties/with-display-properties-HOC";
 // hooks
 import { useAppTheme } from "@/hooks/store/use-app-theme";
 import { useIssueDetail } from "@/hooks/store/use-issue-detail";
@@ -228,7 +229,7 @@ export const IssueBlock = observer(function IssueBlock(props: IssueBlockProps) {
                   </div>
                 </Tooltip>
               )}
-              {displayProperties && (displayProperties.key || displayProperties.issue_type) && (
+              <WithDisplayPropertiesHOC displayProperties={displayProperties || {}} displayPropertyKey="key">
                 <div className="flex-shrink-0" style={{ minWidth: `${keyMinWidth}px` }}>
                   {issue.project_id && (
                     <IssueIdentifier
@@ -240,7 +241,7 @@ export const IssueBlock = observer(function IssueBlock(props: IssueBlockProps) {
                     />
                   )}
                 </div>
-              )}
+              </WithDisplayPropertiesHOC>
 
               {/* sub-issues chevron */}
               <div className="grid size-4 flex-shrink-0 place-items-center">

--- a/packages/utils/src/work-item/base.ts
+++ b/packages/utils/src/work-item/base.ts
@@ -312,6 +312,15 @@ export const getComputedDisplayProperties = (
   issue_type: displayProperties?.issue_type ?? true,
 });
 
+/**
+ * @description Hide work item IDs when Display → IDs is off. Callers that omit
+ * `displayProperties` (detail views, pickers, search) always show the identifier.
+ */
+export const shouldDisplayWorkItemId = (displayProperties?: IIssueDisplayProperties): boolean => {
+  if (!displayProperties) return true;
+  return !!displayProperties.key;
+};
+
 export const generateWorkItemLink = ({
   workspaceSlug,
   projectId,


### PR DESCRIPTION
### Description
Toggling **Display → IDs** off did not hide `PROJ-123` next to work items. List layout kept the identifier mounted whenever work-item type was on, and board/calendar/gantt did not use the same display-property gate as other properties (and as the published Space app).

This gates identifiers on the `key` display property via `WithDisplayPropertiesHOC`, matching sub-issues and Space, and centralizes the show/hide check in `shouldDisplayWorkItemId`. Detail views, search, and pickers still always show IDs because they omit `displayProperties`.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
N/A — local Plane stack (Docker + ~12GB RAM) was not run. Spreadsheet already hid IDs via `displayProperties.key`; list/board/calendar/gantt now share that gate.

### Test Scenarios
- [ ] Project work items, list layout: Display → IDs off hides `PROJ-123`; on shows it again
- [ ] Same check on board, calendar, gantt sidebar, and spreadsheet
- [ ] Other display properties (assignee, labels, etc.) still toggle independently
- [ ] Work item detail / peek still shows the identifier
- [ ] Creating/searching/picking work items still shows IDs

### References
Fixes #9565

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Issue identifiers now consistently follow display-property settings across list, board, calendar, and Gantt views.
  - Users can hide or show issue keys according to their configured display preferences.
  - Issue keys remain visible by default when no display preference is specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->