### PR TITLE
fix(web): show sub-work items on the parent in local

### DIFF
--- a/apps/web/core/components/issues/issue-detail-widgets/sub-issues/content.tsx
+++ b/apps/web/core/components/issues/issue-detail-widgets/sub-issues/content.tsx
@@ -84,16 +84,28 @@ export const SubIssuesCollapsibleContent = observer(function SubIssuesCollapsibl
   );
 
   const handleFetchSubIssues = useCallback(async () => {
-    const currentSubIssueHelpers = subIssueHelpersByIssueId(`${parentIssueId}_root`);
-    if (!currentSubIssueHelpers.issue_visibility.includes(parentIssueId)) {
-      try {
-        setSubIssueHelpers(`${parentIssueId}_root`, "preview_loader", parentIssueId);
-        await subIssueOperations.fetchSubIssues(workspaceSlug, projectId, parentIssueId);
-        setSubIssueHelpers(`${parentIssueId}_root`, "issue_visibility", parentIssueId);
-      } catch (error) {
-        console.error("Error fetching sub-work items:", error);
-      } finally {
-        setSubIssueHelpers(`${parentIssueId}_root`, "preview_loader", "");
+    const helperId = `${parentIssueId}_root`;
+    const currentSubIssueHelpers = subIssueHelpersByIssueId(helperId);
+    // setSubIssueHelpers toggles membership. Skip if visible or a fetch is already in flight
+    // so React Strict Mode's double effect does not add then remove visibility.
+    if (
+      currentSubIssueHelpers.issue_visibility.includes(parentIssueId) ||
+      currentSubIssueHelpers.preview_loader.includes(parentIssueId)
+    ) {
+      return;
+    }
+
+    try {
+      setSubIssueHelpers(helperId, "preview_loader", parentIssueId);
+      await subIssueOperations.fetchSubIssues(workspaceSlug, projectId, parentIssueId);
+      if (!subIssueHelpersByIssueId(helperId).issue_visibility.includes(parentIssueId)) {
+        setSubIssueHelpers(helperId, "issue_visibility", parentIssueId);
+      }
+    } catch (error) {
+      console.error("Error fetching sub-work items:", error);
+    } finally {
+      if (subIssueHelpersByIssueId(helperId).preview_loader.includes(parentIssueId)) {
+        setSubIssueHelpers(helperId, "preview_loader", parentIssueId);
       }
     }
   }, [parentIssueId, projectId, setSubIssueHelpers, subIssueHelpersByIssueId, subIssueOperations, workspaceSlug]);


### PR DESCRIPTION
### Description
Sub-work items added to a parent did not appear under the collapsible in local. \`setSubIssueHelpers\` toggles array membership, and React Strict Mode runs the mount fetch twice. The second completion removed \`issue_visibility\`, so the list stayed empty even though the fetch succeeded.

This skips a second in-flight fetch, only adds visibility when it is missing, and clears the preview loader with the same toggle (empty string was a no-op).

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
N/A — full local Plane stack was not run. The reporter already isolated the \`issue_visibility\` gate in \`sub-issues/content.tsx\`.

### Test Scenarios
- [ ] Local dev: add a sub-work item to a parent; it appears under the collapsible without a refresh
- [ ] Expand/collapse nested sub-items still works
- [ ] Cloud/production (no Strict Mode double-mount) still shows sub-items

### References
Fixes #9612

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved sub-issue loading to prevent duplicate fetches.
  - Prevented redundant updates when an issue is already visible.
  - Improved loading-state cleanup to avoid clearing unrelated state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->