### PR TITLE
fix(web): drop deleted workflow states on refetch

### DIFF
--- a/apps/api/plane/app/views/workspace/state.py
+++ b/apps/api/plane/app/views/workspace/state.py
@@ -16,7 +16,7 @@ from collections import defaultdict
 
 class WorkspaceStatesEndpoint(BaseAPIView):
     permission_classes = [WorkspaceEntityPermission]
-    use_read_replica = True
+    use_read_replica = False
 
     def get(self, request, slug):
         states = State.objects.filter(

--- a/apps/web/core/store/state.store.ts
+++ b/apps/web/core/store/state.store.ts
@@ -219,6 +219,12 @@ export class StateStore implements IStateStore {
   fetchProjectStates = async (workspaceSlug: string, projectId: string) => {
     const statesResponse = await this.stateService.getStates(workspaceSlug, projectId);
     runInAction(() => {
+      const incomingIds = new Set(statesResponse.map((state) => state.id));
+      Object.keys(this.stateMap).forEach((stateId) => {
+        if (this.stateMap[stateId]?.project_id === projectId && !incomingIds.has(stateId)) {
+          delete this.stateMap[stateId];
+        }
+      });
       statesResponse.forEach((state) => {
         set(this.stateMap, [state.id], state);
       });
@@ -250,6 +256,12 @@ export class StateStore implements IStateStore {
   fetchWorkspaceStates = async (workspaceSlug: string) => {
     const statesResponse = await this.stateService.getWorkspaceStates(workspaceSlug);
     runInAction(() => {
+      const incomingIds = new Set(statesResponse.map((state) => state.id));
+      Object.keys(this.stateMap).forEach((stateId) => {
+        if (!incomingIds.has(stateId)) {
+          delete this.stateMap[stateId];
+        }
+      });
       statesResponse.forEach((state) => {
         set(this.stateMap, [state.id], state);
       });


### PR DESCRIPTION
### Description
Deleting a project workflow state removed it in the UI, then a refresh brought it back.

`fetchProjectStates` / `fetchWorkspaceStates` only merged into `stateMap`, so a stale workspace payload (including from the read replica) could resurrect a soft-deleted state. Fetches now drop ids that are no longer in the API response, and workspace states are read from the primary.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
N/A — full Plane UI was not run. Soft-delete already sets `deleted_at`; the list APIs already exclude those rows.

### Test Scenarios
- [ ] Project settings → States: create a state, delete it, refresh — it stays gone
- [ ] Remaining states still render, grouped, and can be marked default
- [ ] Work item state dropdown still lists live states after a refresh

### References
Fixes #9582

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Workspace state data now reflects the latest updates more reliably.
  * Removed stale project and workspace states when refreshing state lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->