### PR TITLE
fix: repair the project invitation endpoint

### DIFF
--- a/apps/api/plane/app/views/project/invite.py
+++ b/apps/api/plane/app/views/project/invite.py
@@ -64,9 +64,7 @@ class ProjectInvitationsViewset(BaseViewSet):
 
         for email in emails:
             workspace_role = (
-                WorkspaceMember.objects.filter(
-                    workspace__slug=slug, member__email=email.get("email"), is_active=True
-                )
+                WorkspaceMember.objects.filter(workspace__slug=slug, member__email=email.get("email"), is_active=True)
                 .values_list("role", flat=True)
                 .first()
             )

--- a/apps/api/plane/app/views/project/invite.py
+++ b/apps/api/plane/app/views/project/invite.py
@@ -34,6 +34,7 @@ from plane.db.models import (
     ProjectUserProperty,
 )
 from plane.db.models.project import ProjectNetwork
+from plane.bgtasks.project_invitation_task import project_invitation
 from plane.utils.host import base_host
 
 
@@ -62,9 +63,13 @@ class ProjectInvitationsViewset(BaseViewSet):
             return Response({"error": "Emails are required"}, status=status.HTTP_400_BAD_REQUEST)
 
         for email in emails:
-            workspace_role = WorkspaceMember.objects.filter(
-                workspace__slug=slug, member__email=email.get("email"), is_active=True
-            ).role
+            workspace_role = (
+                WorkspaceMember.objects.filter(
+                    workspace__slug=slug, member__email=email.get("email"), is_active=True
+                )
+                .values_list("role", flat=True)
+                .first()
+            )
 
             if workspace_role in [5, 20] and workspace_role != email.get("role", 5):
                 return Response({"error": "You cannot invite a user with different role than workspace role"})
@@ -98,14 +103,14 @@ class ProjectInvitationsViewset(BaseViewSet):
                 )
 
         # Create workspace member invite
