### PR TITLE
perf: bind outside-click once and cache platform detection

### DIFF
--- a/apps/web/core/hooks/use-dropdown.ts
+++ b/apps/web/core/hooks/use-dropdown.ts
@@ -68,7 +68,8 @@ export const useDropdown = (args: TArguments) => {
   };
 
   // close the dropdown when the user clicks outside of the dropdown
-  useOutsideClickDetector(dropdownRef, handleClose);
+  // skip binding the document listener entirely while the dropdown is closed
+  useOutsideClickDetector(dropdownRef, handleClose, false, isOpen);
 
   // focus the search input when the dropdown is open
   useEffect(() => {

--- a/apps/web/core/hooks/use-platform-os.tsx
+++ b/apps/web/core/hooks/use-platform-os.tsx
@@ -4,7 +4,16 @@
  * See the LICENSE file for details.
  */
 
-export const usePlatformOS = () => {
+type PlatformOS = {
+  isMobile: boolean;
+  platform: string;
+};
+
+const detectPlatformOS = (): PlatformOS => {
+  if (typeof window === "undefined") {
+    return { isMobile: false, platform: "" };
+  }
+
   const userAgent = window.navigator.userAgent;
   const isMobile = /iPhone|iPad|iPod|Android/i.test(userAgent);
   let platform = "";
@@ -22,3 +31,8 @@ export const usePlatformOS = () => {
   }
   return { isMobile, platform };
 };
+
+// device/OS can't change mid-session, so detect once at module load and return a stable reference
+const PLATFORM_OS: PlatformOS = Object.freeze(detectPlatformOS());
+
+export const usePlatformOS = () => PLATFORM_OS;

--- a/packages/hooks/src/use-outside-click-detector.tsx
+++ b/packages/hooks/src/use-outside-click-detector.tsx
@@ -5,32 +5,46 @@
  */
 
 import type React from "react";
-import { useEffect } from "react";
+import { useEffect, useLayoutEffect, useRef } from "react";
 
 export const useOutsideClickDetector = (
   ref: React.RefObject<HTMLElement | null> | any,
   callback: () => void,
-  useCapture = false
+  useCapture = false,
+  enabled = true
 ) => {
-  const handleClick = (event: MouseEvent) => {
-    if (ref.current && !ref.current.contains(event.target as any)) {
-      // check for the closest element with attribute name data-prevent-outside-click
-      const preventOutsideClickElement = (event.target as unknown as HTMLElement | undefined)?.closest(
-        "[data-prevent-outside-click]"
-      );
-      // if the closest element with attribute name data-prevent-outside-click is found, return
-      if (preventOutsideClickElement) {
-        return;
-      }
-      // else call the callback
-      callback();
-    }
-  };
+  // Keep the latest callback/useCapture in refs so the document listener binds once per
+  // consumer instead of re-attaching on every render.
+  const callbackRef = useRef(callback);
+  const useCaptureRef = useRef(useCapture);
+
+  useLayoutEffect(() => {
+    callbackRef.current = callback;
+    useCaptureRef.current = useCapture;
+  });
 
   useEffect(() => {
-    document.addEventListener("mousedown", handleClick, useCapture);
-    return () => {
-      document.removeEventListener("mousedown", handleClick, useCapture);
+    if (!enabled) return;
+
+    const handleClick = (event: MouseEvent) => {
+      if (ref.current && !ref.current.contains(event.target as any)) {
+        // check for the closest element with attribute name data-prevent-outside-click
+        const preventOutsideClickElement = (event.target as unknown as HTMLElement | undefined)?.closest(
+          "[data-prevent-outside-click]"
+        );
+        // if the closest element with attribute name data-prevent-outside-click is found, return
+        if (preventOutsideClickElement) {
+          return;
+        }
+        // else call the callback
+        callbackRef.current();
+      }
     };
-  });
+
+    const capture = useCaptureRef.current;
+    document.addEventListener("mousedown", handleClick, capture);
+    return () => {
+      document.removeEventListener("mousedown", handleClick, capture);
+    };
+  }, [ref, enabled, useCapture]);
 };


### PR DESCRIPTION
### Description

Two behavior-preserving render-cost reductions in hot dropdown/card code paths.

- `useOutsideClickDetector` previously re-created its handler and tore down + re-added a document `mousedown` listener on every render of every consumer. It now reads the latest `callback`/`useCapture` from refs so the listener binds once per consumer, with stable effect deps `[ref, enabled, useCapture]`. The `data-prevent-outside-click` traversal logic is unchanged.
- A new optional 4th `enabled` param (default `true`, fully backward-compatible) lets callers skip binding the listener while inactive. `use-dropdown` now passes `enabled={isOpen}`, so a closed dropdown holds zero document listeners instead of an idle one whose callback already no-op'd.
- `usePlatformOS` ran a UA regex + `indexOf` scans and allocated a fresh `{ isMobile, platform }` object on every call (twice per card). It now detects once at module load behind a `typeof window` guard, freezes the result, and returns that stable reference.

No user-facing behavior changes; these only remove per-render work.

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [x] Code refactoring
- [x] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots here -->

### Test Scenarios
- Open a dropdown / select / context menu (priority, assignee, label, etc.) and confirm clicking outside still closes it.
- Confirm a `data-prevent-outside-click` container still suppresses the close (e.g. a dropdown nested inside a floating panel stays open when clicking elsewhere within that panel).
- Confirm a dropdown that flips capture mode (custom-menu) still closes on outside click.
- Confirm platform-dependent behavior is unchanged (keyboard shortcut hints, mobile input-focus skip) since `usePlatformOS` returns the same values.

### References
- https://github.com/makeplane/plane-ee/pull/7745

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved dropdown behavior by preventing outside-click handling while dropdowns are closed.
  - Improved platform detection consistency by preserving the detected operating system throughout a session.

- **Performance**
  - Reduced unnecessary event-listener activity during dropdown interactions.
  - Reduced repeated platform checks for a smoother, more stable experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->