### PR TITLE
perf: isolate kanban delete-drop-zone

### DIFF
--- a/apps/web/core/components/issues/issue-layouts/kanban/base-kanban-root.tsx
+++ b/apps/web/core/components/issues/issue-layouts/kanban/base-kanban-root.tsx
@@ -125,8 +125,8 @@ export const BaseKanBanRoot = observer(function BaseKanBanRoot(props: IBaseKanBa
 
   const handleOnDrop = useGroupIssuesDragNDrop(storeType, orderBy, group_by, sub_group_by);
 
-  const handleRequestDelete = useCallback((issueId: string | undefined) => {
-    setDraggedIssueId(issueId);
+  const handleRequestDelete = useCallback((workItemId: string | undefined) => {
+    setDraggedIssueId(workItemId);
     setDeleteIssueModal(true);
   }, []);
 

--- a/apps/web/core/components/issues/issue-layouts/kanban/base-kanban-root.tsx
+++ b/apps/web/core/components/issues/issue-layouts/kanban/base-kanban-root.tsx
@@ -7,7 +7,6 @@
 import type { FC } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { combine } from "@atlaskit/pragmatic-drag-and-drop/combine";
-import { dropTargetForElements } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
 import { autoScrollForElements } from "@atlaskit/pragmatic-drag-and-drop-auto-scroll/element";
 import { observer } from "mobx-react";
 import { useParams } from "next/navigation";
@@ -17,7 +16,6 @@ import { EIssueServiceType, EIssueLayoutTypes } from "@plane/types";
 //hooks
 import { useIssueDetail } from "@/hooks/store/use-issue-detail";
 import { useIssues } from "@/hooks/store/use-issues";
-import { useKanbanView } from "@/hooks/store/use-kanban-view";
 import { useUserPermissions } from "@/hooks/store/user";
 import { useGroupIssuesDragNDrop } from "@/hooks/use-group-dragndrop";
 import { useIssueStoreType } from "@/hooks/use-issue-layout-store";
@@ -29,8 +27,8 @@ import { DeleteIssueModal } from "../../delete-issue-modal";
 import { IssueLayoutHOC } from "../issue-layout-HOC";
 import type { IQuickActionProps, TRenderQuickActions } from "../list/list-view-types";
 //components
-import { getSourceFromDropPayload } from "../utils";
 import { KanBan } from "./default";
+import { KanbanDeleteDropZone } from "./kanban-delete-drop-zone";
 import { KanBanSwimLanes } from "./swimlanes";
 
 export type KanbanStoreType =
@@ -51,6 +49,9 @@ export interface IBaseKanBanLayout {
   viewId?: string | undefined;
   isEpic?: boolean;
 }
+
+// Stable identity so an empty kanban-filter value doesn't churn the per-column cache's sharedDeps.
+const EMPTY_KANBAN_FILTERS = { group_by: [], sub_group_by: [] };
 
 export const BaseKanBanRoot = observer(function BaseKanBanRoot(props: IBaseKanBanLayout) {
   const {
@@ -82,11 +83,6 @@ export const BaseKanBanRoot = observer(function BaseKanBanRoot(props: IBaseKanBa
     updateFilters,
   } = useIssuesActions(storeType);
 
-  const deleteAreaRef = useRef<HTMLDivElement | null>(null);
-  const [isDragOverDelete, setIsDragOverDelete] = useState(false);
-
-  const { isDragging } = useKanbanView();
-
   const displayFilters = issuesFilter?.issueFilters?.displayFilters;
   const displayProperties = issuesFilter?.issueFilters?.displayProperties;
 
@@ -105,7 +101,7 @@ export const BaseKanBanRoot = observer(function BaseKanBanRoot(props: IBaseKanBa
         fetchNextIssues(groupId, subgroupId);
       }
     },
-    [fetchNextIssues]
+    [fetchNextIssues, issues]
   );
 
   const groupedIssueIds = issues?.groupedIssueIds;
@@ -129,10 +125,17 @@ export const BaseKanBanRoot = observer(function BaseKanBanRoot(props: IBaseKanBa
 
   const handleOnDrop = useGroupIssuesDragNDrop(storeType, orderBy, group_by, sub_group_by);
 
+  const handleRequestDelete = useCallback((issueId: string | undefined) => {
+    setDraggedIssueId(issueId);
+    setDeleteIssueModal(true);
+  }, []);
+
   const canEditProperties = useCallback(
-    (projectId: string | undefined) => {
+    (issueProjectId: string | undefined) => {
       const isEditingAllowedBasedOnProject =
-        canEditPropertiesBasedOnProject && projectId ? canEditPropertiesBasedOnProject(projectId) : isEditingAllowed;
+        canEditPropertiesBasedOnProject && issueProjectId
+          ? canEditPropertiesBasedOnProject(issueProjectId)
+          : isEditingAllowed;
 
       return enableInlineEditing && isEditingAllowedBasedOnProject;
     },
@@ -151,35 +154,6 @@ export const BaseKanBanRoot = observer(function BaseKanBanRoot(props: IBaseKanBa
       })
     );
   }, []);
-
-  // Make the Issue Delete Box a Drop Target
-  useEffect(() => {
-    const element = deleteAreaRef.current;
-
-    if (!element) return;
-
-    return combine(
-      dropTargetForElements({
-        element,
-        getData: () => ({ columnId: "issue-trash-box", groupId: "issue-trash-box", type: "DELETE" }),
-        onDragEnter: () => {
-          setIsDragOverDelete(true);
-        },
-        onDragLeave: () => {
-          setIsDragOverDelete(false);
-        },
-        onDrop: (payload) => {
-          setIsDragOverDelete(false);
-          const source = getSourceFromDropPayload(payload);
-
-          if (!source) return;
-
-          setDraggedIssueId(source.id);
-          setDeleteIssueModal(true);
-        },
-      })
-    );
-  }, [setIsDragOverDelete, setDraggedIssueId, setDeleteIssueModal]);
 
   const renderQuickActions: TRenderQuickActions = useCallback(
     ({ issue, parentRef, customActionButton }) => (
@@ -231,7 +205,7 @@ export const BaseKanBanRoot = observer(function BaseKanBanRoot(props: IBaseKanBa
     [workspaceSlug, issuesFilter, projectId, updateFilters]
   );
 
-  const collapsedGroups = issuesFilter?.issueFilters?.kanbanFilters || { group_by: [], sub_group_by: [] };
+  const collapsedGroups = issuesFilter?.issueFilters?.kanbanFilters || EMPTY_KANBAN_FILTERS;
 
   return (
     <>
@@ -242,23 +216,7 @@ export const BaseKanBanRoot = observer(function BaseKanBanRoot(props: IBaseKanBa
         onSubmit={handleDeleteIssue}
         isEpic={isEpic}
       />
-      {/* drag and delete component */}
-      <div
-        className={`fixed left-1/2 -translate-x-1/2 ${
-          isDragging ? "z-40" : ""
-        } top-3 mx-3 flex w-72 items-center justify-center`}
-        ref={deleteAreaRef}
-      >
-        <div
-          className={`${
-            isDragging ? `opacity-100` : `opacity-0`
-          } flex w-full items-center justify-center rounded-sm border-2 border-danger-strong/20 bg-surface-1 px-3 py-5 text-11 font-medium text-danger-primary italic ${
-            isDragOverDelete ? "bg-danger-primary blur-2xl" : ""
-          } transition duration-300`}
-        >
-          Drop here to delete the work item.
-        </div>
-      </div>
+      <KanbanDeleteDropZone onRequestDelete={handleRequestDelete} />
       <IssueLayoutHOC layout={EIssueLayoutTypes.KANBAN}>
         <div
           className={`horizontal-scrollbar relative scrollbar-lg flex h-full w-full bg-surface-2 ${sub_group_by ? "vertical-scrollbar overflow-y-auto" : "overflow-x-auto overflow-y-hidden"}`}

--- a/apps/web/core/components/issues/issue-layouts/kanban/kanban-delete-drop-zone.tsx
+++ b/apps/web/core/components/issues/issue-layouts/kanban/kanban-delete-drop-zone.tsx
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2023-present Plane Software, Inc. and contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See the LICENSE file for details.
+ */
+
+import { useEffect, useRef, useState } from "react";
+import { combine } from "@atlaskit/pragmatic-drag-and-drop/combine";
+import { dropTargetForElements } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
+import { observer } from "mobx-react";
+// hooks
+import { useKanbanView } from "@/hooks/store/use-kanban-view";
+// helpers
+import { getSourceFromDropPayload } from "../utils";
+
+type Props = {
+  onRequestDelete: (issueId: string | undefined) => void;
+};
+
+// Isolated from BaseKanBanRoot so a drag start/end re-renders only this banner, not the whole board.
+export const KanbanDeleteDropZone = observer(function KanbanDeleteDropZone({ onRequestDelete }: Props) {
+  // refs
+  const deleteAreaRef = useRef<HTMLDivElement | null>(null);
+  // states
+  const [isDragOverDelete, setIsDragOverDelete] = useState(false);
+  // store hooks
+  const { isDragging } = useKanbanView();
+
+  useEffect(() => {
+    const element = deleteAreaRef.current;
+    if (!element) return;
+
+    return combine(
+      dropTargetForElements({
+        element,
+        getData: () => ({ columnId: "issue-trash-box", groupId: "issue-trash-box", type: "DELETE" }),
+        onDragEnter: () => setIsDragOverDelete(true),
+        onDragLeave: () => setIsDragOverDelete(false),
+        onDrop: (payload) => {
+          setIsDragOverDelete(false);
+          const source = getSourceFromDropPayload(payload);
+          if (!source) return;
+          onRequestDelete(source.id);
+        },
+      })
+    );
+  }, [onRequestDelete]);
+
+  return (
+    <div
+      className={`fixed left-1/2 -translate-x-1/2 ${
+        isDragging ? "z-40" : ""
+      } top-3 mx-3 flex w-72 items-center justify-center`}
+      ref={deleteAreaRef}
+    >
+      <div
+        className={`${
+          isDragging ? `opacity-100` : `opacity-0`
+        } flex w-full items-center justify-center rounded-sm border-2 border-danger-strong/20 bg-surface-1 px-3 py-5 text-11 font-medium text-danger-primary italic ${
+          isDragOverDelete ? "bg-danger-primary blur-2xl" : ""
+        } transition duration-300`}
+      >
+        Drop here to delete the work item.
+      </div>
+    </div>
+  );
+});

--- a/apps/web/core/components/issues/issue-layouts/kanban/kanban-delete-drop-zone.tsx
+++ b/apps/web/core/components/issues/issue-layouts/kanban/kanban-delete-drop-zone.tsx
@@ -14,7 +14,7 @@ import { useKanbanView } from "@/hooks/store/use-kanban-view";
 import { getSourceFromDropPayload } from "../utils";
 
 type Props = {
-  onRequestDelete: (issueId: string | undefined) => void;
+  onRequestDelete: (workItemId: string | undefined) => void;
 };
 
 // Isolated from BaseKanBanRoot so a drag start/end re-renders only this banner, not the whole board.


### PR DESCRIPTION
### Description

Extracts the board trash drop-zone out of `BaseKanBanRoot` into its own `KanbanDeleteDropZone` observer. The `isDragging` subscription and trash drop-target used to live in the board root, so every drag start/end re-rendered the whole board and cascaded into the `KanBan` subtree. Moving them into a small isolated observer means a drag start/end re-renders only that banner.

Also adds an `EMPTY_KANBAN_FILTERS` module constant so an empty kanban-filter fallback has a stable identity.

No behavior change — render-cost isolation only.

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [x] Code refactoring
- [x] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots here -->

### Test Scenarios
- On a Kanban board, drag a work item: the "Drop here to delete the work item" banner appears on drag start and clears on drop/cancel; dropping a card onto it opens the delete-confirmation modal and deletes the work item.
- Verify normal board interactions are unchanged: drag between columns, collapse/expand groups, quick-add, peek.
- Repeat on project, cycle, module, view, profile, and epic boards.

### References
<!-- Link related work items if there are any -->

Generated with Claude Code

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated delete drop zone to Kanban boards.
  * Dragging a work item over the delete banner now provides visual feedback and supports dropping to request deletion.

* **Bug Fixes**
  * Improved Kanban pagination updates so newly changed issues are reflected reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->