### PR TITLE
fix(api): decode HTML entities in plain-text email bodies

### DIFF
--- a/apps/api/plane/tests/unit/utils/test_email.py
+++ b/apps/api/plane/tests/unit/utils/test_email.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+import pytest
+from plane.utils.email import generate_plain_text_from_html
+
+
+@pytest.mark.unit
+class TestGeneratePlainTextFromHtml:
+    """Test HTML-to-plain-text conversion used for email fallback bodies."""
+
+    def test_decodes_escaped_query_separators_in_invitation_urls(self):
+        html_content = """
+        <p>If the button doesn’t work, copy and paste this link into your browser:</p>
+        <a href="https://example.com/workspace-invitations/?invitation_id=abc&amp;slug=acme&amp;token=xyz">
+          https://example.com/workspace-invitations/?invitation_id=abc&amp;slug=acme&amp;token=xyz
+        </a>
+        """
+
+        text_content = generate_plain_text_from_html(html_content)
+
+        assert "&amp;" not in text_content
+        assert (
+            "https://example.com/workspace-invitations/?invitation_id=abc&slug=acme&token=xyz" in text_content
+        )
+
+    def test_strips_style_blocks_and_tags(self):
+        html_content = """
+        <style>p { color: red; }</style>
+        <p>Hello <strong>world</strong></p>
+        """
+
+        text_content = generate_plain_text_from_html(html_content)
+
+        assert "color: red" not in text_content
+        assert "<p>" not in text_content
+        assert "Hello world" in text_content

--- a/apps/api/plane/utils/email.py
+++ b/apps/api/plane/utils/email.py
@@ -10,6 +10,7 @@
 # NOTICE: Proprietary and confidential. Unauthorized use or distribution is prohibited.
 
 # Python imports
+import html
 import re
 
 # Django imports
@@ -30,8 +31,8 @@ def generate_plain_text_from_html(html_content):
     # Remove style tags and their content
     html_content = re.sub(r"<style[^>]*>.*?</style>", "", html_content, flags=re.DOTALL | re.IGNORECASE)
 
-    # Strip HTML tags
-    text_content = strip_tags(html_content)
+    # Strip HTML tags, then decode entities so query strings keep `&` instead of `&amp;`
+    text_content = html.unescape(strip_tags(html_content))
 
     # Remove excessive empty lines
     text_content = re.sub(r"\n\s*\n\s*\n+", "\n\n", text_content)


### PR DESCRIPTION
### Description
Workspace invitation emails keep a fallback URL under “If the button doesn’t work, copy and paste this link”. HTML templates escape `&` as `&amp;`, and `generate_plain_text_from_html()` only stripped tags, so the plain-text part still contained `&amp;slug` / `&amp;token`. Copied links never loaded invitation details.

This decodes entities after stripping tags in the shared helper used by invitation and other email tasks.

Related stale draft: #9522 (targets `develop` / old `apiserver/` paths; current tasks already go through this helper).

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
N/A — full SMTP stack was not run. Verified `html.unescape(strip_tags(...))` turns invitation URLs back into `?invitation_id=…&slug=…&token=…`.

### Test Scenarios
- [x] Unit: `generate_plain_text_from_html` decodes `&amp;` in invitation URLs and still strips `<style>` / tags
- [ ] Send a workspace invitation with SMTP and copy the fallback URL — query params should be `slug` and `token`, not `amp;slug` / `amp;token`
- [ ] HTML invitation emails still use escaped `&amp;` in `href` attributes

### References
Fixes #9497

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Invitation links in plain-text emails now preserve ampersands in query parameters instead of displaying encoded HTML entities.
  - Plain-text email conversion continues to remove styling blocks and HTML tags while preserving readable text.

- **Tests**
  - Added coverage for HTML entity decoding and removal of styles and tags in plain-text email content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->