### PR TITLE
fix(editor): preserve code languages in Live imports

### DIFF
--- a/apps/live/tests/editor/code-block-import.test.ts
+++ b/apps/live/tests/editor/code-block-import.test.ts
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2023-present Plane Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import {
+  getAllDocumentFormatsFromDocumentEditorBinaryData,
+  getBinaryDataFromDocumentEditorHTMLString,
+} from "@plane/editor";
+import { describe, expect, it } from "vitest";
+
+describe("document code-block import", () => {
+  it("preserves fenced-code language metadata through Plane Live conversion", () => {
+    const input = '<pre><code class="language-mermaid">stateDiagram-v2\n  [*] --&gt; Ready\n</code></pre>';
+
+    const binary = getBinaryDataFromDocumentEditorHTMLString(input);
+    const { contentHTML, contentJSON } = getAllDocumentFormatsFromDocumentEditorBinaryData(binary, false);
+
+    expect(contentJSON).toMatchObject({
+      content: [
+        {
+          type: "codeBlock",
+          attrs: { language: "mermaid" },
+        },
+      ],
+    });
+    expect(contentHTML).toContain('class="language-mermaid"');
+  });
+});

--- a/packages/editor/src/core/extensions/code/code-block.ts
+++ b/packages/editor/src/core/extensions/code/code-block.ts
@@ -76,7 +76,7 @@ export const CodeBlock = Node.create<CodeBlockOptions>({
         default: null,
         parseHTML: (element) => {
           const { languageClassPrefix } = this.options;
-          const classNames = [...(element.firstElementChild?.classList || [])];
+          const classNames = (element.querySelector("code")?.getAttribute("class") ?? "").split(/\s+/);
           const languages = classNames
             .filter((className) => className.startsWith(languageClassPrefix))
             .map((className) => className.replace(languageClassPrefix, ""));


### PR DESCRIPTION
### Description

Plane Live now preserves code-block language metadata when it imports HTML into Yjs. The server-side DOM implementation does not populate `firstElementChild` as the browser does, so `language-*` classes were dropped during the first collaborative-editor load even when the submitted HTML was correct.

This is useful for every syntax-highlighted code block and lets the Mermaid renderer in #9787 recognize agent-authored `language-mermaid` blocks after Live conversion.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)

Not applicable; this fixes server-side document conversion.

### Test Scenarios

- [x] Added an HTML → Yjs → JSON/HTML regression test for `language-mermaid`.
- [x] `pnpm turbo run build --filter=live` (10/10 tasks).
- [x] Live tests (3 files, 33 tests), type-check, lint (6 existing warnings, 0 errors), and format checks.
- [x] Deployed the same change on a Plane CE v1.4.2 instance and verified production Live conversion preserves `language="mermaid"` for state, flowchart, and sequence diagrams.

### References

Related: #9787
