### PR TITLE
fix: scope draft publish to the draft's owner

### DIFF
--- a/apps/api/plane/app/views/workspace/draft.py
+++ b/apps/api/plane/app/views/workspace/draft.py
@@ -204,7 +204,15 @@ class WorkspaceDraftIssueViewSet(BaseViewSet):
 
     @allow_permission(allowed_roles=[ROLE.ADMIN, ROLE.MEMBER], level="WORKSPACE")
     def create_draft_to_issue(self, request, slug, draft_id):
-        draft_issue = self.get_queryset().filter(pk=draft_id).first()
+        # Drafts are personal: every other action on this viewset scopes by creator, and
+        # the decorator's creator check keys off `pk`, which this route does not carry.
+        draft_issue = self.get_queryset().filter(pk=draft_id, created_by=request.user).first()
+
+        if not draft_issue:
+            return Response(
+                {"error": "The required object does not exist."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
 
         if not draft_issue.project_id:
             return Response(

--- a/apps/api/plane/tests/unit/views/test_workspace_draft.py
+++ b/apps/api/plane/tests/unit/views/test_workspace_draft.py
@@ -1,0 +1,94 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""
+Unit regression tests for WorkspaceDraftIssueViewSet.create_draft_to_issue.
+
+Drafts are personal, but the publish route looked the draft up by id alone, so any
+workspace member could convert (and thereby delete) someone else's draft.
+See: https://github.com/makeplane/plane/issues/9363
+"""
+
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+from rest_framework import status
+from rest_framework.parsers import JSONParser
+from rest_framework.request import Request
+from rest_framework.test import APIRequestFactory
+
+from plane.app.views.workspace.draft import WorkspaceDraftIssueViewSet
+
+
+@pytest.mark.unit
+class TestCreateDraftToIssue:
+    @pytest.fixture(autouse=True)
+    def setup_view(self):
+        self.factory = APIRequestFactory()
+        self.view = WorkspaceDraftIssueViewSet()
+        self.slug = "test-workspace"
+        self.draft_id = str(uuid.uuid4())
+        self.owner_id = str(uuid.uuid4())
+        self.other_user_id = str(uuid.uuid4())
+
+    def _allow_workspace_member(self):
+        queryset = MagicMock()
+        queryset.exists.return_value = True
+        return patch(
+            "plane.app.permissions.base.WorkspaceMember.objects.filter",
+            return_value=queryset,
+        )
+
+    def _request(self, user_id):
+        wsgi_request = self.factory.post("/api/test/", data={}, format="json")
+        request = Request(wsgi_request, parsers=[JSONParser()])
+        request.user = MagicMock()
+        request.user.id = user_id
+        return request
+
+    def test_lookup_is_scoped_to_the_requesting_user(self):
+        """The publish lookup must carry created_by, not the draft id alone."""
+        queryset = MagicMock()
+        queryset.filter.return_value.first.return_value = None
+        request = self._request(self.other_user_id)
+
+        with (
+            self._allow_workspace_member(),
+            patch.object(WorkspaceDraftIssueViewSet, "get_queryset", return_value=queryset),
+        ):
+            response = self.view.create_draft_to_issue(request, slug=self.slug, draft_id=self.draft_id)
+
+        queryset.filter.assert_called_once_with(pk=self.draft_id, created_by=request.user)
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_another_users_draft_is_not_published(self):
+        """A draft the requester does not own falls out of the queryset, so nothing is created."""
+        queryset = MagicMock()
+        queryset.filter.return_value.first.return_value = None
+        request = self._request(self.other_user_id)
+
+        with (
+            self._allow_workspace_member(),
+            patch.object(WorkspaceDraftIssueViewSet, "get_queryset", return_value=queryset),
+            patch("plane.app.views.workspace.draft.IssueCreateSerializer") as serializer_cls,
+        ):
+            response = self.view.create_draft_to_issue(request, slug=self.slug, draft_id=self.draft_id)
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        serializer_cls.assert_not_called()
+
+    def test_missing_draft_returns_404_instead_of_raising(self):
+        """A draft id that matches nothing previously hit AttributeError on None."""
+        queryset = MagicMock()
+        queryset.filter.return_value.first.return_value = None
+        request = self._request(self.owner_id)
+
+        with (
+            self._allow_workspace_member(),
+            patch.object(WorkspaceDraftIssueViewSet, "get_queryset", return_value=queryset),
+        ):
+            response = self.view.create_draft_to_issue(request, slug=self.slug, draft_id=self.draft_id)
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND


### PR DESCRIPTION
### Description

Draft work items are personal. `list`, `retrieve` and `partial_update` in `WorkspaceDraftIssueViewSet` all resolve them with `created_by=request.user`, but `create_draft_to_issue` looked the draft up by id alone:

```python
draft_issue = self.get_queryset().filter(pk=draft_id).first()
```

`get_queryset()` only filters by workspace, so any workspace member holding a draft's UUID could publish another user's draft. Publishing also deletes the original, so the author loses the draft with nothing in the activity trail naming who did it.

Worth noting why the decorator does not already cover this: `allow_permission(..., creator=True, model=...)` checks `kwargs["pk"]`, and this route receives `draft_id`. That is why `destroy` is protected and this action is not, and why the fix belongs in the query rather than on the decorator.

The unresolved case now returns 404 instead of raising `AttributeError` on `None.project_id`, matching how `retrieve` handles a draft that is not there.

### Test

`plane/tests/unit/views/test_workspace_draft.py` asserts the lookup carries `created_by`, that a draft the caller does not own never reaches `IssueCreateSerializer`, and that a missing draft returns 404. Reverting the fix fails all three, the last with the `AttributeError` the guard removes.

`ruff check` and `ruff format --check` are clean on both files.

Fixes #9363

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted draft-to-issue publishing to drafts owned by the requesting user.
  * Drafts belonging to another user can no longer be published.
  * Missing or inaccessible drafts now return a clear 404 response instead of causing an error.

* **Tests**
  * Added regression coverage for ownership checks and missing-draft handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
