### PR TITLE
fix(web): relayout stickies masonry after refresh

### DIFF
--- a/apps/web/core/components/stickies/layout/stickies-list.tsx
+++ b/apps/web/core/components/stickies/layout/stickies-list.tsx
@@ -47,6 +47,16 @@ type TProps = TStickiesLayout & {
   columnCount: number;
 };
 
+const getColumnCount = (width: number | null): number => {
+  if (width === null) return 4;
+
+  if (width < 640) return 2; // sm
+  if (width < 850) return 3; // md
+  if (width < 1024) return 4; // lg
+  if (width < 1280) return 5; // xl
+  return 6; // 2xl and above
+};
+
 export const StickiesList = observer(function StickiesList(props: TProps) {
   const { workspaceSlug, intersectionElement, columnCount } = props;
   // navigation
@@ -72,6 +82,7 @@ export const StickiesList = observer(function StickiesList(props: TProps) {
   const stickiesResolvedPath = resolvedTheme === "light" ? lightStickiesAsset : darkStickiesAsset;
   const stickiesSearchResolvedPath = resolvedTheme === "light" ? lightStickiesSearchAsset : darkStickiesSearchAsset;
   const masonryRef = useRef<any>(null);
+  const stickyLayoutKey = workspaceStickyIds.join(",");
 
   const handleLayout = () => {
     if (masonryRef.current) {
@@ -79,6 +90,17 @@ export const StickiesList = observer(function StickiesList(props: TProps) {
       masonryRef.current.performLayout();
     }
   };
+
+  // Masonry measures once on mount. If that happens before the container
+  // width is known, or after column count / item list changes, notes stack
+  // in a single column until something else calls performLayout (e.g. add).
+  useEffect(() => {
+    if (loader !== "loaded") return;
+    const frame = requestAnimationFrame(() => {
+      masonryRef.current?.performLayout?.();
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [columnCount, stickyLayoutKey, loader]);
 
   // Function to determine if an item is in first or last row
   const getRowPositions = (index: number) => {
@@ -194,20 +216,11 @@ export function StickiesLayout(props: TStickiesLayout) {
     return () => resizeObserver.disconnect();
   }, []);
 
-  const getColumnCount = (width: number | null): number => {
-    if (width === null) return 4;
-
-    if (width < 640) return 2; // sm
-    if (width < 850) return 3; // md
-    if (width < 1024) return 4; // lg
-    if (width < 1280) return 5; // xl
-    return 6; // 2xl and above
-  };
   const columnCount = getColumnCount(containerWidth);
 
   return (
     <div ref={ref} className="size-full">
-      <StickiesList {...props} columnCount={columnCount} />
+      {containerWidth !== null && <StickiesList {...props} columnCount={columnCount} />}
     </div>
   );
 }


### PR DESCRIPTION
### Description
Stickies laid out in a row when adding, then stacked vertically after refresh. `react-masonry-component` measures on mount; that ran while container width was still unknown, and column-count changes did not call `performLayout`.

Wait to mount masonry until the container is measured, then relayout when column count or the sticky list changes.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
N/A — full Plane UI was not run. The masonry mount/relayout path is the same one already used when adding a sticky.

### Test Scenarios
- [ ] Open Stickies with several notes — they stay in a multi-column grid
- [ ] Refresh / leave and come back — layout still horizontal, not a single column
- [ ] Add a sticky — it still inserts into the grid
- [ ] Resize the window across the existing breakpoints (2–6 columns)

### References
Fixes #9581

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sticky note layout updates when notes or column settings change.
  * Prevented the sticky list from rendering before the container width is available.
  * Ensured masonry layouts reflow correctly after content finishes loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->