-        project_invitations = ProjectMemberInvite.objects.bulk_create(
+        created_invitations = ProjectMemberInvite.objects.bulk_create(
             project_invitations, batch_size=10, ignore_conflicts=True
         )
         current_site = base_host(request=request, is_app=True)
 
         # Send invitations
-        for invitation in project_invitations:
-            project_invitations.delay(
+        for invitation in created_invitations:
+            project_invitation.delay(
                 invitation.email,
                 project_id,
                 invitation.token,

--- a/apps/api/plane/app/views/project/invite.py
+++ b/apps/api/plane/app/views/project/invite.py
@@ -72,7 +72,10 @@ class ProjectInvitationsViewset(BaseViewSet):
             )
 
             if workspace_role in [5, 20] and workspace_role != email.get("role", 5):
-                return Response({"error": "You cannot invite a user with different role than workspace role"})
+                return Response(
+                    {"error": "You cannot invite a user with different role than workspace role"},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
 
         workspace = Workspace.objects.get(slug=slug)
 

--- a/apps/api/plane/tests/unit/views/test_project_invite.py
+++ b/apps/api/plane/tests/unit/views/test_project_invite.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2023-present Plane Software, Inc. and contributors
+# SPDX-License-Identifier: AGPL-3.0-only
+# See the LICENSE file for details.
+
+"""
+Unit regression tests for ProjectInvitationViewSet.create.
+
+The workspace-role guard read `.role` off the queryset rather than a row, so every
+project invitation raised AttributeError before anything was persisted.
+See: https://github.com/makeplane/plane/issues/9476
+"""
+
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+from rest_framework import status
+from rest_framework.parsers import JSONParser
+from rest_framework.request import Request
+from rest_framework.test import APIRequestFactory
+
+from plane.app.views.project.invite import ProjectInvitationsViewset
+
+
+@pytest.mark.unit
+class TestProjectInvitationCreate:
+    @pytest.fixture(autouse=True)
+    def setup_view(self):
+        self.factory = APIRequestFactory()
+        self.view = ProjectInvitationsViewset()
+        self.slug = "test-workspace"
+        self.project_id = str(uuid.uuid4())
+
+    def _request(self, emails):
+        wsgi_request = self.factory.post("/api/test/", data={"emails": emails}, format="json")
+        request = Request(wsgi_request, parsers=[JSONParser()])
+        request.user = MagicMock()
+        return request
+
+    def _call(self, emails, existing_role):
+        """Run create() with the invitee's existing workspace role, or None if they have none."""
+        role_queryset = MagicMock()
+        role_queryset.values_list.return_value.first.return_value = existing_role
+
+        admin_queryset = MagicMock()
+        admin_queryset.exists.return_value = True
+
+        with (
+            patch("plane.app.permissions.base.ProjectMember.objects.filter", return_value=admin_queryset),
+            patch("plane.app.permissions.base.WorkspaceMember.objects.filter", return_value=admin_queryset),
+            patch("plane.app.views.project.invite.WorkspaceMember.objects.filter", return_value=role_queryset),
+            patch("plane.app.views.project.invite.Workspace.objects.get", return_value=MagicMock()),
+            patch("plane.app.views.project.invite.ProjectMemberInvite") as invite_model,
+            patch("plane.app.views.project.invite.base_host", return_value="https://app.plane.so"),
+            patch("plane.app.views.project.invite.project_invitation"),
+        ):
+            invite_model.objects.bulk_create.return_value = []
+            return self.view.create(self._request(emails), slug=self.slug, project_id=self.project_id)
+
+    def test_inviting_a_new_email_does_not_raise(self):
+        """No workspace membership means no role to compare against."""
+        response = self._call([{"email": "newcomer@example.com", "role": 15}], existing_role=None)
+        assert response.status_code == status.HTTP_200_OK
+
+    def test_role_is_read_from_the_membership_row(self):
+        """A guest invited as a guest is allowed through."""
+        response = self._call([{"email": "guest@example.com", "role": 5}], existing_role=5)
+        assert response.status_code == status.HTTP_200_OK
+
+    def test_mismatched_workspace_role_is_still_rejected(self):
+        """The guard itself is unchanged: an admin cannot be invited as a member."""
+        response = self._call([{"email": "admin@example.com", "role": 15}], existing_role=20)
+        assert "different role than workspace role" in str(response.data)
+
+    def test_the_send_step_uses_the_task_not_the_created_rows(self):
+        """The loop called .delay on the bulk_create list, which is not the celery task."""
+        invitation = MagicMock()
+        invitation.email = "newcomer@example.com"
+        invitation.token = "tok"
+        role_queryset = MagicMock()
+        role_queryset.values_list.return_value.first.return_value = None
+        admin_queryset = MagicMock()
+        admin_queryset.exists.return_value = True
+
+        with (
+            patch("plane.app.permissions.base.ProjectMember.objects.filter", return_value=admin_queryset),
+            patch("plane.app.permissions.base.WorkspaceMember.objects.filter", return_value=admin_queryset),
+            patch("plane.app.views.project.invite.WorkspaceMember.objects.filter", return_value=role_queryset),
+            patch("plane.app.views.project.invite.Workspace.objects.get", return_value=MagicMock()),
+            patch("plane.app.views.project.invite.ProjectMemberInvite") as invite_model,
+            patch("plane.app.views.project.invite.base_host", return_value="https://app.plane.so"),
+            patch("plane.app.views.project.invite.project_invitation") as invitation_task,
+        ):
+            invite_model.objects.bulk_create.return_value = [invitation]
+            response = self.view.create(
+                self._request([{"email": "newcomer@example.com", "role": 15}]),
+                slug=self.slug,
+                project_id=self.project_id,
+            )
+
+        assert response.status_code == status.HTTP_200_OK
+        invitation_task.delay.assert_called_once()
+
+    def test_missing_emails_returns_400(self):
+        response = self._call([], existing_role=None)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/apps/api/plane/tests/unit/views/test_project_invite.py
+++ b/apps/api/plane/tests/unit/views/test_project_invite.py
@@ -70,6 +70,7 @@ class TestProjectInvitationCreate:
     def test_mismatched_workspace_role_is_still_rejected(self):
         """The guard itself is unchanged: an admin cannot be invited as a member."""
         response = self._call([{"email": "admin@example.com", "role": 15}], existing_role=20)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert "different role than workspace role" in str(response.data)
 
     def test_the_send_step_uses_the_task_not_the_created_rows(self):


### PR DESCRIPTION
### Description

`POST /api/workspaces/{slug}/projects/{project_id}/invitations/` returns 500 before persisting anything. There are two faults on that path, and fixing only the reported one moves the failure a few lines down rather than making the endpoint work.

**1. The role guard reads `.role` off a queryset.**

```python
workspace_role = WorkspaceMember.objects.filter(...).role
```

`AttributeError: 'SoftDeletionQuerySet' object has no attribute 'role'`, on every request. Reading it with `values_list("role", flat=True).first()` also returns `None` for an invitee who is not a workspace member yet, so the `workspace_role in [5, 20]` comparison below keeps the meaning it was written with.

**2. The send loop calls `.delay` on a list.**

```python
project_invitations = ProjectMemberInvite.objects.bulk_create(...)
for invitation in project_invitations:
    project_invitations.delay(...)
```

`project_invitations` starts as the list being built, gets reassigned to the `bulk_create` result, and is then used as if it were the celery task. The task of that name, `plane.bgtasks.project_invitation_task.project_invitation`, is not imported in this module at all. So once the first fault is out of the way, any successful invitation hits `'list' object has no attribute 'delay'`.

This imports the task and keeps the created rows in `created_invitations` so the names stop colliding.

### Test

`plane/tests/unit/views/test_project_invite.py` covers a new invitee, an invitee whose workspace role matches, the rejection path for a mismatched role, the empty-emails 400, and that the send step calls the task rather than the created rows. Reverting either fix on its own fails exactly one test:

`ruff check` and `ruff format --check` are clean on both files. The pre-existing unused `User` import in this module is untouched, it is already flagged on `preview`.

Fixes #9476

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed project invitations so valid new invitees can be added successfully.
  - Corrected workspace-role validation when sending project invitations.
  - Ensured invitation notifications are dispatched correctly after invitations are created.
  - Preserved validation for mismatched workspace roles and missing email addresses.
  - Improved error handling so invalid invitation requests return clear client errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
