### PR TITLE
fix: enforce trailing slash on API requests and settings URLs

### DIFF
--- a/apps/live/package.json
+++ b/apps/live/package.json
@@ -38,6 +38,7 @@
     "@plane/decorators": "workspace:*",
     "@plane/editor": "workspace:*",
     "@plane/logger": "workspace:*",
+    "@plane/services": "workspace:*",
     "@plane/types": "workspace:*",
     "@plane/utils": "workspace:*",
     "@react-pdf/renderer": "catalog:",

--- a/apps/live/src/services/api.service.ts
+++ b/apps/live/src/services/api.service.ts
@@ -6,6 +6,7 @@
 
 import type { AxiosInstance } from "axios";
 import { create } from "axios";
+import { normalizeAPIRequestURL } from "@plane/services";
 import { env } from "@/env";
 import { AppError } from "@/lib/errors";
 
@@ -25,6 +26,19 @@ export abstract class APIService {
   }
 
   private setupInterceptors() {
+    this.axiosInstance.interceptors.request.use((config) => {
+      try {
+        if (config.url) {
+          config.url = normalizeAPIRequestURL(config.url, this.baseURL);
+        }
+      } catch (error) {
+        // Never block a request because of slash normalization — fall back to the
+        // original URL and let the call proceed.
+        console.warn("[APIService] Failed to normalize trailing slash:", config.url, error);
+      }
+      return config;
+    });
+
     this.axiosInstance.interceptors.response.use(
       (response) => response,
       (error) => {

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -4,11 +4,23 @@
  * See the LICENSE file for details.
  */
 
-import { Outlet } from "react-router";
+import { Outlet, redirect } from "react-router";
 // plane imports
 import { cn } from "@plane/utils";
 // local
+import { ensureTrailingSlash } from "./compat/next/helper";
 import { AppProvider } from "./provider";
+import type { Route } from "./+types/layout";
+
+const trailingSlashRedirectMiddleware: Route.ClientMiddlewareFunction = async ({ request }, next) => {
+  const canonical = ensureTrailingSlash(request.url);
+  if (canonical !== request.url) {
+    throw redirect(canonical, { status: 308 });
+  }
+  return next();
+};
+
+export const clientMiddleware: Route.ClientMiddlewareFunction[] = [trailingSlashRedirectMiddleware];
 
 // Pathless layout route wrapping every route (see app/routes.ts). Providers, the store
 // layer, and app chrome live here instead of root.tsx so they stay out of the SPA-mode

--- a/apps/web/core/services/api.service.ts
+++ b/apps/web/core/services/api.service.ts
@@ -7,6 +7,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type { AxiosInstance, AxiosRequestConfig } from "axios";
 import { create } from "axios";
+import { normalizeAPIRequestURL } from "@plane/services";
 
 export abstract class APIService {
   protected baseURL: string;
@@ -23,6 +24,19 @@ export abstract class APIService {
   }
 
   private setupInterceptors() {
+    this.axiosInstance.interceptors.request.use((config) => {
+      try {
+        if (config.url) {
+          config.url = normalizeAPIRequestURL(config.url, this.baseURL);
+        }
+      } catch (error) {
+        // Never block a request because of slash normalization — fall back to the
+        // original URL and let the call proceed.
+        console.warn("[APIService] Failed to normalize trailing slash:", config.url, error);
+      }
+      return config;
+    });
+
     this.axiosInstance.interceptors.response.use(
       (response) => response,
       (error) => {

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -19,6 +19,7 @@
     "check:format": "oxfmt --check .",
     "fix:lint": "oxlint --fix .",
     "fix:format": "oxfmt .",
+    "test": "vitest run",
     "clean": "rm -rf .turbo && rm -rf .next && rm -rf node_modules && rm -rf dist"
   },
   "dependencies": {
@@ -30,6 +31,7 @@
   "devDependencies": {
     "@plane/typescript-config": "workspace:*",
     "tsdown": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   }
 }

--- a/packages/services/src/api.service.ts
+++ b/packages/services/src/api.service.ts
@@ -6,6 +6,7 @@
 
 import type { AxiosInstance, AxiosRequestConfig } from "axios";
 import { create } from "axios";
+import { normalizeAPIRequestURL } from "./helpers/url";
 
 /**
  * Abstract base class for making HTTP requests using axios
@@ -24,6 +25,19 @@ export abstract class APIService {
     this.axiosInstance = create({
       baseURL,
       withCredentials: true,
+    });
+
+    this.axiosInstance.interceptors.request.use((config) => {
+      try {
+        if (config.url) {
+          config.url = normalizeAPIRequestURL(config.url, this.baseURL);
+        }
+      } catch (error) {
+        // Never block a request because of slash normalization — fall back to the
+        // original URL and let the call proceed.
+        console.warn("[APIService] Failed to normalize trailing slash:", config.url, error);
+      }
+      return config;
     });
   }
 

--- a/packages/services/src/helpers/index.ts
+++ b/packages/services/src/helpers/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Copyright (c) 2023-present Plane Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+export * from "./url";

--- a/packages/services/src/helpers/url.test.ts
+++ b/packages/services/src/helpers/url.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2023-present Plane Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { describe, expect, it } from "vitest";
+import { ensureAPITrailingSlash, normalizeAPIRequestURL } from "./url";
+
+describe("ensureAPITrailingSlash", () => {
+  it.each([
+    ["/api/foo", "/api/foo/"],
+    ["/api/foo/", "/api/foo/"],
+    ["/api/foo?x=1", "/api/foo/?x=1"],
+    ["/api/foo#frag", "/api/foo/#frag"],
+    ["", ""],
+    ["/", "/"],
+    ["/api/foo/?x=1", "/api/foo/?x=1"],
+    ["https://h/api/foo", "https://h/api/foo/"],
+  ])("turns %j into %j", (input, expected) => {
+    expect(ensureAPITrailingSlash(input)).toBe(expected);
+  });
+});
+
+describe("normalizeAPIRequestURL", () => {
+  it("leaves signed upload URLs unchanged when baseURL is empty", () => {
+    const signedUrl = "https://bucket.s3.amazonaws.com/path?X-Amz-Signature=abc";
+    expect(normalizeAPIRequestURL(signedUrl, "")).toBe(signedUrl);
+  });
+
+  it("leaves signed upload URLs unchanged when origin is not the API baseURL", () => {
+    const signedUrl = "https://bucket.s3.amazonaws.com/path?X-Amz-Signature=abc";
+    expect(normalizeAPIRequestURL(signedUrl, "https://api.plane.so")).toBe(signedUrl);
+  });
+
+  it("leaves already-slashed relative Django paths unchanged", () => {
+    expect(normalizeAPIRequestURL("/api/assets/v2/workspaces/acme/", "https://api.plane.so")).toBe(
+      "/api/assets/v2/workspaces/acme/"
+    );
+  });
+
+  it("adds a trailing slash to relative Django paths", () => {
+    expect(normalizeAPIRequestURL("/api/assets/v2/workspaces/acme", "https://api.plane.so")).toBe(
+      "/api/assets/v2/workspaces/acme/"
+    );
+  });
+
+  it("adds a trailing slash to same-origin absolute Django URLs", () => {
+    expect(normalizeAPIRequestURL("https://api.plane.so/api/foo", "https://api.plane.so")).toBe(
+      "https://api.plane.so/api/foo/"
+    );
+  });
+});

--- a/packages/services/src/helpers/url.ts
+++ b/packages/services/src/helpers/url.ts
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2023-present Plane Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+/**
+ * Ensures an API request URL has a trailing slash on its path component, preserving
+ * the query string and hash. Required by the Django backend's `APPEND_SLASH` behavior
+ * — under Kubernetes ingress, requests without a trailing slash can fail instead of
+ * 301-redirecting. Intended to be applied by an axios request interceptor so callers
+ * do not need to remember to add the slash.
+ *
+ * Examples:
+ *   "/api/foo"             -> "/api/foo/"
+ *   "/api/foo/"            -> "/api/foo/"
+ *   "/api/foo?x=1"         -> "/api/foo/?x=1"
+ *   "/api/foo#frag"        -> "/api/foo/#frag"
+ *   "https://h/api/foo"    -> "https://h/api/foo/"
+ *   "" | "/"               -> unchanged
+ */
+export function ensureAPITrailingSlash(url: string): string {
+  if (!url) return url;
+  const boundary = url.search(/[?#]/);
+  const path = boundary === -1 ? url : url.slice(0, boundary);
+  const suffix = boundary === -1 ? "" : url.slice(boundary);
+  if (!path || path.endsWith("/")) return url;
+  return `${path}/${suffix}`;
+}
+
+/**
+ * Same as `ensureAPITrailingSlash`, but skips absolute URLs whose origin is not this
+ * instance's Django `baseURL`. Signed S3/GCS upload URLs go through `APIService` with
+ * an empty `baseURL`; slashing them invalidates the signature and 403s the upload.
+ */
+export function normalizeAPIRequestURL(url: string, baseURL: string): string {
+  if (isForeignAbsoluteURL(url, baseURL)) return url;
+  return ensureAPITrailingSlash(url);
+}
+
+function isForeignAbsoluteURL(url: string, baseURL: string): boolean {
+  try {
+    const requestUrl = new URL(url);
+    if (!baseURL) return true;
+    try {
+      return requestUrl.origin !== new URL(baseURL).origin;
+    } catch {
+      return true;
+    }
+  } catch {
+    return false;
+  }
+}

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -19,3 +19,4 @@ export * from "./file";
 export * from "./label";
 export * from "./state";
 export * from "./issue";
+export * from "./helpers";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -746,6 +746,9 @@ importers:
       '@plane/logger':
         specifier: workspace:*
         version: link:../../packages/logger
+      '@plane/services':
+        specifier: workspace:*
+        version: link:../../packages/services
       '@plane/types':
         specifier: workspace:*
         version: link:../../packages/types
@@ -1668,6 +1671,9 @@ importers:
       typescript:
         specifier: 5.8.3
         version: 5.8.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.12.0)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@22.12.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.3))
 
   packages/shared-state:
     dependencies:


### PR DESCRIPTION
### Description

Django `APPEND_SLASH` 301s missing slashes locally, but under Kubernetes ingress the bare request often fails outright. Community has been patching individual call sites; this fixes it once at the axios client.

- Add `ensureAPITrailingSlash` / `normalizeAPIRequestURL` in `@plane/services` and apply them via a request interceptor on every Django `APIService` (shared package, web, and live).
- Skip absolute URLs whose origin is not this instance's `baseURL` (empty `baseURL` skips every absolute URL) so signed S3/GCS uploads through `FileUploadService` are not rewritten. That is community hardening over EE, which applied the slash interceptor blindly.
- 308 unsashed web navigations to the canonical trailing-slash URL so cold-loaded settings routes match sidebar highlight comparators. This lives on `app/layout.tsx` (the pathless shell around every app route) so we do not have to edit `root.tsx` font side-effect imports.

Existing call sites such as `export-issues` are left unsashed on purpose; the interceptor covers them.

Ported from:

- https://github.com/makeplane/plane-ee/pull/7164
- https://github.com/makeplane/plane-ee/pull/8011
- https://github.com/makeplane/plane-ee/pull/6984

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots here -->

### Test Scenarios

- `pnpm --filter=@plane/services test` — helper table plus signed-upload skip.
- Hit a previously unsashed Django path (e.g. `GET /api/workspaces/<slug>/export-issues`) and confirm it succeeds under ingress.
- Confirm already-slashed endpoints and query strings still work (`/foo/?x=1`, not `/foo?x=1`).
- Upload an avatar or cover image and confirm the signed URL is not rewritten (no 403).
- Open a workspace settings URL without a trailing slash and confirm a 308 to the slashed URL and that the sidebar tab highlights.

### References

- https://github.com/makeplane/plane-ee/pull/7164
- https://github.com/makeplane/plane-ee/pull/8011
- https://github.com/makeplane/plane-ee/pull/6984
- https://github.com/makeplane/plane/issues/9521 (call-site slash was the wrong layer)

Claude Code session: https://claude.ai/code

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Standardized API request URLs with trailing slashes for more consistent routing.
  - Added automatic redirects to canonical trailing-slash URLs in the web application.
  - Preserved query parameters and URL fragments during normalization.
  - Prevented external URLs, including signed upload links, from being modified.
  - Requests continue normally if URL normalization encounters an unexpected error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->