### PR TITLE
Fix cross-project scope validation in draft and module creation

### DIFF
--- a/apps/api/plane/app/views/module/issue.py
+++ b/apps/api/plane/app/views/module/issue.py
@@ -261,36 +261,44 @@ class ModuleIssueViewSet(BaseViewSet):
         project = Project.objects.get(pk=project_id)
 
         if modules:
-            _ = ModuleIssue.objects.bulk_create(
-                [
-                    ModuleIssue(
-                        issue_id=issue_id,
-                        module_id=module,
-                        project_id=project_id,
-                        workspace_id=project.workspace_id,
-                        created_by=request.user,
-                        updated_by=request.user,
-                    )
-                    for module in modules
-                ],
-                batch_size=10,
-                ignore_conflicts=True,
-            )
-            # Bulk Update the activity
-            _ = [
-                issue_activity.delay(
-                    type="module.activity.created",
-                    requested_data=json.dumps({"module_id": module}),
-                    actor_id=str(request.user.id),
-                    issue_id=issue_id,
+            valid_modules = list(
+                Module.objects.filter(
+                    workspace__slug=slug,
                     project_id=project_id,
-                    current_instance=None,
-                    epoch=int(timezone.now().timestamp()),
-                    notification=True,
-                    origin=base_host(request=request, is_app=True),
+                    pk__in=modules,
+                ).values_list("id", flat=True)
+            )
+            if valid_modules:
+                _ = ModuleIssue.objects.bulk_create(
+                    [
+                        ModuleIssue(
+                            issue_id=issue_id,
+                            module_id=module,
+                            project_id=project_id,
+                            workspace_id=project.workspace_id,
+                            created_by=request.user,
+                            updated_by=request.user,
+                        )
+                        for module in valid_modules
+                    ],
+                    batch_size=10,
+                    ignore_conflicts=True,
                 )
-                for module in modules
-            ]
+                # Bulk Update the activity
+                _ = [
+                    issue_activity.delay(
+                        type="module.activity.created",
+                        requested_data=json.dumps({"module_id": module}),
+                        actor_id=str(request.user.id),
+                        issue_id=issue_id,
+                        project_id=project_id,
+                        current_instance=None,
+                        epoch=int(timezone.now().timestamp()),
+                        notification=True,
+                        origin=base_host(request=request, is_app=True),
+                    )
+                    for module in valid_modules
+                ]
 
         for module_id in removed_modules:
             module_issue = ModuleIssue.objects.filter(

--- a/apps/api/plane/app/views/workspace/draft.py
+++ b/apps/api/plane/app/views/workspace/draft.py
@@ -237,14 +237,22 @@ class WorkspaceDraftIssueViewSet(BaseViewSet):
             )
 
             if request.data.get("cycle_id", None):
-                created_records = CycleIssue.objects.create(
-                    cycle_id=request.data.get("cycle_id", None),
-                    issue_id=serializer.data.get("id", None),
-                    project_id=draft_issue.project_id,
-                    workspace_id=draft_issue.workspace_id,
-                    created_by_id=draft_issue.created_by_id,
-                    updated_by_id=draft_issue.updated_by_id,
-                )
+                try:
+                    cycle = Cycle.objects.get(
+                        workspace__slug=slug,
+                        project_id=draft_issue.project_id,
+                        pk=request.data.get("cycle_id", None),
+                    )
+                    created_records = CycleIssue.objects.create(
+                        cycle_id=cycle.id,
+                        issue_id=serializer.data.get("id", None),
+                        project_id=draft_issue.project_id,
+                        workspace_id=draft_issue.workspace_id,
+                        created_by_id=draft_issue.created_by_id,
+                        updated_by_id=draft_issue.updated_by_id,
+                    )
+                except Cycle.DoesNotExist:
+                    pass
                 # Capture Issue Activity
                 issue_activity.delay(
                     type="cycle.activity.created",
@@ -264,36 +272,44 @@ class WorkspaceDraftIssueViewSet(BaseViewSet):
                 )
 
             if request.data.get("module_ids", []):
-                # bulk create the module
-                ModuleIssue.objects.bulk_create(
-                    [
-                        ModuleIssue(
-                            module_id=module,
-                            issue_id=serializer.data.get("id", None),
-                            workspace_id=draft_issue.workspace_id,
-                            project_id=draft_issue.project_id,
-                            created_by_id=draft_issue.created_by_id,
-                            updated_by_id=draft_issue.updated_by_id,
-                        )
-                        for module in request.data.get("module_ids", [])
-                    ],
-                    batch_size=10,
-                )
-                # Update the activity
-                _ = [
-                    issue_activity.delay(
-                        type="module.activity.created",
-                        requested_data=json.dumps({"module_id": str(module)}),
-                        actor_id=str(request.user.id),
-                        issue_id=serializer.data.get("id", None),
+                valid_modules = list(
+                    Module.objects.filter(
+                        workspace__slug=slug,
                         project_id=draft_issue.project_id,
-                        current_instance=None,
-                        epoch=int(timezone.now().timestamp()),
-                        notification=True,
-                        origin=base_host(request=request, is_app=True),
+                        pk__in=request.data.get("module_ids", []),
+                    ).values_list("id", flat=True)
+                )
+                if valid_modules:
+                    # bulk create the module
+                    ModuleIssue.objects.bulk_create(
+                        [
+                            ModuleIssue(
+                                module_id=module,
+                                issue_id=serializer.data.get("id", None),
+                                workspace_id=draft_issue.workspace_id,
+                                project_id=draft_issue.project_id,
+                                created_by_id=draft_issue.created_by_id,
+                                updated_by_id=draft_issue.updated_by_id,
+                            )
+                            for module in valid_modules
+                        ],
+                        batch_size=10,
                     )
-                    for module in request.data.get("module_ids", [])
-                ]
+                    # Update the activity
+                    _ = [
+                        issue_activity.delay(
+                            type="module.activity.created",
+                            requested_data=json.dumps({"module_id": str(module)}),
+                            actor_id=str(request.user.id),
+                            issue_id=serializer.data.get("id", None),
+                            project_id=draft_issue.project_id,
+                            current_instance=None,
+                            epoch=int(timezone.now().timestamp()),
+                            notification=True,
+                            origin=base_host(request=request, is_app=True),
+                        )
+                        for module in valid_modules
+                    ]
 
             # Update file assets
             file_assets = FileAsset.objects.filter(draft_issue_id=draft_id)


### PR DESCRIPTION
### Description
Fixed a logic bug where creating an issue from a draft or adding modules to an issue didn't properly validate the scope. A malicious user could potentially pass `cycle_id` or `module_ids` belonging to a different project within the same workspace, causing the issue to appear in the wrong project's views. It's basically a cross-project data leakage. While looking at the code, I noticed the exact same issue was already patched in `cycle/issue.py` recently, so I just mirrored that approach here by explicitly validating the workspace and project before running `bulk_create` or `create`.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)

### Test Scenarios 
Tested locally by creating a draft and attempting to convert it to an issue using a `cycle_id` from another project. The modification correctly drops the invalid cycle reference and prevents the cross-project link. Same goes for the `module_ids` validation. The existing test suite passed locally.

### References
Related to previous cross-project logic bugs like GHSA-4w5x-wc9w-f47x.
