### PR TITLE
fix(aio): honor CORS_ALLOWED_ORIGINS instead of overwriting it

### DIFF
--- a/deployments/aio/community/start.sh
+++ b/deployments/aio/community/start.sh
@@ -15,6 +15,7 @@ print_header(){
     echo "    SITE_ADDRESS (default: ':80')"
     echo "    FILE_SIZE_LIMIT (default: 5242880)"
     echo "    APP_PROTOCOL (http or https)"
+    echo "    CORS_ALLOWED_ORIGINS (default: http(s)://DOMAIN_NAME, comma-separated)"
     echo "    SECRET_KEY (auto-generated on first boot if not set)"
     echo "    LIVE_SERVER_SECRET_KEY (auto-generated on first boot if not set)"
     echo ""
@@ -128,7 +129,12 @@ update_env_file(){
         update_env_value "SITE_ADDRESS" ":80"
     fi
     update_env_value "WEB_URL" "$app_protocol://$DOMAIN_NAME"
-    update_env_value "CORS_ALLOWED_ORIGINS" "http://$DOMAIN_NAME,https://$DOMAIN_NAME"
+    # Honor operator-supplied CORS_ALLOWED_ORIGINS. Overwriting with DOMAIN_NAME
+    # on every boot made extra frontend origins (and an empty override) a no-op.
+    if [ -z "$CORS_ALLOWED_ORIGINS" ]; then
+        CORS_ALLOWED_ORIGINS="http://$DOMAIN_NAME,https://$DOMAIN_NAME"
+    fi
+    update_env_value "CORS_ALLOWED_ORIGINS" "$CORS_ALLOWED_ORIGINS"
 
     # update database url
     update_env_value "DATABASE_URL" "$DATABASE_URL"


### PR DESCRIPTION
### Description
`CORS_ALLOWED_ORIGINS` never stuck on AIO. Every boot rewrote it to `http://$DOMAIN_NAME,https://$DOMAIN_NAME` in `plane.env`, then exported that over the container environment. Extra frontend origins (and an empty override) were ignored.

If the env var is set, it is written through. If it is unset, the instance hostname default is unchanged.

Note: django-cors-headers still reflects a single `Access-Control-Allow-Origin` matching the request `Origin`. S3/MinIO buckets need their own CORS config; this only controls Plane API / live.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
N/A — AIO image was not rebuilt.

### Test Scenarios
- [ ] AIO without `CORS_ALLOWED_ORIGINS` — still defaults to `http(s)://$DOMAIN_NAME`
- [ ] AIO with `CORS_ALLOWED_ORIGINS=https://plane.example.com,https://app.example.com` — both origins are in the running API env
- [ ] Docker Compose CLI already passed the var through; unchanged

### References
Fixes #8390

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Custom CORS allowed-origin settings are now preserved across deployments instead of being overwritten by default values.
  - Startup output now documents the `CORS_ALLOWED_ORIGINS` environment variable for easier configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->