### PR TITLE
fix(aio): create supervisor log directories on boot

### DIFF
--- a/deployments/aio/community/start.sh
+++ b/deployments/aio/community/start.sh
@@ -189,6 +189,11 @@ main(){
     # load plane.env as exported variables
     export $(grep -v '^#' plane.env | xargs)
 
+    # Recreate log dirs at boot. A host bind of /app/logs replaces the
+    # directories baked into the image, and supervisord refuses to start
+    # if stdout_logfile's parent path is missing.
+    mkdir -p /app/logs/access /app/logs/error
+
     /usr/local/bin/supervisord -c /etc/supervisor/conf.d/supervisor.conf
 }
 


### PR DESCRIPTION
### Description
The AIO image creates `/app/logs/access` at build time, but a host bind of `/app/logs` replaces that tree with an empty directory. Supervisord then exits because `stdout_logfile=/app/logs/access/migrator.log` has no parent path.

`start.sh` now recreates `access/` and `error/` on every boot so the volume mount still works.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
N/A — AIO image was not rebuilt. The failure is the documented supervisord missing-directory error.

### Test Scenarios
- [ ] `docker run` AIO with `-v /tmp/plane-logs:/app/logs` — container gets past supervisord start
- [ ] Same without a logs volume — still starts (dirs already exist in the image)
- [ ] Migrator / API log files appear under `/app/logs/access/`

### References
Fixes #9266

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved application startup reliability by recreating required access and error log directories before services launch.
  - Prevented startup failures when host-mounted paths replace the application’s default log directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->